### PR TITLE
Feat(Gate): Add dataType column to ChangelogEntry entity

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.GateChangelogApi
 import org.eclipse.tractusx.bpdm.gate.api.model.request.ChangeLogSearchRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogResponse
@@ -37,13 +38,13 @@ class ChangelogController(
     override fun getInputChangelog(
         paginationRequest: PaginationRequest, searchRequest: ChangeLogSearchRequest
     ): PageChangeLogResponse<ChangelogResponse> {
-        return changelogService.getChangeLogEntries(searchRequest.externalIds, searchRequest.lsaTypes, searchRequest.fromTime, paginationRequest.page, paginationRequest.size)
+        return changelogService.getChangeLogEntries(searchRequest.externalIds, searchRequest.lsaTypes, searchRequest.fromTime,OutputInputEnum.Input, paginationRequest.page, paginationRequest.size)
     }
 
     override fun getOutputChangelog(paginationRequest: PaginationRequest,
                                     searchRequest: ChangeLogSearchRequest): PageChangeLogResponse<ChangelogResponse> {
-        throw NotImplementedError()
-        TODO("Not yet implemented")
+
+        return changelogService.getChangeLogEntries(searchRequest.externalIds, searchRequest.lsaTypes, searchRequest.fromTime,OutputInputEnum.Output, paginationRequest.page, paginationRequest.size)
     }
 
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/ChangelogEntry.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/ChangelogEntry.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.gate.entity
 
 import jakarta.persistence.*
 import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 
 
@@ -32,7 +33,12 @@ class ChangelogEntry(
     val externalId: String,
     @Enumerated(EnumType.STRING)
     @Column(name = "business_partner_type", nullable = false, updatable = false)
-    val businessPartnerType: LsaType
+    val businessPartnerType: LsaType,
+    @Column(name = "data_type")
+    @Enumerated(EnumType.STRING)
+    var dataType: OutputInputEnum
+
+
 
 ) : BaseEntity()
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/ChangelogRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/ChangelogRepository.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.repository
 
+import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 import org.eclipse.tractusx.bpdm.gate.entity.ChangelogEntry
 import org.springframework.data.jpa.domain.Specification
@@ -65,6 +66,13 @@ interface ChangelogRepository : JpaRepository<ChangelogEntry, Long>, JpaSpecific
                         root.get<String>(ChangelogEntry::businessPartnerType.name).`in`(lsaTypes.map { lsaType -> lsaType })
                     else
                         null
+                }
+            }
+
+        fun byOutputInputEnum(outputInputEnum: OutputInputEnum?) =
+            Specification<ChangelogEntry> { root, _, builder ->
+                outputInputEnum?.let {
+                    builder.equal(root.get<OutputInputEnum>(ChangelogEntry::dataType.name), outputInputEnum)
                 }
             }
     }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
@@ -124,6 +124,11 @@ class AddressService(
      **/
     fun upsertOutputAddresses(addresses: Collection<AddressGateOutputRequest>) {
 
+        // create changelog entry if all goes well from saasClient
+        addresses.forEach { address ->
+            changelogRepository.save(ChangelogEntry(address.externalId, LsaType.ADDRESS,OutputInputEnum.Output))
+        }
+
         addressPersistenceService.persistOutputAddressBP(addresses, OutputInputEnum.Output)
 
     }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
@@ -24,11 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.dto.saas.BusinessPartnerSaas
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
-import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateInputRequest
-import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateInputResponse
-import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputRequest
-import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
-import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.config.BpnConfigProperties
 import org.eclipse.tractusx.bpdm.gate.entity.ChangelogEntry
 import org.eclipse.tractusx.bpdm.gate.entity.LogisticAddress
@@ -117,7 +113,7 @@ class AddressService(
 
         // create changelog entry if all goes well from saasClient
         addresses.forEach { address ->
-            changelogRepository.save(ChangelogEntry(address.externalId, LsaType.ADDRESS))
+            changelogRepository.save(ChangelogEntry(address.externalId, LsaType.ADDRESS,OutputInputEnum.Input))
         }
 
         addressPersistenceService.persistAddressBP(addresses, OutputInputEnum.Input)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ChangelogService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ChangelogService.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
+import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.exception.ChangeLogOutputError
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogResponse
@@ -28,6 +29,7 @@ import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byCreatedAtGreaterThan
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byExternalIdsIn
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byLsaTypes
+import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byOutputInputEnum
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
@@ -36,11 +38,12 @@ import java.time.Instant
 @Service
 class ChangelogService(private val changelogRepository: ChangelogRepository) {
 
-    fun getChangeLogEntries(externalIds: Set<String>?, lsaTypes: Set<LsaType>?, createdAt: Instant?, page: Int, pageSize: Int): PageChangeLogResponse<ChangelogResponse> {
+    fun getChangeLogEntries(externalIds: Set<String>?, lsaTypes: Set<LsaType>?, createdAt: Instant?, outputInputEnum: OutputInputEnum?,page: Int, pageSize: Int): PageChangeLogResponse<ChangelogResponse> {
 
         val nonNullExternalIds = externalIds ?: emptySet()
 
-        val spec = Specification.allOf(byExternalIdsIn(externalIds = nonNullExternalIds), byCreatedAtGreaterThan(createdAt = createdAt), byLsaTypes(lsaTypes))
+        val spec = Specification.allOf(byExternalIdsIn(externalIds = nonNullExternalIds), byCreatedAtGreaterThan(createdAt = createdAt), byLsaTypes(lsaTypes), byOutputInputEnum(outputInputEnum))
+
         val pageable = PageRequest.of(page, pageSize)
         val pageResponse = changelogRepository.findAll(spec, pageable)
         val setDistinctList = changelogRepository.findExternalIdsInListDistinct(nonNullExternalIds)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -86,7 +86,7 @@ class LegalEntityService(
      */
     fun getLegalEntitiesOutput(externalIds: Collection<String>?, page: Int, size: Int): PageResponse<LegalEntityGateOutputResponse> {
 
-        val legalEntityPage = if (externalIds != null && externalIds.isNotEmpty()) {
+        val legalEntityPage = if (!externalIds.isNullOrEmpty()) {
             legalEntityRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Output, PageRequest.of(page, size))
         } else {
             legalEntityRepository.findByDataType(OutputInputEnum.Output, PageRequest.of(page, size))

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
@@ -27,10 +27,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.entity.*
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository
-import org.eclipse.tractusx.bpdm.gate.entity.AddressState
-import org.eclipse.tractusx.bpdm.gate.entity.LegalEntity
-import org.eclipse.tractusx.bpdm.gate.entity.LogisticAddress
-import org.eclipse.tractusx.bpdm.gate.entity.Site
 import org.eclipse.tractusx.bpdm.gate.repository.GateAddressRepository
 import org.eclipse.tractusx.bpdm.gate.repository.LegalEntityRepository
 import org.eclipse.tractusx.bpdm.gate.repository.SiteRepository
@@ -66,18 +62,18 @@ class SitePersistenceService(
                 updateAddress(logisticAddressRecord, fullSite.mainAddress)
                 updateSite(existingSite, site, legalEntityRecord)
                 siteRepository.save(existingSite)
-                saveChangelog(site)
+                saveChangelog(site.externalId,datatype)
             } ?: run {
                 siteRepository.save(fullSite)
-                saveChangelog(site)
+                saveChangelog(site.externalId,datatype)
             }
         }
     }
 
     //Creates Changelog For both Site and Logistic Address when they are created or updated
-    private fun saveChangelog(site: SiteGateInputRequest) {
-        changelogRepository.save(ChangelogEntry(getMainAddressForSiteExternalId(site.externalId), LsaType.ADDRESS))
-        changelogRepository.save(ChangelogEntry(site.externalId, LsaType.SITE))
+    private fun saveChangelog(externalId: String,outputInputEnum: OutputInputEnum) {
+        changelogRepository.save(ChangelogEntry(getMainAddressForSiteExternalId(externalId), LsaType.ADDRESS,outputInputEnum))
+        changelogRepository.save(ChangelogEntry(externalId, LsaType.SITE,outputInputEnum))
     }
 
     private fun getAddressRecord(externalId: String, datatype: OutputInputEnum): LogisticAddress {
@@ -134,11 +130,13 @@ class SitePersistenceService(
                 updateAddress(logisticAddressRecord, fullSite.mainAddress)
                 updateSiteOutput(existingSite, site, legalEntityRecord)
                 siteRepository.save(existingSite)
+                saveChangelog(site.externalId,datatype)
             } ?: run {
                 if (siteRecord.find { it.externalId == fullSite.externalId && it.dataType == OutputInputEnum.Input } == null) {
                     throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Input Site doesn't exist")
                 } else {
                     siteRepository.save(fullSite)
+                    saveChangelog(site.externalId,datatype)
                 }
             }
         }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
@@ -24,10 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.dto.saas.BusinessPartnerSaas
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
-import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateInputRequest
-import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateInputResponse
-import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateOutputRequest
-import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateOutputResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.config.BpnConfigProperties
 import org.eclipse.tractusx.bpdm.gate.entity.Site
 import org.eclipse.tractusx.bpdm.gate.exception.SaasNonexistentParentException
@@ -80,7 +77,7 @@ class SiteService(
      */
     fun getSitesOutput(externalIds: Collection<String>?, page: Int, size: Int): PageResponse<SiteGateOutputResponse> {
 
-        val sitePage = if (externalIds != null && externalIds.isNotEmpty()) {
+        val sitePage = if (!externalIds.isNullOrEmpty()) {
             siteRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Output, PageRequest.of(page, size))
         } else {
             siteRepository.findByDataType(OutputInputEnum.Output, PageRequest.of(page, size))

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_1__update_change_log_entry_add_column.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_1__update_change_log_entry_add_column.sql
@@ -1,3 +1,0 @@
-ALTER TABLE changelog_entries
-    ADD COLUMN data_type VARCHAR(255) NOT NULL;
-

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_1__update_change_log_entry_add_column.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_1__update_change_log_entry_add_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE changelog_entries
+    ADD COLUMN data_type VARCHAR(255) NOT NULL;
+

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_2__update_change_log_entry_add_column.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_2__update_change_log_entry_add_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE changelog_entries
+    ADD COLUMN data_type VARCHAR(255) NOT NULL DEFAULT 'Input';
+


### PR DESCRIPTION
---
title: 'feat: Add dataType column to ChangelogEntry entity'
---

## Description

This PR enhances the ChangelogService by updating it to use the new dataType column introduced in the ChangelogEntry entity. This allows the service to filter changelog entries based on the dataType value, providing more precise and efficient querying capabilities.

Fixes #https://github.com/eclipse-tractusx/bpdm/issues/269

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files


