### PR TITLE
Feat/charts/configurable probes

### DIFF
--- a/charts/gate/CHANGELOG.md
+++ b/charts/gate/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [3.2.0] - 2023-03-16
+
+### Changed
+
+- Startup, Readiness and Liveness probes can now be fully configured over the values
+
 ## [3.1.0] - 2023-03-08
 
 ### Changed

--- a/charts/gate/Chart.yaml
+++ b/charts/gate/Chart.yaml
@@ -22,11 +22,10 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "3.1.0"
-version: 3.1.0
+version: 3.2.0
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 maintainers:
   - name: Nico Koprowski
-  - name: Patrick Zeller

--- a/charts/gate/templates/deployment.yaml
+++ b/charts/gate/templates/deployment.yaml
@@ -64,33 +64,11 @@ spec:
               protocol: TCP
           # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
           livenessProbe:
-            httpGet:
-              path: "/actuator/health/liveness"
-              port: 8081
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: "/actuator/health/readiness"
-              port: 8081
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: "/actuator/health/readiness"
-              port: 8081
-              scheme: HTTP
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/gate/values.yaml
+++ b/charts/gate/values.yaml
@@ -84,18 +84,31 @@ affinity:
           topologyKey: kubernetes.io/hostname
 
 livenessProbe:
+  httpGet:
+    path: "/actuator/health/liveness"
+    port: 8081
+    scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
   timeoutSeconds: 1
 readinessProbe:
+  httpGet:
+    path: "/actuator/health/readiness"
+    port: 8081
+    scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
   timeoutSeconds: 1
 startupProbe:
+  httpGet:
+    path: "/actuator/health/readiness"
+    port: 8081
+    scheme: HTTP
+  initialDelaySeconds: 10
   failureThreshold: 20
   periodSeconds: 10
 

--- a/charts/pool/CHANGELOG.md
+++ b/charts/pool/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [4.2.0] - 2023-03-16
+
+### Changed
+
+- Startup, Readiness and Liveness probes can now be fully configured over the values
+
 ## [4.1.0] - 2023-03-08
 
 ### Changed

--- a/charts/pool/Chart.yaml
+++ b/charts/pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "3.1.0"
-version: 4.1.0
+version: 4.2.0
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
@@ -40,4 +40,3 @@ dependencies:
     condition: postgres.enabled
 maintainers:
   - name: Nico Koprowski
-  - name: Patrick Zeller

--- a/charts/pool/templates/deployment.yaml
+++ b/charts/pool/templates/deployment.yaml
@@ -62,35 +62,12 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
           livenessProbe:
-            httpGet:
-              path: "/actuator/health/liveness"
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: "/actuator/health/readiness"
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: "/actuator/health/readiness"
-              port: 8080
-              scheme: HTTP
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/pool/values.yaml
+++ b/charts/pool/values.yaml
@@ -83,18 +83,33 @@ affinity:
           topologyKey: kubernetes.io/hostname
 
 livenessProbe:
+  httpGet:
+    path: "/actuator/health/liveness"
+    port: 8080
+    scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
   timeoutSeconds: 1
+
 readinessProbe:
+  httpGet:
+    path: "/actuator/health/readiness"
+    port: 8080
+    scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
   timeoutSeconds: 1
+
 startupProbe:
+  httpGet:
+    path: "/actuator/health/readiness"
+    port: 8080
+    scheme: HTTP
+  initialDelaySeconds: 10
   failureThreshold: 20
   periodSeconds: 10
 


### PR DESCRIPTION
Make readiness, liveness and startup probes be completely configurable over values for pool and gate chart.