### PR TITLE
cicd(worfklows): remove deploy-maven.yaml workflow path conditions

### DIFF
--- a/.github/workflows/deploy-maven.yaml
+++ b/.github/workflows/deploy-maven.yaml
@@ -1,12 +1,6 @@
 name: Maven Deploy
 on:
   push:
-    # only execute when source specific files change
-    paths:
-      - pom.xml
-      - bpdm-common/**
-      - bpdm-gate-api/**
-      - bpdm-pool-api/**
     branches:
       - main
       - rc/**


### PR DESCRIPTION
Remove push path conditions for maven deploy workflow. This enables the workflow to try to deploy a maven library module everytime a push to main or release candidate branch has happened.