### PR TITLE
Pool Api Search by name

### DIFF
--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/CommonValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/CommonValues.kt
@@ -66,6 +66,8 @@ object CommonValues {
     const val bpnAddress2 = "BPNA0000000002XY"
     const val bpnAddress3 = "BPNA0000000003X9"
 
+    const val bpnAddress1Name = "BPNAME0000000001XY"
+
     val language1 = LanguageCode.de
     val language2 = LanguageCode.en
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -60,8 +60,6 @@ interface PoolLegalEntityApi {
     @GetExchange
     fun getLegalEntities(
         @ParameterObject bpSearchRequest: LegalEntityPropertiesSearchRequest,
-        @ParameterObject addressSearchRequest: AddressPropertiesSearchRequest,
-        @ParameterObject siteSearchRequest: SitePropertiesSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageResponse<LegalEntityMatchResponse>
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerSearchRequest.kt
@@ -19,31 +19,18 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model.request
 
-import com.neovisionaries.i18n.CountryCode
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 
 // TODO rename to LogisticAddressSearchRequest / adjust
 @Schema(name = "AddressPartnerSearchRequest", description = "Contains keywords used for searching in address properties")
 data class AddressPartnerSearchRequest constructor(
-    @field:Parameter(description = "Filter business partners by administrative area name")
-    var administrativeArea: String? = null,
-    @field:Parameter(description = "Filter business partners by postcode or postcodes")
-    var postCode: String? = null,
-    @field:Parameter(description = "Filter business partners by locality full denotation")
-    var locality: String? = null,
-    @field:Parameter(description = "Filter business partners by thoroughfare full denotation")
-    var thoroughfare: String? = null,
-    @field:Parameter(description = "Filter business partners by premise full denotation")
-    var premise: String? = null,
-    @field:Parameter(description = "Filter business partners by postal delivery point full denotation")
-    var postalDeliveryPoint: String? = null,
-    @field:Parameter(description = "Filter business partners by ISO 3166-1 alpha-2 country code")
-    var countryCode: CountryCode? = null
+    @field:Parameter(description = "Filter business partners by name")
+    var name: String? = null
 ) {
     companion object {
         val EmptySearchRequest = AddressPartnerSearchRequest()
     }
-
-
 }
+
+

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/BusinessPartnerSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/BusinessPartnerSearchRequest.kt
@@ -20,15 +20,11 @@
 package org.eclipse.tractusx.bpdm.pool.api.model.request
 
 data class BusinessPartnerSearchRequest(
-    val partnerProperties: LegalEntityPropertiesSearchRequest,
-    val addressProperties: AddressPropertiesSearchRequest,
-    val siteProperties: SitePropertiesSearchRequest
+    val partnerProperties: LegalEntityPropertiesSearchRequest
 ) {
     companion object {
         val EmptySearchRequest = BusinessPartnerSearchRequest(
-            LegalEntityPropertiesSearchRequest.EmptySearchRequest,
-            AddressPropertiesSearchRequest.EmptySearchRequest,
-            SitePropertiesSearchRequest.EmptySearchRequest
+            LegalEntityPropertiesSearchRequest.EmptySearchRequest
         )
     }
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPropertiesSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPropertiesSearchRequest.kt
@@ -26,16 +26,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(name = "LegalEntityPropertiesSearchRequest", description = "Contains keywords used for searching in legal entity properties")
 data class LegalEntityPropertiesSearchRequest constructor(
     @field:Parameter(description = "Filter legal entities by name")
-    val legalName: String?,
-    @field:Parameter(description = "Filter legal entities by legal form name")
-    val legalForm: String?,
-    @field:Parameter(description = "Filter legal entities by status official denotation")
-    val status: String?,
-    @field:Parameter(description = "Filter legal entities by classification denotation")
-    val classification: String?,
+    val legalName: String?
 ) {
     companion object {
-        val EmptySearchRequest = LegalEntityPropertiesSearchRequest(null, null, null, null)
+        val EmptySearchRequest = LegalEntityPropertiesSearchRequest(null)
     }
 }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/doc/AddressPartnerDoc.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/doc/AddressPartnerDoc.kt
@@ -27,11 +27,6 @@ const val MAPPINGS_FILE_PATH_ADDRESSES = "opensearch/index-mappings-addresses.js
 data class AddressPartnerDoc(
     @JsonIgnore // ignore since this is the id and does not need to be in the document source
     val bpn: String,
-    val administrativeAreas: Collection<String>,
-    val postCodes: Collection<String>,
-    val localities: Collection<String>,
-    val thoroughfares: Collection<String>,
-    val premises: Collection<String>,
-    val postalDeliveryPoints: Collection<String>,
-    val countryCode: String
+    val name: Collection<String>
 )
+

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/repository/AddressDocSearchRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/repository/AddressDocSearchRepository.kt
@@ -91,9 +91,7 @@ class AddressDocSearchRepository(
             .map { (fieldName, queryText) -> bpdmQueryBuilder.buildInnerShouldQuery(fieldName, queryText) }
             .forEach { mustQuery.add(it) }
 
-        if (partnerSearchRequest.countryCode != null) {
-            boolQuery.filter(QueryBuilders.termQuery(AddressPartnerSearchRequest::countryCode.name, partnerSearchRequest.countryCode!!.name))
-        }
+
 
         val searchRequest = SearchRequest()
         val searchSourceBuilder = SearchSourceBuilder()

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/AddressToSaasMapping.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/AddressToSaasMapping.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.service
 
-import org.eclipse.tractusx.bpdm.common.dto.saas.CountrySaas
 import org.eclipse.tractusx.bpdm.common.dto.saas.GeoCoordinatesSaas
 
 interface AddressToSaasMapping {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/DocumentMappingService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/DocumentMappingService.kt
@@ -55,8 +55,8 @@ class DocumentMappingService {
     fun toDocument(logisticAddress: LogisticAddress): Collection<AddressPartnerDoc> {
 
         val addresses: MutableList<AddressPartnerDoc> = mutableListOf()
-
-        addresses.add(toAddressPartnerDoc((PhysicalPostalAddressToSaasMapping(logisticAddress.physicalPostalAddress)), logisticAddress.bpn))
+        val list = listOfNotNull(logisticAddress.name)
+        addresses.add(toAddressPartnerDoc(list,(PhysicalPostalAddressToSaasMapping(logisticAddress.physicalPostalAddress)), logisticAddress.bpn))
         // TODO OpenSearch indexing doesn't work as expected when creating two AddressPartnerDocs with the same BPN (which is the ID), only last is indexed!
         //  For now don't index alternativePostalAddress, since this would override (more important) physicalPostalAddress!
 //        if (logisticAddress.alternativePostalAddress != null) {
@@ -81,18 +81,13 @@ class DocumentMappingService {
         return addresses
     }
 
-    fun toAddressPartnerDoc(address: AddressToSaasMapping, bpn: String): AddressPartnerDoc {
+    fun toAddressPartnerDoc(name: List<String>, address: AddressToSaasMapping, bpn: String): AddressPartnerDoc {
         return AddressPartnerDoc(
             bpn = bpn,
-            administrativeAreas = address.administrativeAreas().map { it },
-            postCodes = address.postcodes().map { it },
-            localities = address.localities().map { it },
-            thoroughfares = address.thoroughfares().map { it },
-            premises = address.premises().map { it },
-            postalDeliveryPoints = address.postalDeliveryPoints().map { it },
-            countryCode = address.country()
+            name = name
         )
     }
+
 
     fun toAddressDoc(address: AddressToSaasMapping): AddressDoc {
         return AddressDoc(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/PhysicalPostalAddressToSaasMapping.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/PhysicalPostalAddressToSaasMapping.kt
@@ -96,4 +96,5 @@ class PhysicalPostalAddressToSaasMapping(private val postalAdress: PhysicalPosta
         return listOf()
     }
 
+
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/util/BpdmOpenSearchQueryBuilder.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/util/BpdmOpenSearchQueryBuilder.kt
@@ -77,7 +77,7 @@ class BpdmOpenSearchQueryBuilder {
      * Fields with no query text are omitted.
      */
     fun toFieldTextPairs(searchRequest: BusinessPartnerSearchRequest): Collection<Pair<String, String>> {
-        return toFieldTextPairs(searchRequest.partnerProperties) + toFieldTextPairs(searchRequest.addressProperties) + toFieldTextPairs(searchRequest.siteProperties)
+        return toFieldTextPairs(searchRequest.partnerProperties)
     }
 
     /**
@@ -87,9 +87,6 @@ class BpdmOpenSearchQueryBuilder {
     fun toFieldTextPairs(bpSearch: LegalEntityPropertiesSearchRequest): Collection<Pair<String, String>> {
         val bpParamPairs = mutableListOf(
             Pair(LegalEntityDoc::legalName.name, bpSearch.legalName),
-            Pair(LegalEntityDoc::legalForm.name, bpSearch.legalForm),
-            Pair(LegalEntityDoc::classifications.name, bpSearch.classification),
-            Pair(LegalEntityDoc::status.name, bpSearch.status)
         )
 
         return bpParamPairs
@@ -140,26 +137,23 @@ class BpdmOpenSearchQueryBuilder {
      */
     fun toFieldTextPairs(addressSearch: AddressPartnerSearchRequest): Collection<Pair<String, String>> {
         val addressParamPairs = listOf(
-            Pair(AddressPartnerDoc::localities.name, addressSearch.locality),
-            Pair(AddressPartnerDoc::administrativeAreas.name, addressSearch.administrativeArea),
-            Pair(AddressPartnerDoc::postCodes.name, addressSearch.postCode),
-            Pair(AddressPartnerDoc::premises.name, addressSearch.premise),
-            Pair(AddressPartnerDoc::postalDeliveryPoints.name, addressSearch.postalDeliveryPoint),
-            Pair(AddressPartnerDoc::thoroughfares.name, addressSearch.thoroughfare)
+            Pair(AddressPartnerDoc::name.name, addressSearch.name)
+
         )
 
-        return addressParamPairs.filter { (_, query) -> query != null }
+        return addressParamPairs
+            .filter { (_, query) -> query != null }
             .map { (fieldName, query) -> Pair(fieldName, query!!) }
     }
+
+
 
     /**
      * Returns a lowercase representation of [searchRequest]
      */
     fun toLowerCaseSearchRequest(searchRequest: BusinessPartnerSearchRequest): BusinessPartnerSearchRequest {
         return BusinessPartnerSearchRequest(
-            toLowerCaseSearchRequest(searchRequest.partnerProperties),
-            toLowerCaseSearchRequest(searchRequest.addressProperties),
-            toLowerCaseSearchRequest(searchRequest.siteProperties)
+            toLowerCaseSearchRequest(searchRequest.partnerProperties)
         )
     }
 
@@ -168,10 +162,7 @@ class BpdmOpenSearchQueryBuilder {
      */
     fun toLowerCaseSearchRequest(searchRequest: LegalEntityPropertiesSearchRequest): LegalEntityPropertiesSearchRequest {
         return LegalEntityPropertiesSearchRequest(
-            searchRequest.legalName?.lowercase(),
-            searchRequest.legalForm?.lowercase(),
-            searchRequest.status?.lowercase(),
-            searchRequest.classification?.lowercase()
+            searchRequest.legalName?.lowercase()
         )
     }
 
@@ -203,13 +194,7 @@ class BpdmOpenSearchQueryBuilder {
      */
     fun toLowerCaseSearchRequest(searchRequest: AddressPartnerSearchRequest): AddressPartnerSearchRequest {
         return AddressPartnerSearchRequest(
-            searchRequest.administrativeArea?.lowercase(),
-            searchRequest.postCode?.lowercase(),
-            searchRequest.locality?.lowercase(),
-            searchRequest.thoroughfare?.lowercase(),
-            searchRequest.premise?.lowercase(),
-            searchRequest.postalDeliveryPoint?.lowercase(),
-            searchRequest.countryCode
+            searchRequest.name?.lowercase()
         )
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BusinessPartnerLegacyController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BusinessPartnerLegacyController.kt
@@ -71,7 +71,7 @@ class BusinessPartnerLegacyController(
         @ParameterObject paginationRequest: PaginationRequest
     ): PageResponse<BusinessPartnerMatchResponse> {
         return searchService.searchBusinessPartners(
-            BusinessPartnerSearchRequest(bpSearchRequest, addressSearchRequest, siteSearchRequest),
+            BusinessPartnerSearchRequest(bpSearchRequest),
             paginationRequest
         )
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -25,7 +25,10 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityResponse
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteResponse
 import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi
-import org.eclipse.tractusx.bpdm.pool.api.model.request.*
+import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
@@ -55,12 +58,10 @@ class LegalEntityController(
 
     override fun getLegalEntities(
         bpSearchRequest: LegalEntityPropertiesSearchRequest,
-        addressSearchRequest: AddressPropertiesSearchRequest,
-        siteSearchRequest: SitePropertiesSearchRequest,
         paginationRequest: PaginationRequest
     ): PageResponse<LegalEntityMatchResponse> {
         return searchService.searchLegalEntities(
-            BusinessPartnerSearchRequest(bpSearchRequest, addressSearchRequest, siteSearchRequest),
+            BusinessPartnerSearchRequest(bpSearchRequest),
             paginationRequest
         )
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LogisticAddress.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LogisticAddress.kt
@@ -43,7 +43,7 @@ class LogisticAddress(
     var site: Site?,
 
     @Column(name = "name")
-    var name: String? = null,
+    var name: String?,
 
     @Embedded
     var physicalPostalAddress: PhysicalPostalAddress,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -405,7 +405,8 @@ class BusinessPartnerBuildService(
             legalEntity = null,
             site = null,
             physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap),
-            alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap) }
+            alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap) },
+            name = dto.name
         )
 
         updateLogisticAddress(address, dto, metadataMap)

--- a/bpdm-pool/src/main/resources/opensearch/index-mappings-addresses.json
+++ b/bpdm-pool/src/main/resources/opensearch/index-mappings-addresses.json
@@ -1,26 +1,8 @@
 {
   "dynamic": "strict",
   "properties": {
-    "administrativeAreas": {
+    "name": {
       "type": "search_as_you_type"
-    },
-    "postCodes": {
-      "type": "search_as_you_type"
-    },
-    "localities": {
-      "type": "search_as_you_type"
-    },
-    "thoroughfares": {
-      "type": "search_as_you_type"
-    },
-    "premises": {
-      "type": "search_as_you_type"
-    },
-    "postalDeliveryPoints": {
-      "type": "search_as_you_type"
-    },
-    "countryCode": {
-      "type": "keyword"
     }
   }
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/InvalidIndexStartupIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/InvalidIndexStartupIT.kt
@@ -25,9 +25,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.doc.LEGAL_ENTITIES_INDEX_NAME
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
@@ -133,8 +131,6 @@ class InvalidIndexStartupIT @Autowired constructor(
 
         val searchResult = poolClient.legalEntities().getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
-            AddressPropertiesSearchRequest.EmptySearchRequest,
-            SitePropertiesSearchRequest.EmptySearchRequest,
             PaginationRequest()
         )
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/ValidIndexStartupIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/ValidIndexStartupIT.kt
@@ -25,9 +25,7 @@ import org.assertj.core.api.Assertions
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
@@ -102,8 +100,6 @@ class ValidIndexStartupIT @Autowired constructor(
         //Make sure entries are indeed there
         val searchResult = poolClient.legalEntities().getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
-            AddressPropertiesSearchRequest.EmptySearchRequest,
-            SitePropertiesSearchRequest.EmptySearchRequest,
             PaginationRequest()
         )
         Assertions.assertThat(searchResult.content).isNotEmpty
@@ -121,8 +117,6 @@ class ValidIndexStartupIT @Autowired constructor(
 
         val searchResult = poolClient.legalEntities().getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
-            AddressPropertiesSearchRequest.EmptySearchRequest,
-            SitePropertiesSearchRequest.EmptySearchRequest,
             PaginationRequest()
         )
         Assertions.assertThat(searchResult.content).isNotEmpty

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.pool.component.opensearch.controller
 
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
@@ -29,13 +30,9 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.dto.saas.PagedResponseSaas
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.service.OpenSearchSyncStarterService
-
-
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -211,9 +208,7 @@ class OpenSearchControllerIT @Autowired constructor(
     private fun searchBusinessPartnerByName(name: String): PageResponse<LegalEntityMatchResponse> {
 
         return poolClient.legalEntities().getLegalEntities(
-            LegalEntityPropertiesSearchRequest(name, null, null, null),
-            AddressPropertiesSearchRequest.EmptySearchRequest,
-            SitePropertiesSearchRequest.EmptySearchRequest,
+            LegalEntityPropertiesSearchRequest(name),
             PaginationRequest()
         )
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
@@ -28,7 +28,6 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequ
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchResponse
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -61,6 +60,7 @@ class AddressControllerSearchIT @Autowired constructor(
         addresses = listOf(RequestValues.addressPartnerCreate1, RequestValues.addressPartnerCreate3)
     )
 
+
     val partnerStructure2 = LegalEntityStructureRequest(
         legalEntity = RequestValues.legalEntityCreate2,
         siteStructures = listOf(
@@ -71,9 +71,13 @@ class AddressControllerSearchIT @Autowired constructor(
         )
     )
 
+    val partnerStructure3 = LegalEntityStructureRequest(
+        legalEntity = RequestValues.legalEntityCreate1,
+        addresses = listOf(RequestValues.addressPartnerCreate4)
+    )
+
     private lateinit var givenAddress1: LogisticAddressResponse
-    private lateinit var givenAddress2: LogisticAddressResponse
-    private lateinit var givenAddress3: LogisticAddressResponse
+
 
 
     @BeforeEach
@@ -83,189 +87,22 @@ class AddressControllerSearchIT @Autowired constructor(
         poolClient.opensearch().clear()
         testHelpers.createTestMetadata()
 
-        val givenStructure = testHelpers.createBusinessPartnerStructure(listOf(partnerStructure1, partnerStructure2))
+
+        val givenStructure = testHelpers.createBusinessPartnerStructure(listOf(partnerStructure3))
         givenAddress1 = givenStructure[0].addresses[0].address                      // addressPartnerCreate1
-        givenAddress2 = givenStructure[1].siteStructures[0].addresses[0].address    // addressPartnerCreate2
-        givenAddress3 = givenStructure[0].addresses[1].address                      // addressPartnerCreate3
 
         testHelpers.startSyncAndAwaitSuccess(webTestClient, EndpointValues.OPENSEARCH_SYNC_PATH)
     }
 
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address by administrative area
-     * Then the matching address is returned
-     */
-    @Test
-    fun `search address via administrative area`() {
-        val expected = PageResponse(
-            3, 1, 0, 3, listOf(
-                AddressMatchResponse(0f, givenAddress1),        // addressPartnerCreate1
-                AddressMatchResponse(0f, givenAddress1),        // legalEntityCreate1.legalAddress
-                AddressMatchResponse(0f, givenAddress1),        // siteCreate1.mainAddress
-            )
-        )
-        val addressSearchRequest = AddressPartnerSearchRequest(
-            administrativeArea = RequestValues.addressPartnerCreate1.address.physicalPostalAddress.areaPart.administrativeAreaLevel2
-        )
 
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-        assertPageEquals(pageResponse, expected)
-    }
 
     /**
      * Given addresses in OpenSearch
-     * When searching an address by post code
+     * When searching an address by name of BPN search criteria
      * Then the matching address is returned
      */
     @Test
-    fun `search address via post code`() {
-        // regular, legal and site main address
-        val expected = PageResponse(
-            3, 1, 0, 3, listOf(
-                AddressMatchResponse(0f, givenAddress1),        // addressPartnerCreate1
-                AddressMatchResponse(0f, givenAddress1),        // legalEntityCreate1.legalAddress
-                AddressMatchResponse(0f, givenAddress1),        // siteCreate1.mainAddress
-            )
-        )
-
-        val addressSearchRequest = AddressPartnerSearchRequest(
-            postCode = givenAddress1.physicalPostalAddress.baseAddress.postalCode
-        )
-
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-        assertPageEquals(pageResponse, expected)
-    }
-
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address by locality
-     * Then the matching address is returned
-     */
-    @Test
-    fun `search address via locality`() {
-        // regular, legal and site main address
-        val expected = PageResponse(
-            3, 1, 0, 3, listOf(
-                AddressMatchResponse(0f, givenAddress1),        // addressPartnerCreate1
-                AddressMatchResponse(0f, givenAddress1),        // legalEntityCreate1.legalAddress
-                AddressMatchResponse(0f, givenAddress1),        // siteCreate1.mainAddress
-            )
-        )
-
-        val addressSearchRequest = AddressPartnerSearchRequest(
-            locality = givenAddress1.physicalPostalAddress.baseAddress.city
-        )
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-        assertPageEquals(pageResponse, expected)
-    }
-
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address by thoroughfare
-     * Then the matching address is returned
-     */
-    @Test
-    fun `search address via thoroughfare`() {
-        // regular, legal and site main address
-        val expected = PageResponse(
-            3, 1, 0, 3, listOf(
-                AddressMatchResponse(0f, givenAddress1),        // addressPartnerCreate1
-                AddressMatchResponse(0f, givenAddress1),        // legalEntityCreate1.legalAddress
-                AddressMatchResponse(0f, givenAddress1),        // siteCreate1.mainAddress
-            )
-        )
-
-        val addressSearchRequest = AddressPartnerSearchRequest(
-            thoroughfare = givenAddress1.physicalPostalAddress.street!!.name
-        )
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-        assertPageEquals(pageResponse, expected)
-    }
-
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address by premise
-     * Then the matching address is returned
-     */
-    @Test
-    fun `search address via premise`() {
-        // regular, legal and site main address
-        val expected = PageResponse(
-            3, 1, 0, 3, listOf(
-                AddressMatchResponse(0f, givenAddress1),        // addressPartnerCreate1
-                AddressMatchResponse(0f, givenAddress1),        // legalEntityCreate1.legalAddress
-                AddressMatchResponse(0f, givenAddress1),        // siteCreate1.mainAddress
-            )
-        )
-
-        val addressSearchRequest = AddressPartnerSearchRequest(
-            premise = givenAddress1.physicalPostalAddress.basePhysicalAddress.building
-        )
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-        assertPageEquals(pageResponse, expected)
-    }
-
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address by postal delivery point
-     * Then the matching address is returned
-     */
-    @Test
-    @Disabled("TODO create alternative address")
-    fun `search address via postal delivery point`() {
-        val expected = PageResponse(
-            1, 1, 0, 1, listOf(
-                AddressMatchResponse(0f, givenAddress1)
-            )
-        )
-
-        val addressSearchRequest = AddressPartnerSearchRequest()
-        addressSearchRequest.postalDeliveryPoint = RequestValues.addressPartnerCreate1.address.alternativePostalAddress!!.deliveryServiceNumber
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-        assertPageEquals(pageResponse, expected)
-    }
-
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address by country code
-     * Then the matching address is returned
-     */
-    @Test
-    fun `search address via country code`() {
-        // regular, legal and site main address
-        val expected = PageResponse(
-            3, 1, 0, 3, listOf(
-                AddressMatchResponse(0f, givenAddress1),        // addressPartnerCreate1
-                AddressMatchResponse(0f, givenAddress1),        // legalEntityCreate1.legalAddress
-                AddressMatchResponse(0f, givenAddress1),        // siteCreate1.mainAddress
-            )
-        )
-
-        val addressSearchRequest = AddressPartnerSearchRequest(
-            countryCode = givenAddress1.physicalPostalAddress.baseAddress.country.technicalKey
-        )
-
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-
-        assertPageEquals(pageResponse, expected)
-    }
-
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address by multiple search criteria
-     * Then the matching address is returned
-     */
-    @Test
-    @Disabled("TODO create alternative address")
-    fun `search address via multiple criteria`() {
+    fun `search address via name`() {
         val expected = PageResponse(
             1, 1, 0, 1, listOf(
                 AddressMatchResponse(0f, givenAddress1)
@@ -274,73 +111,34 @@ class AddressControllerSearchIT @Autowired constructor(
 
 
         val addressSearchRequest = AddressPartnerSearchRequest()
-        addressSearchRequest.postalDeliveryPoint = RequestValues.addressPartnerCreate1.address.alternativePostalAddress!!.deliveryServiceNumber
-        addressSearchRequest.postCode = RequestValues.addressPartnerCreate1.address.physicalPostalAddress.baseAddress.postalCode
+        addressSearchRequest.name = RequestValues.addressPartnerCreate4.address.name
+
         val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
 
         assertPageEquals(pageResponse, expected)
     }
 
-
     /**
      * Given addresses in OpenSearch
-     * When searching an address by multiple search criteria, one of which does not match any of the existing addresses
-     * Then there should be no result
+     * When searching an address by name of BPN that not exists in search criteria
+     * Then the matching address is not found
      */
     @Test
-    fun `search address via multiple criteria, no match found`() {
+    fun `search address via name not found`() {
         val expected = PageResponse(
             0, 0, 0, 0, emptyList<AddressMatchResponse>()
         )
 
 
         val addressSearchRequest = AddressPartnerSearchRequest()
-        addressSearchRequest.postCode = RequestValues.addressPartnerCreate1.address.physicalPostalAddress.baseAddress.postalCode
-        addressSearchRequest.administrativeArea = "someNonexistentValue"
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
+        addressSearchRequest.name = "NONEXISTENT"
 
-
-        assertPageEquals(pageResponse, expected)
-    }
-
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address via search terms that don't match any of the existing addresses
-     * Then there should be no result
-     */
-    @Test
-    fun `search address, no match found`() {
-        val expected = PageResponse(
-            0, 0, 0, 0, emptyList<AddressMatchResponse>()
-        )
-
-        val addressSearchRequest = AddressPartnerSearchRequest()
-        addressSearchRequest.administrativeArea = "someNonexistentValue"
         val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
 
         assertPageEquals(pageResponse, expected)
     }
 
-    /**
-     * Given addresses in OpenSearch
-     * When searching an address that belongs to a site
-     * Then the matching address is returned
-     */
-    @Test
-    fun `search address of site`() {
-        val expected = PageResponse(
-            1, 1, 0, 1, listOf(
-                AddressMatchResponse(0f, givenAddress3)
-            )
-        )
 
-        val addressSearchRequest = AddressPartnerSearchRequest(
-            postCode = givenAddress3.physicalPostalAddress.baseAddress.postalCode
-        )
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
-
-        assertPageEquals(pageResponse, expected)
-    }
 
     private fun assertPageEquals(actual: PageResponse<AddressMatchResponse>, expected: PageResponse<AddressMatchResponse>) {
         testHelpers.assertRecursively(actual)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
@@ -19,14 +19,12 @@
 
 package org.eclipse.tractusx.bpdm.pool.controller
 
-import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityResponse
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressResponse
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
@@ -137,42 +135,42 @@ class LegalEntityControllerSearchIT @Autowired constructor(
         assertPageEquals(secondPage, expectedSecondPage)
     }
 
-    /**
-     * Given partners in OpenSearch
-     * When searching by site name
-     * Then business partner is found
-     */
-    @Test
-    fun `search business partner by site name, result found`() {
-
-        val expected = PageResponse(
-            1, 1, 0, 1, listOf(
-                LegalEntityMatchResponse(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
-            )
-        )
-
-        val pageResponse = searchBusinessPartnerBySiteName(RequestValues.siteCreate2.site.name, 0, 10)
-
-        assertPageEquals(pageResponse, expected)
-    }
+//    /**
+//     * Given partners in OpenSearch
+//     * When searching by site name
+//     * Then business partner is found
+//     */
+//    @Test
+//    fun `search business partner by site name, result found`() {
+//
+//        val expected = PageResponse(
+//            1, 1, 0, 1, listOf(
+//                LegalEntityMatchResponse(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
+//            )
+//        )
+//
+//        val pageResponse = searchBusinessPartnerBySiteName(RequestValues.siteCreate2.site.name, 0, 10)
+//
+//        assertPageEquals(pageResponse, expected)
+//    }
 
     /**
      * Given partners in OpenSearch
      * When searching by nonexistent site name
      * Then no business partner is found
      */
-    @Test
-    fun `search business partner by site name, no result found`() {
-        val foundPartners = searchBusinessPartnerBySiteName("nonexistent name", 0, 10).content
-        assertThat(foundPartners).isEmpty()
-    }
+//    @Test
+//    fun `search business partner by site name, no result found`() {
+//        val foundPartners = searchBusinessPartnerBySiteName("nonexistent name", 0, 10).content
+//        assertThat(foundPartners).isEmpty()
+//    }
 
     private fun searchBusinessPartnerBySiteName(siteName: String, page: Int, size: Int): PageResponse<LegalEntityMatchResponse> {
         val sitePropertiesSearchRequest = SitePropertiesSearchRequest(siteName)
 
         return poolClient.legalEntities().getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
-            AddressPropertiesSearchRequest.EmptySearchRequest, sitePropertiesSearchRequest, PaginationRequest(page, size)
+             PaginationRequest(page, size)
         )
 
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/RequestValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/RequestValues.kt
@@ -159,6 +159,9 @@ object RequestValues {
     val logisticAddress3 = LogisticAddressDto(
         physicalPostalAddress = postalAddress3,
     )
+    val logisticAddress4 = LogisticAddressDto(
+        physicalPostalAddress = postalAddress1, name = CommonValues.name1
+    )
 
 
     val legalEntityCreate1 = LegalEntityPartnerCreateRequest(
@@ -280,6 +283,12 @@ object RequestValues {
 
     val addressPartnerCreate3 = AddressPartnerCreateRequest(
         address = logisticAddress3,
+        bpnParent = legalEntityUpdate3.bpnl,
+        index = CommonValues.index3
+    )
+
+    val addressPartnerCreate4 = AddressPartnerCreateRequest(
+        address = logisticAddress4,
         bpnParent = legalEntityUpdate3.bpnl,
         index = CommonValues.index3
     )


### PR DESCRIPTION
Rebase with the main.
Remove fields that are no longer used for search.
Only be able to search by name or legalEntity on the address endpoint and on the legalentity endpoint respectively.