### PR TITLE
Gate Persistence: Legal Form should be optional

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
@@ -38,8 +38,8 @@ class LegalEntity(
     @Column(name = "name_shortname")
     var shortName: String?,
 
-    @Column(name = "legal_form_id", nullable = false)
-    var legalForm: String?,
+    @Column(name = "legal_form_id")
+    var legalForm: String? = null,
 
     @Column(name = "data_type")
     @Enumerated(EnumType.STRING)

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_6__make_legal_form_id_optional.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_6__make_legal_form_id_optional.sql
@@ -1,0 +1,3 @@
+-- Description: Make 'legal_form_id' column optional in the 'legal_entities' table
+-- Alter the 'legal_form_id' column to allow NULL values
+ALTER TABLE legal_entities ALTER COLUMN legal_form_id DROP NOT NULL;


### PR DESCRIPTION
---
title: 'Gate Persistence: Legal Form should be optional'
---

## Description
This pull request makes column 'legal_form_id' from table 'bpdmgate.legal_entities' to accept Null values. And making Legal Form as optional attribute for Legal Entity on Gate Service.

Fixes #272 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files
