### PR TITLE
cicd(Dockerfiles): exchange Docker base image to eclipse-temurin

### DIFF
--- a/.github/workflows/build-docker-all.yaml
+++ b/.github/workflows/build-docker-all.yaml
@@ -1,21 +1,21 @@
 name: Build All - Docker images (SemVer)
 on:
   push:
-    # only execute when source specific files change
+    # only execute when source specific files or workflows change
     paths:
       - pom.xml
       - bpdm-pool/**
       - bpdm-gate/**
       - bpdm-common/**
+      - .github/workflows/**
     tags:
       - 'v*.*.*'
       - 'v*.*.*-*'
-    push:
-      branches:
-        - main
-    pull_request:
-      branches:
-        - main
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   build-docker-pool:
     uses: ./.github/workflows/build-docker.yaml
@@ -25,7 +25,6 @@ jobs:
       push: ${{ github.event_name != 'pull_request' }}
 
   build-docker-gate:
-    needs: [ call-sonar-scan ]
     uses: ./.github/workflows/build-docker.yaml
     with:
       imageName: gate

--- a/README.adoc
+++ b/README.adoc
@@ -404,6 +404,21 @@ applicationSecrets:
             secret: your_client_secret
 ----
 
+== Container images
+
+This application provides container images for demonstration purposes.
+The base image used, to build this demo application image is `eclipse-temurin:17-jre-alpine`
+
+Docker Hub:
+
+* https://hub.docker.com/_/eclipse-temurin[eclipse-temurin]
+* https://hub.docker.com/layers/library/eclipse-temurin/17-jre-alpine/images/sha256-02c04793fa49ad5cd193c961403223755f9209a67894622e05438598b32f210e?context=explore[17-jre-alpine image]
+
+Source:
+
+* https://github.com/adoptium/temurin-build[temurin-build]
+* https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin[temurin docker repo info]
+
 == GitHub Workflows
 
 For releasing new Docker images of the BPDM Pool and Gate we use GitHub Actions/Workflows, by convention found in the `.github/workflows` folder.

--- a/bpdm-gate/Dockerfile
+++ b/bpdm-gate/Dockerfile
@@ -3,7 +3,7 @@ COPY . /home/app
 WORKDIR /home/app
 RUN mvn -B -U clean package -pl bpdm-gate -am -DskipTests
 
-FROM amazoncorretto:17-alpine-jdk
+FROM eclipse-temurin:17-jre-alpine
 COPY --from=build /home/app/bpdm-gate/target/bpdm-gate.jar /usr/local/lib/bpdm/app.jar
 RUN addgroup -S bpdm && adduser -S bpdm -G bpdm
 USER bpdm

--- a/bpdm-pool/Dockerfile
+++ b/bpdm-pool/Dockerfile
@@ -3,7 +3,7 @@ COPY . /home/app
 WORKDIR /home/app
 RUN mvn -B -U clean package -pl bpdm-pool -am -DskipTests
 
-FROM amazoncorretto:17-alpine-jdk
+FROM eclipse-temurin:17-jre-alpine
 COPY --from=build /home/app/bpdm-pool/target/bpdm-pool.jar /usr/local/lib/bpdm/app.jar
 RUN addgroup -S bpdm && adduser -S bpdm -G bpdm
 USER bpdm


### PR DESCRIPTION
Based on [Docker release guidelines](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-2)