### PR TITLE
Version 3.2.x: Fix License Header issues for Helmv2 

### DIFF
--- a/charts/gate/CHANGELOG.md
+++ b/charts/gate/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [3.3.2] - 2023-05-12
+
+### Changed
+
+- move ingress license headers under metadata section for helmv2 backwards compatibility
+
 ## [3.3.1] - 2023-05-11
 
 ### Changed

--- a/charts/gate/Chart.yaml
+++ b/charts/gate/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "3.2.2"
-version: 3.3.1
+version: 3.3.2
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/gate/templates/ingress.yaml
+++ b/charts/gate/templates/ingress.yaml
@@ -1,22 +1,4 @@
 {{- if .Values.ingress.enabled -}}
-################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-################################################################################
 {{- $fullName := include "bpdm.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
@@ -33,6 +15,24 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
+  ################################################################################
+  # Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ################################################################################
   name: {{ $fullName }}
   labels:
     {{- include "bpdm.labels" . | nindent 4 }}

--- a/charts/pool/CHANGELOG.md
+++ b/charts/pool/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [4.3.2] - 2023-05-12
+
+### Changed
+
+- move ingress license headers under metadata section for helmv2 backwards compatibility
+
 ## [4.3.1] - 2023-05-11
 
 ### Changed

--- a/charts/pool/Chart.yaml
+++ b/charts/pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "3.2.2"
-version: 4.3.1
+version: 4.3.2
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/pool/templates/ingress.yaml
+++ b/charts/pool/templates/ingress.yaml
@@ -1,22 +1,4 @@
 {{- if .Values.ingress.enabled -}}
-################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-################################################################################
 {{- $fullName := include "bpdm.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
@@ -33,6 +15,24 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
+  ################################################################################
+  # Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ################################################################################
   name: {{ $fullName }}
   labels:
     {{- include "bpdm.labels" . | nindent 4 }}


### PR DESCRIPTION
Move License Headers under the metadata section so that they don't break the deployment.

Updates issue #143 