### PR TITLE
cicd(Charts): set docker images for pool and gate to tx-bpdm

### DIFF
--- a/charts/gate/Chart.yaml
+++ b/charts/gate/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.1
+version: 3.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gate/values.yaml
+++ b/charts/gate/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   registry: ghcr.io
-  repository: catenax-ng/product-bpdm/gate
+  repository: catenax-ng/tx-bpdm/gate
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v3.0.0"

--- a/charts/pool/Chart.yaml
+++ b/charts/pool/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pool/values.yaml
+++ b/charts/pool/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   registry: ghcr.io
-  repository: catenax-ng/product-bpdm/pool
+  repository: catenax-ng/tx-bpdm/pool
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v3.0.0"


### PR DESCRIPTION
Docker images should be pulled from the catenax-ng fork of this repository for now.