### PR TITLE
Feat - Fetch the number of records in CX Pool

### DIFF
--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -30,10 +30,7 @@ import org.eclipse.tractusx.bpdm.common.dto.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
@@ -134,4 +131,21 @@ interface PoolSiteApi {
         @RequestBody
         requests: Collection<SitePartnerUpdateRequest>
     ): SitePartnerUpdateResponseWrapper
+
+    @Operation(
+        summary = "Get page of sites matching the pagination search criteria",
+        description = "This endpoint retrieves all existing business partners of type sites." +
+                "Note that when using search parameters the max page is \${bpdm.opensearch.max-page}."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of business partners matching the search criteria, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()])
+        ]
+    )
+    @GetMapping
+    @GetExchange
+    fun getSitesPaginated(
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<SiteMatchVerboseDto>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SiteMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SiteMatchVerboseDto.kt
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.model.response
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(name = "SiteMatchVerboseDto", description = "Match with score for a business partner record of type site.")
+data class SiteMatchVerboseDto(
+
+//    @Schema(description = "Relative quality score of the match. The higher the better")
+//    val score: Float,
+
+    @Schema(description = "Main address where this site resides")
+    val mainAddress: LogisticAddressVerboseDto,
+
+    @Schema(description = "Site information")
+    val site: SiteVerboseDto,
+)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/SearchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/SearchService.kt
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequ
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteMatchVerboseDto
 
 /**
  * Provides search functionality on the Catena-x data for the BPDM system
@@ -46,5 +47,12 @@ interface SearchService {
         searchRequest: AddressPartnerSearchRequest,
         paginationRequest: PaginationRequest
     ): PageDto<AddressMatchVerboseDto>
+
+    /**
+     * Find sites by matching their field values to [searchRequest] field query texts
+     */
+    fun searchSites(
+        paginationRequest: PaginationRequest
+    ): PageDto<SiteMatchVerboseDto>
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/mock/service/SearchServiceMock.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/mock/service/SearchServiceMock.kt
@@ -26,9 +26,11 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequ
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.component.opensearch.SearchService
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
 import org.eclipse.tractusx.bpdm.pool.repository.LogisticAddressRepository
+import org.eclipse.tractusx.bpdm.pool.repository.SiteRepository
 import org.eclipse.tractusx.bpdm.pool.service.toDto
 import org.eclipse.tractusx.bpdm.pool.service.toMatchDto
 import org.springframework.data.domain.PageRequest
@@ -40,7 +42,8 @@ import org.springframework.stereotype.Service
 @Service
 class SearchServiceMock(
     val legalEntityRepository: LegalEntityRepository,
-    val logisticAddressRepository: LogisticAddressRepository
+    val logisticAddressRepository: LogisticAddressRepository,
+    val siteRepository: SiteRepository
 ) : SearchService {
 
     private val logger = KotlinLogging.logger { }
@@ -71,6 +74,14 @@ class SearchServiceMock(
         logger.info { "Mock search: Returning ${resultPage.size} addresses from database" }
 
         return resultPage.toDto(resultPage.content.map { it.toMatchDto(1f) })
+    }
+
+    override fun searchSites(paginationRequest: PaginationRequest): PageDto<SiteMatchVerboseDto> {
+        val resultPage = siteRepository.findAll(PageRequest.of(paginationRequest.page, paginationRequest.size))
+
+        logger.info { "Mock search: Returning ${resultPage.size} sites from database" }
+
+        return resultPage.toDto(resultPage.content.map { it.toMatchDto() })
     }
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -23,12 +23,9 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.MainAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.component.opensearch.SearchService
 import org.eclipse.tractusx.bpdm.pool.service.AddressService
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService
 import org.eclipse.tractusx.bpdm.pool.service.SiteService
@@ -39,7 +36,8 @@ import org.springframework.web.bind.annotation.RestController
 class SiteController(
     private val siteService: SiteService,
     private val businessPartnerBuildService: BusinessPartnerBuildService,
-    private val addressService: AddressService
+    private val addressService: AddressService,
+    val searchService: SearchService,
 ) : PoolSiteApi {
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
@@ -76,5 +74,12 @@ class SiteController(
         requests: Collection<SitePartnerUpdateRequest>
     ): SitePartnerUpdateResponseWrapper {
         return businessPartnerBuildService.updateSites(requests)
+    }
+
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
+    override fun getSitesPaginated(
+        paginationRequest: PaginationRequest
+    ): PageDto<SiteMatchVerboseDto> {
+        return searchService.searchSites(paginationRequest)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -216,6 +216,13 @@ fun LogisticAddress.toCreateResponse(index: String?): AddressPartnerCreateVerbos
     )
 }
 
+fun Site.toMatchDto(): SiteMatchVerboseDto {
+    return SiteMatchVerboseDto(
+        mainAddress = this.mainAddress.toDto(),
+        site = this.toDto(),
+    )
+}
+
 fun Site.toUpsertDto(entryId: String?): SitePartnerCreateVerboseDto {
     return SitePartnerCreateVerboseDto(
         site = toDto(),

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
@@ -67,4 +67,14 @@ class SiteService(
         val addresses = sites.flatMap { it.addresses }.toSet()
         addressService.fetchLogisticAddressDependencies(addresses)
     }
+
+    fun fetchSiteDependenciesPage(sites: Set<Site>): Set<Site> {
+        siteRepository.joinAddresses(sites)
+        siteRepository.joinStates(sites)
+        val addresses = sites.flatMap { it.addresses }.toSet()
+        addressService.fetchLogisticAddressDependencies(addresses)
+
+        return sites
+    }
+
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -374,24 +374,32 @@ class SiteControllerIT @Autowired constructor(
     @Test
     fun `retrieve sites with pagination`() {
 
-        lateinit var site1: SiteVerboseDto
-
-        val givenStructure = testHelpers.createBusinessPartnerStructure(
+        val createdStructures = testHelpers.createBusinessPartnerStructure(
             listOf(
                 LegalEntityStructureRequest(
                     legalEntity = RequestValues.legalEntityCreate1,
-                    siteStructures = listOf(SiteStructureRequest(site = RequestValues.siteCreate1))
+                    siteStructures = listOf(
+                        SiteStructureRequest(site = RequestValues.siteCreate1),
+                        SiteStructureRequest(site = RequestValues.siteCreate2)
+                    )
                 )
             )
         )
 
+        val bpnL1 = createdStructures[0].legalEntity.legalEntity.bpnl
+
         val legalAddress1: LogisticAddressVerboseDto =
             ResponseValues.addressPartner1.copy(isMainAddress = true, bpnSite = CommonValues.bpnS1, bpna = "BPNA0000000001YN")
-        site1 = givenStructure[0].siteStructures[0].site.site
+        val site1 = ResponseValues.site1.copy(bpnLegalEntity = bpnL1)
+
+        val legalAddress2: LogisticAddressVerboseDto =
+            ResponseValues.addressPartner2.copy(isMainAddress = true, bpnSite = CommonValues.bpnS2, bpna = "BPNA0000000002XY")
+        val site2 = ResponseValues.site2.copy(bpnLegalEntity = bpnL1)
 
         val expectedFirstPage = PageDto(
-            1, 1, 0, 1, listOf(
-                SiteMatchVerboseDto(mainAddress = legalAddress1, site = site1)
+            2, 1, 0, 2, listOf(
+                SiteMatchVerboseDto(mainAddress = legalAddress1, site = site1),
+                SiteMatchVerboseDto(mainAddress = legalAddress2, site = site2)
             )
         )
 


### PR DESCRIPTION
---
name: Fetch the number of records in CX Pool
---

## Description

In this PR, it was added an new endpoint for the Sites, which returns a list of paginated sites, and also the needed total number of all results in all pages.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
