### PR TITLE
docs(branching) add branching strategy diagram to docs

### DIFF
--- a/docs/dev-process/branching-strategy.mmd
+++ b/docs/dev-process/branching-strategy.mmd
@@ -1,0 +1,38 @@
+---
+title: BPDM Branching Strategy
+---
+gitGraph
+    commit
+    commit
+    branch "release/1.0.x"
+    checkout "release/1.0.x"
+    commit id: "ver(1.0.0)" tag: "1.0.0"
+
+    checkout main
+    commit id: "ver(0.1.0-SNAPSHOT)"
+    commit id: "fix(A)"
+    commit
+    checkout "release/1.0.x"
+    branch "fix/1.0.x/A"
+    cherry-pick id: "fix(A)"
+    checkout "release/1.0.x"
+    merge "fix/1.0.x/A"
+
+    checkout "release/1.0.x"
+    commit id: "ver(1.0.1)" tag: "1.0.1"
+    checkout main
+    commit
+    commit
+    branch "release/1.1.x"
+    checkout "release/1.1.x"
+    commit id: "ver(1.1.0)" tag: "1.1.0"
+    checkout main
+    commit id: "ver(1.2.0-SNAPSHOT)"
+    commit
+    commit id: "ver(2.0.0-SNAPSHOT)"
+    branch "feat(B)"
+    commit id: "feat(B)"
+    checkout main
+    branch "fix/C"
+    commit id: "fix(C)"
+


### PR DESCRIPTION
Adds a branching strategy diagram in mermaid notation to the docs folder.

In order to review it, best use a renderer for mermaid diagrams (intellij plugin or similar).

In Github you can also preview it under the "view file" option.