### PR TITLE
feat: Increase BPDM Chart app-version to 4.0.0-alpha.9

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,23 +22,23 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the gate and pool applications
-version: 3.0.2-alpha.5
-appVersion: "4.0.0-alpha.8"
+version: 3.0.2-alpha.6
+appVersion: "4.0.0-alpha.9"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 
 dependencies:
   - name: bpdm-gate
-    version: 4.0.0-alpha.10
+    version: 4.0.0-alpha.11
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 5.0.0-alpha.9
+    version: 5.0.0-alpha.10
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 1.0.1-alpha.5
+    version: 1.0.1-alpha.6
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: opensearch

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
-appVersion: "4.0.0-alpha.8"
-version: 1.0.1-alpha.5
+appVersion: "4.0.0-alpha.9"
+version: 1.0.1-alpha.6
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "4.0.0-alpha.8"
-version: 4.0.0-alpha.10
+appVersion: "4.0.0-alpha.9"
+version: 4.0.0-alpha.11
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "4.0.0-alpha.8"
-version: 5.0.0-alpha.9
+appVersion: "4.0.0-alpha.9"
+version: 5.0.0-alpha.10
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:


### PR DESCRIPTION
## Description

This pull request increases the app version of the BPDM chart and its subcharts to 4.0.0-alpha.9. Also bumps the alpha versions of those charts.

Will introduce alpga release 3.0.2-alpha.6 of the BPDM chart.