### PR TITLE
Fix(Gate): Fix error 500 when calling sharing api

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
@@ -27,7 +27,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateInputResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputResponse
 import org.eclipse.tractusx.bpdm.gate.config.ApiConfigProperties
-import org.eclipse.tractusx.bpdm.gate.config.GateSecurityConfigProperties
 import org.eclipse.tractusx.bpdm.gate.containsDuplicates
 import org.eclipse.tractusx.bpdm.gate.service.AddressService
 import org.springframework.http.HttpStatus
@@ -38,8 +37,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class AddressController(
     private val addressService: AddressService,
-    private val apiConfigProperties: ApiConfigProperties,
-    val gateSecurityConfigProperties: GateSecurityConfigProperties
+    private val apiConfigProperties: ApiConfigProperties
 ) : GateAddressApi {
 
 
@@ -61,7 +59,7 @@ class AddressController(
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyInputDataAsRole())")
     override fun getAddressByExternalId(externalId: String): AddressGateInputResponse {
-        gateSecurityConfigProperties.getReadCompanyOutputDataAsRole()
+
         return addressService.getAddressByExternalId(externalId)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
@@ -25,7 +25,6 @@ import org.eclipse.tractusx.bpdm.gate.api.GateChangelogApi
 import org.eclipse.tractusx.bpdm.gate.api.model.request.ChangeLogSearchRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.PageChangeLogResponse
-import org.eclipse.tractusx.bpdm.gate.config.GateSecurityConfigProperties
 import org.eclipse.tractusx.bpdm.gate.service.ChangelogService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
@@ -34,8 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @Validated
 class ChangelogController(
-    private val changelogService: ChangelogService,
-    val gateSecurityConfigProperties: GateSecurityConfigProperties
+    private val changelogService: ChangelogService
 ) : GateChangelogApi {
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyInputDataAsRole())")
@@ -48,7 +46,6 @@ class ChangelogController(
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyOutputDataAsRole())")
     override fun getOutputChangelog(paginationRequest: PaginationRequest,
                                     searchRequest: ChangeLogSearchRequest): PageChangeLogResponse<ChangelogResponse> {
-
         return changelogService.getChangeLogEntries(searchRequest.externalIds, searchRequest.lsaTypes, searchRequest.fromTime,OutputInputEnum.Output, paginationRequest.page, paginationRequest.size)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
@@ -27,7 +27,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateInputResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityGateOutputResponse
 import org.eclipse.tractusx.bpdm.gate.config.ApiConfigProperties
-import org.eclipse.tractusx.bpdm.gate.config.GateSecurityConfigProperties
 import org.eclipse.tractusx.bpdm.gate.containsDuplicates
 import org.eclipse.tractusx.bpdm.gate.service.LegalEntityService
 import org.springframework.http.HttpStatus
@@ -38,8 +37,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class LegalEntityController(
     val legalEntityService: LegalEntityService,
-    val apiConfigProperties: ApiConfigProperties,
-    val gateSecurityConfigProperties: GateSecurityConfigProperties
+    val apiConfigProperties: ApiConfigProperties
 ) : GateLegalEntityApi {
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getChangeCompanyInputDataAsRole())")
     override fun upsertLegalEntities(legalEntities: Collection<LegalEntityGateInputRequest>): ResponseEntity<Unit> {

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
@@ -25,25 +25,22 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.gate.api.GateSharingStateApi
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateDto
-import org.eclipse.tractusx.bpdm.gate.config.GateSecurityConfigProperties
 import org.eclipse.tractusx.bpdm.gate.service.SharingStateService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class SharingStateController(
-    val sharingStateService: SharingStateService,
-    val gateSecurityConfigProperties: GateSecurityConfigProperties
+    val sharingStateService: SharingStateService
 ) : GateSharingStateApi {
-
     private val logger = KotlinLogging.logger { }
 
-    @PreAuthorize("hasAuthority(gateSecurityConfigProperties.getReadCompanyOutputDataAsRole())")
+    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyOutputDataAsRole())")
     override fun getSharingStates(paginationRequest: PaginationRequest, lsaType: LsaType?, externalIds: Collection<String>?): PageResponse<SharingStateDto> {
         return sharingStateService.findSharingStates(paginationRequest, lsaType, externalIds)
     }
 
-    @PreAuthorize("hasAuthority(gateSecurityConfigProperties.getChangeCompanyOutputDataAsRole())")
+    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getChangeCompanyOutputDataAsRole())")
     override fun upsertSharingState(request: SharingStateDto) {
         logger.info { "upsertSharingState() called with $request" }
         sharingStateService.upsertSharingState(request)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteController.kt
@@ -27,7 +27,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateInputResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateOutputResponse
 import org.eclipse.tractusx.bpdm.gate.config.ApiConfigProperties
-import org.eclipse.tractusx.bpdm.gate.config.GateSecurityConfigProperties
 import org.eclipse.tractusx.bpdm.gate.containsDuplicates
 import org.eclipse.tractusx.bpdm.gate.service.SiteService
 import org.springframework.http.HttpStatus
@@ -38,8 +37,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class SiteController(
     val siteService: SiteService,
-    val apiConfigProperties: ApiConfigProperties,
-    val gateSecurityConfigProperties: GateSecurityConfigProperties
+    val apiConfigProperties: ApiConfigProperties
 ) : GateSiteApi {
 
 


### PR DESCRIPTION
---
title: 'fix: Fix error 500 when calling sharing api'
---

## Description
Fix error when calling sharing state api /api/catena/sharing-state
Missing annotation on var for pre auth 
Added and removed unused declared vars

Fixes # 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
