### PR TITLE
Persistence of shared business partners - (Logistic Addresses)

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/CollectionUtils.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/CollectionUtils.kt
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.util
+
+fun <T> MutableCollection<T>.replace(elements: Collection<T>) {
+    clear()
+    addAll(elements)
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AddressIdentifier.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AddressIdentifier.kt
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+
+@Entity
+@Table(
+    name = "address_identifiers",
+    indexes = [
+        Index(columnList = "address_id")
+    ]
+)
+class AddressIdentifier(
+    @Column(name = "`value`", nullable = false)
+    var value: String,
+
+    @Column(name = "identifier_type_key", nullable = false)
+    var type: String,
+
+    @ManyToOne
+    @JoinColumn(name = "address_id", nullable = false)
+    var address: LogisticAddress
+
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AddressState.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AddressState.kt
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "address_states",
+    indexes = [
+        Index(columnList = "address_id")
+    ]
+)
+class AddressState(
+    @Column(name = "description")
+    val description: String?,
+
+    @Column(name = "valid_from")
+    val validFrom: LocalDateTime?,
+
+    @Column(name = "valid_to")
+    val validTo: LocalDateTime?,
+
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val type: BusinessStateType,
+
+    @ManyToOne
+    @JoinColumn(name = "address_id", nullable = false)
+    var address: LogisticAddress
+
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AlternativePostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AlternativePostalAddress.kt
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import com.neovisionaries.i18n.CountryCode
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
+
+@Embeddable
+class AlternativePostalAddress(
+    @Embedded
+    @AttributeOverride(name = "latitude", column = Column(name = "alt_latitude"))
+    @AttributeOverride(name = "longitude", column = Column(name = "alt_longitude"))
+    @AttributeOverride(name = "altitude", column = Column(name = "alt_altitude"))
+    val geographicCoordinates: GeographicCoordinate?,
+
+    @Column(name = "alt_country")
+    @Enumerated(EnumType.STRING)
+    val country: CountryCode,
+
+    /**
+     * Region within the country
+     */
+    @ManyToOne
+    @JoinColumn(name = "alt_admin_area_l1_region")
+    val administrativeAreaLevel1: Region?,
+
+    /**
+     * Further possibility to describe the region/address(e.g. County)
+     */
+    @Column(name = "alt_admin_area_l2")
+    val administrativeAreaLevel2: String? = null,
+
+    /**
+     * Further possibility to describe the region/address(e.g. Township)
+     */
+    @Column(name = "alt_admin_area_l3")
+    val administrativeAreaLevel3: String? = null,
+
+    /**
+     * Further possibility to describe the region/address(e.g. Sub-Province for China
+     */
+    @Column(name = "alt_admin_area_l4")
+    val administrativeAreaLevel4: String? = null,
+
+    /**
+     * A postal code, also known as postcode, PIN or ZIP Code
+     */
+    @Column(name = "alt_postcode")
+    val postCode: String? = null,
+
+    /**
+     * The city of the address (Synonym: Town, village, municipality)
+     */
+    @Column(name = "alt_city")
+    val city: String,
+
+    /**
+     * Divides the city in several smaller areas
+     */
+    @Column(name = "alt_district_l1")
+    val districtLevel1: String? = null,
+
+    /**
+     * Divides the DistrictLevel1 in several smaller areas. Synonym: Subdistrict
+     */
+    @Column(name = "alt_district_l2")
+    val districtLevel2: String? = null,
+
+    @Embedded
+    @AttributeOverride(name = "name", column = Column(name = "alt_street_name"))
+    @AttributeOverride(name = "houseNumber", column = Column(name = "alt_street_number"))
+    @AttributeOverride(name = "milestone", column = Column(name = "alt_street_milestone"))
+    @AttributeOverride(name = "direction", column = Column(name = "alt_street_direction"))
+    val street: Street? = null,
+
+    // specific for AlternativePostalAddress
+
+    /**
+     * The type of this specified delivery
+     */
+    @Column(name = "alt_delivery_service_type")
+    @Enumerated(EnumType.STRING)
+    val deliveryServiceType: DeliveryServiceType = DeliveryServiceType.PO_BOX,
+
+    /**
+     * Describes the PO Box or private Bag number the delivery should be placed at.
+     */
+    @Column(name = "alt_delivery_service_number")
+    val deliveryServiceNumber: String = "",
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/GeographicCoordinate.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/GeographicCoordinate.kt
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class GeographicCoordinate(
+    @Column(name = "latitude")
+    val latitude: Float,
+    @Column(name = "longitude")
+    val longitude: Float,
+    @Column(name = "altitude")
+    val altitude: Float?,
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
@@ -31,8 +31,8 @@ import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 //    ]
 )
 class LogisticAddress(
-    @Column(name = "bpn", nullable = false, unique = true)
-    var bpn: String,
+    @Column(name = "bpn")
+    var bpn: String?,
 
     @Column(name = "external_id", nullable = false, unique = true)
     var externalId: String,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+
+@Entity
+@Table(
+    name = "logistic_addresses",
+//    indexes = [
+//        Index(columnList = "legal_entity_id"),
+//        Index(columnList = "site_id"),
+//    ]
+)
+class LogisticAddress(
+    @Column(name = "bpn", nullable = false, unique = true)
+    var bpn: String,
+
+    @Column(name = "external_id", nullable = false, unique = true)
+    var externalId: String,
+
+    @Column(name = "legal_entity_external_id", nullable = true)
+    var legalEntityExternalId: String,
+
+    @Column(name = "site_external_id", nullable = true)
+    var siteExternalId: String,
+
+//    @ManyToOne
+//    @JoinColumn(name = "legal_entity_id")
+//    var legalEntity: LegalEntity?,
+
+//    @ManyToOne
+//    @JoinColumn(name = "site_id")
+//    var site: Site?,
+
+    @Column(name = "name")
+    var name: String? = null,
+
+    @Embedded
+    var physicalPostalAddress: PhysicalPostalAddress,
+
+    @Embedded
+    var alternativePostalAddress: AlternativePostalAddress?
+
+) : BaseEntity() {
+    @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val identifiers: MutableSet<AddressIdentifier> = mutableSetOf()
+
+    @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val states: MutableSet<AddressState> = mutableSetOf()
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
@@ -93,6 +93,12 @@ class PhysicalPostalAddress(
     // specific for PhysicalPostalAddress
 
     /**
+     * A separate postal code for a company, also known as postcode, PIN or ZIP Code
+     */
+    @Column(name = "phy_company_postcode")
+    val companyPostCode: String? = null,
+
+    /**
      * The practice of designating an area for industrial development
      */
     @Column(name = "phy_industrial_zone")

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import com.neovisionaries.i18n.CountryCode
+import jakarta.persistence.*
+
+@Embeddable
+class PhysicalPostalAddress(
+    @Embedded
+    @AttributeOverride(name = "latitude", column = Column(name = "phy_latitude"))
+    @AttributeOverride(name = "longitude", column = Column(name = "phy_longitude"))
+    @AttributeOverride(name = "altitude", column = Column(name = "phy_altitude"))
+    val geographicCoordinates: GeographicCoordinate?,
+
+    @Column(name = "phy_country")
+    @Enumerated(EnumType.STRING)
+    val country: CountryCode,
+
+    /**
+     * Region within the country
+     */
+    @ManyToOne
+    @JoinColumn(name = "phy_admin_area_l1_region")
+    val administrativeAreaLevel1: Region?,
+
+    /**
+     * Further possibility to describe the region/address(e.g. County)
+     */
+    @Column(name = "phy_admin_area_l2")
+    val administrativeAreaLevel2: String? = null,
+
+    /**
+     * Further possibility to describe the region/address(e.g. Township)
+     */
+    @Column(name = "phy_admin_area_l3")
+    val administrativeAreaLevel3: String? = null,
+
+    /**
+     * Further possibility to describe the region/address(e.g. Sub-Province for China
+     */
+    @Column(name = "phy_admin_area_l4")
+    val administrativeAreaLevel4: String? = null,
+
+    /**
+     * A postal code, also known as postcode, PIN or ZIP Code
+     */
+    @Column(name = "phy_postcode")
+    val postCode: String? = null,
+
+    /**
+     * The city of the address (Synonym: Town, village, municipality)
+     */
+    @Column(name = "phy_city")
+    val city: String,
+
+    /**
+     * Divides the city in several smaller areas
+     */
+    @Column(name = "phy_district_l1")
+    val districtLevel1: String? = null,
+
+    /**
+     * Divides the DistrictLevel1 in several smaller areas. Synonym: Subdistrict
+     */
+    @Column(name = "phy_district_l2")
+    val districtLevel2: String? = null,
+
+    @Embedded
+    @AttributeOverride(name = "name", column = Column(name = "phy_street_name"))
+    @AttributeOverride(name = "houseNumber", column = Column(name = "phy_street_number"))
+    @AttributeOverride(name = "milestone", column = Column(name = "phy_street_milestone"))
+    @AttributeOverride(name = "direction", column = Column(name = "phy_street_direction"))
+    val street: Street? = null,
+
+    // specific for PhysicalPostalAddress
+
+    /**
+     * The practice of designating an area for industrial development
+     */
+    @Column(name = "phy_industrial_zone")
+    val industrialZone: String? = null,
+
+    /**
+     * Describes a specific building within the address
+     */
+    @Column(name = "phy_building")
+    val building: String? = null,
+
+    /**
+     * Describes the floor/level the delivery shall take place
+     */
+    @Column(name = "phy_floor")
+    val floor: String? = null,
+
+    /**
+     * Describes the door/room/suite on the respective floor the delivery shall take place
+     */
+    @Column(name = "phy_door")
+    val door: String? = null,
+
+    )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Region.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Region.kt
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import com.neovisionaries.i18n.CountryCode
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+
+@Entity
+@Table(
+    name = "regions",
+)
+class Region(
+    @Column(name = "country_code")
+    @Enumerated(EnumType.STRING)
+    val countryCode: CountryCode,
+
+    @Column(name = "region_code")
+    val regionCode: String,
+
+    @Column(name = "region_name")
+    val regionName: String
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Street.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Street.kt
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class Street(
+    @Column
+    val name: String? = null,
+
+    @Column
+    val houseNumber: String? = null,
+
+    /**
+     * The Milestone is relevant for long roads without specific house numbers.
+     */
+    @Column
+    val milestone: String? = null,
+
+    @Column
+    val direction: String? = null
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/GateAddressRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/GateAddressRepository.kt
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.repository
+
+import org.eclipse.tractusx.bpdm.gate.entity.LogisticAddress
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.CrudRepository
+
+interface GateAddressRepository : JpaRepository<LogisticAddress, Long>, CrudRepository<LogisticAddress, Long> {
+
+    fun findByExternalIdIn(externalId: Collection<String>): Set<LogisticAddress>
+
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/GateAddressRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/GateAddressRepository.kt
@@ -27,4 +27,6 @@ interface GateAddressRepository : JpaRepository<LogisticAddress, Long>, CrudRepo
 
     fun findByExternalIdIn(externalId: Collection<String>): Set<LogisticAddress>
 
+    fun findByExternalId(externalId: String): LogisticAddress?
+
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
@@ -40,7 +40,7 @@ class AddressPersistenceService(private val gateAddressRepository: GateAddressRe
         addresses.forEach { address ->
             val fullAddress = address.toAddressGate()
             addressRecord.find { it.externalId == address.externalId }?.let { existingAddress ->
-                updateAddress(existingAddress, fullAddress)
+                updateAddress(existingAddress, address)
                 gateAddressRepository.save(existingAddress)
             } ?: run {
                 gateAddressRepository.save(fullAddress)
@@ -48,18 +48,18 @@ class AddressPersistenceService(private val gateAddressRepository: GateAddressRe
         }
     }
 
-    private fun updateAddress(address: LogisticAddress, changeAddress: LogisticAddress) {
+    private fun updateAddress(address: LogisticAddress, addressRequest: AddressGateInputRequest) {
 
-        address.name = changeAddress.name
-        address.bpn = changeAddress.bpn
-        address.externalId = changeAddress.externalId
-        address.legalEntityExternalId = changeAddress.legalEntityExternalId
-        address.siteExternalId = changeAddress.siteExternalId
-        address.physicalPostalAddress = changeAddress.physicalPostalAddress
-        address.alternativePostalAddress = changeAddress.alternativePostalAddress
+        address.name = addressRequest.address.name
+        address.bpn = addressRequest.bpn.toString()
+        address.externalId = addressRequest.externalId
+        address.legalEntityExternalId = addressRequest.legalEntityExternalId.toString()
+        address.siteExternalId = addressRequest.siteExternalId.toString()
+        address.physicalPostalAddress = addressRequest.address.physicalPostalAddress.toPhysicalPostalAddressEntity()
+        address.alternativePostalAddress = addressRequest.address.alternativePostalAddress?.toAlternativePostalAddressEntity()
 
-        address.identifiers.replace(changeAddress.identifiers)
-        address.states.replace(changeAddress.states)
+        address.identifiers.replace(addressRequest.address.identifiers.map { toEntityIdentifier(it, address) }.toSet())
+        address.states.replace(addressRequest.address.states.map { toEntityAddress(it, address) }.toSet())
 
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.service
+
+import jakarta.transaction.Transactional
+import org.eclipse.tractusx.bpdm.common.util.replace
+import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateInputRequest
+import org.eclipse.tractusx.bpdm.gate.entity.LogisticAddress
+import org.eclipse.tractusx.bpdm.gate.repository.GateAddressRepository
+import org.springframework.stereotype.Service
+
+@Service
+class AddressPersistenceService(private val gateAddressRepository: GateAddressRepository) {
+
+    @Transactional
+    fun persistAddressBP(addresses: Collection<AddressGateInputRequest>) {
+
+        val externalIdColl: MutableCollection<String> = mutableListOf()
+        addresses.forEach { externalIdColl.add(it.externalId) }
+
+        val addressRecord = gateAddressRepository.findByExternalIdIn(externalIdColl)
+
+        addresses.forEach { address ->
+            val fullAddress = address.toAddressGate()
+            addressRecord.find { it.externalId == address.externalId }?.let { existingAddress ->
+                updateAddress(existingAddress, fullAddress)
+                gateAddressRepository.save(existingAddress)
+            } ?: run {
+                gateAddressRepository.save(fullAddress)
+            }
+        }
+    }
+
+    private fun updateAddress(address: LogisticAddress, changeAddress: LogisticAddress) {
+
+        address.name = changeAddress.name
+        address.bpn = changeAddress.bpn
+        address.externalId = changeAddress.externalId
+        address.legalEntityExternalId = changeAddress.legalEntityExternalId
+        address.siteExternalId = changeAddress.siteExternalId
+        address.physicalPostalAddress = changeAddress.physicalPostalAddress
+        address.alternativePostalAddress = changeAddress.alternativePostalAddress
+
+        address.identifiers.replace(changeAddress.identifiers)
+        address.states.replace(changeAddress.states)
+
+    }
+
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
@@ -48,7 +48,8 @@ class AddressService(
     private val poolClient: PoolClient,
     private val bpnConfigProperties: BpnConfigProperties,
     private val typeMatchingService: TypeMatchingService,
-    private val changelogRepository: ChangelogRepository
+    private val changelogRepository: ChangelogRepository,
+    private val addressPersistenceService: AddressPersistenceService
 ) {
     private val logger = KotlinLogging.logger { }
 
@@ -185,6 +186,8 @@ class AddressService(
         deleteParentRelationsOfAddresses(addresses)
 
         upsertParentRelations(addresses)
+
+        addressPersistenceService.persistAddressBP(addresses)
     }
 
     /**

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -29,7 +29,7 @@ import org.springframework.data.domain.Page
 fun AddressGateInputRequest.toAddressGate(): LogisticAddress {
 
     val logisticAddress = LogisticAddress(
-        bpn = bpn.toString(),
+        bpn = bpn,
         externalId = externalId,
         legalEntityExternalId = legalEntityExternalId.toString(),
         siteExternalId = siteExternalId.toString(),

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -86,6 +86,7 @@ fun PhysicalPostalAddressDto.toPhysicalPostalAddressEntity(): PhysicalPostalAddr
         districtLevel1 = baseAddress.districtLevel1,
         districtLevel2 = baseAddress.districtLevel2,
         street = baseAddress.street?.toStreetEntity(),
+        companyPostCode = companyPostCode,
         industrialZone = industrialZone,
         building = building,
         floor = floor,

--- a/bpdm-gate/src/main/resources/db/migration/V0_1_0_0__table_creation_address.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V0_1_0_0__table_creation_address.sql
@@ -45,7 +45,7 @@ CREATE TABLE logistic_addresses (
   alt_street_number VARCHAR(255),
   alt_street_milestone VARCHAR(255),
   alt_street_name VARCHAR(255),
-  bpn VARCHAR(255) NOT NULL,
+  bpn VARCHAR(255) NULL,
   external_id VARCHAR(255) NOT NULL,
   legal_entity_external_id VARCHAR(255),
   NAME VARCHAR(255),
@@ -97,9 +97,6 @@ ADD CONSTRAINT uk_2hleh9jm9ef1eq6851bp30v1r UNIQUE (uuid);
 
 ALTER TABLE IF EXISTS logistic_addresses
 ADD CONSTRAINT uk_fbtqvm8vt1nx20nxlr0ixpsi8 UNIQUE (uuid);
-
-ALTER TABLE IF EXISTS logistic_addresses
-ADD CONSTRAINT uk_a2n9sw8djucdywjcnuvkpkssr UNIQUE (bpn);
 
 ALTER TABLE IF EXISTS logistic_addresses
 ADD CONSTRAINT uk_7xolefhhm30nlfrp5fc25a3i2 UNIQUE (external_id);

--- a/bpdm-gate/src/main/resources/db/migration/V0_1_0_0__table_creation_address.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V0_1_0_0__table_creation_address.sql
@@ -64,6 +64,7 @@ CREATE TABLE logistic_addresses (
   phy_longitude FLOAT4,
   phy_industrial_zone VARCHAR(255),
   phy_postcode VARCHAR(255),
+  phy_company_postcode VARCHAR(255),
   phy_street_direction VARCHAR(255),
   phy_street_number VARCHAR(255),
   phy_street_milestone VARCHAR(255),

--- a/bpdm-gate/src/main/resources/db/migration/V0_1_0_0__table_creation_address.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V0_1_0_0__table_creation_address.sql
@@ -1,0 +1,121 @@
+
+CREATE TABLE address_identifiers (
+  id BIGINT NOT NULL,
+  created_at TIMESTAMP WITH time zone NOT NULL,
+  updated_at TIMESTAMP WITH time zone NOT NULL,
+  uuid UUID NOT NULL,
+  "value" VARCHAR(255) NOT NULL,
+  identifier_type_key VARCHAR(255) NOT NULL,
+  address_id BIGINT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE address_states (
+  id BIGINT NOT NULL,
+  created_at TIMESTAMP WITH time zone NOT NULL,
+  updated_at TIMESTAMP WITH time zone NOT NULL,
+  uuid UUID NOT NULL,
+  description VARCHAR(255),
+  type VARCHAR(255) NOT NULL,
+  valid_from TIMESTAMP,
+  valid_to TIMESTAMP,
+  address_id BIGINT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE logistic_addresses (
+  id BIGINT NOT NULL,
+  created_at TIMESTAMP WITH time zone NOT NULL,
+  updated_at TIMESTAMP WITH time zone NOT NULL,
+  uuid UUID NOT NULL,
+  alt_admin_area_l2 VARCHAR(255),
+  alt_admin_area_l3 VARCHAR(255),
+  alt_admin_area_l4 VARCHAR(255),
+  alt_city VARCHAR(255),
+  alt_country VARCHAR(255),
+  alt_delivery_service_number VARCHAR(255),
+  alt_delivery_service_type VARCHAR(255),
+  alt_district_l1 VARCHAR(255),
+  alt_district_l2 VARCHAR(255),
+  alt_altitude FLOAT4,
+  alt_latitude FLOAT4,
+  alt_longitude FLOAT4,
+  alt_postcode VARCHAR(255),
+  alt_street_direction VARCHAR(255),
+  alt_street_number VARCHAR(255),
+  alt_street_milestone VARCHAR(255),
+  alt_street_name VARCHAR(255),
+  bpn VARCHAR(255) NOT NULL,
+  external_id VARCHAR(255) NOT NULL,
+  legal_entity_external_id VARCHAR(255),
+  NAME VARCHAR(255),
+  phy_admin_area_l2 VARCHAR(255),
+  phy_admin_area_l3 VARCHAR(255),
+  phy_admin_area_l4 VARCHAR(255),
+  phy_building VARCHAR(255),
+  phy_city VARCHAR(255),
+  phy_country VARCHAR(255),
+  phy_district_l1 VARCHAR(255),
+  phy_district_l2 VARCHAR(255),
+  phy_door VARCHAR(255),
+  phy_floor VARCHAR(255),
+  phy_altitude FLOAT4,
+  phy_latitude FLOAT4,
+  phy_longitude FLOAT4,
+  phy_industrial_zone VARCHAR(255),
+  phy_postcode VARCHAR(255),
+  phy_street_direction VARCHAR(255),
+  phy_street_number VARCHAR(255),
+  phy_street_milestone VARCHAR(255),
+  phy_street_name VARCHAR(255),
+  site_external_id VARCHAR(255),
+  alt_admin_area_l1_region BIGINT,
+  phy_admin_area_l1_region BIGINT,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE regions (
+  id BIGINT NOT NULL,
+  created_at TIMESTAMP WITH time zone NOT NULL,
+  updated_at TIMESTAMP WITH time zone NOT NULL,
+  uuid UUID NOT NULL,
+  country_code VARCHAR(255),
+  region_code VARCHAR(255),
+  region_name VARCHAR(255),
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idxt1nfv727tjqujqr7b0hxggbq5 ON address_identifiers (address_id);
+
+ALTER TABLE IF EXISTS address_identifiers
+ADD CONSTRAINT uk_rcrdyqidxxabhh6hgajyd5g9b UNIQUE (uuid);
+
+CREATE INDEX idx6nuoy4ynerttj0kmrx9h0o9w1 ON address_states (address_id);
+
+ALTER TABLE IF EXISTS address_states
+ADD CONSTRAINT uk_2hleh9jm9ef1eq6851bp30v1r UNIQUE (uuid);
+
+ALTER TABLE IF EXISTS logistic_addresses
+ADD CONSTRAINT uk_fbtqvm8vt1nx20nxlr0ixpsi8 UNIQUE (uuid);
+
+ALTER TABLE IF EXISTS logistic_addresses
+ADD CONSTRAINT uk_a2n9sw8djucdywjcnuvkpkssr UNIQUE (bpn);
+
+ALTER TABLE IF EXISTS logistic_addresses
+ADD CONSTRAINT uk_7xolefhhm30nlfrp5fc25a3i2 UNIQUE (external_id);
+
+ALTER TABLE IF EXISTS regions
+ADD CONSTRAINT uk_po9lr0ewg38m4xhdaxo9t2hmt UNIQUE (uuid);
+
+ALTER TABLE IF EXISTS address_identifiers
+ADD CONSTRAINT fkfiidrdbv4um8eaxwdb7737cs5 FOREIGN KEY (address_id) REFERENCES logistic_addresses;
+
+ALTER TABLE IF EXISTS address_states
+ADD CONSTRAINT fk6mrebbkx9qe0mnbi9fxrj0d0j FOREIGN KEY (address_id) REFERENCES logistic_addresses;
+
+ALTER TABLE IF EXISTS logistic_addresses
+ADD CONSTRAINT fk1msrc2opgg7y8hllv9mxydm41 FOREIGN KEY (alt_admin_area_l1_region) REFERENCES regions;
+
+ALTER TABLE IF EXISTS logistic_addresses
+ADD CONSTRAINT fkejpo9hh93uu777fbmmixh8v2f FOREIGN KEY (phy_admin_area_l1_region) REFERENCES regions;
+

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerInputIT.kt
@@ -50,12 +50,14 @@ import org.eclipse.tractusx.bpdm.gate.api.model.response.PageStartAfterResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ValidationResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ValidationStatus
 import org.eclipse.tractusx.bpdm.gate.config.SaasConfigProperties
+import org.eclipse.tractusx.bpdm.gate.repository.GateAddressRepository
 
 import org.eclipse.tractusx.bpdm.gate.util.*
 import org.eclipse.tractusx.bpdm.gate.util.EndpointValues.SAAS_MOCK_BUSINESS_PARTNER_PATH
 import org.eclipse.tractusx.bpdm.gate.util.EndpointValues.SAAS_MOCK_RELATIONS_PATH
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -75,7 +77,8 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 internal class AddressControllerInputIT @Autowired constructor(
     private val objectMapper: ObjectMapper,
     private val saasConfigProperties: SaasConfigProperties,
-    val gateClient: GateClient
+    val gateClient: GateClient,
+    private val gateAddressRepository: GateAddressRepository
 ) {
     companion object {
         @RegisterExtension
@@ -701,6 +704,13 @@ internal class AddressControllerInputIT @Autowired constructor(
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.OK, e.statusCode)
         }
+
+        //Check if persisted Address data
+        val addressExternal1 = gateAddressRepository.findByExternalId("address-external-1")
+        assertNotEquals(addressExternal1, null)
+
+        val addressExternal2 = gateAddressRepository.findByExternalId("address-external-2")
+        assertNotEquals(addressExternal2, null)
 
         // TODO
 //        val upsertAddressesRequest = wireMockServer.deserializeMatchedRequests<UpsertRequest>(stubMappingUpsertAddresses, objectMapper).single()


### PR DESCRIPTION
When a sharing member shares a business partner via the Gate API, the information can be persisted in the database. If the information is already present in the database, then the entries are overwritten and updated. First implementation for the Addresses logic. Relationships between Legal Entities and Addresses not in place.