### PR TITLE
Gate API: Overhaul Changelog Endpoint

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
@@ -50,7 +50,7 @@ class GateQueryService(
         val content = mutableListOf<ChangelogResponse>()
 
         do {
-            val pageResponse = gateClient.changelog().getChangelogEntries(
+            val pageResponse = gateClient.changelog().getInputChangelog(
                 searchRequest = ChangeLogSearchRequest(fromTime = modifiedAfter),
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
             )

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
@@ -26,6 +26,11 @@ import com.catenax.bpdm.bridge.dummy.dto.GateSiteInfo
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
+import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateInputResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateInputResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateInputResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.request.ChangeLogSearchRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogResponse
 import org.springframework.stereotype.Service
@@ -45,9 +50,8 @@ class GateQueryService(
         val content = mutableListOf<ChangelogResponse>()
 
         do {
-            val pageResponse = gateClient.changelog().getChangelogEntriesLsaType(
-                lsaType = null,
-                fromTime = modifiedAfter,
+            val pageResponse = gateClient.changelog().getChangelogEntries(
+                searchRequest = ChangeLogSearchRequest(fromTime = modifiedAfter),
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
             )
             page++
@@ -61,16 +65,16 @@ class GateQueryService(
             .also {
                 logger.info {
                     "Changed entries in Gate since last sync: " +
-                            "${it[LsaType.LegalEntity]?.size ?: 0} legal entities, " +
-                            "${it[LsaType.Site]?.size ?: 0} sites, " +
-                            "${it[LsaType.Address]?.size ?: 0} addresses"
+                            "${it[LsaType.LEGAL_ENTITY]?.size ?: 0} legal entities, " +
+                            "${it[LsaType.SITE]?.size ?: 0} sites, " +
+                            "${it[LsaType.ADDRESS]?.size ?: 0} addresses"
                 }
             }
     }
 
     fun getLegalEntityInfos(externalIds: Set<String>): Collection<GateLegalEntityInfo> {
         val entries = getLegalEntitiesInput(externalIds)
-        val bpnByExternalId = getBpnByExternalId(LsaType.LegalEntity, externalIds)
+        val bpnByExternalId = getBpnByExternalId(LsaType.LEGAL_ENTITY, externalIds)
 
         return entries.map {
             GateLegalEntityInfo(
@@ -84,7 +88,7 @@ class GateQueryService(
 
     fun getSiteInfos(externalIds: Set<String>): Collection<GateSiteInfo> {
         val entries = getSitesInput(externalIds)
-        val bpnByExternalId = getBpnByExternalId(LsaType.Site, externalIds)
+        val bpnByExternalId = getBpnByExternalId(LsaType.SITE, externalIds)
 
         return entries.map {
             GateSiteInfo(
@@ -98,7 +102,7 @@ class GateQueryService(
 
     fun getAddressInfos(externalIds: Set<String>): Collection<GateAddressInfo> {
         val entries = getAddressesInput(externalIds)
-        val bpnByExternalId = getBpnByExternalId(LsaType.Address, externalIds)
+        val bpnByExternalId = getBpnByExternalId(LsaType.ADDRESS, externalIds)
 
         return entries.map {
             GateAddressInfo(

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
@@ -41,12 +41,12 @@ class GateUpdateService(
     ) {
         for (entity in responseWrapper.entities) {
             val externalId = entity.index
-            buildSuccessSharingStateDto(LsaType.LegalEntity, externalId, entity.legalEntity.bpnl, true)
+            buildSuccessSharingStateDto(LsaType.LEGAL_ENTITY, externalId, entity.legalEntity.bpnl, true)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         for (errorInfo in responseWrapper.errors) {
             val externalId = errorInfo.entityKey
-            buildErrorSharingStateDto(LsaType.LegalEntity, externalId, null, errorInfo, true)
+            buildErrorSharingStateDto(LsaType.LEGAL_ENTITY, externalId, null, errorInfo, true)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         logger.info { "Sharing states for ${responseWrapper.entityCount} valid and ${responseWrapper.errorCount} invalid new legal entities were updated in the Gate" }
@@ -59,13 +59,13 @@ class GateUpdateService(
         for (entity in responseWrapper.entities) {
             val bpn = entity.legalEntity.bpnl
             val externalId = externalIdByBpn[bpn]
-            buildSuccessSharingStateDto(LsaType.LegalEntity, externalId, bpn, false)
+            buildSuccessSharingStateDto(LsaType.LEGAL_ENTITY, externalId, bpn, false)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         for (errorInfo in responseWrapper.errors) {
             val bpn = errorInfo.entityKey
             val externalId = externalIdByBpn[bpn]
-            buildErrorSharingStateDto(LsaType.LegalEntity, externalId, bpn, errorInfo, false)
+            buildErrorSharingStateDto(LsaType.LEGAL_ENTITY, externalId, bpn, errorInfo, false)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         logger.info { "Sharing states for ${responseWrapper.entityCount} valid and ${responseWrapper.errorCount} invalid modified legal entities were updated in the Gate" }
@@ -76,12 +76,12 @@ class GateUpdateService(
     ) {
         for (entity in responseWrapper.entities) {
             val externalId = entity.index
-            buildSuccessSharingStateDto(LsaType.Site, externalId, entity.site.bpns, true)
+            buildSuccessSharingStateDto(LsaType.SITE, externalId, entity.site.bpns, true)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         for (errorInfo in responseWrapper.errors) {
             val externalId = errorInfo.entityKey
-            buildErrorSharingStateDto(LsaType.Site, externalId, null, errorInfo, true)
+            buildErrorSharingStateDto(LsaType.SITE, externalId, null, errorInfo, true)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         logger.info { "Sharing states for ${responseWrapper.entityCount} valid and ${responseWrapper.errorCount} invalid new sites were updated in the Gate" }
@@ -94,13 +94,13 @@ class GateUpdateService(
         for (entity in responseWrapper.entities) {
             val bpn = entity.site.bpns
             val externalId = externalIdByBpn[bpn]
-            buildSuccessSharingStateDto(LsaType.Site, externalId, bpn, false)
+            buildSuccessSharingStateDto(LsaType.SITE, externalId, bpn, false)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         for (errorInfo in responseWrapper.errors) {
             val bpn = errorInfo.entityKey
             val externalId = externalIdByBpn[bpn]
-            buildErrorSharingStateDto(LsaType.Site, externalId, bpn, errorInfo, false)
+            buildErrorSharingStateDto(LsaType.SITE, externalId, bpn, errorInfo, false)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         logger.info { "Sharing states for ${responseWrapper.entityCount} valid and ${responseWrapper.errorCount} invalid modified sites were updated in the Gate" }
@@ -111,12 +111,12 @@ class GateUpdateService(
     ) {
         for (entity in responseWrapper.entities) {
             val externalId = entity.index
-            buildSuccessSharingStateDto(LsaType.Address, externalId, entity.address.bpna, true)
+            buildSuccessSharingStateDto(LsaType.ADDRESS, externalId, entity.address.bpna, true)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         for (errorInfo in responseWrapper.errors) {
             val externalId = errorInfo.entityKey
-            buildErrorSharingStateDto(LsaType.Address, externalId, null, errorInfo, true)
+            buildErrorSharingStateDto(LsaType.ADDRESS, externalId, null, errorInfo, true)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         logger.info { "Sharing states for ${responseWrapper.entityCount} valid and ${responseWrapper.errorCount} invalid new addresses were updated in the Gate" }
@@ -129,13 +129,13 @@ class GateUpdateService(
         for (entity in responseWrapper.entities) {
             val bpn = entity.bpna
             val externalId = externalIdByBpn[bpn]
-            buildSuccessSharingStateDto(LsaType.Address, externalId, bpn, false)
+            buildSuccessSharingStateDto(LsaType.ADDRESS, externalId, bpn, false)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         for (errorInfo in responseWrapper.errors) {
             val bpn = errorInfo.entityKey
             val externalId = externalIdByBpn[bpn]
-            buildErrorSharingStateDto(LsaType.Address, externalId, bpn, errorInfo, false)
+            buildErrorSharingStateDto(LsaType.ADDRESS, externalId, bpn, errorInfo, false)
                 ?.let { gateClient.sharingState().upsertSharingState(it) }
         }
         logger.info { "Sharing states for ${responseWrapper.entityCount} valid and ${responseWrapper.errorCount} invalid modified addresses were updated in the Gate" }

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -101,7 +101,7 @@ class PoolUpdateService(
     fun createSitesInPool(entriesToCreate: Collection<GateSiteInfo>): SitePartnerCreateResponseWrapper {
         val leParentBpnByExternalId = entriesToCreate
             .map { it.legalEntityExternalId }
-            .let { gateQueryService.getBpnByExternalId(LsaType.LegalEntity, it.toSet()) }
+            .let { gateQueryService.getBpnByExternalId(LsaType.LEGAL_ENTITY, it.toSet()) }
         val createRequests = entriesToCreate.mapNotNull { entry ->
             leParentBpnByExternalId[entry.legalEntityExternalId]
                 ?.let { leParentBpn ->
@@ -146,7 +146,7 @@ class PoolUpdateService(
     fun createAddressesInPool(entriesToCreate: Collection<GateAddressInfo>): AddressPartnerCreateResponseWrapper {
         val leParentBpnByExternalId = entriesToCreate
             .mapNotNull { it.legalEntityExternalId }
-            .let { gateQueryService.getBpnByExternalId(LsaType.LegalEntity, it.toSet()) }
+            .let { gateQueryService.getBpnByExternalId(LsaType.LEGAL_ENTITY, it.toSet()) }
         val leParentsCreateRequests = entriesToCreate.mapNotNull { entry ->
             leParentBpnByExternalId[entry.legalEntityExternalId]
                 ?.let { leParentBpn ->
@@ -160,7 +160,7 @@ class PoolUpdateService(
 
         val siteParentBpnByExternalId = entriesToCreate
             .mapNotNull { it.siteExternalId }
-            .let { gateQueryService.getBpnByExternalId(LsaType.Site, it.toSet()) }
+            .let { gateQueryService.getBpnByExternalId(LsaType.SITE, it.toSet()) }
         val siteParentsCreateRequests = entriesToCreate.mapNotNull { entry ->
             siteParentBpnByExternalId[entry.siteExternalId]
                 ?.let { siteParentBpn ->

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/SyncService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/SyncService.kt
@@ -55,9 +55,9 @@ class SyncService(
         // Check changelog entries from Gate (after last sync time)
         val externalIdsByType = gateQueryService.getChangedExternalIdsByLsaType(modifiedAfter)
 
-        externalIdsByType[LsaType.LegalEntity]?.let { syncLegalEntities(it) }
-        externalIdsByType[LsaType.Site]?.let { syncSites(it) }
-        externalIdsByType[LsaType.Address]?.let { syncAddresses(it) }
+        externalIdsByType[LsaType.LEGAL_ENTITY]?.let { syncLegalEntities(it) }
+        externalIdsByType[LsaType.SITE]?.let { syncSites(it) }
+        externalIdsByType[LsaType.ADDRESS]?.let { syncAddresses(it) }
     }
 
     private fun syncLegalEntities(externalIdsRequested: Set<String>) {

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateChangelogApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateChangelogApi.kt
@@ -34,14 +34,14 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-@RequestMapping("/api/catena/input/business-partners/changelog", produces = [MediaType.APPLICATION_JSON_VALUE])
-@HttpExchange("/api/catena/input/business-partners/changelog")
+@RequestMapping("/api/catena", produces = [MediaType.APPLICATION_JSON_VALUE])
+@HttpExchange("/api/catena")
 interface GateChangelogApi {
 
 
     @Operation(
-        summary = "Get business partner changelog entries by list external id, from timestamp and/or lsa type",
-        description = "Get business partner changelog entries by list external id, from timestamp and/or lsa type"
+        summary = "Get business partner changelog entries for changes to the business partner input data",
+        description = "Get business partner changelog entries for changes to the business partner input data. Filter by list external id, from timestamp and/or lsa type"
     )
     @ApiResponses(
         value = [
@@ -49,11 +49,28 @@ interface GateChangelogApi {
             ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()]),
         ]
     )
-    @PostMapping("/search")
-    @PostExchange("/search")
-    fun getChangelogEntries(
+    @PostMapping("/input/changelog/search")
+    @PostExchange("/input/changelog/search")
+    fun getInputChangelog(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @RequestBody searchRequest: ChangeLogSearchRequest
     ): PageChangeLogResponse<ChangelogResponse>
 
+
+    @Operation(
+        summary = "Get business partner changelog entries for changes to the business partner output data",
+        description = "Get business partner changelog entries for changes to the business partner output data. Filter by list external id, from timestamp and/or lsa type"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "The changelog entries for the specified parameters"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()]),
+        ]
+    )
+    @PostMapping("/output/changelog/search")
+    @PostExchange("/output/changelog/search")
+    fun getOutputChangelog(
+        @ParameterObject @Valid paginationRequest: PaginationRequest,
+        @RequestBody searchRequest: ChangeLogSearchRequest
+    ): PageChangeLogResponse<ChangelogResponse>
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateChangelogApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateChangelogApi.kt
@@ -20,15 +20,12 @@
 package org.eclipse.tractusx.bpdm.gate.api
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
-import jakarta.validation.constraints.NotEmpty
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
-import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
+import org.eclipse.tractusx.bpdm.gate.api.model.request.ChangeLogSearchRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.PageChangeLogResponse
 import org.springdoc.core.annotations.ParameterObject
@@ -36,16 +33,15 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
-import java.time.Instant
 
-@RequestMapping("/api/catena/business-partners/changelog", produces = [MediaType.APPLICATION_JSON_VALUE])
-@HttpExchange("/api/catena/business-partners/changelog")
+@RequestMapping("/api/catena/input/business-partners/changelog", produces = [MediaType.APPLICATION_JSON_VALUE])
+@HttpExchange("/api/catena/input/business-partners/changelog")
 interface GateChangelogApi {
 
 
     @Operation(
-        summary = "Get business partner changelog entries by list external id, from timestamp",
-        description = "Get business partner changelog entries by list external id, from timestamp"
+        summary = "Get business partner changelog entries by list external id, from timestamp and/or lsa type",
+        description = "Get business partner changelog entries by list external id, from timestamp and/or lsa type"
     )
     @ApiResponses(
         value = [
@@ -55,28 +51,9 @@ interface GateChangelogApi {
     )
     @PostMapping("/search")
     @PostExchange("/search")
-    fun getChangelogEntriesExternalId(
+    fun getChangelogEntries(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
-        @Parameter(description = "From Time", example = "2023-03-20T10:23:28.194Z") @RequestParam(required = false) fromTime: Instant?,
-        @RequestBody(required = true) @NotEmpty(message = "Input externalIds list cannot be empty.") externalIds: Set<String>
+        @RequestBody searchRequest: ChangeLogSearchRequest
     ): PageChangeLogResponse<ChangelogResponse>
-
-    @Operation(
-        summary = "Get business partner changelog entries by timestamp or LSA type",
-        description = "Get business partner changelog entries by from timestamp or LSA type"
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "The changelog entries for the specified parameters"),
-            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()]),
-        ]
-    )
-    @PostMapping("/filter")
-    @PostExchange("/filter")
-    fun getChangelogEntriesLsaType(
-        @ParameterObject @Valid paginationRequest: PaginationRequest,
-        @Parameter(description = "From Time", example = "2023-03-20T10:23:28.194Z") @RequestParam(required = false) fromTime: Instant?,
-        @Parameter(description = "LSA Type") @RequestParam(required = false) lsaType: LsaType?
-    ): PageResponse<ChangelogResponse>
 
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/ChangeLogSearchRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/ChangeLogSearchRequest.kt
@@ -17,10 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model
+package org.eclipse.tractusx.bpdm.gate.api.model.request
 
-enum class LsaType {
-    LEGAL_ENTITY,
-    SITE,
-    ADDRESS
-}
+import io.swagger.v3.oas.annotations.Parameter
+import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
+import java.time.Instant
+
+data class ChangeLogSearchRequest(
+    @field:Parameter(description = "From when to search changelog entries", example = "2023-03-20T10:23:28.194Z", required = false)
+    val fromTime: Instant? = null,
+    @field:Parameter(description = "External-IDs of business partners for which to search changelog entries. Ignored if empty", required = false)
+    val externalIds: Set<String> = emptySet(),
+    @field:Parameter(description = "Lsa-Types of business partners for which to search changelog entries. Ignored if empty", required = false)
+    val lsaTypes: Set<LsaType> = emptySet()
+    )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
@@ -20,15 +20,13 @@
 package org.eclipse.tractusx.bpdm.gate.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.gate.api.GateChangelogApi
-import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
+import org.eclipse.tractusx.bpdm.gate.api.model.request.ChangeLogSearchRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.PageChangeLogResponse
 import org.eclipse.tractusx.bpdm.gate.service.ChangelogService
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.RestController
-import java.time.Instant
 
 @RestController
 @Validated
@@ -36,17 +34,10 @@ class ChangelogController(
     private val changelogService: ChangelogService
 ) : GateChangelogApi {
 
-    override fun getChangelogEntriesExternalId(
-        paginationRequest: PaginationRequest, fromTime: Instant?, externalIds: Set<String>
+    override fun getChangelogEntries(
+        paginationRequest: PaginationRequest, searchRequest: ChangeLogSearchRequest
     ): PageChangeLogResponse<ChangelogResponse> {
-        return changelogService.getChangeLogByExternalId(externalIds, fromTime, paginationRequest.page, paginationRequest.size)
+        return changelogService.getChangeLogEntries(searchRequest.externalIds, searchRequest.lsaTypes, searchRequest.fromTime, paginationRequest.page, paginationRequest.size)
     }
-
-    override fun getChangelogEntriesLsaType(
-        paginationRequest: PaginationRequest, fromTime: Instant?, lsaType: LsaType?
-    ): PageResponse<ChangelogResponse> {
-        return changelogService.getChangeLogByLsaType(lsaType, fromTime, paginationRequest.page, paginationRequest.size)
-    }
-
 
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
@@ -34,10 +34,16 @@ class ChangelogController(
     private val changelogService: ChangelogService
 ) : GateChangelogApi {
 
-    override fun getChangelogEntries(
+    override fun getInputChangelog(
         paginationRequest: PaginationRequest, searchRequest: ChangeLogSearchRequest
     ): PageChangeLogResponse<ChangelogResponse> {
         return changelogService.getChangeLogEntries(searchRequest.externalIds, searchRequest.lsaTypes, searchRequest.fromTime, paginationRequest.page, paginationRequest.size)
+    }
+
+    override fun getOutputChangelog(paginationRequest: PaginationRequest,
+                                    searchRequest: ChangeLogSearchRequest): PageChangeLogResponse<ChangelogResponse> {
+        throw NotImplementedError()
+        TODO("Not yet implemented")
     }
 
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/ChangelogRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/ChangelogRepository.kt
@@ -33,15 +33,16 @@ interface ChangelogRepository : JpaRepository<ChangelogEntry, Long>, JpaSpecific
     object Specs {
 
         /**
-         * Restrict to entries with any one of the given ExternalIds; ignore if null
+         * Restrict to entries with any one of the given ExternalIds; ignore if empty
          */
-        fun byExternalIdsIn(externalIds: Collection<String>) =
+        fun byExternalIdsIn(externalIds: Collection<String>?) =
             Specification<ChangelogEntry> { root, _, _ ->
-
-                externalIds.let {
-                    root.get<String>(ChangelogEntry::externalId.name).`in`(externalIds.map { externalId -> externalId })
+                externalIds?.let {
+                    if(externalIds.isNotEmpty())
+                        root.get<String>(ChangelogEntry::externalId.name).`in`(externalIds.map { externalId -> externalId })
+                    else
+                        null
                 }
-
             }
 
         /**
@@ -55,12 +56,15 @@ interface ChangelogRepository : JpaRepository<ChangelogEntry, Long>, JpaSpecific
             }
 
         /**
-         * Restrict to entries for the LsaType; ignore if null
+         * Restrict to entries for the LsaType; ignore if empty
          */
-        fun byLsaType(lsaType: LsaType?) =
+        fun byLsaTypes(lsaTypes: Set<LsaType>?) =
             Specification<ChangelogEntry> { root, _, builder ->
-                lsaType?.let {
-                    builder.equal(root.get<LsaType>(ChangelogEntry::businessPartnerType.name), lsaType)
+                lsaTypes?.let {
+                    if(lsaTypes.isNotEmpty())
+                        root.get<String>(ChangelogEntry::businessPartnerType.name).`in`(lsaTypes.map { lsaType -> lsaType })
+                    else
+                        null
                 }
             }
     }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
@@ -117,7 +117,7 @@ class AddressService(
 
         // create changelog entry if all goes well from saasClient
         addresses.forEach { address ->
-            changelogRepository.save(ChangelogEntry(address.externalId, LsaType.Address))
+            changelogRepository.save(ChangelogEntry(address.externalId, LsaType.ADDRESS))
         }
 
         addressPersistenceService.persistAddressBP(addresses, OutputInputEnum.Input)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -51,7 +51,7 @@ class LegalEntityService(
     fun upsertLegalEntities(legalEntities: Collection<LegalEntityGateInputRequest>) {
 
         legalEntities.forEach { legalEntity ->
-            changelogRepository.save(ChangelogEntry(legalEntity.externalId, LsaType.LegalEntity))
+            changelogRepository.save(ChangelogEntry(legalEntity.externalId, LsaType.LEGAL_ENTITY))
         }
         legalEntityPersistenceService.persistLegalEntitiesBP(legalEntities, OutputInputEnum.Input)
     }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
@@ -112,7 +112,7 @@ class SiteService(
     fun upsertSites(sites: Collection<SiteGateInputRequest>) {
 
         sites.forEach { site ->
-            changelogRepository.save(ChangelogEntry(site.externalId, LsaType.Site))
+            changelogRepository.save(ChangelogEntry(site.externalId, LsaType.SITE))
         }
 
         sitePersistenceService.persistSitesBP(sites, OutputInputEnum.Input)

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_0__uppercase_lsa_types.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_0__uppercase_lsa_types.sql
@@ -1,0 +1,23 @@
+UPDATE changelog_entries
+SET business_partner_type = 'LEGAL_ENTITY'
+WHERE business_partner_type = 'LegalEntity';
+
+UPDATE changelog_entries
+SET business_partner_type = 'SITE'
+WHERE business_partner_type = 'Site';
+
+UPDATE changelog_entries
+SET business_partner_type = 'ADDRESS'
+WHERE business_partner_type = 'Address';
+
+UPDATE sharing_states
+SET lsa_type = 'LEGAL_ENTITY'
+WHERE lsa_type = 'LegalEntity';
+
+UPDATE sharing_states
+SET lsa_type = 'SITE'
+WHERE lsa_type = 'Site';
+
+UPDATE sharing_states
+SET lsa_type = 'ADDRESS'
+WHERE lsa_type = 'Address';

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
@@ -48,6 +48,7 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.saas.*
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.api.exception.ChangeLogOutputError
+import org.eclipse.tractusx.bpdm.gate.api.model.request.ChangeLogSearchRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.gate.config.SaasConfigProperties
@@ -107,7 +108,9 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog by external id`() {
 
-        val searchResult = gateClient.changelog().getChangelogEntriesExternalId(PaginationRequest(), null, setOf(CommonValues.externalIdAddress1))
+        val searchRequest = ChangeLogSearchRequest(externalIds = setOf(CommonValues.externalIdAddress1))
+
+        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content)
             .ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
@@ -123,7 +126,9 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog by external id not found`() {
 
-        val searchResult = gateClient.changelog().getChangelogEntriesExternalId(PaginationRequest(), null, setOf("NONEXIST"))
+        val searchRequest = ChangeLogSearchRequest(externalIds = setOf("NONEXIST"))
+
+        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
 
         assertThat(searchResult.content)
             .usingRecursiveComparison()
@@ -156,7 +161,9 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog by external id and timeStamp`() {
 
-        val searchResult = gateClient.changelog().getChangelogEntriesExternalId(PaginationRequest(), instant, setOf(CommonValues.externalIdAddress1))
+        val searchRequest = ChangeLogSearchRequest(externalIds =  setOf(CommonValues.externalIdAddress1), fromTime = instant)
+
+        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
 
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
@@ -171,7 +178,9 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog by lsaType`() {
 
-        val searchResult = gateClient.changelog().getChangelogEntriesLsaType(PaginationRequest(), null, lsaTypeParam)
+        val searchRequest = ChangeLogSearchRequest(lsaTypes =  setOf(lsaTypeParam))
+
+        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
             .isEqualTo(listOf(ChangelogResponse(CommonValues.externalIdAddress1, lsaTypeParam, instant)))
@@ -185,7 +194,9 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
     @Test
     fun `get changeLog by lsaType not found`() {
-        val searchResult = gateClient.changelog().getChangelogEntriesLsaType(PaginationRequest(), null, lsaTypeParamNotFound)
+        val searchRequest = ChangeLogSearchRequest(lsaTypes =  setOf(lsaTypeParamNotFound))
+
+        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content)
             .isEqualTo(emptyList<ChangelogEntry>())
@@ -198,8 +209,9 @@ internal class ChangeLogControllerIT @Autowired constructor(
      */
     @Test
     fun `get changeLog by lsaType and timeStamp`() {
+        val searchRequest = ChangeLogSearchRequest(lsaTypes =  setOf(lsaTypeParam), fromTime = instant)
 
-        val searchResult = gateClient.changelog().getChangelogEntriesLsaType(PaginationRequest(), instant, lsaTypeParam)
+        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
             .isEqualTo(listOf(ChangelogResponse(CommonValues.externalIdAddress1, lsaTypeParam, instant)))
@@ -213,7 +225,9 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog from timeStamp`() {
 
-        val searchResult = gateClient.changelog().getChangelogEntriesLsaType(paginationRequest = PaginationRequest(), fromTime = instant, lsaType = null)
+        val searchRequest = ChangeLogSearchRequest(lsaTypes =  emptySet(), fromTime = instant)
+
+        val searchResult = gateClient.changelog().getChangelogEntries(paginationRequest = PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
             .isEqualTo(listOf(ChangelogResponse(CommonValues.externalIdAddress1, lsaTypeParam, instant)))
@@ -271,23 +285,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
                         )
                 )
         )
-        val stubMappingUpsertAddresses = wireMockServer.stubFor(
-            put(urlPathMatching(EndpointValues.SAAS_MOCK_BUSINESS_PARTNER_PATH))
-                .willReturn(
-                    aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                            objectMapper.writeValueAsString(
-                                UpsertResponse(
-                                    emptyList(),
-                                    emptyList(),
-                                    2,
-                                    0
-                                )
-                            )
-                        )
-                )
-        )
+
         // mock "get addresses with relations"
         // this simulates the case that the address already had some relations
         wireMockServer.stubFor(
@@ -307,36 +305,6 @@ internal class ChangeLogControllerIT @Autowired constructor(
                                         SaasValues.addressBusinessPartnerWithRelations1,
                                         SaasValues.addressBusinessPartnerWithRelations2
                                     )
-                                )
-                            )
-                        )
-                )
-        )
-        val stubMappingDeleteRelations = wireMockServer.stubFor(
-            post(urlPathMatching(EndpointValues.SAAS_MOCK_DELETE_RELATIONS_PATH))
-                .willReturn(
-                    aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                            objectMapper.writeValueAsString(
-                                DeleteRelationsResponseSaas(2)
-                            )
-                        )
-                )
-        )
-        val stubMappingUpsertRelations = wireMockServer.stubFor(
-            put(urlPathMatching(EndpointValues.SAAS_MOCK_RELATIONS_PATH))
-                .willReturn(
-                    aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                            objectMapper.writeValueAsString(
-                                UpsertRelationsResponseSaas(
-                                    failures = emptyList(),
-                                    numberOfFailed = 0,
-                                    numberOfInserts = 2,
-                                    numberOfProvidedRelations = 2,
-                                    numberOfUpdates = 0
                                 )
                             )
                         )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
@@ -110,7 +110,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangeLogSearchRequest(externalIds = setOf(CommonValues.externalIdAddress1))
 
-        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content)
             .ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
@@ -128,7 +128,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangeLogSearchRequest(externalIds = setOf("NONEXIST"))
 
-        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
         assertThat(searchResult.content)
             .usingRecursiveComparison()
@@ -163,7 +163,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangeLogSearchRequest(externalIds =  setOf(CommonValues.externalIdAddress1), fromTime = instant)
 
-        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
@@ -180,7 +180,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangeLogSearchRequest(lsaTypes =  setOf(lsaTypeParam))
 
-        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
             .isEqualTo(listOf(ChangelogResponse(CommonValues.externalIdAddress1, lsaTypeParam, instant)))
@@ -196,7 +196,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
     fun `get changeLog by lsaType not found`() {
         val searchRequest = ChangeLogSearchRequest(lsaTypes =  setOf(lsaTypeParamNotFound))
 
-        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content)
             .isEqualTo(emptyList<ChangelogEntry>())
@@ -211,7 +211,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
     fun `get changeLog by lsaType and timeStamp`() {
         val searchRequest = ChangeLogSearchRequest(lsaTypes =  setOf(lsaTypeParam), fromTime = instant)
 
-        val searchResult = gateClient.changelog().getChangelogEntries(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
             .isEqualTo(listOf(ChangelogResponse(CommonValues.externalIdAddress1, lsaTypeParam, instant)))
@@ -227,7 +227,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangeLogSearchRequest(lsaTypes =  emptySet(), fromTime = instant)
 
-        val searchResult = gateClient.changelog().getChangelogEntries(paginationRequest = PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog().getInputChangelog(paginationRequest = PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogResponse::modifiedAt.name}")
             .isEqualTo(listOf(ChangelogResponse(CommonValues.externalIdAddress1, lsaTypeParam, instant)))

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateControllerIT.kt
@@ -54,36 +54,36 @@ class SharingStateControllerIT @Autowired constructor(
     @Test
     fun `insert and get sharing states `() {
 
-        val stateAddress = insertSharingStateSuccess(LsaType.Address, externalId = "exIdAddress")
-        val stateSite = insertSharingStateSuccess(LsaType.Site, externalId = "exIdSite")
-        val stateLegalEntity1 = insertSharingStateSuccess(LsaType.LegalEntity, externalId = "exIdEntity1")
-        val stateLegalEntity2 = insertSharingStateSuccess(LsaType.LegalEntity, externalId = "exIdEntity2")
-        insertSharingStateSuccess(LsaType.Address, externalId = "exIdMultiple")
-        insertSharingStateSuccess(LsaType.Site, externalId = "exIdMultiple")
-        insertSharingStateSuccess(LsaType.LegalEntity, externalId = "exIdMultiple")
+        val stateAddress = insertSharingStateSuccess(LsaType.ADDRESS, externalId = "exIdAddress")
+        val stateSite = insertSharingStateSuccess(LsaType.SITE, externalId = "exIdSite")
+        val stateLegalEntity1 = insertSharingStateSuccess(LsaType.LEGAL_ENTITY, externalId = "exIdEntity1")
+        val stateLegalEntity2 = insertSharingStateSuccess(LsaType.LEGAL_ENTITY, externalId = "exIdEntity2")
+        insertSharingStateSuccess(LsaType.ADDRESS, externalId = "exIdMultiple")
+        insertSharingStateSuccess(LsaType.SITE, externalId = "exIdMultiple")
+        insertSharingStateSuccess(LsaType.LEGAL_ENTITY, externalId = "exIdMultiple")
 
-        val searchAddressById = readSharingStates(LsaType.Address, "exIdAddress")
+        val searchAddressById = readSharingStates(LsaType.ADDRESS, "exIdAddress")
         assertThat(searchAddressById).hasSize(1)
         assertThat(searchAddressById.first()).isEqualTo(stateAddress)
 
-        val searchSitesById = readSharingStates(LsaType.Site, "exIdSite")
+        val searchSitesById = readSharingStates(LsaType.SITE, "exIdSite")
         assertThat(searchSitesById).hasSize(1)
         assertThat(searchSitesById.first()).isEqualTo(stateSite)
 
-        val searchAddressWrongId = readSharingStates(LsaType.Address, "exIdEntity")
+        val searchAddressWrongId = readSharingStates(LsaType.ADDRESS, "exIdEntity")
         assertThat(searchAddressWrongId).hasSize(0)
 
-        val searchEntityMultiple = readSharingStates(LsaType.LegalEntity, "exIdEntity1", "exIdEntity2")
+        val searchEntityMultiple = readSharingStates(LsaType.LEGAL_ENTITY, "exIdEntity1", "exIdEntity2")
         assertThat(searchEntityMultiple).hasSize(2)
 
-        val searchEntitySingle = readSharingStates(LsaType.LegalEntity, "exIdEntity2")
+        val searchEntitySingle = readSharingStates(LsaType.LEGAL_ENTITY, "exIdEntity2")
         assertThat(searchEntitySingle).hasSize(1)
         assertThat(searchEntitySingle.first()).isEqualTo(stateLegalEntity2)
 
         val searchAll = readSharingStates(null)
         assertThat(searchAll).hasSize(7)
 
-        val searchEntityAllLegalEntities = readSharingStates(LsaType.LegalEntity)
+        val searchEntityAllLegalEntities = readSharingStates(LsaType.LEGAL_ENTITY)
         assertThat(searchEntityAllLegalEntities).hasSize(3)
         assertThat(searchEntityAllLegalEntities).extracting(SharingStateDto::externalId.name)
             .contains(stateLegalEntity1.externalId, stateLegalEntity2.externalId, "exIdMultiple")
@@ -98,11 +98,11 @@ class SharingStateControllerIT @Autowired constructor(
     @Test
     fun `insert and get sharing states with error code`() {
 
-        val stateAddress1 = insertSharingStateError(LsaType.Address, externalId = "exIdAddress1", errorCode = SharingTimeout)
-        insertSharingStateError(LsaType.Address, externalId = "exIdAddress2", errorCode = SharingProcessError)
-        insertSharingStateError(LsaType.Address, externalId = "exIdAddress3", errorCode = BpnNotInPool)
+        val stateAddress1 = insertSharingStateError(LsaType.ADDRESS, externalId = "exIdAddress1", errorCode = SharingTimeout)
+        insertSharingStateError(LsaType.ADDRESS, externalId = "exIdAddress2", errorCode = SharingProcessError)
+        insertSharingStateError(LsaType.ADDRESS, externalId = "exIdAddress3", errorCode = BpnNotInPool)
 
-        val searchAddress = readSharingStates(LsaType.Address, "exIdAddress1")
+        val searchAddress = readSharingStates(LsaType.ADDRESS, "exIdAddress1")
         assertThat(searchAddress).hasSize(1)
         assertThat(searchAddress.first()).isEqualTo(stateAddress1)
     }
@@ -110,11 +110,11 @@ class SharingStateControllerIT @Autowired constructor(
     @Test
     fun `insert and update states`() {
 
-        val stateAddress1 = insertSharingStateError(LsaType.Address, externalId = "exIdAddress1", errorCode = SharingTimeout)
-        insertSharingStateError(LsaType.Address, externalId = "exIdAddress2", errorCode = SharingProcessError)
-        insertSharingStateError(LsaType.Address, externalId = "exIdAddress3", errorCode = BpnNotInPool)
+        val stateAddress1 = insertSharingStateError(LsaType.ADDRESS, externalId = "exIdAddress1", errorCode = SharingTimeout)
+        insertSharingStateError(LsaType.ADDRESS, externalId = "exIdAddress2", errorCode = SharingProcessError)
+        insertSharingStateError(LsaType.ADDRESS, externalId = "exIdAddress3", errorCode = BpnNotInPool)
 
-        val searchAddress = readSharingStates(LsaType.Address, "exIdAddress1")
+        val searchAddress = readSharingStates(LsaType.ADDRESS, "exIdAddress1")
         assertThat(searchAddress).hasSize(1)
         assertThat(searchAddress.first()).isEqualTo(stateAddress1)
 
@@ -128,7 +128,7 @@ class SharingStateControllerIT @Autowired constructor(
 
         gateClient.sharingState().upsertSharingState(updatedAddress1)
 
-        val readUpdatedAddress = readSharingStates(LsaType.Address, "exIdAddress1")
+        val readUpdatedAddress = readSharingStates(LsaType.ADDRESS, "exIdAddress1")
         assertThat(readUpdatedAddress).hasSize(1)
         assertThat(readUpdatedAddress.first()).isEqualTo(updatedAddress1)
     }
@@ -138,11 +138,11 @@ class SharingStateControllerIT @Autowired constructor(
 
         val startTime = LocalDateTime.now().withNano(0)
         val stateAddress1 = insertSharingStateSuccess(
-            lsaType = LsaType.Address, externalId = "exIdAddress1",
+            lsaType = LsaType.ADDRESS, externalId = "exIdAddress1",
             sharingProcessStarted = startTime
         )
 
-        val readInsertedAddress = readSharingStates(LsaType.Address, "exIdAddress1")
+        val readInsertedAddress = readSharingStates(LsaType.ADDRESS, "exIdAddress1")
         assertThat(readInsertedAddress.first().sharingProcessStarted).isEqualTo(startTime)
 
         val updatedWithEmpyStarted = stateAddress1.copy(
@@ -152,7 +152,7 @@ class SharingStateControllerIT @Autowired constructor(
         )
         gateClient.sharingState().upsertSharingState(updatedWithEmpyStarted)
 
-        val readUpdatedAddress = readSharingStates(LsaType.Address, "exIdAddress1")
+        val readUpdatedAddress = readSharingStates(LsaType.ADDRESS, "exIdAddress1")
         assertThat(readUpdatedAddress.first().sharingStateType).isEqualTo(SharingStateType.Error)
         assertThat(readUpdatedAddress.first().sharingProcessStarted).isEqualTo(startTime).describedAs("Update with null - sharingProcessStarted not changed ")
         assertThat(readUpdatedAddress.first().sharingErrorMessage).isEqualTo("Changed")

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/CommonValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/CommonValues.kt
@@ -44,8 +44,8 @@ object CommonValues {
     const val externalId4 = "external-4"
     const val externalId5 = "external-5"
 
-    val lsaTypeParam = LsaType.Address
-    val lsaTypeParamNotFound = LsaType.Site
+    val lsaTypeParam = LsaType.ADDRESS
+    val lsaTypeParamNotFound = LsaType.SITE
     val lsaNone = OptionalLsaType.None
 
     const val externalIdSite1 = "site-external-1"


### PR DESCRIPTION
Merge the two changelog endpoints of the BPDM Gate and create a new endpoint which contains the filters fromTime, external-ids and lsaTypes. Fixes issue #241