### PR TITLE
Gate API: Replace Name with Nameparts in Logistic Address

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -61,7 +61,7 @@ class PoolUpdateService(
     fun gateToPoolLogisticAddress(gateDto: LogisticAddressGateDto): LogisticAddressDto {
 
         return LogisticAddressDto(
-            name = gateDto.name,
+            name = gateDto.nameParts.firstOrNull(),
             states = gateDto.states,
             identifiers = gateDto.identifiers,
             physicalPostalAddress = gateToPoolPhysicalAddress(gateDto.physicalPostalAddress),
@@ -166,7 +166,7 @@ class PoolUpdateService(
                 ?.let { siteParentBpn ->
                     AddressPartnerCreateRequest(
                         address = LogisticAddressDto(
-                            name = entry.address.name,
+                            name = entry.address.nameParts.firstOrNull(),
                             states = entry.address.states,
                             identifiers = entry.address.identifiers,
                             physicalPostalAddress = gateToPoolPhysicalAddress(entry.address.physicalPostalAddress),
@@ -193,7 +193,7 @@ class PoolUpdateService(
         val updateRequests = entriesToUpdate.map {
             AddressPartnerUpdateRequest(
                 address = LogisticAddressDto(
-                    name = it.address.name,
+                    name = it.address.nameParts.firstOrNull(),
                     states = it.address.states,
                     identifiers = it.address.identifiers,
                     physicalPostalAddress = gateToPoolPhysicalAddress(it.address.physicalPostalAddress),

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LogisticAddressGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LogisticAddressGateDto.kt
@@ -32,7 +32,7 @@ data class LogisticAddressGateDto(
         description = "Name of the logistic address of the business partner. This is not according to official\n" +
                 "registers but according to the name the uploading sharing member chooses."
     )
-    val name: String? = null,
+    val nameParts: Collection<String> = emptyList(),
 
     @ArraySchema(arraySchema = Schema(description = "Indicates if the LogisticAddress is \"Active\" or \"Inactive\"."))
     val states: Collection<AddressStateDto> = emptyList(),

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
@@ -67,7 +67,7 @@ class AddressPersistenceService(
 
     private fun updateAddress(address: LogisticAddress, changeAddress: AddressGateInputRequest, legalEntityRecord: LegalEntity?, siteRecord: Site?) {
 
-        address.name = changeAddress.address.name
+        address.name = changeAddress.address.nameParts.firstOrNull()
         address.externalId = changeAddress.externalId
         address.legalEntity = legalEntityRecord
         address.site = siteRecord
@@ -109,7 +109,7 @@ class AddressPersistenceService(
 
     private fun updateAddressOutput(address: LogisticAddress, changeAddress: AddressGateOutputRequest, legalEntityRecord: LegalEntity?, siteRecord: Site?) {
 
-        address.name = changeAddress.address.name
+        address.name = changeAddress.address.nameParts.firstOrNull()
         address.bpn = changeAddress.bpn
         address.externalId = changeAddress.externalId
         address.legalEntity = legalEntityRecord

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -34,7 +34,7 @@ fun AddressGateInputRequest.toAddressGate(legalEntity: LegalEntity?, site: Site?
     val logisticAddress = LogisticAddress(
         externalId = externalId,
         siteExternalId = siteExternalId.toString(),
-        name = address.name,
+        name = address.nameParts.firstOrNull(),
         physicalPostalAddress = address.physicalPostalAddress.toPhysicalPostalAddressEntity(),
         alternativePostalAddress = address.alternativePostalAddress?.toAlternativePostalAddressEntity(),
         legalEntity = legalEntity,
@@ -54,7 +54,7 @@ fun AddressGateOutputRequest.toAddressGateOutput(legalEntity: LegalEntity?, site
         bpn = bpn,
         externalId = externalId,
         siteExternalId = siteExternalId.toString(),
-        name = address.name,
+        name = address.nameParts.firstOrNull(),
         physicalPostalAddress = address.physicalPostalAddress.toPhysicalPostalAddressEntity(),
         alternativePostalAddress = address.alternativePostalAddress?.toAlternativePostalAddressEntity(),
         legalEntity = legalEntity,
@@ -278,7 +278,7 @@ fun LogisticAddress.toAddressGateInputResponse(logisticAddressPage: LogisticAddr
 fun LogisticAddress.toLogisticAddressDto(): LogisticAddressGateDto {
 
     val logisticAddress = LogisticAddressGateDto(
-        name = name,
+        nameParts = name?.let { listOf(name!!) }?: emptyList(),
         states = mapToDtoStates(states),
         identifiers = mapToDtoIdentifiers(identifiers),
         physicalPostalAddress = physicalPostalAddress.toPhysicalPostalAddress(),

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SaasRequestMappingService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SaasRequestMappingService.kt
@@ -73,7 +73,7 @@ class SaasRequestMappingService(
             dataSource = saasConfigProperties.datasource,
             types = listOf(TypeKeyNameUrlSaas(BusinessPartnerTypeSaas.BP_ADDRESS.name)),
             identifiers = toAddressIdentifiersSaas(address.identifiers, ""),
-            names = toNamesSaas(address.name),
+            names = toNamesSaas(address.nameParts.firstOrNull()?: ""),
             status = address.states.map { it.toSaasModel() }.firstOrNull(),
             addresses = toAddressesSaasModel(address)
         )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/RequestValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/RequestValues.kt
@@ -329,7 +329,7 @@ object RequestValues {
 
     val addressGateInputRequest1 = AddressGateInputRequest(
         address = address1.copy(
-            name = CommonValues.name1,
+            nameParts = listOf(CommonValues.name1),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )
@@ -341,7 +341,7 @@ object RequestValues {
 
     val addressGateInputRequest2 = AddressGateInputRequest(
         address = address2.copy(
-            name = CommonValues.name2,
+            nameParts = listOf(CommonValues.name2),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )
@@ -354,7 +354,7 @@ object RequestValues {
     //Output Endpoint Values
     val addressGateOutputRequest1 = AddressGateOutputRequest(
         address = address1.copy(
-            name = CommonValues.name1,
+            nameParts = listOf(CommonValues.name1),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )
@@ -366,7 +366,7 @@ object RequestValues {
 
     val addressGateOutputRequest2 = AddressGateOutputRequest(
         address = address2.copy(
-            name = CommonValues.name2,
+            nameParts = listOf(CommonValues.name2),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/ResponseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/ResponseValues.kt
@@ -406,7 +406,7 @@ object ResponseValues {
     val addressGateInputResponse1 = AddressGateInputResponse(
         address = RequestValues.address1
             .copy(
-                name = CommonValues.name1,
+                nameParts = listOf(CommonValues.name1),
                 identifiers = listOf(
                     AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!),
                     AddressIdentifierDto(SaasValues.identifier2.value!!, SaasValues.identifier2.type?.technicalKey!!)
@@ -419,7 +419,7 @@ object ResponseValues {
     val addressGateInputResponse2 = AddressGateInputResponse(
         address = RequestValues.address2
             .copy(
-                name = CommonValues.nameSite1,
+                nameParts = listOf(CommonValues.nameSite1),
                 identifiers = listOf(
                     AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!),
                     AddressIdentifierDto(SaasValues.identifier2.value!!, SaasValues.identifier2.type?.technicalKey!!)
@@ -440,7 +440,7 @@ object ResponseValues {
 
     val logisticAddressGateInputResponse1 = AddressGateInputResponse(
         address = RequestValues.logisticAddress1.copy(
-            name = CommonValues.name1,
+            nameParts = listOf(CommonValues.name1),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )
@@ -451,7 +451,7 @@ object ResponseValues {
 
     val logisticAddressGateInputResponse2 = AddressGateInputResponse(
         address = RequestValues.logisticAddress2.copy(
-            name = CommonValues.name2,
+            nameParts = listOf(CommonValues.name2),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )
@@ -463,7 +463,7 @@ object ResponseValues {
     //Output Response Values
     val logisticAddressGateOutputResponse1 = AddressGateOutputResponse(
         address = RequestValues.logisticAddress1.copy(
-            name = CommonValues.name1,
+            nameParts = listOf(CommonValues.name1),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )
@@ -475,7 +475,7 @@ object ResponseValues {
 
     val logisticAddressGateOutputResponse2 = AddressGateOutputResponse(
         address = RequestValues.logisticAddress2.copy(
-            name = CommonValues.name2,
+            nameParts = listOf(CommonValues.name2),
             identifiers = listOf(
                 AddressIdentifierDto(SaasValues.identifier1.value!!, SaasValues.identifier1.type?.technicalKey!!)
             )


### PR DESCRIPTION
In the Gate API replaces the field name with the array nameParts for each DTO describing a logistic address.