### PR TITLE
Temporarily remove Dummy Bridge from Module List

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <module>bpdm-pool</module>
         <module>bpdm-gate-api</module>
         <module>bpdm-gate</module>
-        <module>bpdm-bridge-dummy</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Dummy Bridge is currently broken and blocks the development of the other services. Onlx temporary measure for dealing with issue eclispe-tractusx/bpdm#152