### PR TITLE
(feat): Push Images to Dockerhub

### DIFF
--- a/.github/workflows/build-docker-all.yaml
+++ b/.github/workflows/build-docker-all.yaml
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 name: Build All - Docker images (SemVer)
 on:
   push:
@@ -8,6 +27,7 @@ on:
       - bpdm-gate/**
       - bpdm-common/**
       - bpdm-gate-api/**
+      - bpdm-bridge-dummy/**
       - .github/workflows/**
     tags:
       - 'v*.*.*'
@@ -22,21 +42,24 @@ on:
 jobs:
   build-docker-pool:
     uses: ./.github/workflows/build-docker.yaml
+    secrets: inherit
     with:
-      imageName: pool
-      dockerfilePath: ./bpdm-pool/Dockerfile
+      imageName: bpdm-pool
+      dockerfilePath: ./bpdm-pool
       push: ${{ github.event_name != 'pull_request' }}
 
   build-docker-gate:
     uses: ./.github/workflows/build-docker.yaml
+    secrets: inherit
     with:
-      imageName: gate
-      dockerfilePath: ./bpdm-gate/Dockerfile
+      imageName: bpdm-gate
+      dockerfilePath: ./bpdm-gate
       push: ${{ github.event_name != 'pull_request' }}
 
   build-docker-bridge-dummy:
     uses: ./.github/workflows/build-docker.yaml
+    secrets: inherit
     with:
-      imageName: bridge-dummy
-      dockerfilePath: ./bpdm-bridge-dummy/Dockerfile
+      imageName: bpdm-bridge-dummy
+      dockerfilePath: ./bpdm-bridge-dummy
       push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 name: Build - Docker image (SemVer)
 
 on:
@@ -18,15 +37,15 @@ on:
 
 
 env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}/${{ inputs.imageName }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: ${{ inputs.imageName }}
+
 jobs:
-  build-docker:
+  docker:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,7 +56,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          # Automatically prepare image tags; See action docs for more examples.
+          # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -45,19 +66,33 @@ jobs:
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+      - name: DockerHub login
+        if:  inputs.push
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # Use existing DockerHub credentials present as secrets
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
+          # Build image for verification purposes on every trigger event. Only push if event is not a PR
           push: ${{ inputs.push }}
-          file: ${{ inputs.dockerfilePath }}
+          file: ${{ inputs.dockerfilePath }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      # Important step to push image description to DockerHub
+      - name: Update Docker Hub description
+        if: inputs.push
+        uses: peter-evans/dockerhub-description@v3
+        with:
+        # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'
+        # readme-filepath: path/to/dedicated/notice-for-docker-image.md
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ${{ inputs.dockerfilePath }}/DOCKER_NOTICE.md

--- a/bpdm-bridge-dummy/DOCKER_NOTICE.md
+++ b/bpdm-bridge-dummy/DOCKER_NOTICE.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+**BPDM Bridge**
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/bpdm 
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Bridge Dockerfile: https://github.com/eclipse-tractusx/bpdm/blob/main/bpdm-brige-dumy/Dockerfile 
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/bpdm/blob/main/LICENSE)
+
+
+**Used base image**
+
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/bpdm-gate/DOCKER_NOTICE.md
+++ b/bpdm-gate/DOCKER_NOTICE.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+**BPDM Gate**
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/bpdm 
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Gate Dockerfile: https://github.com/eclipse-tractusx/bpdm/blob/main/bpdm-gate/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/bpdm/blob/main/LICENSE)
+
+
+**Used base image**
+
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/bpdm-pool/DOCKER_NOTICE.md
+++ b/bpdm-pool/DOCKER_NOTICE.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+**BPDM Pool**
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/bpdm 
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Pool Dockerfile: https://github.com/eclipse-tractusx/bpdm/blob/main/bpdm-pool/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/bpdm/blob/main/LICENSE)
+
+
+**Used base image**
+
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.


### PR DESCRIPTION
## Description

This pull request changes the docker build and push workflow to push built images to Dockerhub together with a Notice file. 

Currently, will push to these repositories:

[pool](https://hub.docker.com/r/tractusx/bpdm-pool)
[gate](https://hub.docker.com/r/tractusx/bpdm-gate)
[bridge-dummy](https://hub.docker.com/r/tractusx/bpdm-bridge-dummy)

Fixes #114

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
