### PR TITLE
Add application fixes for Tractus-X quality gate 3.1

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
-maven/mavencentral/ch.qos.logback/logback-classic/1.4.6, EPL-1.0 OR LGPL-2.1-only, approved, #3435
-maven/mavencentral/ch.qos.logback/logback-core/1.4.6, EPL-1.0 OR LGPL-2.1-only, approved, #3373
+maven/mavencentral/ch.qos.logback/logback-classic/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3435
+maven/mavencentral/ch.qos.logback/logback-core/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.carrotsearch/hppc/0.8.1, Apache-2.0, approved, CQ22339
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.2, Apache-2.0, approved, #5303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.2, Apache-2.0 AND MIT, approved, #4303
@@ -26,35 +26,35 @@ maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
 maven/mavencentral/io.github.microutils/kotlin-logging-jvm/2.1.23, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-commons/1.10.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7333
-maven/mavencentral/io.micrometer/micrometer-core/1.10.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #6977
-maven/mavencentral/io.micrometer/micrometer-observation/1.10.5, Apache-2.0, approved, #7331
-maven/mavencentral/io.netty/netty-buffer/4.1.90.Final, Apache-2.0, approved, CQ21842
-maven/mavencentral/io.netty/netty-codec-dns/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-socks/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-common/4.1.90.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-maven/mavencentral/io.netty/netty-handler-proxy/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.90.Final, Apache-2.0, approved, #6367
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.90.Final, Apache-2.0, approved, #7004
-maven/mavencentral/io.netty/netty-resolver-dns/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.90.Final, Apache-2.0, approved, #6366
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport/4.1.90.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.5, Apache-2.0, approved, #5946
-maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.5, Apache-2.0, approved, #6999
-maven/mavencentral/io.projectreactor/reactor-core/3.5.4, Apache-2.0, approved, #5934
+maven/mavencentral/io.micrometer/micrometer-commons/1.10.6, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7333
+maven/mavencentral/io.micrometer/micrometer-core/1.10.6, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #6977
+maven/mavencentral/io.micrometer/micrometer-observation/1.10.6, Apache-2.0, approved, #7331
+maven/mavencentral/io.netty/netty-buffer/4.1.91.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-codec-dns/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-socks/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-common/4.1.91.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+maven/mavencentral/io.netty/netty-handler-proxy/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.91.Final, Apache-2.0, approved, #6367
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.91.Final, Apache-2.0, approved, #7004
+maven/mavencentral/io.netty/netty-resolver-dns/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.91.Final, Apache-2.0, approved, #6366
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport/4.1.91.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.6, Apache-2.0, approved, #5946
+maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.6, Apache-2.0, approved, #6999
+maven/mavencentral/io.projectreactor/reactor-core/3.5.5, Apache-2.0, approved, #5934
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.7, Apache-2.0, approved, #5919
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.1, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
-maven/mavencentral/jakarta.json/jakarta.json-api/2.1.1, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/jakarta.json/jakarta.json-api/2.1.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7907
 maven/mavencentral/jakarta.persistence/jakarta.persistence-api/3.1.0, EPL-2.0 OR BSD-3-Clause AND (EPL-2.0 OR BSD-3-Clause AND BSD-3-Clause), approved, #7696
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, clearlydefined
@@ -86,16 +86,16 @@ maven/mavencentral/org.apache.lucene/lucene-sandbox/9.4.2, Apache-2.0, approved,
 maven/mavencentral/org.apache.lucene/lucene-spatial-extras/9.4.2, Apache-2.0, approved, #6991
 maven/mavencentral/org.apache.lucene/lucene-spatial3d/9.4.2, Apache-2.0, approved, #6975
 maven/mavencentral/org.apache.lucene/lucene-suggest/9.4.2, Apache-2.0, approved, #6970
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.7, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.7, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.7, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.8, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.8, Apache-2.0, approved, #6997
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.8, Apache-2.0, approved, #7920
 maven/mavencentral/org.aspectj/aspectjweaver/1.9.19, EPL-1.0, approved, tools.aspectj
 maven/mavencentral/org.eclipse.parsson/parsson/1.0.0, EPL-2.0, approved, ee4j.parsson
-maven/mavencentral/org.eclipse.tractusx/bpdm-common/4.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/4.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/4.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-common/3.2.1, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/3.2.1, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/3.2.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/8.5.12, Apache-2.0, approved, #2764
-maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, , approved, CQ13192
+maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, BSD-2-Clause OR LicenseRef-Public-Domain, approved, CQ13192
 maven/mavencentral/org.hibernate.orm/hibernate-core/6.1.7.Final, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-only) AND (CC-PDDC AND LGPL-2.1-only) AND (EPL-2.0 OR BSD-3-Clause), approved, #5939
 maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.0.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss.logging/jboss-logging/3.5.0.Final, Apache-2.0, approved, clearlydefined
@@ -126,49 +126,49 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.7, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.0, Apache-2.0, approved, #5920
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.0, Apache-2.0, approved, #5950
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.0, Apache-2.0, approved, #5923
-maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.0.5, Apache-2.0, approved, #7336
-maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.0.5, Apache-2.0, approved, #7334
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.0.5, Apache-2.0, approved, #6981
-maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.0.5, Apache-2.0, approved, #6973
-maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.0.5, Apache-2.0, approved, #6983
-maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.0.5, Apache-2.0, approved, #6965
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.0.5, Apache-2.0, approved, #7351
-maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.0.5, Apache-2.0, approved, #6974
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.0.5, Apache-2.0, approved, #7006
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.0.5, Apache-2.0, approved, #6982
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.0.5, Apache-2.0, approved, #5932
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.0.5, Apache-2.0, approved, #6967
-maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.0.5, Apache-2.0, approved, #6989
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.0.5, Apache-2.0, approved, #7329
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.0.5, Apache-2.0, approved, #6987
-maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.0.5, Apache-2.0, approved, #6971
-maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.0.5, Apache-2.0, approved, #5945
-maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.0.5, Apache-2.0, approved, #6986
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.0.5, Apache-2.0, approved, #7330
-maven/mavencentral/org.springframework.boot/spring-boot/3.0.5, Apache-2.0, approved, #7327
-maven/mavencentral/org.springframework.data/spring-data-commons/3.0.4, Apache-2.0, approved, #5943
-maven/mavencentral/org.springframework.data/spring-data-jpa/3.0.4, Apache-2.0, approved, #5935
-maven/mavencentral/org.springframework.security/spring-security-config/6.0.2, Apache-2.0, approved, #7338
-maven/mavencentral/org.springframework.security/spring-security-core/6.0.2, Apache-2.0, approved, #7325
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.0.2, Apache-2.0 AND ISC, approved, #7326
-maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.0.2, Apache-2.0, approved, #5931
-maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.0.2, Apache-2.0, approved, #7324
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.0.2, Apache-2.0, approved, #7337
-maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.0.2, Apache-2.0, approved, #7335
-maven/mavencentral/org.springframework.security/spring-security-web/6.0.2, Apache-2.0, approved, #7328
-maven/mavencentral/org.springframework/spring-aop/6.0.7, Apache-2.0, approved, #5940
-maven/mavencentral/org.springframework/spring-aspects/6.0.7, Apache-2.0, approved, #5930
-maven/mavencentral/org.springframework/spring-beans/6.0.7, Apache-2.0, approved, #5937
-maven/mavencentral/org.springframework/spring-context/6.0.7, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.7, Apache-2.0 AND BSD-3-Clause, approved, #5948
-maven/mavencentral/org.springframework/spring-expression/6.0.7, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-jcl/6.0.7, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-jdbc/6.0.7, Apache-2.0, approved, #5924
-maven/mavencentral/org.springframework/spring-orm/6.0.7, Apache-2.0, approved, #5925
-maven/mavencentral/org.springframework/spring-tx/6.0.7, Apache-2.0, approved, #5926
-maven/mavencentral/org.springframework/spring-web/6.0.7, Apache-2.0, approved, #5942
-maven/mavencentral/org.springframework/spring-webflux/6.0.7, Apache-2.0, approved, #6964
-maven/mavencentral/org.springframework/spring-webmvc/6.0.7, Apache-2.0, approved, #5944
+maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.0.6, Apache-2.0, approved, #7336
+maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.0.6, Apache-2.0, approved, #7334
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.0.6, Apache-2.0, approved, #6981
+maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.0.6, Apache-2.0, approved, #6973
+maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.0.6, Apache-2.0, approved, #6983
+maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.0.6, Apache-2.0, approved, #6965
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.0.6, Apache-2.0, approved, #7351
+maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.0.6, Apache-2.0, approved, #6974
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.0.6, Apache-2.0, approved, #7006
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.0.6, Apache-2.0, approved, #6982
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.0.6, Apache-2.0, approved, #5932
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.0.6, Apache-2.0, approved, #6967
+maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.0.6, Apache-2.0, approved, #6989
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.0.6, Apache-2.0, approved, #7329
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.0.6, Apache-2.0, approved, #6987
+maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.0.6, Apache-2.0, approved, #6971
+maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.0.6, Apache-2.0, approved, #5945
+maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.0.6, Apache-2.0, approved, #6986
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.0.6, Apache-2.0, approved, #7330
+maven/mavencentral/org.springframework.boot/spring-boot/3.0.6, Apache-2.0, approved, #7327
+maven/mavencentral/org.springframework.data/spring-data-commons/3.0.5, Apache-2.0, approved, #5943
+maven/mavencentral/org.springframework.data/spring-data-jpa/3.0.5, Apache-2.0, approved, #5935
+maven/mavencentral/org.springframework.security/spring-security-config/6.0.3, Apache-2.0, approved, #7338
+maven/mavencentral/org.springframework.security/spring-security-core/6.0.3, Apache-2.0, approved, #7325
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.0.3, Apache-2.0 AND ISC, approved, #7326
+maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.0.3, Apache-2.0, approved, #5931
+maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.0.3, Apache-2.0, approved, #7324
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.0.3, Apache-2.0, approved, #7337
+maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.0.3, Apache-2.0, approved, #7335
+maven/mavencentral/org.springframework.security/spring-security-web/6.0.3, Apache-2.0, approved, #7328
+maven/mavencentral/org.springframework/spring-aop/6.0.8, Apache-2.0, approved, #5940
+maven/mavencentral/org.springframework/spring-aspects/6.0.8, Apache-2.0, approved, #5930
+maven/mavencentral/org.springframework/spring-beans/6.0.8, Apache-2.0, approved, #5937
+maven/mavencentral/org.springframework/spring-context/6.0.8, Apache-2.0, approved, #5936
+maven/mavencentral/org.springframework/spring-core/6.0.8, Apache-2.0 AND BSD-3-Clause, approved, #5948
+maven/mavencentral/org.springframework/spring-expression/6.0.8, Apache-2.0, approved, #3284
+maven/mavencentral/org.springframework/spring-jcl/6.0.8, Apache-2.0, approved, #3283
+maven/mavencentral/org.springframework/spring-jdbc/6.0.8, Apache-2.0, approved, #5924
+maven/mavencentral/org.springframework/spring-orm/6.0.8, Apache-2.0, approved, #5925
+maven/mavencentral/org.springframework/spring-tx/6.0.8, Apache-2.0, approved, #5926
+maven/mavencentral/org.springframework/spring-web/6.0.8, Apache-2.0, approved, #5942
+maven/mavencentral/org.springframework/spring-webflux/6.0.8, Apache-2.0, approved, #6964
+maven/mavencentral/org.springframework/spring-webmvc/6.0.8, Apache-2.0, approved, #5944
 maven/mavencentral/org.webjars/swagger-ui/4.15.5, Apache-2.0 AND MIT, approved, #5921
 maven/mavencentral/org.webjars/webjars-locator-core/0.52, MIT, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ## Project Description
 
-This repository is part of the overarching Catena-X project.
+This repository is part of the overarching Eclipse Tractus-X project.
 
 BPDM is an acronym for business partner data management.
-This project provides core services for querying, adding and changing business partner base information in the Catena-X landscape.
+This project provides core services for querying, adding and changing business partner base information in the Eclipse Tractus-X landscape.
 
 Currently, BPDM consists of the Pool and Gate services.
 
 ## BPDM Pool
 
-The BPDM Pool is the single source of truth in Catena-X for business partner base information such as addresses and official identifiers.
-Each record in the Pool has a unique identifier with which it can be referenced across the entire Catena-X landscape, the business partner number.
+The BPDM Pool is the single source of truth in Eclipse Tractus-X for business partner base information such as addresses and official identifiers.
+Each record in the Pool has a unique identifier with which it can be referenced across the entire Eclipse Tractus-X landscape, the business partner number.
 Business partner records are divided into legal entities, sites and partner addresses.
 Self-explanatory, a legal entity record represents the legal entity information about a business partner.
 A site may represent legal entity's plant or campus which is big enough to contain several contact/delivery addresses.
@@ -24,7 +24,8 @@ The Pool offers an API to query these business partner records by BPN, other ide
 
 ## BPDM Gate
 
-The BPDM Gate offers an API for Catena-X members to share their own business partner data with Catena-X. Such members are called sharing members.
+The BPDM Gate offers an API for Eclipse Tractus-X members to share their own business partner data with Eclipse Tractus-X. Such members are called sharing
+members.
 Via the Gate service they can add their own business partner records but also retrieve cleaned and enhanced data back in return over the sharing process.
 Shared business partner records that have successfully gone through the sharing process end up in the BPDM Pool and will receive a BPN there (or merge with an
 existing record).

--- a/bpdm-common/pom.xml
+++ b/bpdm-common/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bpdm-common/pom.xml
+++ b/bpdm-common/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>3.2.2</version>
     </parent>
 
     <dependencies>

--- a/bpdm-gate-api/pom.xml
+++ b/bpdm-gate-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <artifactId>bpdm-parent</artifactId>
         <groupId>org.eclipse.tractusx</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/bpdm-gate-api/pom.xml
+++ b/bpdm-gate-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <artifactId>bpdm-parent</artifactId>
         <groupId>org.eclipse.tractusx</groupId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>3.2.2</version>
     </parent>
 
     <properties>

--- a/bpdm-gate/Dockerfile
+++ b/bpdm-gate/Dockerfile
@@ -6,8 +6,12 @@ RUN mvn -B -U clean package -pl bpdm-gate -am -DskipTests
 FROM eclipse-temurin:17-jre-alpine
 COPY --from=build /home/app/bpdm-gate/target/bpdm-gate.jar /usr/local/lib/bpdm/app.jar
 RUN apk update && apk upgrade libssl3 libcrypto3
-RUN addgroup -S bpdm && adduser -S bpdm -G bpdm
-USER bpdm
+ARG USERNAME=bpdm
+ARG USERID=10001
+ARG GID=3000
+RUN addgroup -g $GID -S $USERNAME
+RUN adduser -u $USERID -S $USERNAME $USERNAME
+USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/bpdm-gate/pom.xml
+++ b/bpdm-gate/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bpdm-gate/pom.xml
+++ b/bpdm-gate/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>3.2.2</version>
     </parent>
 
     <dependencies>

--- a/bpdm-pool-api/pom.xml
+++ b/bpdm-pool-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/bpdm-pool-api/pom.xml
+++ b/bpdm-pool-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>3.2.2</version>
     </parent>
 
     <properties>

--- a/bpdm-pool/Dockerfile
+++ b/bpdm-pool/Dockerfile
@@ -6,8 +6,12 @@ RUN mvn -B -U clean package -pl bpdm-pool -am -DskipTests
 FROM eclipse-temurin:17-jre-alpine
 COPY --from=build /home/app/bpdm-pool/target/bpdm-pool.jar /usr/local/lib/bpdm/app.jar
 RUN apk update && apk upgrade libssl3 libcrypto3
-RUN addgroup -S bpdm && adduser -S bpdm -G bpdm
-USER bpdm
+ARG USERNAME=bpdm
+ARG USERID=10001
+ARG GID=3000
+RUN addgroup -g $GID -S $USERNAME
+RUN adduser -u $USERID -S $USERNAME $USERNAME
+USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/bpdm-pool/pom.xml
+++ b/bpdm-pool/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/bpdm-pool/pom.xml
+++ b/bpdm-pool/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>3.2.2</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.5</version>
+        <version>3.0.6</version>
     </parent>
     <modules>
         <module>bpdm-pool-api</module>
@@ -115,29 +115,17 @@
                 <artifactId>springdoc-openapi-starter-common</artifactId>
                 <version>${springdoc.version}</version>
             </dependency>
-            <!-- Kotlin wrapper for slf4j (Logging)-->
-            <dependency>
-                <groupId>io.github.microutils</groupId>
-                <artifactId>kotlin-logging-jvm</artifactId>
-                <version>${kotlinlogging.version}</version>
-            </dependency>
             <!-- Override snakeyaml version used by transitive dependencies due to security issue -->
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>2.0</version>
             </dependency>
-            <!-- Override spring expression version used by transitive dependencies due to security issue -->
+            <!-- Kotlin wrapper for slf4j (Logging)-->
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-expression</artifactId>
-                <version>6.0.8</version>
-            </dependency>
-            <!-- Override spring core version used by transitive dependencies due to security issue -->
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-core</artifactId>
-                <version>6.0.8</version>
+                <groupId>io.github.microutils</groupId>
+                <artifactId>kotlin-logging-jvm</artifactId>
+                <version>${kotlinlogging.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>bpdm-parent</artifactId>
     <name>Business Partner Data Management Parent</name>
     <description>Parent pom of Business Partner Data Management</description>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.2</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>bpdm-parent</artifactId>
     <name>Business Partner Data Management Parent</name>
     <description>Parent pom of Business Partner Data Management</description>
-    <version>3.2.1</version>
+    <version>3.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
Introduces fixes and optimizations for BPDM services to satisfy Tractus-X quality gate rules in order to be compatible with the 3.1 release.

Bumps the minor version number of BPDM 3.2.x to 3.2.2.

Helm chart appversion changes need to follow.