### PR TITLE
feat: API - Rename Type to DeliveryServiceType in AlternativePostalAddressVerboseDto

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -175,7 +175,7 @@ private fun poolToGateAlternativeAddress(address: AlternativePostalAddressVerbos
         baseAddress = baseAddress,
         areaPart = areaPart,
         deliveryServiceNumber = address.deliveryServiceNumber,
-        deliveryServiceType = address.type,
+        deliveryServiceType = address.deliveryServiceType,
         deliveryServiceQualifier = address.deliveryServiceQualifier
     )
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AlternativePostalAddressVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AlternativePostalAddressVerboseDto.kt
@@ -39,7 +39,7 @@ data class AlternativePostalAddressVerboseDto(
     val deliveryServiceNumber: String = "",
 
     @get:Schema(description = "The type of this specified delivery")
-    val type: DeliveryServiceType = DeliveryServiceType.PO_BOX,
+    val deliveryServiceType: DeliveryServiceType = DeliveryServiceType.PO_BOX,
 
     @get:Schema(description = "Delivery Service Qualifier")
     val deliveryServiceQualifier: String?,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -190,7 +190,7 @@ fun AlternativePostalAddress.toDto(): AlternativePostalAddressVerboseDto {
         areaPart = AreaDistrictAlternativVerboseDto(
             administrativeAreaLevel1 = administrativeAreaLevel1?.let { NameRegioncodeVerboseDto(it.regionName, it.regionCode) },
         ),
-        type = deliveryServiceType,
+        deliveryServiceType = deliveryServiceType,
         deliveryServiceNumber = deliveryServiceNumber,
         deliveryServiceQualifier = deliveryServiceQualifier
     )


### PR DESCRIPTION
Rename field **type** to **deliveryServiceType** in class **AlternativePostalAddressVerboseDto**

Fixes #357