### PR TITLE
Fix - Legal/Main Address Changelogs on Update/Create

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -23,10 +23,11 @@ import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
-import org.eclipse.tractusx.bpdm.gate.api.model.*
-import org.eclipse.tractusx.bpdm.gate.entity.ChangelogEntry
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateInputResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateOutputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateOutputResponse
 import org.eclipse.tractusx.bpdm.gate.entity.LegalEntity
-import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository
 import org.eclipse.tractusx.bpdm.gate.repository.LegalEntityRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -34,7 +35,6 @@ import org.springframework.stereotype.Service
 
 @Service
 class LegalEntityService(
-    private val changelogRepository: ChangelogRepository,
     private val legalEntityPersistenceService: LegalEntityPersistenceService,
     private val legalEntityRepository: LegalEntityRepository
 ) {
@@ -46,9 +46,6 @@ class LegalEntityService(
      **/
     fun upsertLegalEntities(legalEntities: Collection<LegalEntityGateInputRequest>) {
 
-        legalEntities.forEach { legalEntity ->
-            changelogRepository.save(ChangelogEntry(legalEntity.externalId, LsaType.LEGAL_ENTITY))
-        }
         legalEntityPersistenceService.persistLegalEntitiesBP(legalEntities, OutputInputEnum.Input)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
@@ -23,17 +23,14 @@ import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.dto.saas.BusinessPartnerSaas
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
-import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateInputResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateOutputResponse
 import org.eclipse.tractusx.bpdm.gate.config.BpnConfigProperties
-import org.eclipse.tractusx.bpdm.gate.entity.ChangelogEntry
 import org.eclipse.tractusx.bpdm.gate.entity.Site
 import org.eclipse.tractusx.bpdm.gate.exception.SaasNonexistentParentException
-import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository
 import org.eclipse.tractusx.bpdm.gate.repository.SiteRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -44,7 +41,6 @@ class SiteService(
     private val saasRequestMappingService: SaasRequestMappingService,
     private val saasClient: SaasClient,
     private val bpnConfigProperties: BpnConfigProperties,
-    private val changelogRepository: ChangelogRepository,
     private val sitePersistenceService: SitePersistenceService,
     private val siteRepository: SiteRepository
 ) {
@@ -111,11 +107,8 @@ class SiteService(
      **/
     fun upsertSites(sites: Collection<SiteGateInputRequest>) {
 
-        sites.forEach { site ->
-            changelogRepository.save(ChangelogEntry(site.externalId, LsaType.SITE))
-        }
-
         sitePersistenceService.persistSitesBP(sites, OutputInputEnum.Input)
+
     }
 
     /**


### PR DESCRIPTION
When the legal entity is updated there should be a changelog entry for the legal address. Likewise there should be a changelog entry for the main address if a site is updated.

Related Issue: fix #270 