### PR TITLE
feat/doc: Generate Mermaid Persistence Class Diagram from JPA metadata

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/JpaMermaidCreator.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/JpaMermaidCreator.kt
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.util
+
+class JpaMermaidCreator {
+
+    val MAX_ENUM_VALUES = 15
+
+    fun getMermaid(allClassInfos: MutableCollection<JpaClassInfo>, title: String): String {
+
+        val mermaid = StringBuilder()
+        val mermaidRelationship = StringBuilder()
+
+        appendHeader(mermaid, title)
+        appendEnums(mermaid, allClassInfos)
+
+        allClassInfos
+            .sortedBy { it.entityName }
+            .forEach { classInfo ->
+                mermaid.append("    class ").append(classInfo.entityName).append("{").appendLine()
+                if (classInfo.embeddable) {
+                    mermaid.appendLine("        <<embeddable>>")
+                }
+                classInfo.attributeList.forEach { attrInfo ->
+                    if (attrInfo is JpaPrimitiveAttributeInfo) {
+                        if (attrInfo.primitiveType is JpaStringType && attrInfo.primitiveType.typeHint == TypeHint.ENUM) {
+                            mermaid.append("        ").append(attrInfo.primitiveType.domValueType?.simpleName)
+                        } else {
+                            mermaid.append("        ").append(attrInfo.primitiveType.getTypeName())
+                        }
+                    }
+                    if (attrInfo is JdyObjectReferenceInfo) {
+                        mermaid.append("        ").append(attrInfo.referencedClass.entityName)
+                        if (attrInfo.embedded) {
+                            mermaidRelationship.append("   ").append(classInfo.entityName).append(" ..> ").append(attrInfo.referencedClass.entityName)
+                                .appendLine()
+                        }
+                    }
+                    mermaid.append(" ").append(attrInfo.attrName)
+                    if (attrInfo.notNull) {
+                        mermaid.append(" [1]")
+                    }
+                    mermaid.appendLine()
+                }
+                mermaid.appendLine("   }")
+                classInfo.associationList.forEach { assocInfo ->
+                    mermaidRelationship.append("   ").append(classInfo.entityName).append(" ..> ").append(assocInfo.detailClass.entityName)
+                        .append(" : ").append(assocInfo.assocName).appendLine()
+                }
+            }
+
+        mermaid.appendLine()
+        mermaid.append(mermaidRelationship)
+        return mermaid.toString()
+    }
+
+    private fun appendEnums(mermaid: StringBuilder, allClassInfos: MutableCollection<JpaClassInfo>) {
+
+        val allEnums: MutableSet<Class<out Any>> = mutableSetOf()
+
+        allClassInfos.forEach { classInfo ->
+            classInfo.attributeList.forEach { attrInfo ->
+
+                if (attrInfo is JpaPrimitiveAttributeInfo && attrInfo.primitiveType is JpaStringType && attrInfo.primitiveType.typeHint == TypeHint.ENUM) {
+
+                    if (attrInfo.primitiveType.domValueType != null && !allEnums.contains(attrInfo.primitiveType.domValueType)) {
+                        appendEnum(mermaid, attrInfo.primitiveType.domValueType, attrInfo.primitiveType.domValues)
+                        allEnums.add(attrInfo.primitiveType.domValueType)
+                    }
+                }
+            }
+        }
+
+    }
+
+    private fun appendEnum(mermaid: StringBuilder, enumTyp: Class<out Any>?, domValues: List<DbDomainValue>?) {
+        if (enumTyp != null && domValues != null) {
+            mermaid.append("    class ").append(enumTyp.simpleName).append("{").appendLine()
+                .appendLine("        <<enumeration>>")
+            domValues
+                .sortedBy { it.domValue }
+                .take(MAX_ENUM_VALUES)
+                .forEach {
+                    mermaid.append("        ").appendLine(it.domValue)
+                }
+            mermaid.appendLine("    } ")
+        }
+    }
+
+    private fun appendHeader(mermaid: StringBuilder, title: String) {
+        mermaid.appendLine("---")
+        mermaid.appendLine(title)
+        mermaid.appendLine("---")
+        mermaid.appendLine("classDiagram")
+    }
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/JpaMetaModelReader.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/JpaMetaModelReader.kt
@@ -1,0 +1,453 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.util
+
+import jakarta.persistence.*
+import jakarta.persistence.metamodel.*
+import jakarta.persistence.metamodel.Attribute.PersistentAttributeType.*
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Email
+import java.lang.reflect.Field
+import java.lang.reflect.Member
+import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.*
+
+class JpaMetaModelReader {
+
+    companion object {
+        val DECIMAL_MIN_VALUE: BigDecimal = BigDecimal("-9999999999999.999999")
+        val DECIMAL_MAX_VALUE: BigDecimal = BigDecimal("9999999999999.999999")
+    }
+
+
+    fun createJpaClassInfos(metaModel: Metamodel): MutableCollection<JpaClassInfo> {
+
+        return this.createJpaClassInfos(metaModel.entities, metaModel.embeddables)
+    }
+
+    private fun createJpaClassInfos(allEntityInfos: Set<EntityType<*>?>, allEmbeddableInfos: Set<EmbeddableType<*>?>): MutableCollection<JpaClassInfo> {
+
+        val className2InfoMap = mutableMapOf<String, JpaClassInfo>()
+        val allManagedEntities: MutableList<ManagedType<*>> = mutableListOf()
+        allManagedEntities.addAll(allEmbeddableInfos.filterNotNull().map { it })
+        allManagedEntities.addAll(allEntityInfos.filterNotNull().map { it })
+
+        // build base classes
+        allManagedEntities.forEach { jpaEntity ->
+            val entity = createJpaClassInfo(jpaEntity)
+            className2InfoMap[entity.entityName] = entity
+        }
+
+        // add entity attributes
+        allManagedEntities.forEach { jpsEntity ->
+            className2InfoMap[JpaFieldWrapper.getEntityName(jpsEntity)]?.let { classInfo ->
+                buildAttrForClassInfo(classInfo = classInfo, jpaEntity = jpsEntity, className2InfoMap)
+            }
+        }
+
+        // add associations to entities
+        allEntityInfos.forEach { jpaEntity ->
+            jpaEntity?.let {
+                className2InfoMap[it.name]?.let { classInfo ->
+                    buildAssociationsForClassInfo(classInfo = classInfo, jpaEntity = jpaEntity, className2InfoMap)
+                }
+            }
+        }
+
+        return className2InfoMap.values
+    }
+
+    private fun createJpaClassInfo(jpaEntity: ManagedType<*>): JpaClassInfo {
+
+        return JpaClassInfo(
+            entityName = JpaFieldWrapper.getEntityName(jpaEntity),
+            nameSpace = jpaEntity.javaType.name.replace('.', '_'),
+            embeddable = jpaEntity is EmbeddableType
+        )
+    }
+
+    private fun buildAttrForClassInfo(classInfo: JpaClassInfo, jpaEntity: ManagedType<*>, className2InfoMap: MutableMap<String, JpaClassInfo>) {
+
+
+        jpaEntity.attributes.forEach { attr ->
+            if (!attr.isCollection) {
+                if (attr.persistentAttributeType === Attribute.PersistentAttributeType.BASIC) {
+
+                    createPrimitiveField(attr)?.let {
+                        classInfo.attributeList.add(it)
+                    }
+                } else if (attr.persistentAttributeType === ONE_TO_ONE || attr.persistentAttributeType === MANY_TO_ONE) {
+
+                    createObjectReference(attr, className2InfoMap)?.let {
+                        classInfo.attributeList.add(it)
+                    }
+                } else if (attr.persistentAttributeType === EMBEDDED) {
+
+                    createObjectReference(attr, className2InfoMap)?.let {
+                        classInfo.attributeList.add(it)
+                    }
+                }
+            }
+        }
+    }
+
+
+    private fun buildAssociationsForClassInfo(classInfo: JpaClassInfo, jpaEntity: EntityType<*>, className2InfoMap: MutableMap<String, JpaClassInfo>) {
+
+        jpaEntity.attributes.forEach {
+            if (it.isCollection) {
+                if (it.persistentAttributeType === Attribute.PersistentAttributeType.ONE_TO_MANY) {
+                    val wrapper = JpaCollectionWrapper(it)
+                    val metaDetailClass = className2InfoMap[wrapper.referencedType?.name]
+                    val mapping = wrapper.getAnnotationInfo(OneToMany::class.java)
+                    val joinColumn = wrapper.getAnnotationInfo(JoinColumn::class.java)
+                    val metaAssocName = it.name
+                    val metaAssoc = metaDetailClass?.let { it1 -> JpaAssociationInfo(assocName = metaAssocName, detailClass = it1) }
+                    metaAssoc?.let { it1 -> classInfo.associationList.add(it1) }
+                }
+            }
+        }
+    }
+
+    private fun createObjectReference(
+        curAttr: Attribute<*, *>,
+        className2InfoMap: MutableMap<String, JpaClassInfo>
+    ): JdyObjectReferenceInfo? {
+
+        val wrapper = JpaFieldWrapper(curAttr)
+        val isKey = (curAttr as SingularAttribute).isId
+        val isNotNull = !curAttr.isOptional || !wrapper.isNullable()
+        val isGenerated = wrapper.getGeneratedInfo() != null
+        val refTypeName = wrapper.getRefTypeName()
+        val referenceType = className2InfoMap[refTypeName]
+        val metaAttr = referenceType?.let {
+            JdyObjectReferenceInfo(referencedClass = it, attrName = curAttr.getName(), isKey = isKey, notNull = isNotNull, embedded = wrapper.embedded)
+        }
+
+        return metaAttr
+
+    }
+
+    private fun createPrimitiveField(curAttr: Attribute<*, *>): JpaAttributeInfo? {
+        val wrapper = JpaFieldWrapper(curAttr)
+        val metaType = getPrimitiveType(wrapper)
+        return if (metaType != null) {
+
+            val isKey = (curAttr as SingularAttribute).isId
+            val isNotNull = !curAttr.isOptional || !wrapper.isNullable()
+            val isGenerated = wrapper.getGeneratedInfo() != null
+            val metaAttr = JpaPrimitiveAttributeInfo(primitiveType = metaType, attrName = curAttr.name, isKey = isKey, notNull = isNotNull)
+            metaAttr.generated = isGenerated
+            metaAttr
+        } else {
+            null
+        }
+    }
+
+    private fun getPrimitiveType(wrapper: JpaFieldWrapper): JpaPrimitiveType? {
+        val aTypeClass: Class<*>? = wrapper.getJavaType()
+        return if (aTypeClass == null) {
+            null
+        } else if (aTypeClass.isAssignableFrom(UUID::class.java)) {
+            JpaUuidType()
+        } else if (aTypeClass.isAssignableFrom(Int::class.java) || Int::class.javaPrimitiveType!!.isAssignableFrom(aTypeClass)) {
+            JpaLongType(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+        } else if (aTypeClass.isAssignableFrom(Long::class.java) || Long::class.javaPrimitiveType!!.isAssignableFrom(aTypeClass)) {
+            JpaLongType(Long.MIN_VALUE, Long.MAX_VALUE)
+        } else if (aTypeClass.isAssignableFrom(Short::class.java) || Short::class.javaPrimitiveType!!.isAssignableFrom(aTypeClass)) {
+            JpaLongType(Short.MIN_VALUE.toLong(), Short.MAX_VALUE.toLong())
+        } else if (aTypeClass.isAssignableFrom(Byte::class.java) || ByteArray::class.java.isAssignableFrom(aTypeClass)) {
+            JpaBlobType()
+        } else if (aTypeClass.isAssignableFrom(String::class.java)) {
+            val column = wrapper.getAnnotationInfo(Column::class.java)
+            val length = column?.length ?: 40
+            val email = wrapper.getAnnotationInfo(Email::class.java)
+            if (email == null) JpaStringType(length) else JpaStringType(length, TypeHint.EMAIL)
+        } else if (aTypeClass.isAssignableFrom(Date::class.java) || aTypeClass.isAssignableFrom(Timestamp::class.java)
+            || aTypeClass.isAssignableFrom(Instant::class.java)
+        ) {
+            val temporal = wrapper.getAnnotationInfo(Temporal::class.java)
+            val temporalType: TemporalType = temporal?.value ?: TemporalType.TIMESTAMP
+            val hasDate = temporalType === TemporalType.TIMESTAMP || temporalType === TemporalType.DATE
+            val hasTime = temporalType === TemporalType.TIMESTAMP || temporalType === TemporalType.TIME
+            JpaTimeStampType(hasDate, hasTime)
+        } else if (aTypeClass.isAssignableFrom(LocalDate::class.java)) {
+            JpaTimeStampType(isDatePartUsed = true, isTimePartUsed = false)
+        } else if (aTypeClass.isAssignableFrom(LocalTime::class.java)) {
+            JpaTimeStampType(isDatePartUsed = false, isTimePartUsed = true)
+        } else if (aTypeClass.isAssignableFrom(LocalDateTime::class.java)) {
+            JpaTimeStampType(isDatePartUsed = true, isTimePartUsed = true)
+        } else if (aTypeClass.isAssignableFrom(Boolean::class.java) || Boolean::class.javaPrimitiveType!!.isAssignableFrom(aTypeClass)) {
+            JpaBooleanType()
+        } else if (aTypeClass.isAssignableFrom(Double::class.java) || aTypeClass.isAssignableFrom(Float::class.java)
+            || Double::class.javaPrimitiveType!!.isAssignableFrom(aTypeClass) || Float::class.javaPrimitiveType!!.isAssignableFrom(aTypeClass)
+        ) {
+            JpaFloatType()
+        } else if (aTypeClass.isAssignableFrom(BigDecimal::class.java)) {
+            val column = wrapper.getAnnotationInfo(Column::class.java)
+            var scale = 0
+            var precision = 0
+            if (column != null) {
+                scale = column.scale
+                precision = column.precision
+            }
+            val decMin: DecimalMin? = wrapper.getAnnotationInfo(DecimalMin::class.java)
+            val decMax: DecimalMax? = wrapper.getAnnotationInfo(DecimalMax::class.java)
+            val minValue = if (decMin != null) BigDecimal(decMin.value) else DECIMAL_MIN_VALUE
+            val maxValue = if (decMax != null) BigDecimal(decMax.value) else DECIMAL_MAX_VALUE
+            JpaDecimalType(minValue, maxValue, scale)
+        } else {
+            if (aTypeClass.isEnum) {
+                val column = wrapper.getAnnotationInfo(Column::class.java)
+                val length = column?.length ?: 40
+                val domainValues: MutableList<DbDomainValue> = ArrayList<DbDomainValue>()
+                for (jpaField in aTypeClass.declaredFields) {
+                    if (jpaField.isEnumConstant) {
+                        domainValues.add(DbDomainValue(jpaField.name, jpaField.name))
+                    }
+                }
+                return JpaStringType(length, TypeHint.ENUM, domainValues, wrapper.type.javaType)
+            }
+            null
+        }
+    }
+
+}
+
+
+class JpaClassInfo(
+    val entityName: String,
+    val nameSpace: String,
+    val attributeList: MutableList<JpaAttributeInfo> = mutableListOf(),
+    val associationList: MutableList<JpaAssociationInfo> = mutableListOf(),
+    val embeddable: Boolean = false
+
+)
+
+abstract class JpaAttributeInfo(val attrName: String, val isKey: Boolean = false, var generated: Boolean = false, val notNull: Boolean = false)
+
+class JpaPrimitiveAttributeInfo(
+    val primitiveType: JpaPrimitiveType, attrName: String, isKey: Boolean = false, generated: Boolean = false, notNull: Boolean = false
+
+) : JpaAttributeInfo(attrName, isKey, generated, notNull)
+
+class JdyObjectReferenceInfo(
+    val referencedClass: JpaClassInfo,
+    attrName: String,
+    isKey: Boolean = false,
+    generated: Boolean = false,
+    notNull: Boolean = false,
+    val embedded: Boolean = false
+
+) : JpaAttributeInfo(attrName, isKey, generated, notNull)
+
+
+class JpaAssociationInfo(
+    val assocName: String,
+    val detailClass: JpaClassInfo
+)
+
+interface JpaPrimitiveType {
+    fun getTypeName(): String
+}
+
+class JpaLongType(
+    val minValue: Long?,
+    val maxValue: Long?,
+    val domValues: List<DbDomainValue>? = null
+) : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "Long"
+    }
+}
+
+class JpaUuidType : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "UUID"
+    }
+}
+
+class JpaBlobType : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "Blob"
+    }
+}
+
+class JpaStringType(
+    val length: Int,
+    val typeHint: TypeHint? = null,
+    val domValues: List<DbDomainValue>? = null,
+    val domValueType: Class<out Any>? = null
+) : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "String"
+    }
+}
+
+class JpaTimeStampType(
+    val isDatePartUsed: Boolean,
+    val isTimePartUsed: Boolean
+) : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "DateTime"
+    }
+}
+
+class JpaBooleanType : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "Boolean"
+    }
+}
+
+class JpaFloatType : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "Float"
+    }
+}
+
+class JpaDecimalType(
+    val minValue: BigDecimal?,
+    val maxValue: BigDecimal?,
+    val scale: Int,
+    val domValues: List<DbDomainValue>? = null
+) : JpaPrimitiveType {
+    override fun getTypeName(): String {
+        return "BigDecimal"
+    }
+}
+
+
+enum class TypeHint {
+    TELEPHONE,
+    URL,
+    ENUM,
+    EMAIL;
+
+    val dbValue: String
+        get() = name
+    val representation: String
+        get() = name
+}
+
+
+class DbDomainValue(
+    val domValue: String,
+    val representation: String
+)
+
+class JpaCollectionWrapper(anAttr: Attribute<*, *>) {
+
+    private var attr: Attribute<*, *> = anAttr
+    var field: Field? = null
+    var type: PluralAttribute.CollectionType? = null
+    var referencedType: EntityType<*>? = null
+
+    init {
+        val listAttr: PluralAttribute<*, *, *> = anAttr as PluralAttribute<*, *, *>
+        type = listAttr.collectionType
+        field = if (anAttr.getJavaMember() is Field) {
+            anAttr.getJavaMember() as Field
+        } else {
+            null
+        }
+        referencedType = listAttr.elementType as EntityType
+    }
+
+    fun getJavaType(): Class<*>? {
+        return attr.javaType
+    }
+
+    fun <T : Annotation?> getAnnotationInfo(annotation: Class<T>): T? {
+        return if (field is Field) {
+            field!!.getAnnotation(annotation)
+        } else {
+            null
+        }
+    }
+
+    fun isNullable(): Boolean {
+        val columnInfo = getAnnotationInfo(Column::class.java)
+        return columnInfo?.nullable ?: false
+    }
+
+}
+
+class JpaFieldWrapper(anAttr: Attribute<*, *>) {
+
+    companion object {
+        fun getEntityName(jpaEntity: Type<*>): String {
+
+            return when (jpaEntity) {
+                is EntityType -> jpaEntity.name
+                is EmbeddableType -> jpaEntity.getJavaType().simpleName
+                else -> ""
+            }
+        }
+    }
+
+    private var attr: Attribute<*, *> = anAttr
+    var field: Member? = null
+    val type: Type<*>
+    val embedded: Boolean
+
+    init {
+        val singAttr: SingularAttribute<*, *> = anAttr as SingularAttribute
+        this.type = singAttr.type
+        this.field = if (anAttr.getJavaMember() is Field) {
+            anAttr.getJavaMember()
+        } else {
+            null
+        }
+        this.embedded = attr.persistentAttributeType === EMBEDDED
+    }
+
+    fun <T : Annotation?> getAnnotationInfo(annotation: Class<T>): T? {
+        return if (field is Field) {
+            (field as Field?)!!.getAnnotation(annotation)
+        } else {
+            null
+        }
+    }
+
+    fun getJavaType(): Class<*>? {
+        return attr.javaType
+    }
+
+    fun isNullable(): Boolean {
+        val columnInfo = getAnnotationInfo(Column::class.java)
+        return columnInfo?.nullable ?: true
+    }
+
+    fun getGeneratedInfo(): Any? {
+        return getAnnotationInfo(GeneratedValue::class.java)
+    }
+
+    fun getRefTypeName(): String {
+
+        return getEntityName(type)
+
+    }
+}

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateDocumentationApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateDocumentationApi.kt
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.service.annotation.GetExchange
+import org.springframework.web.service.annotation.HttpExchange
+
+@RequestMapping("/api/catena", produces = [MediaType.APPLICATION_JSON_VALUE])
+@HttpExchange("/api/catena")
+interface GateDocumentationApi {
+
+    @Operation(
+        summary = "Get mermaid class diagramm for the gate JPA model",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Entity model as mermaid diagramm"),
+        ]
+    )
+    @GetMapping("/mermaid/", produces = [MediaType.TEXT_PLAIN_VALUE])
+    @GetExchange("/mermaid/")
+    fun getMermaidGatePersistence(): ResponseEntity<String>
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/GateDocumentationController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/GateDocumentationController.kt
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.controller
+
+import org.eclipse.tractusx.bpdm.gate.api.GateDocumentationApi
+import org.eclipse.tractusx.bpdm.gate.service.DocumentationService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class GateDocumentationController(
+    val documentationService: DocumentationService
+) : GateDocumentationApi {
+
+    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyOutputDataAsRole())")
+    override fun getMermaidGatePersistence(): ResponseEntity<String> {
+        
+        return ResponseEntity(documentationService.getMermaidGatePersistence(), HttpStatus.OK)
+    }
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
@@ -19,6 +19,9 @@
 
 package org.eclipse.tractusx.bpdm.gate.controller
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.gate.api.GateLegalEntityApi
@@ -30,8 +33,10 @@ import org.eclipse.tractusx.bpdm.gate.config.ApiConfigProperties
 import org.eclipse.tractusx.bpdm.gate.containsDuplicates
 import org.eclipse.tractusx.bpdm.gate.service.LegalEntityService
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -83,4 +88,18 @@ class LegalEntityController(
         return ResponseEntity(HttpStatus.OK)
     }
 
+    @Operation(
+        summary = "Get Mermaid class Diagramm form Pool JPA model",
+        description = "List the country specific data rules for entity fields." +
+                "All fields that are not in this list are considered to be forbidden."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Enity Model as Mermaid"),
+        ]
+    )
+    @GetMapping("/mermaid/", produces = [MediaType.TEXT_PLAIN_VALUE])
+    fun getMermaid(): ResponseEntity<String> {
+        return ResponseEntity(legalEntityService.getMermaid(), HttpStatus.OK)
+    }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityController.kt
@@ -87,19 +87,5 @@ class LegalEntityController(
         legalEntityService.upsertLegalEntitiesOutput(legalEntities)
         return ResponseEntity(HttpStatus.OK)
     }
-
-    @Operation(
-        summary = "Get Mermaid class Diagramm form Pool JPA model",
-        description = "List the country specific data rules for entity fields." +
-                "All fields that are not in this list are considered to be forbidden."
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "Enity Model as Mermaid"),
-        ]
-    )
-    @GetMapping("/mermaid/", produces = [MediaType.TEXT_PLAIN_VALUE])
-    fun getMermaid(): ResponseEntity<String> {
-        return ResponseEntity(legalEntityService.getMermaid(), HttpStatus.OK)
-    }
+    
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/DocumentationService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/DocumentationService.kt
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.service
+
+import jakarta.persistence.EntityManager
+import org.eclipse.tractusx.bpdm.common.util.JpaMermaidCreator
+import org.eclipse.tractusx.bpdm.common.util.JpaMetaModelReader
+import org.springframework.stereotype.Service
+
+/**
+ * Service to generate documentation
+ */
+@Service
+class DocumentationService(
+    val entityManager: EntityManager
+) {
+
+    fun getMermaidGatePersistence(): String {
+
+        val allClassInfos = JpaMetaModelReader().createJpaClassInfos(this.entityManager.metamodel)
+        return JpaMermaidCreator().getMermaid(allClassInfos, "Gate persistence")
+    }
+
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -19,10 +19,13 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
+import jakarta.persistence.EntityManager
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
+import org.eclipse.tractusx.bpdm.common.util.JpaMermaidCreator
+import org.eclipse.tractusx.bpdm.common.util.JpaMetaModelReader
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.LegalEntityGateInputDto
@@ -36,7 +39,8 @@ import org.springframework.stereotype.Service
 @Service
 class LegalEntityService(
     private val legalEntityPersistenceService: LegalEntityPersistenceService,
-    private val legalEntityRepository: LegalEntityRepository
+    private val legalEntityRepository: LegalEntityRepository,
+    private val entityManager: EntityManager
 ) {
 
     private val logger = KotlinLogging.logger { }
@@ -115,6 +119,13 @@ class LegalEntityService(
         }
     }
 
+
+    fun getMermaid(): String {
+
+        val allClassInfos = JpaMetaModelReader().createJpaClassInfos(this.entityManager.metamodel)
+        return JpaMermaidCreator().getMermaid(allClassInfos, "Gate persistence")
+    }
+
 }
 
 private fun toValidSingleLegalEntity(legalEntity: LegalEntity): LegalEntityGateInputDto {
@@ -126,4 +137,5 @@ private fun toValidSingleLegalEntity(legalEntity: LegalEntity): LegalEntityGateI
         legalAddress = legalEntity.legalAddress.toAddressGateInputResponse(legalEntity.legalAddress),
         externalId = legalEntity.externalId
     )
+
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -19,13 +19,10 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
-import jakarta.persistence.EntityManager
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
-import org.eclipse.tractusx.bpdm.common.util.JpaMermaidCreator
-import org.eclipse.tractusx.bpdm.common.util.JpaMetaModelReader
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.LegalEntityGateInputDto
@@ -39,8 +36,7 @@ import org.springframework.stereotype.Service
 @Service
 class LegalEntityService(
     private val legalEntityPersistenceService: LegalEntityPersistenceService,
-    private val legalEntityRepository: LegalEntityRepository,
-    private val entityManager: EntityManager
+    private val legalEntityRepository: LegalEntityRepository
 ) {
 
     private val logger = KotlinLogging.logger { }
@@ -117,13 +113,6 @@ class LegalEntityService(
         return legalEntityPage.content.map { legalEntity ->
             legalEntity.toLegalEntityGateInputResponse(legalEntity)
         }
-    }
-
-
-    fun getMermaid(): String {
-
-        val allClassInfos = JpaMetaModelReader().createJpaClassInfos(this.entityManager.metamodel)
-        return JpaMermaidCreator().getMermaid(allClassInfos, "Gate persistence")
     }
 
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolDocumentationApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolDocumentationApi.kt
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.service.annotation.GetExchange
+import org.springframework.web.service.annotation.HttpExchange
+
+@RequestMapping("/api/catena", produces = [MediaType.APPLICATION_JSON_VALUE])
+@HttpExchange("/api/catena")
+interface PoolDocumentationApi {
+
+    @Operation(
+        summary = "Get mermaid class diagramm for the pool JPA model",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Entity model as mermaid diagramm"),
+        ]
+    )
+    @GetMapping("/mermaid/", produces = [MediaType.TEXT_PLAIN_VALUE])
+    @GetExchange("/mermaid/")
+    fun getMermaidPoolPersistence(): ResponseEntity<String>
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -20,9 +20,6 @@
 package org.eclipse.tractusx.bpdm.pool.controller
 
 import com.neovisionaries.i18n.CountryCode
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.FieldQualityRuleDto
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
@@ -35,10 +32,8 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.service.MetadataService
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -20,6 +20,9 @@
 package org.eclipse.tractusx.bpdm.pool.controller
 
 import com.neovisionaries.i18n.CountryCode
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.FieldQualityRuleDto
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
@@ -32,8 +35,10 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.service.MetadataService
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -79,4 +84,5 @@ class MetadataController(
     override fun createRegion(type: RegionDto): RegionDto {
         return metadataService.createRegion(type)
     }
+
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/PoolDocumentationController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/PoolDocumentationController.kt
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller
+
+import org.eclipse.tractusx.bpdm.pool.api.PoolDocumentationApi
+import org.eclipse.tractusx.bpdm.pool.service.GateDocumentationService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class PoolDocumentationController(
+    val documentationService: GateDocumentationService
+) : PoolDocumentationApi {
+
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
+    override fun getMermaidPoolPersistence(): ResponseEntity<String> {
+        return ResponseEntity(documentationService.getMermaidPoolPersistence(), HttpStatus.OK)
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/GateDocumentationService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/GateDocumentationService.kt
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import jakarta.persistence.EntityManager
+import org.eclipse.tractusx.bpdm.common.util.JpaMermaidCreator
+import org.eclipse.tractusx.bpdm.common.util.JpaMetaModelReader
+import org.springframework.stereotype.Service
+
+/**
+ * Service to generate documentation
+ */
+@Service
+class GateDocumentationService(
+    val entityManager: EntityManager
+) {
+
+    fun getMermaidPoolPersistence(): String {
+
+        val allClassInfos = JpaMetaModelReader().createJpaClassInfos(this.entityManager.metamodel)
+        return JpaMermaidCreator().getMermaid(allClassInfos, "Pool persistence")
+    }
+
+}


### PR DESCRIPTION
## Description

Generate Mermaid Persistence Class Diagram from JPA metadata. Add temporary a Rest endpoint to gate and pool to test the generated diagram

Enums are depicted as attributes without reference to the UML Enum Class, Max 15 enum entries are displayed
Not Null Attributes are extended by [1]

@OneToMany elements are depicted as refrence 
@ManyToOne are displayed as attributes without reference. (Mostly they are back references)

## Test instructions

Start gate and pool 
In the Browser (Chrome) call

http://localhost:8080/api/catena/mermaid/
http://localhost:8081/api/catena/mermaid/

Copy result in the mermaid live editor to see result: https://mermaid.live/edit 

Fixes #338 #339
