### PR TITLE
Feat/api model rename dtos step3

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PageDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PageDto.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Paginated collection of results")
-data class PageResponse<T>(
+data class PageDto<T>(
 
     @get:Schema(description = "Total number of all results in all pages")
     val totalElements: Long,

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateAddressApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateAddressApi.kt
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputResponse
@@ -93,7 +93,7 @@ interface GateAddressApi {
     fun getAddressesByExternalIds(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @RequestBody externalIds: Collection<String>
-    ): PageResponse<AddressGateInputResponse>
+    ): PageDto<AddressGateInputResponse>
 
 
     @Operation(
@@ -108,7 +108,7 @@ interface GateAddressApi {
     )
     @GetMapping("/input/addresses")
     @GetExchange("/input/addresses")
-    fun getAddresses(@ParameterObject @Valid paginationRequest: PaginationRequest): PageResponse<AddressGateInputResponse>
+    fun getAddresses(@ParameterObject @Valid paginationRequest: PaginationRequest): PageDto<AddressGateInputResponse>
 
     @Operation(
         summary = "Get page of addresses (Output)",
@@ -125,7 +125,7 @@ interface GateAddressApi {
     fun getAddressesOutput(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @RequestBody(required = false) externalIds: Collection<String>?
-    ): PageResponse<AddressGateOutputDto>
+    ): PageDto<AddressGateOutputDto>
 
     @Operation(
         summary = "Create or update output addresses.",

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateLegalEntityApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateLegalEntityApi.kt
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.LegalEntityGateInputDto
@@ -90,7 +90,7 @@ interface GateLegalEntityApi {
     fun getLegalEntitiesByExternalIds(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @RequestBody externalIds: Collection<String>
-    ): PageResponse<LegalEntityGateInputDto>
+    ): PageDto<LegalEntityGateInputDto>
 
     @Operation(
         summary = "Get page of legal entities",
@@ -104,7 +104,7 @@ interface GateLegalEntityApi {
     )
     @GetMapping("/input/legal-entities")
     @GetExchange("/input/legal-entities")
-    fun getLegalEntities(@ParameterObject @Valid paginationRequest: PaginationRequest): PageResponse<LegalEntityGateInputDto>
+    fun getLegalEntities(@ParameterObject @Valid paginationRequest: PaginationRequest): PageDto<LegalEntityGateInputDto>
 
     @Operation(
         summary = "Get page of legal entities",
@@ -121,7 +121,7 @@ interface GateLegalEntityApi {
     fun getLegalEntitiesOutput(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @RequestBody(required = false) externalIds: Collection<String>?
-    ): PageResponse<LegalEntityGateOutputResponse>
+    ): PageDto<LegalEntityGateOutputResponse>
 
     @Operation(
         summary = "Create or update output legal entities.",

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
 import org.springdoc.core.annotations.ParameterObject
@@ -54,7 +54,7 @@ interface GateSharingStateApi {
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @Parameter(description = "LSA Type") @RequestParam(required = false) lsaType: LsaType?,
         @Parameter(description = "External identifiers") @RequestParam(required = false) externalIds: Collection<String>?
-    ): PageResponse<SharingStateDto>
+    ): PageDto<SharingStateDto>
 
     @Operation(
         summary = "Insert/update sharing state (including error info and BPN) for business partner with LSA type and external ID"

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSiteApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSiteApi.kt
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.SiteGateInputDto
@@ -90,7 +90,7 @@ interface GateSiteApi {
     fun getSitesByExternalIds(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @RequestBody externalIds: Collection<String>
-    ): PageResponse<SiteGateInputDto>
+    ): PageDto<SiteGateInputDto>
 
     @Operation(
         summary = "Get page of sites",
@@ -104,7 +104,7 @@ interface GateSiteApi {
     )
     @GetMapping("/input/sites")
     @GetExchange("/input/sites")
-    fun getSites(@ParameterObject @Valid paginationRequest: PaginationRequest): PageResponse<SiteGateInputDto>
+    fun getSites(@ParameterObject @Valid paginationRequest: PaginationRequest): PageDto<SiteGateInputDto>
 
     @Operation(
         summary = "Get page of sites",
@@ -121,7 +121,7 @@ interface GateSiteApi {
     fun getSitesOutput(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @RequestBody(required = false) externalIds: Collection<String>?
-    ): PageResponse<SiteGateOutputResponse>
+    ): PageDto<SiteGateOutputResponse>
 
     @Operation(
         summary = "Create or update output sites.",

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.GateAddressApi
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateOutputRequest
@@ -67,12 +67,12 @@ class AddressController(
     override fun getAddressesByExternalIds(
         paginationRequest: PaginationRequest,
         externalIds: Collection<String>
-    ): PageResponse<AddressGateInputResponse> {
+    ): PageDto<AddressGateInputResponse> {
         return addressService.getAddresses(page = paginationRequest.page, size = paginationRequest.size, externalIds = externalIds)
     }
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyInputDataAsRole())")
-    override fun getAddresses(paginationRequest: PaginationRequest): PageResponse<AddressGateInputResponse> {
+    override fun getAddresses(paginationRequest: PaginationRequest): PageDto<AddressGateInputResponse> {
         return addressService.getAddresses(page = paginationRequest.page, size = paginationRequest.size)
     }
 
@@ -80,7 +80,7 @@ class AddressController(
     override fun getAddressesOutput(
         paginationRequest: PaginationRequest,
         externalIds: Collection<String>?
-    ): PageResponse<AddressGateOutputDto> {
+    ): PageDto<AddressGateOutputDto> {
         return addressService.getAddressesOutput(externalIds = externalIds, page = paginationRequest.page, size = paginationRequest.size)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.GateLegalEntityApi
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateOutputRequest
@@ -57,12 +57,12 @@ class LegalEntityController(
     override fun getLegalEntitiesByExternalIds(
         paginationRequest: PaginationRequest,
         externalIds: Collection<String>
-    ): PageResponse<LegalEntityGateInputDto> {
+    ): PageDto<LegalEntityGateInputDto> {
         return legalEntityService.getLegalEntities(page = paginationRequest.page, size = paginationRequest.size, externalIds = externalIds)
     }
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyInputDataAsRole())")
-    override fun getLegalEntities(paginationRequest: PaginationRequest): PageResponse<LegalEntityGateInputDto> {
+    override fun getLegalEntities(paginationRequest: PaginationRequest): PageDto<LegalEntityGateInputDto> {
         return legalEntityService.getLegalEntities(page = paginationRequest.page, size = paginationRequest.size)
     }
 
@@ -70,7 +70,7 @@ class LegalEntityController(
     override fun getLegalEntitiesOutput(
         paginationRequest: PaginationRequest,
         externalIds: Collection<String>?
-    ): PageResponse<LegalEntityGateOutputResponse> {
+    ): PageDto<LegalEntityGateOutputResponse> {
         return legalEntityService.getLegalEntitiesOutput(externalIds = externalIds, page = paginationRequest.page, size = paginationRequest.size)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.gate.controller
 
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.GateSharingStateApi
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
@@ -36,7 +36,7 @@ class SharingStateController(
     private val logger = KotlinLogging.logger { }
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyOutputDataAsRole())")
-    override fun getSharingStates(paginationRequest: PaginationRequest, lsaType: LsaType?, externalIds: Collection<String>?): PageResponse<SharingStateDto> {
+    override fun getSharingStates(paginationRequest: PaginationRequest, lsaType: LsaType?, externalIds: Collection<String>?): PageDto<SharingStateDto> {
         return sharingStateService.findSharingStates(paginationRequest, lsaType, externalIds)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteController.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.GateSiteApi
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateOutputRequest
@@ -59,17 +59,17 @@ class SiteController(
     override fun getSitesByExternalIds(
         paginationRequest: PaginationRequest,
         externalIds: Collection<String>
-    ): PageResponse<SiteGateInputDto> {
+    ): PageDto<SiteGateInputDto> {
         return siteService.getSites(page = paginationRequest.page, size = paginationRequest.size, externalIds = externalIds)
     }
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyInputDataAsRole())")
-    override fun getSites(paginationRequest: PaginationRequest): PageResponse<SiteGateInputDto> {
+    override fun getSites(paginationRequest: PaginationRequest): PageDto<SiteGateInputDto> {
         return siteService.getSites(page = paginationRequest.page, size = paginationRequest.size)
     }
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyOutputDataAsRole())")
-    override fun getSitesOutput(paginationRequest: PaginationRequest, externalIds: Collection<String>?): PageResponse<SiteGateOutputResponse> {
+    override fun getSitesOutput(paginationRequest: PaginationRequest, externalIds: Collection<String>?): PageDto<SiteGateOutputResponse> {
         return siteService.getSitesOutput(externalIds = externalIds, page = paginationRequest.page, size = paginationRequest.size)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.service
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
@@ -46,7 +46,7 @@ class AddressService(
 ) {
     private val logger = KotlinLogging.logger { }
 
-    fun getAddresses(page: Int, size: Int, externalIds: Collection<String>? = null): PageResponse<AddressGateInputResponse> {
+    fun getAddresses(page: Int, size: Int, externalIds: Collection<String>? = null): PageDto<AddressGateInputResponse> {
 
         val logisticAddressPage = if (externalIds != null) {
             addressRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Input, PageRequest.of(page, size))
@@ -54,7 +54,7 @@ class AddressService(
             addressRepository.findByDataType(OutputInputEnum.Input, PageRequest.of(page, size))
         }
 
-        return PageResponse(
+        return PageDto(
             page = page,
             totalElements = logisticAddressPage.totalElements,
             totalPages = logisticAddressPage.totalPages,
@@ -81,7 +81,7 @@ class AddressService(
     /**
      * Get output addresses by fetching addresses from the database.
      */
-    fun getAddressesOutput(externalIds: Collection<String>? = null, page: Int, size: Int): PageResponse<AddressGateOutputDto> {
+    fun getAddressesOutput(externalIds: Collection<String>? = null, page: Int, size: Int): PageDto<AddressGateOutputDto> {
 
         val logisticAddressPage = if (externalIds != null && externalIds.isNotEmpty()) {
             addressRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Output, PageRequest.of(page, size))
@@ -89,7 +89,7 @@ class AddressService(
             addressRepository.findByDataType(OutputInputEnum.Output, PageRequest.of(page, size))
         }
 
-        return PageResponse(
+        return PageDto(
             page = page,
             totalElements = logisticAddressPage.totalElements,
             totalPages = logisticAddressPage.totalPages,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.service
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
@@ -64,7 +64,7 @@ class LegalEntityService(
         return toValidSingleLegalEntity(legalEntity)
     }
 
-    fun getLegalEntities(page: Int, size: Int, externalIds: Collection<String>? = null): PageResponse<LegalEntityGateInputDto> {
+    fun getLegalEntities(page: Int, size: Int, externalIds: Collection<String>? = null): PageDto<LegalEntityGateInputDto> {
 
         val legalEntitiesPage = if (externalIds != null) {
             legalEntityRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Input, PageRequest.of(page, size))
@@ -72,7 +72,7 @@ class LegalEntityService(
             legalEntityRepository.findByDataType(OutputInputEnum.Input, PageRequest.of(page, size))
         }
 
-        return PageResponse(
+        return PageDto(
             page = page,
             totalElements = legalEntitiesPage.totalElements,
             totalPages = legalEntitiesPage.totalPages,
@@ -84,7 +84,7 @@ class LegalEntityService(
     /**
      * Get output legal entities by first fetching legal entities from the database
      */
-    fun getLegalEntitiesOutput(externalIds: Collection<String>?, page: Int, size: Int): PageResponse<LegalEntityGateOutputResponse> {
+    fun getLegalEntitiesOutput(externalIds: Collection<String>?, page: Int, size: Int): PageDto<LegalEntityGateOutputResponse> {
 
         val legalEntityPage = if (!externalIds.isNullOrEmpty()) {
             legalEntityRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Output, PageRequest.of(page, size))
@@ -92,7 +92,7 @@ class LegalEntityService(
             legalEntityRepository.findByDataType(OutputInputEnum.Output, PageRequest.of(page, size))
         }
 
-        return PageResponse(
+        return PageDto(
             page = page,
             totalElements = legalEntityPage.totalElements,
             totalPages = legalEntityPage.totalPages,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.service
 
 import org.eclipse.tractusx.bpdm.common.dto.*
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.api.model.request.*
@@ -127,8 +127,8 @@ private fun StreetGateDto.toStreetEntity(): Street {
     )
 }
 
-fun <S, T> Page<S>.toDto(dtoContent: Collection<T>): PageResponse<T> {
-    return PageResponse(this.totalElements, this.totalPages, this.number, this.numberOfElements, dtoContent)
+fun <S, T> Page<S>.toDto(dtoContent: Collection<T>): PageDto<T> {
+    return PageDto(this.totalElements, this.totalPages, this.number, this.numberOfElements, dtoContent)
 }
 
 // Site Mappers

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SharingStateService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SharingStateService.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.service
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
 import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
 import org.eclipse.tractusx.bpdm.gate.entity.SharingState
@@ -72,7 +72,7 @@ class SharingStateService(private val stateRepository: SharingStateRepository) {
         this.stateRepository.save(entity)
     }
 
-    fun findSharingStates(paginationRequest: PaginationRequest, lsaType: LsaType?, externalIds: Collection<String>?): PageResponse<SharingStateDto> {
+    fun findSharingStates(paginationRequest: PaginationRequest, lsaType: LsaType?, externalIds: Collection<String>?): PageDto<SharingStateDto> {
 
         val spec = Specification.allOf(byLsaType(lsaType), byExternalIdsIn(externalIds))
         val pageRequest = PageRequest.of(paginationRequest.page, paginationRequest.size)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SiteService.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.service
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateInputRequest
@@ -42,7 +42,7 @@ class SiteService(
 ) {
     private val logger = KotlinLogging.logger { }
 
-    fun getSites(page: Int, size: Int, externalIds: Collection<String>? = null): PageResponse<SiteGateInputDto> {
+    fun getSites(page: Int, size: Int, externalIds: Collection<String>? = null): PageDto<SiteGateInputDto> {
 
         val sitesPage = if (externalIds != null) {
             siteRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Input, PageRequest.of(page, size))
@@ -50,7 +50,7 @@ class SiteService(
             siteRepository.findByDataType(OutputInputEnum.Input, PageRequest.of(page, size))
         }
 
-        return PageResponse(
+        return PageDto(
             page = page,
             totalElements = sitesPage.totalElements,
             totalPages = sitesPage.totalPages,
@@ -74,7 +74,7 @@ class SiteService(
     /**
      * Get output sites by first fetching sites from the database
      */
-    fun getSitesOutput(externalIds: Collection<String>?, page: Int, size: Int): PageResponse<SiteGateOutputResponse> {
+    fun getSitesOutput(externalIds: Collection<String>?, page: Int, size: Int): PageDto<SiteGateOutputResponse> {
 
         val sitePage = if (!externalIds.isNullOrEmpty()) {
             siteRepository.findByExternalIdInAndDataType(externalIds, OutputInputEnum.Output, PageRequest.of(page, size))
@@ -82,7 +82,7 @@ class SiteService(
             siteRepository.findByDataType(OutputInputEnum.Output, PageRequest.of(page, size))
         }
 
-        return PageResponse(
+        return PageDto(
             page = page,
             totalElements = sitePage.totalElements,
             totalPages = sitePage.totalPages,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerInputIT.kt
@@ -43,7 +43,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.repository.GateAddressRepository
 import org.eclipse.tractusx.bpdm.gate.util.*
@@ -151,7 +151,7 @@ internal class AddressControllerInputIT @Autowired constructor(
         val pageResponse = gateClient.addresses().getAddresses(paginationValue)
 
         assertThat(pageResponse).isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,
@@ -195,7 +195,7 @@ internal class AddressControllerInputIT @Autowired constructor(
         val pageResponse = gateClient.addresses().getAddressesByExternalIds(pagination, listExternalIds)
 
         assertThat(pageResponse).isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerOutputIT.kt
@@ -43,7 +43,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.repository.GateAddressRepository
@@ -177,7 +177,7 @@ internal class AddressControllerOutputIT @Autowired constructor(
         val pageResponse = gateClient.addresses().getAddressesOutput(paginationValue, emptyList())
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*processStartedAt*").isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,
@@ -224,7 +224,7 @@ internal class AddressControllerOutputIT @Autowired constructor(
         val pageResponse = gateClient.addresses().getAddressesOutput(paginationValue, listOf(CommonValues.externalIdAddress1, CommonValues.externalIdAddress2))
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*processStartedAt*").isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerInputIT.kt
@@ -28,7 +28,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.repository.LegalEntityRepository
@@ -221,7 +221,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
         gateClient.legalEntities().upsertLegalEntities(legalEntities)
         val pageResponse = gateClient.legalEntities().getLegalEntities(paginationValue)
 
-        val expectedPage = PageResponse(
+        val expectedPage = PageDto(
             totalElements,
             totalPages,
             page,
@@ -266,7 +266,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
 
         val pageResponse = gateClient.legalEntities().getLegalEntitiesByExternalIds(paginationValue, listExternalIds)
 
-        val expectedPage = PageResponse(
+        val expectedPage = PageDto(
             totalElements,
             totalPages,
             page,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerOutputIT.kt
@@ -24,7 +24,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.repository.LegalEntityRepository
@@ -159,7 +159,7 @@ internal class LegalEntityControllerOutputIT @Autowired constructor(
 
         val pageResponse = gateClient.legalEntities().getLegalEntitiesOutput(paginationValue, emptyList())
 
-        val expectedPage = PageResponse(
+        val expectedPage = PageDto(
             totalElements,
             totalPages,
             page,
@@ -209,7 +209,7 @@ internal class LegalEntityControllerOutputIT @Autowired constructor(
 
         val pageResponse = gateClient.legalEntities().getLegalEntitiesOutput(paginationValue, listOf(CommonValues.externalId1, CommonValues.externalId2))
 
-        val expectedPage = PageResponse(
+        val expectedPage = PageDto(
             totalElements,
             totalPages,
             page,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerInputIT.kt
@@ -24,7 +24,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.repository.SiteRepository
 import org.eclipse.tractusx.bpdm.gate.util.*
@@ -142,7 +142,7 @@ internal class SiteControllerInputIT @Autowired constructor(
         val pageResponse = gateClient.sites().getSites(paginationValue)
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*").isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,
@@ -192,7 +192,7 @@ internal class SiteControllerInputIT @Autowired constructor(
         val pageResponse = gateClient.sites().getSitesByExternalIds(paginationValue, externalIds)
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*").isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerOutputIT.kt
@@ -24,7 +24,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.repository.SiteRepository
@@ -194,7 +194,7 @@ internal class SiteControllerOutputIT @Autowired constructor(
         val pageResponse = gateClient.sites().getSitesOutput(paginationValue, emptyList())
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*", ".*processStartedAt*").isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,
@@ -253,7 +253,7 @@ internal class SiteControllerOutputIT @Autowired constructor(
         val pageResponse = gateClient.sites().getSitesOutput(paginationValue, listOf(CommonValues.externalIdSite1, CommonValues.externalIdSite2))
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*", ".*processStartedAt*").isEqualTo(
-            PageResponse(
+            PageDto(
                 totalElements = totalElements,
                 totalPages = totalPages,
                 page = pageValue,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
@@ -63,7 +63,7 @@ interface PoolAddressApi {
     fun getAddresses(
         @ParameterObject addressSearchRequest: AddressPartnerSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<AddressMatchResponse>
+    ): PageResponse<AddressMatchVerboseDto>
 
     @Operation(
         summary = "Get address partners by bpna",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
@@ -27,7 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.request.AddressPartnerBpnSearchRequest
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
@@ -63,7 +63,7 @@ interface PoolAddressApi {
     fun getAddresses(
         @ParameterObject addressSearchRequest: AddressPartnerSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<AddressMatchVerboseDto>
+    ): PageDto<AddressMatchVerboseDto>
 
     @Operation(
         summary = "Get address partners by bpna",
@@ -97,7 +97,7 @@ interface PoolAddressApi {
     fun searchAddresses(
         @RequestBody addressSearchRequest: AddressPartnerBpnSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<LogisticAddressVerboseDto>
+    ): PageDto<LogisticAddressVerboseDto>
 
     @Operation(
         summary = "Create new address business partners",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
@@ -25,7 +25,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -57,5 +57,5 @@ interface PoolBpnApi {
     )
     @PostMapping("/search")
     @PostExchange("/search")
-    fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingResponse>>
+    fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingDto>>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolChangelogApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolChangelogApi.kt
@@ -25,7 +25,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryResponse
 import org.springdoc.core.annotations.ParameterObject
@@ -56,5 +56,5 @@ interface PoolChangelogApi {
     fun getChangelogEntries(
         @RequestBody changelogSearchRequest: ChangelogSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<ChangelogEntryResponse>
+    ): PageDto<ChangelogEntryResponse>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -61,7 +61,7 @@ interface PoolLegalEntityApi {
     fun getLegalEntities(
         @ParameterObject bpSearchRequest: LegalEntityPropertiesSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchResponse>
+    ): PageResponse<LegalEntityMatchVerboseDto>
 
     @Operation(
         summary = "Get legal entity business partner by identifier",
@@ -181,7 +181,7 @@ interface PoolLegalEntityApi {
     fun searchLegalAddresses(
         @RequestBody
         bpnLs: Collection<String>
-    ): Collection<LegalAddressResponse>
+    ): Collection<LegalAddressVerboseDto>
 
     @Operation(
         summary = "Create new legal entity business partners",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -61,7 +61,7 @@ interface PoolLegalEntityApi {
     fun getLegalEntities(
         @ParameterObject bpSearchRequest: LegalEntityPropertiesSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchVerboseDto>
+    ): PageDto<LegalEntityMatchVerboseDto>
 
     @Operation(
         summary = "Get legal entity business partner by identifier",
@@ -146,7 +146,7 @@ interface PoolLegalEntityApi {
     fun getSites(
         @Parameter(description = "Bpnl value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<SiteVerboseDto>
+    ): PageDto<SiteVerboseDto>
 
     @Operation(
         summary = "Get address partners of a legal entity",
@@ -164,7 +164,7 @@ interface PoolLegalEntityApi {
     fun getAddresses(
         @Parameter(description = "Bpn value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<LogisticAddressVerboseDto>
+    ): PageDto<LogisticAddressVerboseDto>
 
     @Operation(
         summary = "Search Legal Addresses",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -30,7 +30,7 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierLsaType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
@@ -86,7 +86,7 @@ interface PoolMetadataApi {
         @Parameter lsaType: IdentifierLsaType,
         @Parameter country: CountryCode?
     ):
-            PageResponse<IdentifierTypeDto>
+            PageDto<IdentifierTypeDto>
 
 
     @Operation(
@@ -117,7 +117,7 @@ interface PoolMetadataApi {
     )
     @GetMapping("/legal-forms")
     @GetExchange("/legal-forms")
-    fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageResponse<LegalFormDto>
+    fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageDto<LegalFormDto>
 
 
     @Operation(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolOpenSearchApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolOpenSearchApi.kt
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncDto
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -53,7 +53,7 @@ interface PoolOpenSearchApi {
     )
     @PostMapping("/business-partner")
     @PostExchange("/business-partner")
-    fun export(): SyncResponse
+    fun export(): SyncDto
 
     @Operation(
         summary = "Fetch information about the latest OpenSearch export",
@@ -67,7 +67,7 @@ interface PoolOpenSearchApi {
     )
     @GetMapping("/business-partner")
     @GetExchange("/business-partner")
-    fun getBusinessPartners(): SyncResponse
+    fun getBusinessPartners(): SyncDto
 
 
     @Operation(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSaasApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSaasApi.kt
@@ -25,7 +25,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.ImportIdEntry
 import org.eclipse.tractusx.bpdm.pool.api.model.request.ImportIdFilterRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ImportIdMappingDto
@@ -102,5 +102,5 @@ interface PoolSaasApi {
     )
     @GetMapping("/identifier-mappings")
     @GetExchange("/identifier-mappings")
-    fun getImportEntries(@ParameterObject paginationRequest: PaginationRequest): PageResponse<ImportIdEntry>
+    fun getImportEntries(@ParameterObject paginationRequest: PaginationRequest): PageDto<ImportIdEntry>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSaasApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSaasApi.kt
@@ -28,8 +28,8 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.ImportIdEntry
 import org.eclipse.tractusx.bpdm.pool.api.model.request.ImportIdFilterRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.ImportIdMappingResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ImportIdMappingDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -60,7 +60,7 @@ interface PoolSaasApi {
     )
     @PostMapping("/business-partner/sync")
     @PostExchange("/business-partner/sync")
-    fun importBusinessPartners(): SyncResponse
+    fun importBusinessPartners(): SyncDto
 
     @Operation(
         summary = "Fetch information about the SaaS synchronization",
@@ -74,7 +74,7 @@ interface PoolSaasApi {
     )
     @GetMapping("/business-partner/sync")
     @GetExchange("/business-partner/sync")
-    fun getSyncStatus(): SyncResponse
+    fun getSyncStatus(): SyncDto
 
     @Operation(
         summary = "Filter Identifier Mappings by CX-Pool Identifiers",
@@ -88,7 +88,7 @@ interface PoolSaasApi {
     )
     @PostMapping("/identifier-mappings/filter")
     @PostExchange("/identifier-mappings/filter")
-    fun getImportEntries(@RequestBody importIdFilterRequest: ImportIdFilterRequest): ImportIdMappingResponse
+    fun getImportEntries(@RequestBody importIdFilterRequest: ImportIdFilterRequest): ImportIdMappingDto
 
     @Operation(
         summary = "Paginate Identifier Mappings by CX-Pool Identifiers",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -30,10 +30,10 @@ import org.eclipse.tractusx.bpdm.common.dto.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
@@ -62,7 +62,7 @@ interface PoolSiteApi {
     fun searchMainAddresses(
         @RequestBody
         bpnS: Collection<String>
-    ): Collection<MainAddressResponse>
+    ): Collection<MainAddressVerboseDto>
 
     @Operation(
         summary = "Get site partners by bpn",
@@ -79,7 +79,7 @@ interface PoolSiteApi {
     @GetExchange("/{bpn}")
     fun getSite(
         @Parameter(description = "Bpn value") @PathVariable bpn: String
-    ): SitePoolResponse
+    ): SitePoolVerboseDto
 
     @Operation(
         summary = "Search site partners by BPNs and/or parent BPNs",
@@ -96,7 +96,7 @@ interface PoolSiteApi {
     fun searchSites(
         @RequestBody siteSearchRequest: SiteBpnSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<SitePoolResponse>
+    ): PageResponse<SitePoolVerboseDto>
 
     @Operation(
         summary = "Create new site business partners",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -27,7 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.request.SiteBpnSearchRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressVerboseDto
@@ -96,7 +96,7 @@ interface PoolSiteApi {
     fun searchSites(
         @RequestBody siteSearchRequest: SiteBpnSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageResponse<SitePoolVerboseDto>
+    ): PageDto<SitePoolVerboseDto>
 
     @Operation(
         summary = "Create new site business partners",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressMatchVerboseDto.kt
@@ -20,25 +20,15 @@
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.response.AlternativePostalAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerboseDto
-import java.time.Instant
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 
-@Schema(name = "MainAddressResponse", description = "Main address for site")
-data class MainAddressResponse(
 
-    @Schema(description = "Physical postal address")
-    val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
+@Schema(name = "AddressMatchVerboseDto", description = "Match with score for a business partner record of type address")
+data class AddressMatchVerboseDto(
 
-    @Schema(description = "Alternative postal address")
-    val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
+    @Schema(description = "Relative quality score of the match. The higher the better")
+    val score: Float,
 
-    @Schema(description = "BPN of the related site")
-    val bpnSite: String,
-
-    @Schema(description = "The timestamp the business partner data was created")
-    val createdAt: Instant,
-
-    @Schema(description = "The timestamp the business partner data was last updated")
-    val updatedAt: Instant
+    @Schema(description = "Matched address business partner record")
+    val address: LogisticAddressVerboseDto
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressPartnerCreateVerboseDto.kt
@@ -22,22 +22,15 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityPartnerCreateResponse", description = "Created business partner of type legal entity")
-data class LegalEntityPartnerCreateResponse(
-
-    @get:Schema(description = "Legal name the partner goes by")
-    val legalName: String,
+@Schema(name = "AddressPartnerCreateVerboseDto", description = "Created business partners of type address")
+data class AddressPartnerCreateVerboseDto(
 
     @field:JsonUnwrapped
-    val legalEntity: LegalEntityVerboseDto,
-
-    @get:Schema(description = "Address of the official seat of this legal entity")
-    val legalAddress: LogisticAddressVerboseDto,
+    val address: LogisticAddressVerboseDto,
 
     @Schema(description = "User defined index to conveniently match this entry to the corresponding entry from the request")
     val index: String?

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/BpnIdentifierMappingDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/BpnIdentifierMappingDto.kt
@@ -20,25 +20,13 @@
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.response.AlternativePostalAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerboseDto
-import java.time.Instant
 
-@Schema(name = "LegalAddressResponse", description = "Legal address for legal entity")
-data class LegalAddressResponse(
+@Schema(name = "BpnIdentifierMappingDto", description = "Mapping of Business Partner Number to identifier value")
+data class BpnIdentifierMappingDto(
 
-    @Schema(description = "Physical postal address")
-    val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
+    @Schema(description = "Value of the identifier")
+    val idValue: String,
 
-    @Schema(description = "Alternative postal address")
-    val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
-
-    @Schema(description = "BPN of the related legal entity")
-    val bpnLegalEntity: String,
-
-    @Schema(description = "The timestamp the business partner data was created")
-    val createdAt: Instant,
-
-    @Schema(description = "The timestamp the business partner data was last updated")
-    val updatedAt: Instant
+    @Schema(description = "Business Partner Number")
+    val bpn: String
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/EntitiesWithErrors.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/EntitiesWithErrors.kt
@@ -40,45 +40,45 @@ open class EntitiesWithErrors<ENTITY, out ERROR : ErrorCode>(
     description = "Holds information about successfully and failed entities after the creating/updating of several objects"
 )
 data class LegalEntityPartnerCreateResponseWrapper(
-    override val entities: Collection<LegalEntityPartnerCreateResponse>,
+    override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<LegalEntityCreateError>>
-) : EntitiesWithErrors<LegalEntityPartnerCreateResponse, LegalEntityCreateError>(entities, errors)
+) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityCreateError>(entities, errors)
 
 @Schema(
     name = "LegalEntityUpdateWrapper",
     description = "Holds information about successfully and failed entities after the creating/updating of several objects"
 )
 data class LegalEntityPartnerUpdateResponseWrapper(
-    override val entities: Collection<LegalEntityPartnerCreateResponse>,
+    override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<LegalEntityUpdateError>>
-) : EntitiesWithErrors<LegalEntityPartnerCreateResponse, LegalEntityUpdateError>(entities, errors)
+) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityUpdateError>(entities, errors)
 
 @Schema(
     name = "SiteCreateWrapper",
     description = "Holds information about successfully and failed entities after the creating/updating of several objects"
 )
 data class SitePartnerCreateResponseWrapper(
-    override val entities: Collection<SitePartnerCreateResponse>,
+    override val entities: Collection<SitePartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<SiteCreateError>>
-) : EntitiesWithErrors<SitePartnerCreateResponse, SiteCreateError>(entities, errors)
+) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteCreateError>(entities, errors)
 
 @Schema(
     name = "SiteUpdateWrapper",
     description = "Holds information about successfully and failed entities after the creating/updating of several objects"
 )
 data class SitePartnerUpdateResponseWrapper(
-    override val entities: Collection<SitePartnerCreateResponse>,
+    override val entities: Collection<SitePartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<SiteUpdateError>>
-) : EntitiesWithErrors<SitePartnerCreateResponse, SiteUpdateError>(entities, errors)
+) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteUpdateError>(entities, errors)
 
 @Schema(
     name = "AddressCreateWrapper",
     description = "Holds information about successfully and failed entities after the creating/updating of several objects"
 )
 data class AddressPartnerCreateResponseWrapper(
-    override val entities: Collection<AddressPartnerCreateResponse>,
+    override val entities: Collection<AddressPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<AddressCreateError>>
-) : EntitiesWithErrors<AddressPartnerCreateResponse, AddressCreateError>(entities, errors)
+) : EntitiesWithErrors<AddressPartnerCreateVerboseDto, AddressCreateError>(entities, errors)
 
 @Schema(
     name = "AddressUpdateWrapper",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/ImportIdMappingDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/ImportIdMappingDto.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 
 import org.eclipse.tractusx.bpdm.pool.api.model.ImportIdEntry
 
-data class ImportIdMappingResponse(
+data class ImportIdMappingDto(
     val entries: Collection<ImportIdEntry>,
     val notFound: Collection<String>
 ) {

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalAddressVerboseDto.kt
@@ -19,26 +19,26 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.common.dto.response.AlternativePostalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerboseDto
+import java.time.Instant
 
-@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityMatchResponse", description = "Match with score for a business partner record of type legal entity")
-data class LegalEntityMatchResponse(
+@Schema(name = "LegalAddressVerboseDto", description = "Legal address for legal entity")
+data class LegalAddressVerboseDto(
 
-    @Schema(description = "Relative quality score of the match. The higher the better")
-    val score: Float,
+    @Schema(description = "Physical postal address")
+    val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
 
-    @get:Schema(description = "Legal name the partner goes by")
-    val legalName: String,
+    @Schema(description = "Alternative postal address")
+    val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
 
-    @field:JsonUnwrapped
-    val legalEntity: LegalEntityVerboseDto,
+    @Schema(description = "BPN of the related legal entity")
+    val bpnLegalEntity: String,
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
-    val legalAddress: LogisticAddressVerboseDto,
+    @Schema(description = "The timestamp the business partner data was created")
+    val createdAt: Instant,
+
+    @Schema(description = "The timestamp the business partner data was last updated")
+    val updatedAt: Instant
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
@@ -19,14 +19,26 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
-@Schema(name = "BpnIdentifierMappingResponse", description = "Mapping of Business Partner Number to identifier value")
-data class BpnIdentifierMappingResponse(
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(name = "LegalEntityMatchVerboseDto", description = "Match with score for a business partner record of type legal entity")
+data class LegalEntityMatchVerboseDto(
 
-    @Schema(description = "Value of the identifier")
-    val idValue: String,
+    @Schema(description = "Relative quality score of the match. The higher the better")
+    val score: Float,
 
-    @Schema(description = "Business Partner Number")
-    val bpn: String
+    @get:Schema(description = "Legal name the partner goes by")
+    val legalName: String,
+
+    @field:JsonUnwrapped
+    val legalEntity: LegalEntityVerboseDto,
+
+    @get:Schema(description = "Address of the official seat of this legal entity")
+    val legalAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
@@ -22,19 +22,22 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "SitePartnerCreateResponse", description = "Created business partner record of type site")
-data class SitePartnerCreateResponse(
+@Schema(name = "LegalEntityPartnerCreateVerboseDto", description = "Created business partner of type legal entity")
+data class LegalEntityPartnerCreateVerboseDto(
+
+    @get:Schema(description = "Legal name the partner goes by")
+    val legalName: String,
 
     @field:JsonUnwrapped
-    val site: SiteVerboseDto,
+    val legalEntity: LegalEntityVerboseDto,
 
-    @Schema(description = "Main address of this site")
-    val mainAddress: LogisticAddressVerboseDto,
+    @get:Schema(description = "Address of the official seat of this legal entity")
+    val legalAddress: LogisticAddressVerboseDto,
 
     @Schema(description = "User defined index to conveniently match this entry to the corresponding entry from the request")
     val index: String?

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/MainAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/MainAddressVerboseDto.kt
@@ -19,19 +19,26 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.common.dto.response.AlternativePostalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerboseDto
+import java.time.Instant
 
-@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "AddressPartnerCreateResponse", description = "Created business partners of type address")
-data class AddressPartnerCreateResponse(
+@Schema(name = "MainAddressResponse", description = "Main address for site")
+data class MainAddressVerboseDto(
 
-    @field:JsonUnwrapped
-    val address: LogisticAddressVerboseDto,
+    @Schema(description = "Physical postal address")
+    val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
 
-    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry from the request")
-    val index: String?
+    @Schema(description = "Alternative postal address")
+    val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
+
+    @Schema(description = "BPN of the related site")
+    val bpnSite: String,
+
+    @Schema(description = "The timestamp the business partner data was created")
+    val createdAt: Instant,
+
+    @Schema(description = "The timestamp the business partner data was last updated")
+    val updatedAt: Instant
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePartnerCreateVerboseDto.kt
@@ -19,16 +19,23 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
-import org.eclipse.tractusx.bpdm.common.model.SyncStatus
-import org.eclipse.tractusx.bpdm.pool.api.model.SyncType
-import java.time.Instant
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
-data class SyncResponse(
-    val type: SyncType,
-    val status: SyncStatus,
-    val count: Int = 0,
-    val progress: Float = 0f,
-    val errorDetails: String? = null,
-    val startedAt: Instant? = null,
-    val finishedAt: Instant? = null
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(name = "SitePartnerCreateVerboseDto", description = "Created business partner record of type site")
+data class SitePartnerCreateVerboseDto(
+
+    @field:JsonUnwrapped
+    val site: SiteVerboseDto,
+
+    @Schema(description = "Main address of this site")
+    val mainAddress: LogisticAddressVerboseDto,
+
+    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry from the request")
+    val index: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePoolVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePoolVerboseDto.kt
@@ -17,13 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.dto
+package org.eclipse.tractusx.bpdm.pool.api.model.response
 
-import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogSubject
-import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
-data class ChangelogEntryDto(
-    val bpn: String,
-    val changelogType: ChangelogType,
-    val changelogSubject: ChangelogSubject
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(name = "SitePoolVerboseDto", description = "Site with legal entity reference.")
+data class SitePoolVerboseDto(
+
+    @field:JsonUnwrapped
+    val site: SiteVerboseDto,
+
+    @Schema(description = "Main address where this site resides")
+    val mainAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SyncDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SyncDto.kt
@@ -19,20 +19,16 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
-import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.common.model.SyncStatus
+import org.eclipse.tractusx.bpdm.pool.api.model.SyncType
+import java.time.Instant
 
-@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "SitePoolResponse", description = "Site with legal entity reference.")
-data class SitePoolResponse(
-
-    @field:JsonUnwrapped
-    val site: SiteVerboseDto,
-
-    @Schema(description = "Main address where this site resides")
-    val mainAddress: LogisticAddressVerboseDto,
+data class SyncDto(
+    val type: SyncType,
+    val status: SyncStatus,
+    val count: Int = 0,
+    val progress: Float = 0f,
+    val errorDetails: String? = null,
+    val startedAt: Instant? = null,
+    val finishedAt: Instant? = null
 )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/SearchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/SearchService.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.pool.component.opensearch
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
@@ -37,7 +37,7 @@ interface SearchService {
     fun searchLegalEntities(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchVerboseDto>
+    ): PageDto<LegalEntityMatchVerboseDto>
 
     /**
      * Find addresses by matching their field values to [searchRequest] field query texts
@@ -45,6 +45,6 @@ interface SearchService {
     fun searchAddresses(
         searchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<AddressMatchVerboseDto>
+    ): PageDto<AddressMatchVerboseDto>
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/SearchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/SearchService.kt
@@ -23,8 +23,8 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 
 /**
  * Provides search functionality on the Catena-x data for the BPDM system
@@ -37,7 +37,7 @@ interface SearchService {
     fun searchLegalEntities(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchResponse>
+    ): PageResponse<LegalEntityMatchVerboseDto>
 
     /**
      * Find addresses by matching their field values to [searchRequest] field query texts
@@ -45,6 +45,6 @@ interface SearchService {
     fun searchAddresses(
         searchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<AddressMatchResponse>
+    ): PageResponse<AddressMatchVerboseDto>
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/controller/OpenSearchController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/controller/OpenSearchController.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.controller
 
 
 import org.eclipse.tractusx.bpdm.pool.api.PoolOpenSearchApi
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncDto
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.service.OpenSearchSyncStarterService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
@@ -32,12 +32,12 @@ class OpenSearchController(
 ) : PoolOpenSearchApi {
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getManageOpensearchAsRole())")
-    override fun export(): SyncResponse {
+    override fun export(): SyncDto {
         return openSearchSyncService.exportAsync()
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getManageOpensearchAsRole())")
-    override fun getBusinessPartners(): SyncResponse {
+    override fun getBusinessPartners(): SyncDto {
         return openSearchSyncService.getExportStatus()
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/OpenSearchSyncStarterService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/OpenSearchSyncStarterService.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.service
 
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.pool.api.model.SyncType
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncDto
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.doc.ADDRESS_PARTNER_INDEX_NAME
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.doc.LEGAL_ENTITIES_INDEX_NAME
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.doc.MAPPINGS_FILE_PATH_ADDRESSES
@@ -59,21 +59,21 @@ class OpenSearchSyncStarterService(
      * Checks for changed records since the last export and exports those changes to OpenSearch
      */
     @Scheduled(cron = "\${bpdm.opensearch.export-scheduler-cron-expr:-}", zone = "UTC")
-    fun export(): SyncResponse {
+    fun export(): SyncDto {
         return startExport(true)
     }
 
     /**
      * Non-blocking asynchronous variant of [export]
      */
-    fun exportAsync(): SyncResponse {
+    fun exportAsync(): SyncDto {
         return startExport(false)
     }
 
     /**
-     * Fetch a [SyncResponse] about the state of the latest export
+     * Fetch a [SyncDto] about the state of the latest export
      */
-    fun getExportStatus(): SyncResponse {
+    fun getExportStatus(): SyncDto {
         return syncRecordService.getOrCreateRecord(SyncType.OPENSEARCH).toDto()
     }
 
@@ -150,7 +150,7 @@ class OpenSearchSyncStarterService(
     /**
      *  Start export either asynchronously or synchronously depending on whether [inSync]
      */
-    private fun startExport(inSync: Boolean): SyncResponse {
+    private fun startExport(inSync: Boolean): SyncDto {
         val record = syncRecordService.setSynchronizationStart(SyncType.OPENSEARCH)
         val response = record.toDto()
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/SearchServiceImpl.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/SearchServiceImpl.kt
@@ -24,8 +24,8 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.SearchService
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.repository.AddressDocSearchRepository
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.repository.LegalEntityDocSearchRepository
@@ -72,7 +72,7 @@ class SearchServiceImpl(
     override fun searchLegalEntities(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchResponse> {
+    ): PageResponse<LegalEntityMatchVerboseDto> {
 
         val legalEntityPage = searchAndPreparePage(searchRequest, paginationRequest)
         businessPartnerFetchService.fetchLegalEntityDependencies(legalEntityPage.content.map { (_, legalEntity) -> legalEntity }.toSet())
@@ -86,7 +86,7 @@ class SearchServiceImpl(
     /**
      * @see SearchServiceImpl.searchLegalEntities
      */
-    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageResponse<AddressMatchResponse> {
+    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageResponse<AddressMatchVerboseDto> {
         val addressPage = searchAndPreparePage(searchRequest, paginationRequest)
 
         addressService.fetchLogisticAddressDependencies(addressPage.content.map { (_, address) -> address }.toSet())

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/SearchServiceImpl.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/impl/service/SearchServiceImpl.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.service
 
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
@@ -65,20 +65,20 @@ class SearchServiceImpl(
      * Uses the [searchRequest] to perform an OpenSearch query for business partners.
      * The BPNs of found partners are used to query the whole business partner records from the database.
      * The records are supplied with relevancy scores of the search hits and returned as a paginated result.
-     * In case BPNs found by OpenSearch can not be found in the database, the [PageResponse] properties are
+     * In case BPNs found by OpenSearch can not be found in the database, the [PageDto] properties are
      * adapted accordingly from the OpenSearch page information
      *
      */
     override fun searchLegalEntities(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchVerboseDto> {
+    ): PageDto<LegalEntityMatchVerboseDto> {
 
         val legalEntityPage = searchAndPreparePage(searchRequest, paginationRequest)
         businessPartnerFetchService.fetchLegalEntityDependencies(legalEntityPage.content.map { (_, legalEntity) -> legalEntity }.toSet())
 
         return with(legalEntityPage) {
-            PageResponse(totalElements, totalPages, page, contentSize,
+            PageDto(totalElements, totalPages, page, contentSize,
                 content.map { (score, legalEntity) -> legalEntity.toMatchDto(score) })
         }
     }
@@ -86,13 +86,13 @@ class SearchServiceImpl(
     /**
      * @see SearchServiceImpl.searchLegalEntities
      */
-    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageResponse<AddressMatchVerboseDto> {
+    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageDto<AddressMatchVerboseDto> {
         val addressPage = searchAndPreparePage(searchRequest, paginationRequest)
 
         addressService.fetchLogisticAddressDependencies(addressPage.content.map { (_, address) -> address }.toSet())
 
         return with(addressPage) {
-            PageResponse(totalElements, totalPages, page, contentSize,
+            PageDto(totalElements, totalPages, page, contentSize,
                 content.map { (score, address) -> address.toMatchDto(score) })
         }
     }
@@ -100,7 +100,7 @@ class SearchServiceImpl(
     private fun searchAndPreparePage(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<Pair<Float, LegalEntity>> {
+    ): PageDto<Pair<Float, LegalEntity>> {
         return if (searchRequest == BusinessPartnerSearchRequest.EmptySearchRequest) {
             paginateLegalEntities(paginationRequest)
         } else {
@@ -111,7 +111,7 @@ class SearchServiceImpl(
     private fun searchAndPreparePage(
         searchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<Pair<Float, LogisticAddress>> {
+    ): PageDto<Pair<Float, LogisticAddress>> {
 
         return if (searchRequest == AddressPartnerSearchRequest.EmptySearchRequest) {
             paginateAddressPartner(paginationRequest)
@@ -120,14 +120,14 @@ class SearchServiceImpl(
         }
     }
 
-    private fun paginateLegalEntities(paginationRequest: PaginationRequest): PageResponse<Pair<Float, LegalEntity>> {
+    private fun paginateLegalEntities(paginationRequest: PaginationRequest): PageDto<Pair<Float, LegalEntity>> {
         logger.debug { "Paginate database for legal entities" }
         val legalEntityPage = legalEntityRepository.findAll(PageRequest.of(paginationRequest.page, paginationRequest.size))
 
         return legalEntityPage.toDto(legalEntityPage.content.map { Pair(0f, it) }) // assign 0 score as no search has been conducted
     }
 
-    private fun paginateAddressPartner(paginationRequest: PaginationRequest): PageResponse<Pair<Float, LogisticAddress>> {
+    private fun paginateAddressPartner(paginationRequest: PaginationRequest): PageDto<Pair<Float, LogisticAddress>> {
         logger.debug { "Paginate database for address partners" }
         val addressPage = logisticAddressRepository.findAll(PageRequest.of(paginationRequest.page, paginationRequest.size))
 
@@ -137,7 +137,7 @@ class SearchServiceImpl(
     private fun searchIndex(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<Pair<Float, LegalEntity>> {
+    ): PageDto<Pair<Float, LegalEntity>> {
         logger.debug { "Search index for legal entities" }
 
         if (paginationRequest.page > openSearchConfigProperties.maxPage)
@@ -162,13 +162,13 @@ class SearchServiceImpl(
 
         val totalHits = searchResult.totalHits!!.value - missingPartners.size
         val totalPages = ceil(totalHits.toDouble() / paginationRequest.size).toInt()
-        return PageResponse(totalHits, totalPages, paginationRequest.page, legalEntities.size, scoreLegalEntityPairs)
+        return PageDto(totalHits, totalPages, paginationRequest.page, legalEntities.size, scoreLegalEntityPairs)
     }
 
     private fun searchIndex(
         searchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<Pair<Float, LogisticAddress>> {
+    ): PageDto<Pair<Float, LogisticAddress>> {
         logger.debug { "Search index for addresses" }
 
         if (paginationRequest.page > openSearchConfigProperties.maxPage)
@@ -193,7 +193,7 @@ class SearchServiceImpl(
 
         val totalHits = searchResult.totalHits!!.value - missingPartners.size
         val totalPages = ceil(totalHits.toDouble() / paginationRequest.size).toInt()
-        return PageResponse(totalHits, totalPages, paginationRequest.page, addresses.size, scoreAddressPairs)
+        return PageDto(totalHits, totalPages, paginationRequest.page, addresses.size, scoreAddressPairs)
     }
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/mock/service/SearchServiceMock.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/mock/service/SearchServiceMock.kt
@@ -24,8 +24,8 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.SearchService
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
 import org.eclipse.tractusx.bpdm.pool.repository.LogisticAddressRepository
@@ -52,7 +52,7 @@ class SearchServiceMock(
     override fun searchLegalEntities(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchResponse> {
+    ): PageResponse<LegalEntityMatchVerboseDto> {
         val resultPage =
             legalEntityRepository.findAll(PageRequest.of(paginationRequest.page, paginationRequest.size))
 
@@ -65,7 +65,7 @@ class SearchServiceMock(
      * Ignores [searchRequest] and returns an unfiltered result of addresses in the database,
      * adding a default relevancy score to each entry
      */
-    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageResponse<AddressMatchResponse> {
+    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageResponse<AddressMatchVerboseDto> {
         val resultPage = logisticAddressRepository.findAll(PageRequest.of(paginationRequest.page, paginationRequest.size))
 
         logger.info { "Mock search: Returning ${resultPage.size} addresses from database" }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/mock/service/SearchServiceMock.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/mock/service/SearchServiceMock.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.component.opensearch.mock.service
 
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
@@ -52,7 +52,7 @@ class SearchServiceMock(
     override fun searchLegalEntities(
         searchRequest: BusinessPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchVerboseDto> {
+    ): PageDto<LegalEntityMatchVerboseDto> {
         val resultPage =
             legalEntityRepository.findAll(PageRequest.of(paginationRequest.page, paginationRequest.size))
 
@@ -65,7 +65,7 @@ class SearchServiceMock(
      * Ignores [searchRequest] and returns an unfiltered result of addresses in the database,
      * adding a default relevancy score to each entry
      */
-    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageResponse<AddressMatchVerboseDto> {
+    override fun searchAddresses(searchRequest: AddressPartnerSearchRequest, paginationRequest: PaginationRequest): PageDto<AddressMatchVerboseDto> {
         val resultPage = logisticAddressRepository.findAll(PageRequest.of(paginationRequest.page, paginationRequest.size))
 
         logger.info { "Mock search: Returning ${resultPage.size} addresses from database" }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 import org.eclipse.tractusx.bpdm.common.dto.request.AddressPartnerBpnSearchRequest
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
@@ -47,7 +47,7 @@ class AddressController(
     override fun getAddresses(
         addressSearchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<AddressMatchVerboseDto> {
+    ): PageDto<AddressMatchVerboseDto> {
 
         return searchService.searchAddresses(addressSearchRequest, paginationRequest)
     }
@@ -63,7 +63,7 @@ class AddressController(
     override fun searchAddresses(
         addressSearchRequest: AddressPartnerBpnSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LogisticAddressVerboseDto> {
+    ): PageDto<LogisticAddressVerboseDto> {
         return addressService.findByPartnerAndSiteBpns(addressSearchRequest, paginationRequest)
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
@@ -27,7 +27,7 @@ import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.SearchService
@@ -47,7 +47,7 @@ class AddressController(
     override fun getAddresses(
         addressSearchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<AddressMatchResponse> {
+    ): PageResponse<AddressMatchVerboseDto> {
 
         return searchService.searchAddresses(addressSearchRequest, paginationRequest)
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
 import org.springframework.http.HttpStatus
@@ -37,7 +37,7 @@ class BpnController(
 ) : PoolBpnApi {
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
-    override fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingResponse>> {
+    override fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingDto>> {
         if (request.idValues.size > controllerConfigProperties.searchRequestLimit) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)
         }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolChangelogApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryResponse
@@ -40,7 +40,7 @@ class ChangelogController(
     override fun getChangelogEntries(
         changelogSearchRequest: ChangelogSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<ChangelogEntryResponse> {
+    ): PageDto<ChangelogEntryResponse> {
 
         changelogSearchRequest.bpns?.let { bpns ->
             if (bpns.size > controllerConfigProperties.searchRequestLimit) {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -29,8 +29,8 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchReq
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.SearchService
@@ -62,7 +62,7 @@ class LegalEntityController(
     override fun getLegalEntities(
         bpSearchRequest: LegalEntityPropertiesSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchResponse> {
+    ): PageResponse<LegalEntityMatchVerboseDto> {
         return searchService.searchLegalEntities(
             BusinessPartnerSearchRequest(bpSearchRequest),
             paginationRequest
@@ -110,7 +110,7 @@ class LegalEntityController(
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun searchLegalAddresses(
         bpnLs: Collection<String>
-    ): Collection<LegalAddressResponse> {
+    ): Collection<LegalAddressVerboseDto> {
         return addressService.findLegalAddresses(bpnLs)
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi
@@ -62,7 +62,7 @@ class LegalEntityController(
     override fun getLegalEntities(
         bpSearchRequest: LegalEntityPropertiesSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LegalEntityMatchVerboseDto> {
+    ): PageDto<LegalEntityMatchVerboseDto> {
         return searchService.searchLegalEntities(
             BusinessPartnerSearchRequest(bpSearchRequest),
             paginationRequest
@@ -95,7 +95,7 @@ class LegalEntityController(
     override fun getSites(
         bpnl: String,
         paginationRequest: PaginationRequest
-    ): PageResponse<SiteVerboseDto> {
+    ): PageDto<SiteVerboseDto> {
         return siteService.findByPartnerBpn(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
     }
 
@@ -103,7 +103,7 @@ class LegalEntityController(
     override fun getAddresses(
         bpnl: String,
         paginationRequest: PaginationRequest
-    ): PageResponse<LogisticAddressVerboseDto> {
+    ): PageDto<LogisticAddressVerboseDto> {
         return addressService.findByPartnerBpn(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierLsaType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolMetadataApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.service.MetadataService
@@ -46,7 +46,7 @@ class MetadataController(
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
-    override fun getIdentifierTypes(paginationRequest: PaginationRequest, lsaType: IdentifierLsaType, country: CountryCode?): PageResponse<IdentifierTypeDto> {
+    override fun getIdentifierTypes(paginationRequest: PaginationRequest, lsaType: IdentifierLsaType, country: CountryCode?): PageDto<IdentifierTypeDto> {
         return metadataService.getIdentifierTypes(PageRequest.of(paginationRequest.page, paginationRequest.size), lsaType, country)
     }
 
@@ -56,7 +56,7 @@ class MetadataController(
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
-    override fun getLegalForms(paginationRequest: PaginationRequest): PageResponse<LegalFormDto> {
+    override fun getLegalForms(paginationRequest: PaginationRequest): PageDto<LegalFormDto> {
         return metadataService.getLegalForms(PageRequest.of(paginationRequest.page, paginationRequest.size))
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -25,10 +25,10 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
 import org.eclipse.tractusx.bpdm.pool.service.AddressService
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService
 import org.eclipse.tractusx.bpdm.pool.service.SiteService
@@ -45,14 +45,14 @@ class SiteController(
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun searchMainAddresses(
         bpnS: Collection<String>
-    ): Collection<MainAddressResponse> {
+    ): Collection<MainAddressVerboseDto> {
         return addressService.findMainAddresses(bpnS)
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun getSite(
         bpn: String
-    ): SitePoolResponse {
+    ): SitePoolVerboseDto {
         return siteService.findByBpn(bpn.uppercase())
     }
 
@@ -60,7 +60,7 @@ class SiteController(
     override fun searchSites(
         siteSearchRequest: SiteBpnSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<SitePoolResponse> {
+    ): PageResponse<SitePoolVerboseDto> {
         return siteService.findByPartnerBpns(siteSearchRequest, paginationRequest)
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.request.SiteBpnSearchRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
@@ -60,7 +60,7 @@ class SiteController(
     override fun searchSites(
         siteSearchRequest: SiteBpnSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<SitePoolVerboseDto> {
+    ): PageDto<SitePoolVerboseDto> {
         return siteService.findByPartnerBpns(siteSearchRequest, paginationRequest)
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/ChangelogEntryVerboseDto.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/ChangelogEntryVerboseDto.kt
@@ -17,18 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.response
+package org.eclipse.tractusx.bpdm.pool.dto
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogSubject
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 
-
-@Schema(name = "AddressMatchResponse", description = "Match with score for a business partner record of type address")
-data class AddressMatchResponse(
-
-    @Schema(description = "Relative quality score of the match. The higher the better")
-    val score: Float,
-
-    @Schema(description = "Matched address business partner record")
-    val address: LogisticAddressVerboseDto
+data class ChangelogEntryVerboseDto(
+    val bpn: String,
+    val changelogType: ChangelogType,
+    val changelogSubject: ChangelogSubject
 )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/AddressIdentifierRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/AddressIdentifierRepository.kt
@@ -19,7 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.pool.repository
 
-import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.entity.AddressIdentifier
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierType
 import org.springframework.data.jpa.repository.Query
@@ -31,7 +31,7 @@ interface AddressIdentifierRepository : CrudRepository<AddressIdentifier, Long> 
     @Query("SELECT DISTINCT i FROM AddressIdentifier i LEFT JOIN FETCH i.type WHERE i IN :identifiers")
     fun joinType(identifiers: Set<AddressIdentifier>): Set<AddressIdentifier>
 
-    @Query("SELECT new org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingResponse(i.value,i.address.bpn) FROM AddressIdentifier i WHERE i.type = :identifierType AND i.value in :values")
-    fun findBpnsByIdentifierTypeAndValues(identifierType: IdentifierType, values: Collection<String>): Set<BpnIdentifierMappingResponse>
+    @Query("SELECT new org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto(i.value,i.address.bpn) FROM AddressIdentifier i WHERE i.type = :identifierType AND i.value in :values")
+    fun findBpnsByIdentifierTypeAndValues(identifierType: IdentifierType, values: Collection<String>): Set<BpnIdentifierMappingDto>
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityIdentifierRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityIdentifierRepository.kt
@@ -19,7 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.pool.repository
 
-import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierType
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityIdentifier
 import org.springframework.data.jpa.repository.Query
@@ -31,7 +31,7 @@ interface LegalEntityIdentifierRepository : CrudRepository<LegalEntityIdentifier
     @Query("SELECT DISTINCT i FROM LegalEntityIdentifier i LEFT JOIN FETCH i.type WHERE i IN :identifiers")
     fun joinType(identifiers: Set<LegalEntityIdentifier>): Set<LegalEntityIdentifier>
 
-    @Query("SELECT new org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingResponse(i.value,i.legalEntity.bpn) FROM LegalEntityIdentifier i WHERE i.type = :identifierType AND i.value in :values")
-    fun findBpnsByIdentifierTypeAndValues(identifierType: IdentifierType, values: Collection<String>): Set<BpnIdentifierMappingResponse>
+    @Query("SELECT new org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto(i.value,i.legalEntity.bpn) FROM LegalEntityIdentifier i WHERE i.type = :identifierType AND i.value in :values")
+    fun findBpnsByIdentifierTypeAndValues(identifierType: IdentifierType, values: Collection<String>): Set<BpnIdentifierMappingDto>
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressService.kt
@@ -23,7 +23,7 @@ import jakarta.transaction.Transactional
 import org.eclipse.tractusx.bpdm.common.dto.request.AddressPartnerBpnSearchRequest
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressVerboseDto
@@ -40,7 +40,7 @@ class AddressService(
     private val legalEntityRepository: LegalEntityRepository,
     private val siteRepository: SiteRepository,
 ) {
-    fun findByPartnerBpn(bpn: String, pageIndex: Int, pageSize: Int): PageResponse<LogisticAddressVerboseDto> {
+    fun findByPartnerBpn(bpn: String, pageIndex: Int, pageSize: Int): PageDto<LogisticAddressVerboseDto> {
         if (!legalEntityRepository.existsByBpn(bpn)) {
             throw BpdmNotFoundException("Business Partner", bpn)
         }
@@ -59,7 +59,7 @@ class AddressService(
     fun findByPartnerAndSiteBpns(
         searchRequest: AddressPartnerBpnSearchRequest,
         paginationRequest: PaginationRequest
-    ): PageResponse<LogisticAddressVerboseDto> {
+    ): PageDto<LogisticAddressVerboseDto> {
         val partners = if (searchRequest.legalEntities.isNotEmpty()) legalEntityRepository.findDistinctByBpnIn(searchRequest.legalEntities) else emptyList()
         val sites = if (searchRequest.sites.isNotEmpty()) siteRepository.findDistinctByBpnIn(searchRequest.sites) else emptyList()
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressService.kt
@@ -25,8 +25,8 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddress
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
 import org.eclipse.tractusx.bpdm.pool.repository.LogisticAddressRepository
@@ -73,7 +73,7 @@ class AddressService(
         return addressPage.toDto(addressPage.content.map { it.toDto() })
     }
 
-    fun findLegalAddresses(bpnLs: Collection<String>): Collection<LegalAddressResponse> {
+    fun findLegalAddresses(bpnLs: Collection<String>): Collection<LegalAddressVerboseDto> {
         val legalEntities = legalEntityRepository.findDistinctByBpnIn(bpnLs)
         legalEntityRepository.joinLegalAddresses(legalEntities)
         val addresses = legalEntities.map { it.legalAddress }
@@ -81,7 +81,7 @@ class AddressService(
         return addresses.map { it.toLegalAddressResponse() }
     }
 
-    fun findMainAddresses(bpnS: Collection<String>): Collection<MainAddressResponse> {
+    fun findMainAddresses(bpnS: Collection<String>): Collection<MainAddressVerboseDto> {
         val sites = siteRepository.findDistinctByBpnIn(bpnS)
         siteRepository.joinAddresses(sites)
         val addresses = sites.map { it.mainAddress }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.service
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierLsaType
 import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
-import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierType
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntity
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityIdentifier
@@ -81,7 +81,7 @@ class BusinessPartnerFetchService(
      * Find bpn to identifier value mappings by [idValues] of [identifierTypeKey]
      */
     @Transactional
-    fun findBpnsByIdentifiers(identifierTypeKey: String, lsaType: IdentifierLsaType, idValues: Collection<String>): Set<BpnIdentifierMappingResponse> {
+    fun findBpnsByIdentifiers(identifierTypeKey: String, lsaType: IdentifierLsaType, idValues: Collection<String>): Set<BpnIdentifierMappingDto> {
         val identifierType = findIdentifierTypeOrThrow(identifierTypeKey, lsaType)
         return when (lsaType) {
             IdentifierLsaType.LEGAL_ENTITY -> legalEntityIdentifierRepository.findBpnsByIdentifierTypeAndValues(identifierType, idValues)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
@@ -26,7 +26,7 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierLsaType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.QualityLevel
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.entity.FieldQualityRule
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierType
@@ -70,7 +70,7 @@ class MetadataService(
         return identifierTypeRepository.save(entity).toDto()
     }
 
-    fun getIdentifierTypes(pageRequest: Pageable, lsaType: IdentifierLsaType, country: CountryCode? = null): PageResponse<IdentifierTypeDto> {
+    fun getIdentifierTypes(pageRequest: Pageable, lsaType: IdentifierLsaType, country: CountryCode? = null): PageDto<IdentifierTypeDto> {
         val spec = Specification.allOf(
             IdentifierTypeRepository.Specs.byLsaType(lsaType),
             IdentifierTypeRepository.Specs.byCountry(country)
@@ -95,7 +95,7 @@ class MetadataService(
         return legalFormRepository.save(legalForm).toDto()
     }
 
-    fun getLegalForms(pageRequest: Pageable): PageResponse<LegalFormDto> {
+    fun getLegalForms(pageRequest: Pageable): PageDto<LegalFormDto> {
         val page = legalFormRepository.findAll(pageRequest)
         return page.toDto(page.content.map { it.toDto() })
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/PartnerChangelogService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/PartnerChangelogService.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.pool.service
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogSubject
 import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.PartnerChangelogEntry
@@ -74,7 +74,7 @@ class PartnerChangelogService(
         fromTime: Instant?,
         pageIndex: Int,
         pageSize: Int
-    ): PageResponse<org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryResponse> {
+    ): PageDto<org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryResponse> {
         val spec = Specification.allOf(byBpnsIn(bpns), byLsaTypesIn(lsaTypes), byUpdatedGreaterThan(fromTime))
         val pageRequest = PageRequest.of(pageIndex, pageSize, Sort.by(PartnerChangelogEntry::updatedAt.name).ascending())
         val page = partnerChangelogEntryRepository.findAll(spec, pageRequest)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/PartnerChangelogService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/PartnerChangelogService.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.service
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogSubject
-import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryDto
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.PartnerChangelogEntry
 import org.eclipse.tractusx.bpdm.pool.repository.PartnerChangelogEntryRepository
 import org.eclipse.tractusx.bpdm.pool.repository.PartnerChangelogEntryRepository.Specs.byBpnsIn
@@ -49,7 +49,7 @@ class PartnerChangelogService(
     private val logger = KotlinLogging.logger { }
 
     @Transactional
-    fun createChangelogEntries(changelogEntries: Collection<ChangelogEntryDto>): List<PartnerChangelogEntry> {
+    fun createChangelogEntries(changelogEntries: Collection<ChangelogEntryVerboseDto>): List<PartnerChangelogEntry> {
         logger.debug { "Create ${changelogEntries.size} new change log entries" }
         val entities = changelogEntries.map { it.toEntity() }
         return partnerChangelogEntryRepository.saveAll(entities)
@@ -81,7 +81,7 @@ class PartnerChangelogService(
         return page.toDto(page.content.map { it.toDto() })
     }
 
-    private fun ChangelogEntryDto.toEntity(): PartnerChangelogEntry {
+    private fun ChangelogEntryVerboseDto.toEntity(): PartnerChangelogEntry {
         return PartnerChangelogEntry(this.changelogType, this.bpn, this.changelogSubject)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -28,8 +28,8 @@ import org.eclipse.tractusx.bpdm.pool.entity.*
 import org.springframework.data.domain.Page
 
 
-fun <S, T> Page<S>.toDto(dtoContent: Collection<T>): PageResponse<T> {
-    return PageResponse(this.totalElements, this.totalPages, this.number, this.numberOfElements, dtoContent)
+fun <S, T> Page<S>.toDto(dtoContent: Collection<T>): PageDto<T> {
+    return PageDto(this.totalElements, this.totalPages, this.number, this.numberOfElements, dtoContent)
 }
 
 fun LegalEntity.toMatchDto(score: Float): LegalEntityMatchVerboseDto {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -32,8 +32,8 @@ fun <S, T> Page<S>.toDto(dtoContent: Collection<T>): PageResponse<T> {
     return PageResponse(this.totalElements, this.totalPages, this.number, this.numberOfElements, dtoContent)
 }
 
-fun LegalEntity.toMatchDto(score: Float): LegalEntityMatchResponse {
-    return LegalEntityMatchResponse(
+fun LegalEntity.toMatchDto(score: Float): LegalEntityMatchVerboseDto {
+    return LegalEntityMatchVerboseDto(
         score = score,
         legalEntity = this.toDto(),
         legalName = this.legalName.value,
@@ -41,8 +41,8 @@ fun LegalEntity.toMatchDto(score: Float): LegalEntityMatchResponse {
     )
 }
 
-fun LegalEntity.toUpsertDto(entryId: String?): LegalEntityPartnerCreateResponse {
-    return LegalEntityPartnerCreateResponse(
+fun LegalEntity.toUpsertDto(entryId: String?): LegalEntityPartnerCreateVerboseDto {
+    return LegalEntityPartnerCreateVerboseDto(
         legalEntity = toDto(),
         legalAddress = legalAddress.toDto(),
         index = entryId,
@@ -134,8 +134,8 @@ fun LogisticAddress.toDto(): LogisticAddressVerboseDto {
     )
 }
 
-fun LogisticAddress.toLegalAddressResponse(): LegalAddressResponse {
-    return LegalAddressResponse(
+fun LogisticAddress.toLegalAddressResponse(): LegalAddressVerboseDto {
+    return LegalAddressVerboseDto(
         physicalPostalAddress = physicalPostalAddress.toDto(),
         alternativePostalAddress = alternativePostalAddress?.toDto(),
         bpnLegalEntity = legalEntity?.bpn!!,
@@ -144,8 +144,8 @@ fun LogisticAddress.toLegalAddressResponse(): LegalAddressResponse {
     )
 }
 
-fun LogisticAddress.toMainAddressResponse(): MainAddressResponse {
-    return MainAddressResponse(
+fun LogisticAddress.toMainAddressResponse(): MainAddressVerboseDto {
+    return MainAddressVerboseDto(
         physicalPostalAddress = physicalPostalAddress.toDto(),
         alternativePostalAddress = alternativePostalAddress?.toDto(),
         bpnSite = site?.bpn!!,
@@ -205,19 +205,19 @@ private fun Street.toDto(): StreetDto {
     )
 }
 
-fun LogisticAddress.toMatchDto(score: Float): AddressMatchResponse {
-    return AddressMatchResponse(score, this.toDto())
+fun LogisticAddress.toMatchDto(score: Float): AddressMatchVerboseDto {
+    return AddressMatchVerboseDto(score, this.toDto())
 }
 
-fun LogisticAddress.toCreateResponse(index: String?): AddressPartnerCreateResponse {
-    return AddressPartnerCreateResponse(
+fun LogisticAddress.toCreateResponse(index: String?): AddressPartnerCreateVerboseDto {
+    return AddressPartnerCreateVerboseDto(
         address = toDto(),
         index = index
     )
 }
 
-fun Site.toUpsertDto(entryId: String?): SitePartnerCreateResponse {
-    return SitePartnerCreateResponse(
+fun Site.toUpsertDto(entryId: String?): SitePartnerCreateVerboseDto {
+    return SitePartnerCreateVerboseDto(
         site = toDto(),
         mainAddress = mainAddress.toDto(),
         index = entryId
@@ -235,8 +235,8 @@ fun Site.toDto(): SiteVerboseDto {
     )
 }
 
-fun Site.toPoolDto(): SitePoolResponse {
-    return SitePoolResponse(
+fun Site.toPoolDto(): SitePoolVerboseDto {
+    return SitePoolVerboseDto(
 
         site = SiteVerboseDto(
             bpn,
@@ -269,8 +269,8 @@ fun Relation.toDto(): RelationVerboseDto {
     )
 }
 
-fun SyncRecord.toDto(): SyncResponse {
-    return SyncResponse(type, status, count, progress, errorDetails, startedAt, finishedAt)
+fun SyncRecord.toDto(): SyncDto {
+    return SyncDto(type, status, count, progress, errorDetails, startedAt, finishedAt)
 }
 
 fun PartnerChangelogEntry.toDto(): ChangelogEntryResponse {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.service
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.request.SiteBpnSearchRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
@@ -37,7 +37,7 @@ class SiteService(
     private val legalEntityRepository: LegalEntityRepository,
     private val addressService: AddressService
 ) {
-    fun findByPartnerBpn(bpn: String, pageIndex: Int, pageSize: Int): PageResponse<SiteVerboseDto> {
+    fun findByPartnerBpn(bpn: String, pageIndex: Int, pageSize: Int): PageDto<SiteVerboseDto> {
         if (!legalEntityRepository.existsByBpn(bpn)) {
             throw BpdmNotFoundException("Business Partner", bpn)
         }
@@ -47,7 +47,7 @@ class SiteService(
         return page.toDto(page.content.map { it.toDto() })
     }
 
-    fun findByPartnerBpns(siteSearchRequest: SiteBpnSearchRequest, paginationRequest: PaginationRequest): PageResponse<SitePoolVerboseDto> {
+    fun findByPartnerBpns(siteSearchRequest: SiteBpnSearchRequest, paginationRequest: PaginationRequest): PageDto<SitePoolVerboseDto> {
         val partners =
             if (siteSearchRequest.legalEntities.isNotEmpty()) legalEntityRepository.findDistinctByBpnIn(siteSearchRequest.legalEntities) else emptyList()
         val sitePage =

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
@@ -24,7 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.Site
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
 import org.eclipse.tractusx.bpdm.pool.repository.SiteRepository
@@ -47,7 +47,7 @@ class SiteService(
         return page.toDto(page.content.map { it.toDto() })
     }
 
-    fun findByPartnerBpns(siteSearchRequest: SiteBpnSearchRequest, paginationRequest: PaginationRequest): PageResponse<SitePoolResponse> {
+    fun findByPartnerBpns(siteSearchRequest: SiteBpnSearchRequest, paginationRequest: PaginationRequest): PageResponse<SitePoolVerboseDto> {
         val partners =
             if (siteSearchRequest.legalEntities.isNotEmpty()) legalEntityRepository.findDistinctByBpnIn(siteSearchRequest.legalEntities) else emptyList()
         val sitePage =
@@ -56,7 +56,7 @@ class SiteService(
         return sitePage.toDto(sitePage.content.map { it.toPoolDto() })
     }
 
-    fun findByBpn(bpn: String): SitePoolResponse {
+    fun findByBpn(bpn: String): SitePoolVerboseDto {
         val site = siteRepository.findByBpn(bpn) ?: throw BpdmNotFoundException("Site", bpn)
         return site.toPoolDto()
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
@@ -91,7 +91,7 @@ class OpenSearchControllerIT @Autowired constructor(
         testHelpers.truncateDbTables()
         openSearchSyncService.clearOpenSearch()
 
-        val importCollection = PageResponse(
+        val importCollection = PageDto(
             partnerDocs.size.toLong(),
             1,
             0,
@@ -204,7 +204,7 @@ class OpenSearchControllerIT @Autowired constructor(
 
     }
 
-    private fun searchBusinessPartnerByName(name: String): PageResponse<LegalEntityMatchVerboseDto> {
+    private fun searchBusinessPartnerByName(name: String): PageDto<LegalEntityMatchVerboseDto> {
 
         return poolClient.legalEntities().getLegalEntities(
             LegalEntityPropertiesSearchRequest(name),

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
@@ -30,7 +30,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.impl.service.OpenSearchSyncStarterService
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
@@ -204,7 +204,7 @@ class OpenSearchControllerIT @Autowired constructor(
 
     }
 
-    private fun searchBusinessPartnerByName(name: String): PageResponse<LegalEntityMatchResponse> {
+    private fun searchBusinessPartnerByName(name: String): PageResponse<LegalEntityMatchVerboseDto> {
 
         return poolClient.legalEntities().getLegalEntities(
             LegalEntityPropertiesSearchRequest(name),

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
@@ -28,7 +28,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressCreateError
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressUpdateError
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
@@ -424,14 +424,14 @@ class AddressControllerIT @Autowired constructor(
         testHelpers.assertErrorResponse(response.errors.last(), AddressUpdateError.AddressNotFound, secondInvalidBpn)
     }
 
-    private fun assertCreatedAddressesAreEqual(actuals: Collection<AddressPartnerCreateResponse>, expected: Collection<AddressPartnerCreateResponse>) {
+    private fun assertCreatedAddressesAreEqual(actuals: Collection<AddressPartnerCreateVerboseDto>, expected: Collection<AddressPartnerCreateVerboseDto>) {
         actuals.forEach { assertThat(it.address.bpna).matches(testHelpers.bpnAPattern) }
 
         testHelpers.assertRecursively(actuals)
             .ignoringFields(
-                AddressPartnerCreateResponse::address.name + "." + LogisticAddressVerboseDto::bpna.name,
-                AddressPartnerCreateResponse::address.name + "." + LogisticAddressVerboseDto::bpnLegalEntity.name,
-                AddressPartnerCreateResponse::address.name + "." + LogisticAddressVerboseDto::bpnSite.name
+                AddressPartnerCreateVerboseDto::address.name + "." + LogisticAddressVerboseDto::bpna.name,
+                AddressPartnerCreateVerboseDto::address.name + "." + LogisticAddressVerboseDto::bpnLegalEntity.name,
+                AddressPartnerCreateVerboseDto::address.name + "." + LogisticAddressVerboseDto::bpnSite.name
             )
             .isEqualTo(expected)
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
@@ -101,7 +101,7 @@ class AddressControllerSearchIT @Autowired constructor(
      */
     @Test
     fun `search address via name`() {
-        val expected = PageResponse(
+        val expected = PageDto(
             1, 1, 0, 1, listOf(
                 AddressMatchVerboseDto(0f, givenAddress1)
             )
@@ -123,7 +123,7 @@ class AddressControllerSearchIT @Autowired constructor(
      */
     @Test
     fun `search address via name not found`() {
-        val expected = PageResponse(
+        val expected = PageDto(
             0, 0, 0, 0, emptyList<AddressMatchVerboseDto>()
         )
 
@@ -137,7 +137,7 @@ class AddressControllerSearchIT @Autowired constructor(
     }
 
 
-    private fun assertPageEquals(actual: PageResponse<AddressMatchVerboseDto>, expected: PageResponse<AddressMatchVerboseDto>) {
+    private fun assertPageEquals(actual: PageDto<AddressMatchVerboseDto>, expected: PageDto<AddressMatchVerboseDto>) {
         testHelpers.assertRecursively(actual)
             .ignoringFieldsMatchingRegexes(".*${AddressMatchVerboseDto::score.name}")
             .isEqualTo(expected)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -103,7 +103,7 @@ class AddressControllerSearchIT @Autowired constructor(
     fun `search address via name`() {
         val expected = PageResponse(
             1, 1, 0, 1, listOf(
-                AddressMatchResponse(0f, givenAddress1)
+                AddressMatchVerboseDto(0f, givenAddress1)
             )
         )
 
@@ -124,7 +124,7 @@ class AddressControllerSearchIT @Autowired constructor(
     @Test
     fun `search address via name not found`() {
         val expected = PageResponse(
-            0, 0, 0, 0, emptyList<AddressMatchResponse>()
+            0, 0, 0, 0, emptyList<AddressMatchVerboseDto>()
         )
 
 
@@ -137,9 +137,9 @@ class AddressControllerSearchIT @Autowired constructor(
     }
 
 
-    private fun assertPageEquals(actual: PageResponse<AddressMatchResponse>, expected: PageResponse<AddressMatchResponse>) {
+    private fun assertPageEquals(actual: PageResponse<AddressMatchVerboseDto>, expected: PageResponse<AddressMatchVerboseDto>) {
         testHelpers.assertRecursively(actual)
-            .ignoringFieldsMatchingRegexes(".*${AddressMatchResponse::score.name}")
+            .ignoringFieldsMatchingRegexes(".*${AddressMatchVerboseDto::score.name}")
             .isEqualTo(expected)
     }
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.assertj.core.api.Assertions
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogSubject
@@ -99,7 +99,7 @@ class ChangelogControllerIT @Autowired constructor(
             ChangelogEntryResponse(bpnA2, ChangelogType.UPDATE, timeAfterUpdate, ChangelogSubject.ADDRESS)
         )
 
-        val expectedChangelog = PageResponse(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
+        val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
         val actualChangelog = poolClient.changelogs().getChangelogEntries(
             ChangelogSearchRequest(),
@@ -160,7 +160,7 @@ class ChangelogControllerIT @Autowired constructor(
             ChangelogEntryResponse(bpnMainAddress2, ChangelogType.UPDATE, timeAfterUpdate, ChangelogSubject.ADDRESS)
         )
 
-        val expectedChangelog = PageResponse(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
+        val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
         val actualChangelog = poolClient.changelogs().getChangelogEntries(
             ChangelogSearchRequest(),
@@ -218,7 +218,7 @@ class ChangelogControllerIT @Autowired constructor(
         )
 
 
-        val expectedChangelog = PageResponse(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
+        val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
 
         val actualChangelog = poolClient.changelogs().getChangelogEntries(
@@ -262,8 +262,8 @@ class ChangelogControllerIT @Autowired constructor(
             ChangelogEntryResponse(bpnL3, ChangelogType.CREATE, timeAfterUpdate, ChangelogSubject.LEGAL_ENTITY)
         )
 
-        val expectedFirstPage = PageResponse(3, 2, 0, expectedEntriesFirstPage.size, expectedEntriesFirstPage)
-        val expectedSecondPage = PageResponse(3, 2, 1, expectedEntriesSecondPage.size, expectedEntriesSecondPage)
+        val expectedFirstPage = PageDto(3, 2, 0, expectedEntriesFirstPage.size, expectedEntriesFirstPage)
+        val expectedSecondPage = PageDto(3, 2, 1, expectedEntriesSecondPage.size, expectedEntriesSecondPage)
 
 
         val actualFirstPage = poolClient.changelogs().getChangelogEntries(
@@ -320,9 +320,9 @@ class ChangelogControllerIT @Autowired constructor(
         )
 
         val expectedLegalEntitiesPage =
-            PageResponse(expectedLegalEntityEntries.size.toLong(), 1, 0, expectedLegalEntityEntries.size, expectedLegalEntityEntries)
-        val expectedSitesPage = PageResponse(expectedSiteEntries.size.toLong(), 1, 0, expectedSiteEntries.size, expectedSiteEntries)
-        val expectedAddressesPage = PageResponse(expectedAddressEntries.size.toLong(), 1, 0, expectedAddressEntries.size, expectedAddressEntries)
+            PageDto(expectedLegalEntityEntries.size.toLong(), 1, 0, expectedLegalEntityEntries.size, expectedLegalEntityEntries)
+        val expectedSitesPage = PageDto(expectedSiteEntries.size.toLong(), 1, 0, expectedSiteEntries.size, expectedSiteEntries)
+        val expectedAddressesPage = PageDto(expectedAddressEntries.size.toLong(), 1, 0, expectedAddressEntries.size, expectedAddressEntries)
 
 
         val actualLegalEntityPage = poolClient.changelogs().getChangelogEntries(
@@ -372,7 +372,7 @@ class ChangelogControllerIT @Autowired constructor(
             ChangelogEntryResponse(bpnL2, ChangelogType.CREATE, timeAfterUpdate, ChangelogSubject.LEGAL_ENTITY)
         )
 
-        val expectedChangelog = PageResponse(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
+        val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
         val actualChangelog = poolClient.changelogs().getChangelogEntries(
             ChangelogSearchRequest(bpns = setOf(bpnL1, bpnL2)),
@@ -417,7 +417,7 @@ class ChangelogControllerIT @Autowired constructor(
             ChangelogEntryResponse(bpnL2, ChangelogType.CREATE, timeAfterSecondInsert, ChangelogSubject.LEGAL_ENTITY)
         )
 
-        val expectedChangelog = PageResponse(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
+        val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
         val actualChangelog = poolClient.changelogs().getChangelogEntries(
             ChangelogSearchRequest(fromTime = timeAfterFirstInsert, lsaTypes = setOf(ChangelogSubject.LEGAL_ENTITY)),
@@ -444,15 +444,15 @@ class ChangelogControllerIT @Autowired constructor(
             }
         }
 
-    private fun checkEqual(expected: PageResponse<ChangelogEntryResponse>) =
-        { actualResponse: PageResponse<ChangelogEntryResponse> ->
+    private fun checkEqual(expected: PageDto<ChangelogEntryResponse>) =
+        { actualResponse: PageDto<ChangelogEntryResponse> ->
             testHelpers.assertRecursively(actualResponse).isEqualTo(expected)
             Unit
         }
 
     private fun validateChangelogResponse(
-        actual: PageResponse<ChangelogEntryResponse>,
-        expected: PageResponse<ChangelogEntryResponse>,
+        actual: PageDto<ChangelogEntryResponse>,
+        expected: PageDto<ChangelogEntryResponse>,
         timeBeforeInsert: Instant,
         timeAfterInsert: Instant
     ) {

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -27,9 +27,9 @@ import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityCreateError
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityUpdateError
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
@@ -475,7 +475,7 @@ class LegalEntityControllerIT @Autowired constructor(
 
     }
 
-    fun assertThatCreatedLegalEntitiesEqual(actuals: Collection<LegalEntityPartnerCreateResponse>, expected: Collection<LegalEntityPartnerCreateResponse>) {
+    fun assertThatCreatedLegalEntitiesEqual(actuals: Collection<LegalEntityPartnerCreateVerboseDto>, expected: Collection<LegalEntityPartnerCreateVerboseDto>) {
         val now = Instant.now()
         val justBeforeCreate = now.minusSeconds(2)
         actuals.forEach { assertThat(it.legalEntity.currentness).isBetween(justBeforeCreate, now) }
@@ -488,8 +488,8 @@ class LegalEntityControllerIT @Autowired constructor(
     }
 
     fun assertThatModifiedLegalEntitiesEqual(
-        actuals: Collection<LegalEntityPartnerCreateResponse>,
-        expected: Collection<LegalEntityPartnerCreateResponse>
+        actuals: Collection<LegalEntityPartnerCreateVerboseDto>,
+        expected: Collection<LegalEntityPartnerCreateVerboseDto>
     ) {
         val now = Instant.now()
         val justBeforeCreate = now.minusSeconds(2)
@@ -497,7 +497,7 @@ class LegalEntityControllerIT @Autowired constructor(
 
         testHelpers.assertRecursively(actuals)
             .ignoringFieldsOfTypes(Instant::class.java)
-            .ignoringFields(LegalEntityPartnerCreateResponse::index.name)
+            .ignoringFields(LegalEntityPartnerCreateVerboseDto::index.name)
             .isEqualTo(expected)
     }
 
@@ -518,7 +518,7 @@ class LegalEntityControllerIT @Autowired constructor(
             throw IllegalArgumentException("Can't change case of string $value")
     }
 
-    private fun toLegalAddressResponse(it: LogisticAddressVerboseDto) = LegalAddressResponse(
+    private fun toLegalAddressResponse(it: LogisticAddressVerboseDto) = LegalAddressVerboseDto(
         physicalPostalAddress = it.physicalPostalAddress,
         alternativePostalAddress = it.alternativePostalAddress,
         bpnLegalEntity = it.bpnLegalEntity!!,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
@@ -27,7 +27,7 @@ import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -99,8 +99,8 @@ class LegalEntityControllerSearchIT @Autowired constructor(
         val expected = PageResponse(
             2, 1, 0, 2,
             listOf(
-                LegalEntityMatchResponse(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1),
-                LegalEntityMatchResponse(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1),
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
             )
         )
 
@@ -119,12 +119,12 @@ class LegalEntityControllerSearchIT @Autowired constructor(
 
         val expectedFirstPage = PageResponse(
             2, 2, 0, 1, listOf(
-                LegalEntityMatchResponse(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1)
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1)
             )
         )
         val expectedSecondPage = PageResponse(
             2, 2, 1, 1, listOf(
-                LegalEntityMatchResponse(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
             )
         )
 
@@ -165,7 +165,7 @@ class LegalEntityControllerSearchIT @Autowired constructor(
 //        assertThat(foundPartners).isEmpty()
 //    }
 
-    private fun searchBusinessPartnerBySiteName(siteName: String, page: Int, size: Int): PageResponse<LegalEntityMatchResponse> {
+    private fun searchBusinessPartnerBySiteName(siteName: String, page: Int, size: Int): PageResponse<LegalEntityMatchVerboseDto> {
         val sitePropertiesSearchRequest = SitePropertiesSearchRequest(siteName)
 
         return poolClient.legalEntities().getLegalEntities(
@@ -176,9 +176,9 @@ class LegalEntityControllerSearchIT @Autowired constructor(
 
     }
 
-    private fun assertPageEquals(actual: PageResponse<LegalEntityMatchResponse>, expected: PageResponse<LegalEntityMatchResponse>) {
+    private fun assertPageEquals(actual: PageResponse<LegalEntityMatchVerboseDto>, expected: PageResponse<LegalEntityMatchVerboseDto>) {
         testHelpers.assertRecursively(actual)
-            .ignoringFieldsMatchingRegexes(".*${LegalEntityMatchResponse::score.name}")
+            .ignoringFieldsMatchingRegexes(".*${LegalEntityMatchVerboseDto::score.name}")
             .isEqualTo(expected)
     }
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
@@ -96,7 +96,7 @@ class LegalEntityControllerSearchIT @Autowired constructor(
     @Test
     fun `search business partner with pagination, multiple items in page`() {
 
-        val expected = PageResponse(
+        val expected = PageDto(
             2, 1, 0, 2,
             listOf(
                 LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1),
@@ -117,12 +117,12 @@ class LegalEntityControllerSearchIT @Autowired constructor(
     @Test
     fun `search business partner with pagination, multiple pages`() {
 
-        val expectedFirstPage = PageResponse(
+        val expectedFirstPage = PageDto(
             2, 2, 0, 1, listOf(
                 LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1)
             )
         )
-        val expectedSecondPage = PageResponse(
+        val expectedSecondPage = PageDto(
             2, 2, 1, 1, listOf(
                 LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
             )
@@ -165,7 +165,7 @@ class LegalEntityControllerSearchIT @Autowired constructor(
 //        assertThat(foundPartners).isEmpty()
 //    }
 
-    private fun searchBusinessPartnerBySiteName(siteName: String, page: Int, size: Int): PageResponse<LegalEntityMatchVerboseDto> {
+    private fun searchBusinessPartnerBySiteName(siteName: String, page: Int, size: Int): PageDto<LegalEntityMatchVerboseDto> {
         val sitePropertiesSearchRequest = SitePropertiesSearchRequest(siteName)
 
         return poolClient.legalEntities().getLegalEntities(
@@ -176,7 +176,7 @@ class LegalEntityControllerSearchIT @Autowired constructor(
 
     }
 
-    private fun assertPageEquals(actual: PageResponse<LegalEntityMatchVerboseDto>, expected: PageResponse<LegalEntityMatchVerboseDto>) {
+    private fun assertPageEquals(actual: PageDto<LegalEntityMatchVerboseDto>, expected: PageDto<LegalEntityMatchVerboseDto>) {
         testHelpers.assertRecursively(actual)
             .ignoringFieldsMatchingRegexes(".*${LegalEntityMatchVerboseDto::score.name}")
             .isEqualTo(expected)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
@@ -27,7 +27,7 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.QualityLevel
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PageResponse
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
@@ -55,7 +55,7 @@ import kotlin.math.ceil
 
 private typealias PostFunction = (client: WebTestClient, metaData: Any) -> Any
 private typealias PostFunctionWithoutExpectation = (client: WebTestClient, metaData: Any) -> WebTestClient.ResponseSpec
-private typealias GetFunction = (client: WebTestClient, page: Int, size: Int) -> PageResponse<Any>
+private typealias GetFunction = (client: WebTestClient, page: Int, size: Int) -> PageDto<Any>
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class]
@@ -87,7 +87,7 @@ class MetadataControllerIT @Autowired constructor(
         private fun postIdentifierType(client: WebTestClient, type: IdentifierTypeDto) =
             postMetadataSameResponseType(client, type, EndpointValues.CATENA_METADATA_IDENTIFIER_TYPE_PATH)
 
-        private fun getIdentifierTypes(client: WebTestClient, page: Int, size: Int): PageResponse<IdentifierTypeDto> =
+        private fun getIdentifierTypes(client: WebTestClient, page: Int, size: Int): PageDto<IdentifierTypeDto> =
 //            getMetadata<PageResponse<IdentifierTypeDto>>(client, page, size, EndpointValues.CATENA_METADATA_IDENTIFIER_TYPE_PATH)
             client.invokeGetEndpoint(
                 EndpointValues.CATENA_METADATA_IDENTIFIER_TYPE_PATH,
@@ -102,7 +102,7 @@ class MetadataControllerIT @Autowired constructor(
         private fun postLegalForm(client: WebTestClient, type: LegalFormRequest) =
             postMetadata<LegalFormRequest, LegalFormDto>(client, type, EndpointValues.CATENA_METADATA_LEGAL_FORM_PATH)
 
-        private fun getLegalForms(client: WebTestClient, page: Int, size: Int): PageResponse<LegalFormDto> =
+        private fun getLegalForms(client: WebTestClient, page: Int, size: Int): PageDto<LegalFormDto> =
 //            getMetadata<PageResponse<LegalFormResponse>>(client, page, size, EndpointValues.CATENA_METADATA_LEGAL_FORM_PATH)
             client.invokeGetEndpoint(
                 EndpointValues.CATENA_METADATA_LEGAL_FORM_PATH,
@@ -226,7 +226,7 @@ class MetadataControllerIT @Autowired constructor(
         metadata.forEach { postMetadata(webTestClient, it) }
 
         val returnedPage = getMetadataPage(webTestClient, 0, metadata.size)
-        val expectedPage = PageResponse(expected.size.toLong(), 1, 0, expected.size, expected)
+        val expectedPage = PageDto(expected.size.toLong(), 1, 0, expected.size, expected)
 
         assertThat(returnedPage).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedPage)
     }
@@ -282,7 +282,7 @@ class MetadataControllerIT @Autowired constructor(
         metadata.forEach { postMetadata(webTestClient, it) }
 
         val returnedPage = getMetadataPage(webTestClient, 0, metadata.size + 1)
-        val expectedPage = PageResponse(expected.size.toLong(), 1, 0, expected.size, expected)
+        val expectedPage = PageDto(expected.size.toLong(), 1, 0, expected.size, expected)
 
         assertThat(returnedPage).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedPage)
     }
@@ -298,7 +298,7 @@ class MetadataControllerIT @Autowired constructor(
         metadata.forEach { postMetadata(webTestClient, it) }
 
         val returnedPage = getMetadataPage(webTestClient, metadata.size, 1)
-        val expectedPage = PageResponse(expected.size.toLong(), expected.size, expected.size, 0, emptyList<Any>())
+        val expectedPage = PageDto(expected.size.toLong(), expected.size, expected.size, 0, emptyList<Any>())
 
         assertThat(returnedPage).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expectedPage)
     }
@@ -340,7 +340,7 @@ class MetadataControllerIT @Autowired constructor(
             identifierType3.toDto()
         )
 
-        val result = webTestClient.invokeGetEndpoint<PageResponse<IdentifierTypeDto>>(
+        val result = webTestClient.invokeGetEndpoint<PageDto<IdentifierTypeDto>>(
             EndpointValues.CATENA_METADATA_IDENTIFIER_TYPE_PATH,
             Pair("lsaType", IdentifierLsaType.LEGAL_ENTITY.name),
             Pair("country", CountryCode.PL.alpha2)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -26,8 +26,8 @@ import org.eclipse.tractusx.bpdm.common.dto.response.*
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteCreateError
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteUpdateError
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
@@ -107,11 +107,11 @@ class SiteControllerIT @Autowired constructor(
         val siteSearchRequest = SiteBpnSearchRequest(emptyList(), listOf(bpnS1, bpnS2))
         val searchResult = poolClient.sites().searchSites(siteSearchRequest, PaginationRequest())
 
-        val expectedSiteWithReference1 = SitePoolResponse(
+        val expectedSiteWithReference1 = SitePoolVerboseDto(
             site = ResponseValues.site1.copy(bpnLegalEntity = bpnL),
             mainAddress = ResponseValues.addressPartner1.copy(isMainAddress = true, bpnSite = CommonValues.bpnS1)
         )
-        val expectedSiteWithReference2 = SitePoolResponse(
+        val expectedSiteWithReference2 = SitePoolVerboseDto(
             site = ResponseValues.site2.copy(bpnLegalEntity = bpnL),
             mainAddress = ResponseValues.addressPartner2.copy(isMainAddress = true, bpnSite = CommonValues.bpnS2)
         )
@@ -119,7 +119,7 @@ class SiteControllerIT @Autowired constructor(
         testHelpers.assertRecursively(searchResult.content)
             .ignoringFieldsOfTypes(Instant::class.java)
             .ignoringFields(
-                SitePoolResponse::mainAddress.name + "." + LogisticAddressVerboseDto::bpna.name,
+                SitePoolVerboseDto::mainAddress.name + "." + LogisticAddressVerboseDto::bpna.name,
             )
             .isEqualTo(listOf(expectedSiteWithReference1, expectedSiteWithReference2))
     }
@@ -154,17 +154,17 @@ class SiteControllerIT @Autowired constructor(
         val searchResult = poolClient.sites().searchSites(siteSearchRequest, PaginationRequest())
 
         val expectedSiteWithReference1 =
-            SitePoolResponse(
+            SitePoolVerboseDto(
                 site = ResponseValues.site1.copy(bpnLegalEntity = bpnL1),
                 mainAddress = ResponseValues.addressPartner1.copy(isMainAddress = true, bpnSite = CommonValues.bpnS1)
             )
         val expectedSiteWithReference2 =
-            SitePoolResponse(
+            SitePoolVerboseDto(
                 site = ResponseValues.site2.copy(bpnLegalEntity = bpnL1),
                 mainAddress = ResponseValues.addressPartner2.copy(isMainAddress = true, bpnSite = CommonValues.bpnS2)
             )
         val expectedSiteWithReference3 =
-            SitePoolResponse(
+            SitePoolVerboseDto(
                 site = ResponseValues.site3.copy(bpnLegalEntity = bpnL2),
                 mainAddress = ResponseValues.addressPartner3.copy(isMainAddress = true, bpnSite = CommonValues.bpnS3)
             )
@@ -172,7 +172,7 @@ class SiteControllerIT @Autowired constructor(
         testHelpers.assertRecursively(searchResult.content)
             .ignoringFieldsOfTypes(Instant::class.java)
             .ignoringFields(
-                SitePoolResponse::mainAddress.name + "." + LogisticAddressVerboseDto::bpna.name,
+                SitePoolVerboseDto::mainAddress.name + "." + LogisticAddressVerboseDto::bpna.name,
             )
             .isEqualTo(listOf(expectedSiteWithReference1, expectedSiteWithReference2, expectedSiteWithReference3))
     }
@@ -374,15 +374,15 @@ class SiteControllerIT @Autowired constructor(
         testHelpers.assertRecursively(response).isEqualTo(expected)
     }
 
-    private fun assertThatCreatedSitesEqual(actuals: Collection<SitePartnerCreateResponse>, expected: Collection<SitePartnerCreateResponse>) {
+    private fun assertThatCreatedSitesEqual(actuals: Collection<SitePartnerCreateVerboseDto>, expected: Collection<SitePartnerCreateVerboseDto>) {
         actuals.forEach { assertThat(it.site.bpns).matches(testHelpers.bpnSPattern) }
 
         testHelpers.assertRecursively(actuals)
             .ignoringFields(
-                SitePartnerCreateResponse::site.name + "." + SiteVerboseDto::bpns.name,
-                SitePartnerCreateResponse::site.name + "." + SiteVerboseDto::bpnLegalEntity.name,
-                SitePartnerCreateResponse::mainAddress.name + "." + LogisticAddressVerboseDto::bpna.name,
-                SitePartnerCreateResponse::mainAddress.name + "." + LogisticAddressVerboseDto::bpnSite.name
+                SitePartnerCreateVerboseDto::site.name + "." + SiteVerboseDto::bpns.name,
+                SitePartnerCreateVerboseDto::site.name + "." + SiteVerboseDto::bpnLegalEntity.name,
+                SitePartnerCreateVerboseDto::mainAddress.name + "." + LogisticAddressVerboseDto::bpna.name,
+                SitePartnerCreateVerboseDto::mainAddress.name + "." + LogisticAddressVerboseDto::bpnSite.name
             )
             .isEqualTo(expected)
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerTestDto.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerTestDto.kt
@@ -22,9 +22,9 @@ package org.eclipse.tractusx.bpdm.pool.util
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateVerboseDto
 
 data class LegalEntityStructureRequest(
     val legalEntity: LegalEntityPartnerCreateRequest,
@@ -38,12 +38,12 @@ data class SiteStructureRequest(
 )
 
 data class LegalEntityStructureResponse(
-    val legalEntity: LegalEntityPartnerCreateResponse,
+    val legalEntity: LegalEntityPartnerCreateVerboseDto,
     val siteStructures: List<SiteStructureResponse> = emptyList(),
-    val addresses: List<AddressPartnerCreateResponse> = emptyList()
+    val addresses: List<AddressPartnerCreateVerboseDto> = emptyList()
 )
 
 data class SiteStructureResponse(
-    val site: SitePartnerCreateResponse,
-    val addresses: List<AddressPartnerCreateResponse> = emptyList()
+    val site: SitePartnerCreateVerboseDto,
+    val addresses: List<AddressPartnerCreateVerboseDto> = emptyList()
 )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/ResponseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/ResponseValues.kt
@@ -24,9 +24,9 @@ import org.eclipse.tractusx.bpdm.common.dto.StreetDto
 import org.eclipse.tractusx.bpdm.common.dto.response.*
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.toDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponse
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateVerboseDto
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -180,17 +180,17 @@ object ResponseValues {
         updatedAt = Instant.now()
     )
 
-    val addressPartnerCreate1 = AddressPartnerCreateResponse(
+    val addressPartnerCreate1 = AddressPartnerCreateVerboseDto(
         address = addressPartner1,
         index = CommonValues.index1
     )
 
-    val addressPartnerCreate2 = AddressPartnerCreateResponse(
+    val addressPartnerCreate2 = AddressPartnerCreateVerboseDto(
         address = addressPartner2,
         index = CommonValues.index2
     )
 
-    val addressPartnerCreate3 = AddressPartnerCreateResponse(
+    val addressPartnerCreate3 = AddressPartnerCreateVerboseDto(
         address = addressPartner3,
         index = CommonValues.index3
     )
@@ -222,7 +222,7 @@ object ResponseValues {
         updatedAt = CommonValues.now,
     )
 
-    val siteUpsert1 = SitePartnerCreateResponse(
+    val siteUpsert1 = SitePartnerCreateVerboseDto(
         site = site1,
         mainAddress = addressPartner1.copy(
             bpnSite = site1.bpns,
@@ -231,7 +231,7 @@ object ResponseValues {
         index = CommonValues.index1
     )
 
-    val siteUpsert2 = SitePartnerCreateResponse(
+    val siteUpsert2 = SitePartnerCreateVerboseDto(
         site = site2,
         mainAddress = addressPartner2.copy(
             bpnSite = site2.bpns,
@@ -240,7 +240,7 @@ object ResponseValues {
         index = CommonValues.index2
     )
 
-    val siteUpsert3 = SitePartnerCreateResponse(
+    val siteUpsert3 = SitePartnerCreateVerboseDto(
         site = site3,
         mainAddress = addressPartner3.copy(
             bpnSite = site3.bpns,
@@ -376,7 +376,7 @@ object ResponseValues {
         )
     )
 
-    val legalEntityUpsert1 = LegalEntityPartnerCreateResponse(
+    val legalEntityUpsert1 = LegalEntityPartnerCreateVerboseDto(
         legalName = CommonValues.name1,
         legalEntity = LegalEntityVerboseDto(
             bpnl = CommonValues.bpnL1,
@@ -396,7 +396,7 @@ object ResponseValues {
         index = CommonValues.index1
     )
 
-    val legalEntityUpsert2 = LegalEntityPartnerCreateResponse(
+    val legalEntityUpsert2 = LegalEntityPartnerCreateVerboseDto(
         legalName = CommonValues.name3,
         legalEntity = LegalEntityVerboseDto(
             bpnl = CommonValues.bpnL2,
@@ -415,7 +415,7 @@ object ResponseValues {
         index = CommonValues.index2
     )
 
-    val legalEntityUpsert3 = LegalEntityPartnerCreateResponse(
+    val legalEntityUpsert3 = LegalEntityPartnerCreateVerboseDto(
         legalName = CommonValues.name5,
         legalEntity = LegalEntityVerboseDto(
             bpnl = CommonValues.bpnL3,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
@@ -28,7 +28,7 @@ import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorCode
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncResponse
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SyncDto
 import org.eclipse.tractusx.bpdm.pool.config.BpnConfigProperties
 import org.junit.Assert
 import org.junit.jupiter.api.assertThrows
@@ -194,20 +194,20 @@ class TestHelpers(
     }
 
 
-    fun startSyncAndAwaitSuccess(client: WebTestClient, syncPath: String): SyncResponse {
+    fun startSyncAndAwaitSuccess(client: WebTestClient, syncPath: String): SyncDto {
         return startSyncAndAwaitResult(client, syncPath, SyncStatus.SUCCESS)
     }
 
-    fun startSyncAndAwaitError(client: WebTestClient, syncPath: String): SyncResponse {
+    fun startSyncAndAwaitError(client: WebTestClient, syncPath: String): SyncDto {
         return startSyncAndAwaitResult(client, syncPath, SyncStatus.ERROR)
     }
 
-    private fun startSyncAndAwaitResult(client: WebTestClient, syncPath: String, status: SyncStatus): SyncResponse {
+    private fun startSyncAndAwaitResult(client: WebTestClient, syncPath: String, status: SyncStatus): SyncDto {
 
         client.invokePostEndpointWithoutResponse(syncPath)
         //check for async import to finish several times
         val timeOutAt = Instant.now().plusMillis(ASYNC_TIMEOUT_IN_MS)
-        var syncResponse: SyncResponse
+        var syncResponse: SyncDto
         do {
             Thread.sleep(ASYNC_CHECK_INTERVAL_IN_MS)
 


### PR DESCRIPTION
---
(feat):  API-Model: Rename DTOs Step3
---

## Description

Currently we have an outdated naming scheme for the API model DTOs: Request, Response and DTO suffix. When those DTOs are used in our model this leads to confusion.
The request and response classes are renamed to the following schema 
DTOs that only contain technical keys should be suffixed with Dto,
while DTOs with resolved information should be suffixed with VerboseDto.
_

This Step renames the pool responses

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
