### PR TITLE
Fix Tractus-X QG 3.1 Helm Chart Issues

### DIFF
--- a/charts/gate/CHANGELOG.md
+++ b/charts/gate/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [3.3.1] - 2023-05-11
+
+### Changed
+
+- increase to app version 3.2.2
+
+### Added
+
+- add license header to ingress template
+
 ## [3.3.0] - 2023-03-17
 
 ### Changed

--- a/charts/gate/Chart.yaml
+++ b/charts/gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "3.2.0"
-version: 3.3.0
+appVersion: "3.2.2"
+version: 3.3.1
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/gate/templates/ingress.yaml
+++ b/charts/gate/templates/ingress.yaml
@@ -1,4 +1,22 @@
 {{- if .Values.ingress.enabled -}}
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
 {{- $fullName := include "bpdm.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}

--- a/charts/pool/CHANGELOG.md
+++ b/charts/pool/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [4.3.1] - 2023-05-11
+
+### Changed
+
+- increase to app version 3.2.2
+
+### Added
+
+- license header to ingress template
+
 ## [4.3.0] - 2023-03-17
 
 ### Changed

--- a/charts/pool/Chart.yaml
+++ b/charts/pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "3.2.0"
-version: 4.3.0
+appVersion: "3.2.2"
+version: 4.3.1
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/pool/templates/ingress.yaml
+++ b/charts/pool/templates/ingress.yaml
@@ -1,4 +1,22 @@
 {{- if .Values.ingress.enabled -}}
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
 {{- $fullName := include "bpdm.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}


### PR DESCRIPTION
Resolves issues related to the quality gate rules of tractus-x release 3.1 in scope for the Helm charts:

- Adds missing license headers to the ingress templates.
- Updates the app version in the charts to 3.3.2
- Updates the chart versions themselved