### PR TITLE
BPDM Helm 3.0.2-alpha.4: Change default image registry to dockerhub

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,23 +22,23 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the gate and pool applications
-version: 3.0.2-alpha.3
-appVersion: "4.0.0-alpha.7"
+version: 3.0.2-alpha.4
+appVersion: "4.0.0-alpha.8"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 
 dependencies:
   - name: bpdm-gate
-    version: 4.0.0-alpha.8
+    version: 4.0.0-alpha.9
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 5.0.0-alpha.7
+    version: 5.0.0-alpha.8
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 1.0.1-alpha.3
+    version: 1.0.1-alpha.4
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: opensearch

--- a/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - increase to app version 4.0.0
 - add missing license headers to ingress templates
+- change default registry for image to dockerhub
 
 ### Added
 

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
-appVersion: "4.0.0-alpha.7"
-version: 1.0.1-alpha.3
+appVersion: "4.0.0-alpha.8"
+version: 1.0.1-alpha.4
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
@@ -24,8 +24,8 @@ fullnameOverride:
 replicaCount: 1
 
 image:
-  registry: ghcr.io
-  repository: catenax-ng/tx-bpdm/bridge-dummy
+  registry: docker.io
+  repository: tractusx/bpdm-bridge-dummy
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -108,7 +108,7 @@ startupProbe:
     path: "/actuator/health/readiness"
     port: 8083
     scheme: HTTP
-  initialDelaySeconds: 10
+  initialDelaySeconds: 60
   failureThreshold: 20
   periodSeconds: 15
 

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - increase to app version 4.0.0
 - add missing license headers to ingress templates
+- change default registry for image to dockerhub
 
 ### Added
 

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "4.0.0-alpha.7"
-version: 4.0.0-alpha.8
+appVersion: "4.0.0-alpha.8"
+version: 4.0.0-alpha.9
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -24,8 +24,8 @@ fullnameOverride:
 replicaCount: 1
 
 image:
-  registry: ghcr.io
-  repository: catenax-ng/tx-bpdm/gate
+  registry: docker.io
+  repository: tractusx/bpdm-gate
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -108,7 +108,7 @@ startupProbe:
     path: "/actuator/health/readiness"
     port: 8081
     scheme: HTTP
-  initialDelaySeconds: 10
+  initialDelaySeconds: 60
   failureThreshold: 20
   periodSeconds: 15
 

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - increase to app version 4.0.0
 - add missing license headers to ingress templates
+- change default registry for image to dockerhub
 
 ## [4.3.0] - 2023-03-17
 

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "4.0.0-alpha.7"
-version: 5.0.0-alpha.7
+appVersion: "4.0.0-alpha.8"
+version: 5.0.0-alpha.8
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -24,8 +24,8 @@ fullnameOverride:
 replicaCount: 1
 
 image:
-  registry: ghcr.io
-  repository: catenax-ng/tx-bpdm/pool
+  registry: docker.io
+  repository: tractusx/bpdm-pool
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -109,8 +109,8 @@ startupProbe:
     path: "/actuator/health/readiness"
     port: 8080
     scheme: HTTP
-  initialDelaySeconds: 10
-  failureThreshold: 20
+  initialDelaySeconds: 60
+  failureThreshold: 40
   periodSeconds: 15
 
 applicationConfig:

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -1,29 +1,10 @@
 bpdm-gate:
   enabled: true
-  replicaCount: 1
-  image:
-    registry: ghcr.io
-    repository: catenax-ng/tx-bpdm/gate
-    pullPolicy: Always
-    tag: ""
-  # ... more configuration for bpdm-gate if need...
-  applicationConfig:
-# Use this configuration to specify custom base-urls for the bpdm pool and gate.
-# Only needed if the automatic default deploy is not used.
-#    bpdm:
-#      pool:
-#        base-url: ""
   postgres:
     enabled: false
 
 bpdm-pool:
   enabled: true
-  replicaCount: 1
-  image:
-    registry: ghcr.io
-    repository: catenax-ng/tx-bpdm/pool
-    pullPolicy: Always
-    tag: ""
   opensearch:
     enabled: false
     masterService: ""
@@ -32,21 +13,7 @@ bpdm-pool:
     enabled: false
 
 bpdm-bridge-dummy:
-  enabled: true
-  replicaCount: 1
-  image:
-    registry: ghcr.io
-    repository: catenax-ng/tx-bpdm/bridge-dummy
-    pullPolicy: Always
-    tag: ""
-  applicationConfig:
-# Use this configuration to specify custom base-urls for the bpdm pool and gate.
-# Only needed if the automatic default deploy is not used.
-#    bpdm:
-#      pool:
-#        base-url: ""
-#      gate:
-#        base-url: ""
+  enabled: true"
   postgres:
     enabled: false
 


### PR DESCRIPTION

## Description

BPDM Helm Chart: Default image registry for bpdm images is now docker.io

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files
