### PR TITLE
feat(pom): increase transitive dependency spring-core to version 6.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
                 <artifactId>spring-expression</artifactId>
                 <version>6.0.8</version>
             </dependency>
+            <!-- Override spring core version used by transitive dependencies due to security issue -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>6.0.8</version>
+            </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock-jre8-standalone</artifactId>


### PR DESCRIPTION
Increase the version of the spring-core dependency to 6.0.8 in order to avoid vulnerability issues. 