### PR TITLE
Fix(Pool): Added security permissions to controllers based on the typ…

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/controller/OpenSearchController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/controller/OpenSearchController.kt
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.controller
 import org.eclipse.tractusx.bpdm.pool.api.PoolOpenSearchApi
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncResponse
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.service.OpenSearchSyncStarterService
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -30,15 +31,17 @@ class OpenSearchController(
     val openSearchSyncService: OpenSearchSyncStarterService
 ) : PoolOpenSearchApi {
 
-
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getManageOpensearchAsRole())")
     override fun export(): SyncResponse {
         return openSearchSyncService.exportAsync()
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getManageOpensearchAsRole())")
     override fun getBusinessPartners(): SyncResponse {
         return openSearchSyncService.getExportStatus()
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getManageOpensearchAsRole())")
     override fun clear() {
         openSearchSyncService.clearOpenSearch()
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PoolSecurityConfigProperties.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PoolSecurityConfigProperties.kt
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "bpdm.pool-security")
+data class PoolSecurityConfigProperties(
+    var readPoolPartnerData: String = "read_pool_partner_data",
+    var changePoolPartnerData: String = "change_pool_partner_data",
+    var readMetaData: String = "read_meta_data",
+    var changeMetaData: String = "change_meta_data",
+    var manageOpensearch: String = "manage_opensearch"
+) {
+
+    fun getReadPoolPartnerDataAsRole(): String {
+        return "ROLE_$readPoolPartnerData"
+    }
+
+    fun getChangePoolPartnerDataAsRole(): String {
+        return "ROLE_$changePoolPartnerData"
+    }
+
+    fun getReadMetaDataAsRole(): String {
+        return "ROLE_$readMetaData"
+    }
+
+    fun getChangeMetaDataAsRole(): String {
+        return "ROLE_$changeMetaData"
+    }
+
+    fun getManageOpensearchAsRole(): String {
+        return "ROLE_$manageOpensearch"
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
@@ -33,6 +33,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerUpdateRes
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.SearchService
 import org.eclipse.tractusx.bpdm.pool.service.AddressService
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -42,37 +43,37 @@ class AddressController(
     private val searchService: SearchService
 ) : PoolAddressApi {
 
-
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun getAddresses(
         addressSearchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
     ): PageResponse<AddressMatchResponse> {
-
         return searchService.searchAddresses(addressSearchRequest, paginationRequest)
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun getAddress(
         bpna: String
     ): LogisticAddressResponse {
         return addressService.findByBpn(bpna.uppercase())
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun searchAddresses(
         addressSearchRequest: AddressPartnerBpnSearchRequest,
         paginationRequest: PaginationRequest
     ): PageResponse<LogisticAddressResponse> {
-
         return addressService.findByPartnerAndSiteBpns(addressSearchRequest, paginationRequest)
     }
 
-
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getChangePoolPartnerDataAsRole())")
     override fun createAddresses(
         requests: Collection<AddressPartnerCreateRequest>
     ): AddressPartnerCreateResponseWrapper {
         return businessPartnerBuildService.createAddresses(requests)
     }
 
-
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getChangePoolPartnerDataAsRole())")
     override fun updateAddresses(
         requests: Collection<AddressPartnerUpdateRequest>
     ): AddressPartnerUpdateResponseWrapper {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
@@ -35,6 +36,7 @@ class BpnController(
     val controllerConfigProperties: ControllerConfigProperties
 ) : PoolBpnApi {
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingResponse>> {
         if (request.idValues.size > controllerConfigProperties.searchRequestLimit) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
@@ -27,6 +27,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryResponse
 import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.exception.BpdmRequestSizeException
 import org.eclipse.tractusx.bpdm.pool.service.PartnerChangelogService
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -34,9 +35,11 @@ class ChangelogController(
     private val partnerChangelogService: PartnerChangelogService,
     private val controllerConfigProperties: ControllerConfigProperties
 ): PoolChangelogApi {
+
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun getChangelogEntries(
-       changelogSearchRequest: ChangelogSearchRequest,
-       paginationRequest: PaginationRequest
+        changelogSearchRequest: ChangelogSearchRequest,
+        paginationRequest: PaginationRequest
     ): PageResponse<ChangelogEntryResponse> {
 
         changelogSearchRequest.bpns?.let { bpns ->

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -32,6 +32,7 @@ import org.eclipse.tractusx.bpdm.pool.service.MetadataService
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -39,25 +40,28 @@ class MetadataController(
     val metadataService: MetadataService
 ) : PoolMetadataApi {
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getChangeMetaDataAsRole())")
     override fun createIdentifierType(identifierType: IdentifierTypeDto): IdentifierTypeDto {
         return metadataService.createIdentifierType(identifierType)
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
     override fun getIdentifierTypes(paginationRequest: PaginationRequest, lsaType: IdentifierLsaType, country: CountryCode?): PageResponse<IdentifierTypeDto> {
         return metadataService.getIdentifierTypes(PageRequest.of(paginationRequest.page, paginationRequest.size), lsaType, country)
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getChangeMetaDataAsRole())")
     override fun createLegalForm(type: LegalFormRequest): LegalFormResponse {
         return metadataService.createLegalForm(type)
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
     override fun getLegalForms(paginationRequest: PaginationRequest): PageResponse<LegalFormResponse> {
         return metadataService.getLegalForms(PageRequest.of(paginationRequest.page, paginationRequest.size))
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
     override fun getFieldQualityRules(country: CountryCode): ResponseEntity<Collection<FieldQualityRuleDto>> {
-
         return ResponseEntity(metadataService.getFieldQualityRules(country), HttpStatus.OK)
     }
-
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -32,6 +32,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolResponse
 import org.eclipse.tractusx.bpdm.pool.service.AddressService
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService
 import org.eclipse.tractusx.bpdm.pool.service.SiteService
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -41,18 +42,21 @@ class SiteController(
     private val addressService: AddressService
 ) : PoolSiteApi {
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun searchMainAddresses(
         bpnS: Collection<String>
     ): Collection<MainAddressResponse> {
         return addressService.findMainAddresses(bpnS)
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun getSite(
         bpn: String
     ): SitePoolResponse {
         return siteService.findByBpn(bpn.uppercase())
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun searchSites(
         siteSearchRequest: SiteBpnSearchRequest,
         paginationRequest: PaginationRequest
@@ -60,12 +64,14 @@ class SiteController(
         return siteService.findByPartnerBpns(siteSearchRequest, paginationRequest)
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getChangePoolPartnerDataAsRole())")
     override fun createSite(
         requests: Collection<SitePartnerCreateRequest>
     ): SitePartnerCreateResponseWrapper {
         return businessPartnerBuildService.createSites(requests)
     }
 
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getChangePoolPartnerDataAsRole())")
     override fun updateSite(
         requests: Collection<SitePartnerUpdateRequest>
     ): SitePartnerUpdateResponseWrapper {

--- a/bpdm-pool/src/main/resources/application-auth.properties
+++ b/bpdm-pool/src/main/resources/application-auth.properties
@@ -17,6 +17,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 bpdm.security.enabled=true
+bpdm.pool-security.readPoolPartnerData=read_pool_partner_data
+bpdm.pool-security.changePoolPartnerData=change_pool_partner_data
+bpdm.pool-security.readMetaData=read_meta_data
+bpdm.pool-security.changeMetaData=change_meta_data
+bpdm.pool-security.manageOpensearch=manage_opensearch
 bpdm.security.cors-origins=*
 #Generic OAuth configuration
 bpdm.security.client-id=BPDM_Client


### PR DESCRIPTION
…e of operation (read/write)

---
name: Pull Request Template
about: 'template for PRs that ensures basic information is provided'
title: 'feat: Added security permissions to controllers'
---

## Description

Added security permissions to controllers based on the type of operation (read/write) and the type of data (business partner data, metadata, opensearch). Used Spring Security's @PreAuthorize annotation to enforce these permissions.

Fixes # [(issuenumber from PR destination repo)](https://github.com/eclipse-tractusx/bpdm/issues/264)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
