### PR TITLE
fix(helm): move license "header" of ingress under metadata

### DIFF
--- a/charts/gate/Chart.yaml
+++ b/charts/gate/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "4.0.0-alpha.1"
-version: 4.0.0-alpha.2
+version: 4.0.0-alpha.3
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/gate/templates/ingress.yaml
+++ b/charts/gate/templates/ingress.yaml
@@ -1,22 +1,4 @@
 {{- if .Values.ingress.enabled -}}
-################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-################################################################################
 {{- $fullName := include "bpdm.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
@@ -33,6 +15,24 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
+  ################################################################################
+  # Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ################################################################################
   name: {{ $fullName }}
   labels:
     {{- include "bpdm.labels" . | nindent 4 }}

--- a/charts/pool/Chart.yaml
+++ b/charts/pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "4.0.0-alpha.1"
-version: 5.0.0-alpha.2
+version: 5.0.0-alpha.3
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/pool/templates/ingress.yaml
+++ b/charts/pool/templates/ingress.yaml
@@ -1,22 +1,4 @@
 {{- if .Values.ingress.enabled -}}
-################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-################################################################################
 {{- $fullName := include "bpdm.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
@@ -33,6 +15,24 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
+  ################################################################################
+  # Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ################################################################################
   name: {{ $fullName }}
   labels:
     {{- include "bpdm.labels" . | nindent 4 }}


### PR DESCRIPTION
This avoids the license information coming first in the ingress resource as it causes the helm deployment to be corrupted under helmv2

updates eclipse-tractusx/bpdm#143