### PR TITLE
fix(gate): Gate persist new fields and fix fields retrieval

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/StreetGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/StreetGateDto.kt
@@ -35,7 +35,7 @@ data class StreetGateDto(
     val name: String? = null,
 
     @get:Schema(description = "Describes the name suffix of the Street.")
-    val NameSuffix: String? = null,
+    val nameSuffix: String? = null,
 
     @get:Schema(description = "Describes the additional name suffix of the Street.")
     val additionalNameSuffix: String? = null,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
@@ -58,6 +58,9 @@ class LegalEntity(
     lateinit var legalAddress: LogisticAddress
 
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val roles: MutableSet<LegalEntityRoles> = mutableSetOf()
+
+    @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)
     val addresses: MutableSet<LogisticAddress> = mutableSetOf()
 
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
@@ -58,7 +58,7 @@ class LegalEntity(
     lateinit var legalAddress: LogisticAddress
 
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val roles: MutableSet<LegalEntityRoles> = mutableSetOf()
+    val roles: MutableSet<Roles> = mutableSetOf()
 
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)
     val addresses: MutableSet<LogisticAddress> = mutableSetOf()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityRoles.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityRoles.kt
@@ -48,15 +48,15 @@ class LegalEntityRoles(
 
     @ManyToOne
     @JoinColumn(name = "legal_entity_id", nullable = false)
-    var legalEntity: LegalEntity,
+    var legalEntity: LegalEntity?,
 
 //    @ManyToOne
 //    @JoinColumn(name = "address_id", nullable = true)
 //    var address: LogisticAddress?,
-//
-//    @ManyToOne
-//    @JoinColumn(name = "site_id", nullable = true)
-//    var site: Site?,
+
+    @ManyToOne
+    @JoinColumn(name = "site_id", nullable = true)
+    var site: Site?,
 
     @Column(name = "role_name", nullable = false)
     @Enumerated(EnumType.STRING)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityRoles.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityRoles.kt
@@ -50,9 +50,9 @@ class LegalEntityRoles(
     @JoinColumn(name = "legal_entity_id", nullable = false)
     var legalEntity: LegalEntity?,
 
-//    @ManyToOne
-//    @JoinColumn(name = "address_id", nullable = true)
-//    var address: LogisticAddress?,
+    @ManyToOne
+    @JoinColumn(name = "address_id", nullable = true)
+    var address: LogisticAddress?,
 
     @ManyToOne
     @JoinColumn(name = "site_id", nullable = true)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityRoles.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityRoles.kt
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
+
+@Entity
+@Table(name = "roles")
+class LegalEntityRoles(
+
+    @ManyToOne
+    @JoinColumn(name = "legal_entity_id", nullable = false)
+    var legalEntity: LegalEntity,
+
+//    @ManyToOne
+//    @JoinColumn(name = "address_id", nullable = true)
+//    var address: LogisticAddress?,
+//
+//    @ManyToOne
+//    @JoinColumn(name = "site_id", nullable = true)
+//    var site: Site?,
+
+    @Column(name = "role_name", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val roleName: BusinessPartnerRole
+
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
@@ -65,5 +65,5 @@ class LogisticAddress(
     val nameParts: MutableSet<NameParts> = mutableSetOf()
 
     @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val roles: MutableSet<LegalEntityRoles> = mutableSetOf()
+    val roles: MutableSet<Roles> = mutableSetOf()
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LogisticAddress.kt
@@ -63,4 +63,7 @@ class LogisticAddress(
 
     @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], orphanRemoval = true)
     val nameParts: MutableSet<NameParts> = mutableSetOf()
+
+    @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val roles: MutableSet<LegalEntityRoles> = mutableSetOf()
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
@@ -75,6 +75,10 @@ class PhysicalPostalAddress(
     @AttributeOverride(name = "houseNumber", column = Column(name = "phy_street_number"))
     @AttributeOverride(name = "milestone", column = Column(name = "phy_street_milestone"))
     @AttributeOverride(name = "direction", column = Column(name = "phy_street_direction"))
+    @AttributeOverride(name = "namePrefix", column = Column(name = "phy_name_prefix"))
+    @AttributeOverride(name = "additionalNamePrefix", column = Column(name = "phy_additional_name_prefix"))
+    @AttributeOverride(name = "nameSuffix", column = Column(name = "phy_name_suffix"))
+    @AttributeOverride(name = "additionalNameSuffix", column = Column(name = "phy_additional_name_suffix"))
     val street: Street? = null,
 
     // specific for PhysicalPostalAddress

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Roles.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Roles.kt
@@ -44,7 +44,7 @@ import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 
 @Entity
 @Table(name = "roles")
-class LegalEntityRoles(
+class Roles(
 
     @ManyToOne
     @JoinColumn(name = "legal_entity_id", nullable = false)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Site.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Site.kt
@@ -48,6 +48,9 @@ class Site(
     @OneToMany(mappedBy = "site", cascade = [CascadeType.ALL], orphanRemoval = true)
     val addresses: MutableSet<LogisticAddress> = mutableSetOf()
 
+    @OneToMany(mappedBy = "site", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val roles: MutableSet<LegalEntityRoles> = mutableSetOf()
+
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(name = "main_address_id", nullable = false)
     lateinit var mainAddress: LogisticAddress

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Site.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Site.kt
@@ -49,7 +49,7 @@ class Site(
     val addresses: MutableSet<LogisticAddress> = mutableSetOf()
 
     @OneToMany(mappedBy = "site", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val roles: MutableSet<LegalEntityRoles> = mutableSetOf()
+    val roles: MutableSet<Roles> = mutableSetOf()
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(name = "main_address_id", nullable = false)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Street.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Street.kt
@@ -37,5 +37,18 @@ class Street(
     val milestone: String? = null,
 
     @Column
-    val direction: String? = null
-)
+    val direction: String? = null,
+
+    @Column
+    val namePrefix: String? = null,
+
+    @Column
+    val additionalNamePrefix: String? = null,
+
+    @Column
+    val nameSuffix: String? = null,
+
+    @Column
+    val additionalNameSuffix: String? = null,
+
+    )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
@@ -75,7 +75,7 @@ class AddressPersistenceService(
 
         address.states.replace(changeAddress.address.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.address.nameParts.map { toNameParts(it, address, null, null) })
-        address.roles.replace(changeAddress.address.roles.map { toLegalEntityRoles(it, null, null, address) })
+        address.roles.replace(changeAddress.address.roles.distinct().map { toLegalEntityRoles(it, null, null, address) })
 
     }
 
@@ -117,7 +117,7 @@ class AddressPersistenceService(
 
         address.states.replace(changeAddress.address.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.address.nameParts.map { toNameParts(it, address, null, null) })
-        address.roles.replace(changeAddress.address.roles.map { toLegalEntityRoles(it, null, null, address) })
+        address.roles.replace(changeAddress.address.roles.distinct().map { toLegalEntityRoles(it, null, null, address) })
 
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
@@ -75,7 +75,7 @@ class AddressPersistenceService(
 
         address.states.replace(changeAddress.address.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.address.nameParts.map { toNameParts(it, address, null, null) })
-        address.roles.replace(changeAddress.address.roles.distinct().map { toLegalEntityRoles(it, null, null, address) })
+        address.roles.replace(changeAddress.address.roles.distinct().map { toRoles(it, null, null, address) })
 
     }
 
@@ -117,7 +117,7 @@ class AddressPersistenceService(
 
         address.states.replace(changeAddress.address.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.address.nameParts.map { toNameParts(it, address, null, null) })
-        address.roles.replace(changeAddress.address.roles.distinct().map { toLegalEntityRoles(it, null, null, address) })
+        address.roles.replace(changeAddress.address.roles.distinct().map { toRoles(it, null, null, address) })
 
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
@@ -75,6 +75,7 @@ class AddressPersistenceService(
 
         address.states.replace(changeAddress.address.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.address.nameParts.map { toNameParts(it, address, null, null) })
+        address.roles.replace(changeAddress.address.roles.map { toLegalEntityRoles(it, null, null, address) })
 
     }
 
@@ -116,6 +117,7 @@ class AddressPersistenceService(
 
         address.states.replace(changeAddress.address.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.address.nameParts.map { toNameParts(it, address, null, null) })
+        address.roles.replace(changeAddress.address.roles.map { toLegalEntityRoles(it, null, null, address) })
 
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
@@ -90,7 +90,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity) })
+        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity
@@ -157,7 +157,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity) })
+        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
@@ -90,7 +90,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null) })
+        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity
@@ -107,6 +107,7 @@ class LegalEntityPersistenceService(
 
         address.states.replace(changeAddress.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.nameParts.map { toNameParts(it.namePart, address, null, null) })
+        address.roles.replace(changeAddress.roles.map { toLegalEntityRoles(it.roleName, null, null, address) })
 
     }
 
@@ -157,7 +158,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null) })
+        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
@@ -90,7 +90,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
+        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity
@@ -107,7 +107,7 @@ class LegalEntityPersistenceService(
 
         address.states.replace(changeAddress.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.nameParts.map { toNameParts(it.namePart, address, null, null) })
-        address.roles.replace(changeAddress.roles.distinct().map { toLegalEntityRoles(it.roleName, null, null, address) })
+        address.roles.replace(changeAddress.roles.distinct().map { toRoles(it.roleName, null, null, address) })
 
     }
 
@@ -158,7 +158,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
+        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
@@ -90,6 +90,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
+        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity
@@ -156,6 +157,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
+        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
@@ -90,7 +90,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
+        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity
@@ -107,7 +107,7 @@ class LegalEntityPersistenceService(
 
         address.states.replace(changeAddress.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.nameParts.map { toNameParts(it.namePart, address, null, null) })
-        address.roles.replace(changeAddress.roles.map { toLegalEntityRoles(it.roleName, null, null, address) })
+        address.roles.replace(changeAddress.roles.distinct().map { toLegalEntityRoles(it.roleName, null, null, address) })
 
     }
 
@@ -158,7 +158,7 @@ class LegalEntityPersistenceService(
         legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
         legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
         legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
+        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -121,6 +121,7 @@ private fun toValidSingleLegalEntity(legalEntity: LegalEntity): LegalEntityGateI
     return LegalEntityGateInputResponse(
         legalEntity = legalEntity.toLegalEntityDto(),
         legalNameParts = getNamePartValuesToList(legalEntity.nameParts),
+        roles = legalEntity.roles.map { it.roleName },
         legalAddress = legalEntity.legalAddress.toAddressGateInputResponse(legalEntity.legalAddress),
         externalId = legalEntity.externalId
     )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -41,7 +41,7 @@ fun AddressGateInputRequest.toAddressGate(legalEntity: LegalEntity?, site: Site?
 
     logisticAddress.states.addAll(this.address.states.map { toEntityAddress(it, logisticAddress) }.toSet())
     logisticAddress.nameParts.addAll(this.address.nameParts.map { toNameParts(it, logisticAddress, null, null) }.toSet())
-    logisticAddress.roles.addAll(this.address.roles.distinct().map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
+    logisticAddress.roles.addAll(this.address.roles.distinct().map { toRoles(it, null, null, logisticAddress) }.toSet())
 
     return logisticAddress
 }
@@ -60,7 +60,7 @@ fun AddressGateOutputRequest.toAddressGateOutput(legalEntity: LegalEntity?, site
 
     logisticAddress.states.addAll(this.address.states.map { toEntityAddress(it, logisticAddress) }.toSet())
     logisticAddress.nameParts.addAll(this.address.nameParts.map { toNameParts(it, logisticAddress, null, null) }.toSet())
-    logisticAddress.roles.addAll(this.address.roles.distinct().map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
+    logisticAddress.roles.addAll(this.address.roles.distinct().map { toRoles(it, null, null, logisticAddress) }.toSet())
 
     return logisticAddress
 }
@@ -148,7 +148,7 @@ fun SiteGateInputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputIn
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
-    site.roles.addAll(this.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
+    site.roles.addAll(this.site.roles.distinct().map { toRoles(it, null, site, null) })
 
     site.mainAddress = addressInputRequest.toAddressGate(null, site, datatype)
 
@@ -173,7 +173,7 @@ fun SiteGateOutputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputI
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
-    site.roles.addAll(this.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
+    site.roles.addAll(this.site.roles.distinct().map { toRoles(it, null, site, null) })
 
     site.mainAddress = addressOutputRequest.toAddressGateOutput(null, site, datatype)
 
@@ -210,7 +210,7 @@ fun LegalEntityGateInputRequest.toLegalEntity(datatype: OutputInputEnum): LegalE
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-    legalEntity.roles.addAll(this.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
+    legalEntity.roles.addAll(this.roles.distinct().map { toRoles(it, legalEntity, null, null) })
 
     legalEntity.legalAddress = addressInputRequest.toAddressGate(legalEntity, null, datatype)
 
@@ -237,7 +237,7 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-    legalEntity.roles.addAll(this.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
+    legalEntity.roles.addAll(this.roles.distinct().map { toRoles(it, legalEntity, null, null) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
 
     legalEntity.legalAddress = addressOutputRequest.toAddressGateOutput(legalEntity, null, datatype)
@@ -246,8 +246,8 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
 }
 
-fun toLegalEntityRoles(role: BusinessPartnerRole, legalEntity: LegalEntity?, site: Site?, address: LogisticAddress?): LegalEntityRoles {
-    return LegalEntityRoles(legalEntity, address, site, role)
+fun toRoles(role: BusinessPartnerRole, legalEntity: LegalEntity?, site: Site?, address: LogisticAddress?): Roles {
+    return Roles(legalEntity, address, site, role)
 }
 
 fun toEntityState(dto: LegalEntityStateDto, legalEntity: LegalEntity): LegalEntityState {

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -41,7 +41,7 @@ fun AddressGateInputRequest.toAddressGate(legalEntity: LegalEntity?, site: Site?
 
     logisticAddress.states.addAll(this.address.states.map { toEntityAddress(it, logisticAddress) }.toSet())
     logisticAddress.nameParts.addAll(this.address.nameParts.map { toNameParts(it, logisticAddress, null, null) }.toSet())
-    logisticAddress.roles.addAll(this.address.roles.map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
+    logisticAddress.roles.addAll(this.address.roles.distinct().map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
 
     return logisticAddress
 }
@@ -60,7 +60,7 @@ fun AddressGateOutputRequest.toAddressGateOutput(legalEntity: LegalEntity?, site
 
     logisticAddress.states.addAll(this.address.states.map { toEntityAddress(it, logisticAddress) }.toSet())
     logisticAddress.nameParts.addAll(this.address.nameParts.map { toNameParts(it, logisticAddress, null, null) }.toSet())
-    logisticAddress.roles.addAll(this.address.roles.map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
+    logisticAddress.roles.addAll(this.address.roles.distinct().map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
 
     return logisticAddress
 }
@@ -148,7 +148,7 @@ fun SiteGateInputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputIn
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
-    site.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site, null) })
+    site.roles.addAll(this.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
 
     site.mainAddress = addressInputRequest.toAddressGate(null, site, datatype)
 
@@ -173,7 +173,7 @@ fun SiteGateOutputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputI
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
-    legalEntity.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site, null) })
+    site.roles.addAll(this.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
 
     site.mainAddress = addressOutputRequest.toAddressGateOutput(null, site, datatype)
 
@@ -210,7 +210,7 @@ fun LegalEntityGateInputRequest.toLegalEntity(datatype: OutputInputEnum): LegalE
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
+    legalEntity.roles.addAll(this.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
 
     legalEntity.legalAddress = addressInputRequest.toAddressGate(legalEntity, null, datatype)
 
@@ -237,7 +237,7 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
+    legalEntity.roles.addAll(this.roles.distinct().map { toLegalEntityRoles(it, legalEntity, null, null) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
 
     legalEntity.legalAddress = addressOutputRequest.toAddressGateOutput(legalEntity, null, datatype)
@@ -470,6 +470,7 @@ fun LegalEntity.toLegalEntityGateOutputResponse(legalEntity: LegalEntity): Legal
         legalNameParts = getNamePartValues(legalEntity.nameParts),
         externalId = legalEntity.externalId,
         bpn = legalEntity.bpn!!,
+        roles = roles.map { it.roleName },
         legalAddress = legalAddress.toAddressGateOutputResponse(legalAddress)
     )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -41,6 +41,7 @@ fun AddressGateInputRequest.toAddressGate(legalEntity: LegalEntity?, site: Site?
 
     logisticAddress.states.addAll(this.address.states.map { toEntityAddress(it, logisticAddress) }.toSet())
     logisticAddress.nameParts.addAll(this.address.nameParts.map { toNameParts(it, logisticAddress, null, null) }.toSet())
+    logisticAddress.roles.addAll(this.address.roles.map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
 
     return logisticAddress
 }
@@ -59,6 +60,7 @@ fun AddressGateOutputRequest.toAddressGateOutput(legalEntity: LegalEntity?, site
 
     logisticAddress.states.addAll(this.address.states.map { toEntityAddress(it, logisticAddress) }.toSet())
     logisticAddress.nameParts.addAll(this.address.nameParts.map { toNameParts(it, logisticAddress, null, null) }.toSet())
+    logisticAddress.roles.addAll(this.address.roles.map { toLegalEntityRoles(it, null, null, logisticAddress) }.toSet())
 
     return logisticAddress
 }
@@ -145,8 +147,8 @@ fun SiteGateInputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputIn
     )
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
-    site.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site) })
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
+    site.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site, null) })
 
     site.mainAddress = addressInputRequest.toAddressGate(null, site, datatype)
 
@@ -171,7 +173,7 @@ fun SiteGateOutputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputI
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
-    legalEntity.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site) })
+    legalEntity.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site, null) })
 
     site.mainAddress = addressOutputRequest.toAddressGateOutput(null, site, datatype)
 
@@ -208,7 +210,7 @@ fun LegalEntityGateInputRequest.toLegalEntity(datatype: OutputInputEnum): LegalE
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null) })
+    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
 
     legalEntity.legalAddress = addressInputRequest.toAddressGate(legalEntity, null, datatype)
 
@@ -235,7 +237,7 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null) })
+    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null, null) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
 
     legalEntity.legalAddress = addressOutputRequest.toAddressGateOutput(legalEntity, null, datatype)
@@ -244,8 +246,8 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
 }
 
-fun toLegalEntityRoles(role: BusinessPartnerRole, legalEntity: LegalEntity?, site: Site?): LegalEntityRoles {
-    return LegalEntityRoles(legalEntity, site, role)
+fun toLegalEntityRoles(role: BusinessPartnerRole, legalEntity: LegalEntity?, site: Site?, address: LogisticAddress?): LegalEntityRoles {
+    return LegalEntityRoles(legalEntity, address, site, role)
 }
 
 fun toEntityState(dto: LegalEntityStateDto, legalEntity: LegalEntity): LegalEntityState {
@@ -283,6 +285,7 @@ fun LogisticAddress.toLogisticAddressDto(): LogisticAddressGateDto {
     val logisticAddress = LogisticAddressGateDto(
         nameParts = getNamePartValues(nameParts),
         states = mapToDtoStates(states),
+        roles = roles.map { it.roleName },
         physicalPostalAddress = physicalPostalAddress.toPhysicalPostalAddress(),
         alternativePostalAddress = alternativePostalAddress?.toAlternativePostalAddressDto(),
     )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -145,6 +145,7 @@ fun SiteGateInputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputIn
     )
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
+    site.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site) })
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
 
     site.mainAddress = addressInputRequest.toAddressGate(null, site, datatype)
@@ -170,6 +171,8 @@ fun SiteGateOutputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputI
 
     site.states.addAll(this.site.states.map { toEntityAddress(it, site) }.toSet())
     site.nameParts.addAll(this.site.nameParts.map { toNameParts(it, null, site, null) }.toSet())
+    legalEntity.roles.addAll(this.site.roles.map { toLegalEntityRoles(it, null, site) })
+
     site.mainAddress = addressOutputRequest.toAddressGateOutput(null, site, datatype)
 
     return site
@@ -205,7 +208,7 @@ fun LegalEntityGateInputRequest.toLegalEntity(datatype: OutputInputEnum): LegalE
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity) })
+    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null) })
 
     legalEntity.legalAddress = addressInputRequest.toAddressGate(legalEntity, null, datatype)
 
@@ -232,7 +235,7 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity) })
+    legalEntity.roles.addAll(this.roles.map { toLegalEntityRoles(it, legalEntity, null) })
     legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
 
     legalEntity.legalAddress = addressOutputRequest.toAddressGateOutput(legalEntity, null, datatype)
@@ -241,8 +244,8 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
 }
 
-fun toLegalEntityRoles(role: BusinessPartnerRole, legalEntity: LegalEntity): LegalEntityRoles {
-    return LegalEntityRoles(legalEntity, role)
+fun toLegalEntityRoles(role: BusinessPartnerRole, legalEntity: LegalEntity?, site: Site?): LegalEntityRoles {
+    return LegalEntityRoles(legalEntity, site, role)
 }
 
 fun toEntityState(dto: LegalEntityStateDto, legalEntity: LegalEntity): LegalEntityState {
@@ -408,6 +411,7 @@ fun LegalEntity.toLegalEntityGateInputResponse(legalEntity: LegalEntity): LegalE
 fun Site.toSiteDto(): SiteGateDto {
 
     return SiteGateDto(
+        roles = roles.map { it.roleName },
         nameParts = getNamePartValues(nameParts),
         states = mapToDtoSitesStates(states)
     )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
@@ -93,6 +93,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
+        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site) })
 
     }
 
@@ -150,6 +151,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
+        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site) })
 
     }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
@@ -93,7 +93,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
-        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site) })
+        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site, null) })
 
     }
 
@@ -106,6 +106,8 @@ class SitePersistenceService(
 
         address.states.replace(changeAddress.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.nameParts.map { toNameParts(it.namePart, address, null, null) })
+        address.roles.replace(changeAddress.roles.map { toLegalEntityRoles(it.roleName, null, null, address) })
+
     }
 
     fun toEntityAddress(dto: AddressState, address: LogisticAddress): AddressState {
@@ -151,7 +153,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
-        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site) })
+        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site, null) })
 
     }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
@@ -93,7 +93,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
-        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site, null) })
+        site.roles.replace(updatedSite.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
 
     }
 
@@ -106,7 +106,7 @@ class SitePersistenceService(
 
         address.states.replace(changeAddress.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.nameParts.map { toNameParts(it.namePart, address, null, null) })
-        address.roles.replace(changeAddress.roles.map { toLegalEntityRoles(it.roleName, null, null, address) })
+        address.roles.replace(changeAddress.roles.distinct().map { toLegalEntityRoles(it.roleName, null, null, address) })
 
     }
 
@@ -153,7 +153,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
-        site.roles.replace(updatedSite.site.roles.map { toLegalEntityRoles(it, null, site, null) })
+        site.roles.replace(updatedSite.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
 
     }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
@@ -93,7 +93,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
-        site.roles.replace(updatedSite.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
+        site.roles.replace(updatedSite.site.roles.distinct().map { toRoles(it, null, site, null) })
 
     }
 
@@ -106,7 +106,7 @@ class SitePersistenceService(
 
         address.states.replace(changeAddress.states.map { toEntityAddress(it, address) })
         address.nameParts.replace(changeAddress.nameParts.map { toNameParts(it.namePart, address, null, null) })
-        address.roles.replace(changeAddress.roles.distinct().map { toLegalEntityRoles(it.roleName, null, null, address) })
+        address.roles.replace(changeAddress.roles.distinct().map { toRoles(it.roleName, null, null, address) })
 
     }
 
@@ -153,7 +153,7 @@ class SitePersistenceService(
 
         site.states.replace(updatedSite.site.states.map { toEntityAddress(it, site) })
         site.nameParts.replace(updatedSite.site.nameParts.map { toNameParts(it, null, site, null) })
-        site.roles.replace(updatedSite.site.roles.distinct().map { toLegalEntityRoles(it, null, site, null) })
+        site.roles.replace(updatedSite.site.roles.distinct().map { toRoles(it, null, site, null) })
 
     }
 }

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_5__add_roles_table.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_5__add_roles_table.sql
@@ -15,6 +15,7 @@ CREATE INDEX legal_entity_roles ON roles (legal_entity_id);
 ALTER TABLE IF EXISTS roles ADD CONSTRAINT uuid_roles_uk UNIQUE (uuid);
 
 ALTER TABLE IF EXISTS roles
+ADD CONSTRAINT fk_sites_roles FOREIGN KEY (site_id) REFERENCES sites,
 ADD CONSTRAINT fk_legal_entity_roles FOREIGN KEY (legal_entity_id) REFERENCES legal_entities;
 
 ALTER TABLE logistic_addresses

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_5__add_roles_table.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_5__add_roles_table.sql
@@ -1,0 +1,25 @@
+CREATE TABLE roles (
+  id BIGINT NOT NULL,
+  created_at TIMESTAMP WITH time zone NOT NULL,
+  updated_at TIMESTAMP WITH time zone NOT NULL,
+  uuid UUID NOT NULL,
+  address_id BIGINT NULL,
+  site_id BIGINT NULL,
+  legal_entity_id BIGINT NULL,
+  role_name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX legal_entity_roles ON roles (legal_entity_id);
+
+ALTER TABLE IF EXISTS roles ADD CONSTRAINT uuid_roles_uk UNIQUE (uuid);
+
+ALTER TABLE IF EXISTS roles
+ADD CONSTRAINT fk_legal_entity_roles FOREIGN KEY (legal_entity_id) REFERENCES legal_entities;
+
+ALTER TABLE logistic_addresses
+ADD COLUMN IF NOT EXISTS phy_name_prefix VARCHAR(255),
+ADD COLUMN IF NOT EXISTS phy_additional_name_prefix VARCHAR(255),
+ADD COLUMN IF NOT EXISTS phy_name_suffix VARCHAR(255),
+ADD COLUMN IF NOT EXISTS phy_additional_name_suffix VARCHAR(255);
+

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_5__add_roles_table.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_5__add_roles_table.sql
@@ -16,6 +16,7 @@ ALTER TABLE IF EXISTS roles ADD CONSTRAINT uuid_roles_uk UNIQUE (uuid);
 
 ALTER TABLE IF EXISTS roles
 ADD CONSTRAINT fk_sites_roles FOREIGN KEY (site_id) REFERENCES sites,
+ADD CONSTRAINT fk_addresses_roles FOREIGN KEY (address_id) REFERENCES logistic_addresses,
 ADD CONSTRAINT fk_legal_entity_roles FOREIGN KEY (legal_entity_id) REFERENCES legal_entities;
 
 ALTER TABLE logistic_addresses

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/RequestValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/RequestValues.kt
@@ -183,7 +183,7 @@ object RequestValues {
             door = CommonValues.door1,
         ),
         areaPart = AreaDistrictDto(
-            administrativeAreaLevel1 = null,
+            administrativeAreaLevel1 = CommonValues.adminAreaLevel1RegionCode_1,
             administrativeAreaLevel2 = CommonValues.county1,
             district = CommonValues.district1,
         ),
@@ -204,7 +204,7 @@ object RequestValues {
             door = CommonValues.door2,
         ),
         areaPart = AreaDistrictDto(
-            administrativeAreaLevel1 = null,
+            administrativeAreaLevel1 = CommonValues.adminAreaLevel1RegionCode_2,
             administrativeAreaLevel2 = CommonValues.county2,
             district = CommonValues.district2,
         ),


### PR DESCRIPTION
---
### Title: Gate persist new fields and fix fields retrieval
---

## Description
This PR adds an table (Roles) to be able to persist the Roles in Legal Entities, Addresses and Sites. Also fixes the administrativeAreaLevel1 mapping, and adds new Street suffixes and prefixes with the correct mapping.

Related issues: fix #280 fix #285

---
### Pre-review checks
Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files






