### PR TITLE
feat: Bridge writes back output data from Pool to Gate

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package com.catenax.bpdm.bridge.dummy.dto
+
+import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.response.*
+import org.eclipse.tractusx.bpdm.gate.api.model.*
+
+fun gateToPoolLogisticAddress(gateDto: LogisticAddressGateDto): LogisticAddressDto {
+    return LogisticAddressDto(
+        name = gateDto.nameParts.firstOrNull(),
+        states = gateDto.states,
+        identifiers = gateDto.identifiers,
+        physicalPostalAddress = gateToPoolPhysicalAddress(gateDto.physicalPostalAddress),
+        alternativePostalAddress = gateDto.alternativePostalAddress
+    )
+}
+
+fun gateToPoolPhysicalAddress(gateDto: PhysicalPostalAddressGateDto): PhysicalPostalAddressDto {
+    return PhysicalPostalAddressDto(
+        baseAddress = gateDto.baseAddress,
+        areaPart = gateDto.areaPart,
+        basePhysicalAddress = gateDto.basePhysicalAddress,
+        street = StreetDto(
+            name = gateDto.street?.name,
+            houseNumber = gateDto.street?.houseNumber,
+            milestone = gateDto.street?.milestone,
+            direction = gateDto.street?.direction,
+        ),
+    )
+}
+
+
+fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): LegalEntityDto {
+    val identifiers = legalEntity.identifiers.map {
+        LegalEntityIdentifierDto(
+            value = it.value,
+            type = it.type.technicalKey,
+            issuingBody = it.issuingBody
+        )
+    }
+    val states = legalEntity.states.map {
+        LegalEntityStateDto(
+            officialDenotation = it.officialDenotation,
+            validFrom = it.validFrom,
+            validTo = it.validTo,
+            type = it.type.technicalKey
+        )
+    }
+    val classifications = legalEntity.classifications.map {
+        ClassificationDto(
+            value = it.value,
+            code = it.code,
+            type = it.type.technicalKey
+        )
+    }
+    return LegalEntityDto(
+        identifiers = identifiers,
+        legalShortName = legalEntity.legalShortName,
+        legalForm = legalEntity.legalForm?.technicalKey,
+        states = states,
+        classifications = classifications
+    )
+}
+
+fun poolToGateSite(site: SiteVerboseDto): SiteGateDto {
+    val states = site.states.map {
+        SiteStateDto(
+            description = it.description,
+            validFrom = it.validFrom,
+            validTo = it.validTo,
+            type = it.type.technicalKey
+        )
+    }
+    return SiteGateDto(
+        nameParts = listOfNotNull(site.name),
+        states = states
+    )
+}
+
+fun poolToGateAddressChild(address: LogisticAddressVerboseDto): AddressGateOutputChildRequest {
+    return AddressGateOutputChildRequest(
+        address = poolToGateLogisticAddress(address),
+        bpn = address.bpna
+    )
+}
+
+fun poolToGateLogisticAddress(address: LogisticAddressVerboseDto): LogisticAddressGateDto {
+    val states = address.states.map {
+        AddressStateDto(
+            description = it.description,
+            validFrom = it.validFrom,
+            validTo = it.validTo,
+            type = it.type.technicalKey
+        )
+    }
+    val identifiers = address.identifiers.map {
+        AddressIdentifierDto(
+            value = it.value,
+            type = it.type.technicalKey
+        )
+    }
+    return LogisticAddressGateDto(
+        nameParts = listOfNotNull(address.name),
+        states = states,
+        identifiers = identifiers,
+        physicalPostalAddress = poolToGatePhysicalAddress(address.physicalPostalAddress),
+        alternativePostalAddress = address.alternativePostalAddress?.let { poolToGateAlternativeAddress(it) }
+    )
+}
+
+private fun poolToGatePhysicalAddress(address: PhysicalPostalAddressVerboseDto): PhysicalPostalAddressGateDto {
+    val baseAddress = address.baseAddress.let {
+        BasePostalAddressDto(
+            geographicCoordinates = it.geographicCoordinates,
+            country = it.country.technicalKey,
+            postalCode = it.postalCode,
+            city = it.city
+        )
+    }
+    val street = address.street?.let {
+        StreetGateDto(
+            name = it.name,
+            houseNumber = it.houseNumber,
+            milestone = it.milestone,
+            direction = it.direction
+        )
+    }
+    val areaPart = address.areaPart.let {
+        AreaDistrictDto(
+            administrativeAreaLevel1 = it.administrativeAreaLevel1?.regionCode,
+            administrativeAreaLevel2 = it.administrativeAreaLevel2,
+            administrativeAreaLevel3 = it.administrativeAreaLevel3,
+            district = it.district
+        )
+    }
+    return PhysicalPostalAddressGateDto(
+        baseAddress = baseAddress,
+        basePhysicalAddress = address.basePhysicalAddress,
+        street = street,
+        areaPart = areaPart
+    )
+}
+
+private fun poolToGateAlternativeAddress(address: AlternativePostalAddressVerboseDto): AlternativePostalAddressDto {
+    val baseAddress = address.baseAddress.let {
+        BasePostalAddressDto(
+            geographicCoordinates = it.geographicCoordinates,
+            country = it.country.technicalKey,
+            postalCode = it.postalCode,
+            city = it.city
+        )
+    }
+    val areaPart = AreaDistrictAlternativDto(
+        address.areaPart.administrativeAreaLevel1?.regionCode
+    )
+    return AlternativePostalAddressDto(
+        baseAddress = baseAddress,
+        areaPart = areaPart,
+        deliveryServiceNumber = address.deliveryServiceNumber,
+        deliveryServiceType = address.type,
+        deliveryServiceQualifier = address.deliveryServiceQualifier
+    )
+}

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/GateLegalEntityInfo.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/GateLegalEntityInfo.kt
@@ -23,7 +23,7 @@ import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
 
 data class GateLegalEntityInfo(
-    val legalNameParts: List<String> = emptyList(),
+    val legalNameParts: List<String>,
     val legalEntity: LegalEntityDto,
     val legalAddress: AddressGateInputDto,
     val externalId: String,

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
@@ -74,6 +74,7 @@ class GateQueryService(
 
         return entries.map {
             GateLegalEntityInfo(
+                legalNameParts = it.legalNameParts,
                 legalEntity = it.legalEntity,
                 legalAddress = it.legalAddress,
                 externalId = it.externalId,

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -19,17 +19,11 @@
 
 package com.catenax.bpdm.bridge.dummy.service
 
-import com.catenax.bpdm.bridge.dummy.dto.GateAddressInfo
-import com.catenax.bpdm.bridge.dummy.dto.GateLegalEntityInfo
-import com.catenax.bpdm.bridge.dummy.dto.GateSiteInfo
+import com.catenax.bpdm.bridge.dummy.dto.*
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
-import org.eclipse.tractusx.bpdm.common.dto.PhysicalPostalAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.SiteDto
-import org.eclipse.tractusx.bpdm.common.dto.StreetDto
-import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
-import org.eclipse.tractusx.bpdm.gate.api.model.PhysicalPostalAddressGateDto
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
 import org.eclipse.tractusx.bpdm.pool.api.model.request.*
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
@@ -42,33 +36,6 @@ class PoolUpdateService(
 ) {
 
     private val logger = KotlinLogging.logger { }
-
-    fun gateToPoolPhysicalAddress(gateDto: PhysicalPostalAddressGateDto): PhysicalPostalAddressDto {
-
-        return PhysicalPostalAddressDto(
-            baseAddress = gateDto.baseAddress,
-            areaPart = gateDto.areaPart,
-            basePhysicalAddress = gateDto.basePhysicalAddress,
-            street = StreetDto(
-                name = gateDto.street?.name,
-                houseNumber = gateDto.street?.houseNumber,
-                milestone = gateDto.street?.milestone,
-                direction = gateDto.street?.direction,
-            ),
-        )
-    }
-
-    fun gateToPoolLogisticAddress(gateDto: LogisticAddressGateDto): LogisticAddressDto {
-
-        return LogisticAddressDto(
-            name = gateDto.nameParts.firstOrNull(),
-            states = gateDto.states,
-            identifiers = gateDto.identifiers,
-            physicalPostalAddress = gateToPoolPhysicalAddress(gateDto.physicalPostalAddress),
-            alternativePostalAddress = gateDto.alternativePostalAddress
-        )
-    }
-
 
     fun createLegalEntitiesInPool(entriesToCreate: Collection<GateLegalEntityInfo>): LegalEntityPartnerCreateResponseWrapper {
         val createRequests = entriesToCreate.map {

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/SyncService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/SyncService.kt
@@ -63,51 +63,54 @@ class SyncService(
     private fun syncLegalEntities(externalIdsRequested: Set<String>) {
         // Retrieve business partners (LSA) from Gate
         val entries = gateQueryService.getLegalEntityInfos(externalIdsRequested)
+        val entryByExternalId = entries.associateBy { it.externalId }
         val (entriesToCreate, entriesToUpdate) = entries.partition { it.bpn == null }
 
         // Create or update (LSAs) in Pool
         if (entriesToCreate.isNotEmpty()) {
             val responseWrapper = poolUpdateService.createLegalEntitiesInPool(entriesToCreate)
-            gateUpdateService.handleLegalEntityCreateResponse(responseWrapper)
+            gateUpdateService.handleLegalEntityCreateResponse(responseWrapper, entryByExternalId)
         }
         if (entriesToUpdate.isNotEmpty()) {
             val responseWrapper = poolUpdateService.updateLegalEntitiesInPool(entriesToUpdate)
             val externalIdByBpn = entriesToUpdate.associateBy { it.bpn!! }.mapValues { (_, entry) -> entry.externalId }
-            gateUpdateService.handleLegalEntityUpdateResponse(responseWrapper, externalIdByBpn)
+            gateUpdateService.handleLegalEntityUpdateResponse(responseWrapper, externalIdByBpn, entryByExternalId)
         }
     }
 
     private fun syncSites(externalIdsRequested: Set<String>) {
         // Retrieve business partners (LSA) from Gate
         val entries = gateQueryService.getSiteInfos(externalIdsRequested)
+        val entryByExternalId = entries.associateBy { it.externalId }
         val (entriesToCreate, entriesToUpdate) = entries.partition { it.bpn == null }
 
         // Create or update (LSAs) in Pool
         if (entriesToCreate.isNotEmpty()) {
             val responseWrapper = poolUpdateService.createSitesInPool(entriesToCreate)
-            gateUpdateService.handleSiteCreateResponse(responseWrapper)
+            gateUpdateService.handleSiteCreateResponse(responseWrapper, entryByExternalId)
         }
         if (entriesToUpdate.isNotEmpty()) {
             val responseWrapper = poolUpdateService.updateSitesInPool(entriesToUpdate)
             val externalIdByBpn = entriesToUpdate.associateBy { it.bpn!! }.mapValues { (_, entry) -> entry.externalId }
-            gateUpdateService.handleSiteUpdateResponse(responseWrapper, externalIdByBpn)
+            gateUpdateService.handleSiteUpdateResponse(responseWrapper, externalIdByBpn, entryByExternalId)
         }
     }
 
     private fun syncAddresses(externalIdsRequested: Set<String>) {
         // Retrieve business partners (LSA) from Gate
         val entries = gateQueryService.getAddressInfos(externalIdsRequested)
+        val entryByExternalId = entries.associateBy { it.externalId }
         val (entriesToCreate, entriesToUpdate) = entries.partition { it.bpn == null }
 
         // Create or update (LSAs) in Pool
         if (entriesToCreate.isNotEmpty()) {
             val responseWrapper = poolUpdateService.createAddressesInPool(entriesToCreate)
-            gateUpdateService.handleAddressCreateResponse(responseWrapper)
+            gateUpdateService.handleAddressCreateResponse(responseWrapper, entryByExternalId)
         }
         if (entriesToUpdate.isNotEmpty()) {
             val responseWrapper = poolUpdateService.updateAddressesInPool(entriesToUpdate)
             val externalIdByBpn = entriesToUpdate.associateBy { it.bpn!! }.mapValues { (_, entry) -> entry.externalId }
-            gateUpdateService.handleAddressUpdateResponse(responseWrapper, externalIdByBpn)
+            gateUpdateService.handleAddressUpdateResponse(responseWrapper, externalIdByBpn, entryByExternalId)
         }
     }
 


### PR DESCRIPTION
## Description

After successfully upserting a BP in the Pool its response is converted and upserted as the output version of the BP in the Gate.
Bridge helper methods for converting between Gate and Pool versions are moved to DtoConversionHelper.
Missing legalNameParts was added to GateQueryService.getLegalEntityInfos.

Fixes #279
