### PR TITLE
feat(Gate): Create or Update sharing states for existing business par…

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
@@ -52,9 +52,6 @@ class GateUpdateService(
             putLegalEntityOutput(
                 buildLegalEntityGateOutputRequest(requestEntry, entity)
             )
-            upsertSharingState(
-                buildSuccessSharingStateDto(LsaType.LEGAL_ENTITY, externalId, entity.legalEntity.bpnl, true)
-            )
         }
         for (errorInfo in responseWrapper.errors) {
             val externalId = errorInfo.entityKey
@@ -78,9 +75,6 @@ class GateUpdateService(
             putLegalEntityOutput(
                 buildLegalEntityGateOutputRequest(requestEntry, entity)
             )
-            upsertSharingState(
-                buildSuccessSharingStateDto(LsaType.LEGAL_ENTITY, externalId, bpn, false)
-            )
         }
         for (errorInfo in responseWrapper.errors) {
             val bpn = errorInfo.entityKey
@@ -101,9 +95,6 @@ class GateUpdateService(
             val requestEntry = requestEntryByExternalId[externalId]
             putSiteOutput(
                 buildSiteGateOutputRequest(requestEntry, entity)
-            )
-            upsertSharingState(
-                buildSuccessSharingStateDto(LsaType.SITE, externalId, entity.site.bpns, true)
             )
         }
         for (errorInfo in responseWrapper.errors) {
@@ -127,9 +118,6 @@ class GateUpdateService(
             putSiteOutput(
                 buildSiteGateOutputRequest(requestEntry, entity)
             )
-            upsertSharingState(
-                buildSuccessSharingStateDto(LsaType.SITE, externalId, bpn, false)
-            )
         }
         for (errorInfo in responseWrapper.errors) {
             val bpn = errorInfo.entityKey
@@ -150,9 +138,6 @@ class GateUpdateService(
             val requestEntry = requestEntryByExternalId[externalId]
             putAddressOutput(
                 buildAddressGateOutputRequest(requestEntry, entity.address)
-            )
-            upsertSharingState(
-                buildSuccessSharingStateDto(LsaType.ADDRESS, externalId, entity.address.bpna, true)
             )
         }
         for (errorInfo in responseWrapper.errors) {
@@ -175,9 +160,6 @@ class GateUpdateService(
             val requestEntry = requestEntryByExternalId[externalId]
             putAddressOutput(
                 buildAddressGateOutputRequest(requestEntry, entity)
-            )
-            upsertSharingState(
-                buildSuccessSharingStateDto(LsaType.ADDRESS, externalId, bpn, false)
             )
         }
         for (errorInfo in responseWrapper.errors) {

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
@@ -17,25 +17,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
- ******************************************************************************/
-
 package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressPersistenceService.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdm.gate.service
 import jakarta.transaction.Transactional
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.common.util.replace
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.entity.LegalEntity
@@ -113,6 +114,7 @@ class AddressPersistenceService(
                     gateAddressRepository.save(fullAddress)
                 }
             }
+            sharingStateService.upsertSharingState(address.toSharingStateDTO(SharingStateType.Success))
         }
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.common.util.replace
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.entity.AddressState
@@ -145,6 +146,7 @@ class LegalEntityPersistenceService(
                     saveChangelog(legalEntity.externalId, datatype)
                 }
             }
+            sharingStateService.upsertSharingState(legalEntity.toSharingStateDTO(SharingStateType.Success))
         }
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -514,4 +514,19 @@ fun LegalEntityGateInputRequest.toSharingStateDTO():SharingStateDto {
     return SharingStateDto(LsaType.LEGAL_ENTITY,externalId)
 }
 
+fun AddressGateOutputRequest.toSharingStateDTO(sharingStateType: SharingStateType):SharingStateDto {
+
+    return SharingStateDto(LsaType.ADDRESS,externalId, sharingStateType = sharingStateType)
+}
+
+fun SiteGateOutputRequest.toSharingStateDTO(sharingStateType: SharingStateType):SharingStateDto {
+
+    return SharingStateDto(LsaType.SITE,externalId, sharingStateType = sharingStateType)
+}
+
+fun LegalEntityGateOutputRequest.toSharingStateDTO(sharingStateType: SharingStateType):SharingStateDto {
+
+    return SharingStateDto(LsaType.LEGAL_ENTITY,externalId, sharingStateType = sharingStateType)
+}
+
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -516,17 +516,17 @@ fun LegalEntityGateInputRequest.toSharingStateDTO():SharingStateDto {
 
 fun AddressGateOutputRequest.toSharingStateDTO(sharingStateType: SharingStateType):SharingStateDto {
 
-    return SharingStateDto(LsaType.ADDRESS,externalId, sharingStateType = sharingStateType)
+    return SharingStateDto(LsaType.ADDRESS,externalId, sharingStateType = sharingStateType, bpn = bpn)
 }
 
 fun SiteGateOutputRequest.toSharingStateDTO(sharingStateType: SharingStateType):SharingStateDto {
 
-    return SharingStateDto(LsaType.SITE,externalId, sharingStateType = sharingStateType)
+    return SharingStateDto(LsaType.SITE,externalId, sharingStateType = sharingStateType,bpn = bpn)
 }
 
 fun LegalEntityGateOutputRequest.toSharingStateDTO(sharingStateType: SharingStateType):SharingStateDto {
 
-    return SharingStateDto(LsaType.LEGAL_ENTITY,externalId, sharingStateType = sharingStateType)
+    return SharingStateDto(LsaType.LEGAL_ENTITY,externalId, sharingStateType = sharingStateType,bpn = bpn)
 }
 
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
@@ -23,6 +23,7 @@ import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
 import org.eclipse.tractusx.bpdm.common.util.replace
 import org.eclipse.tractusx.bpdm.gate.api.model.LsaType
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.entity.*
@@ -144,6 +145,7 @@ class SitePersistenceService(
                     saveChangelog(site.externalId, datatype)
                 }
             }
+            sharingStateService.upsertSharingState(site.toSharingStateDTO(SharingStateType.Success))
         }
     }
 


### PR DESCRIPTION
feat: Create or Update sharing states for existing business partners


## Description
When the Gate receives an output business partner it needs to just set the corresponding sharing state to success by itself.



## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
