### PR TITLE
Feat: API - Rename changelog timestamp

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
@@ -47,7 +47,7 @@ class GateQueryService(
 
         do {
             val pageResponse = gateClient.changelog().getInputChangelog(
-                searchRequest = ChangeLogSearchRequest(fromTime = modifiedAfter),
+                searchRequest = ChangeLogSearchRequest(timestampAfter = modifiedAfter),
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
             )
             page++

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/SyncStateIT.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/SyncStateIT.kt
@@ -125,15 +125,15 @@ class SyncStateIT @Autowired constructor(
         Assertions.assertThat(loggedRequests.size).isEqualTo(3)
 
         // 1st sync polls from initial timestamp (2000-01-01)
-        val pollFrom1stSync = parseBody<ChangeLogSearchRequest>(loggedRequests[0]).fromTime
+        val pollFrom1stSync = parseBody<ChangeLogSearchRequest>(loggedRequests[0]).timestampAfter
         Assertions.assertThat(pollFrom1stSync).isEqualTo(TS_INITIAL_POLL_FROM)
 
         // 2nd sync polls from around timestamp of 1st successful sync
-        val pollFrom2ndSync = parseBody<ChangeLogSearchRequest>(loggedRequests[1]).fromTime
+        val pollFrom2ndSync = parseBody<ChangeLogSearchRequest>(loggedRequests[1]).timestampAfter
         Assertions.assertThat(pollFrom2ndSync).isBetween(tsBefore1stSuccessfulSync, tsAfter1stSuccessfulSync)
 
         // 3rd sync polls from around timestamp of 2nd successful sync
-        val pollFrom3rdSync = parseBody<ChangeLogSearchRequest>(loggedRequests[2]).fromTime
+        val pollFrom3rdSync = parseBody<ChangeLogSearchRequest>(loggedRequests[2]).timestampAfter
         Assertions.assertThat(pollFrom3rdSync).isBetween(tsBefore2ndSuccessfulSync, tsAfter2ndSuccessfulSync)
     }
 
@@ -211,23 +211,23 @@ class SyncStateIT @Autowired constructor(
         Assertions.assertThat(loggedRequests.size).isEqualTo(5)
 
         // 1st sync polls from initial timestamp (2000-01-01)
-        val pollFrom1stSync = parseBody<ChangeLogSearchRequest>(loggedRequests[0]).fromTime
+        val pollFrom1stSync = parseBody<ChangeLogSearchRequest>(loggedRequests[0]).timestampAfter
         Assertions.assertThat(pollFrom1stSync).isEqualTo(TS_INITIAL_POLL_FROM)
 
         // 2nd sync polls from around timestamp of 1st successful sync
-        val pollFrom2ndSync = parseBody<ChangeLogSearchRequest>(loggedRequests[1]).fromTime
+        val pollFrom2ndSync = parseBody<ChangeLogSearchRequest>(loggedRequests[1]).timestampAfter
         Assertions.assertThat(pollFrom2ndSync).isBetween(tsBefore1stSuccessfulSync, tsAfter1stSuccessfulSync)
 
         // 3rd sync still polls from same timestamp because last sync has failed!
-        val pollFrom3rdSync = parseBody<ChangeLogSearchRequest>(loggedRequests[2]).fromTime
+        val pollFrom3rdSync = parseBody<ChangeLogSearchRequest>(loggedRequests[2]).timestampAfter
         Assertions.assertThat(pollFrom3rdSync).isEqualTo(pollFrom2ndSync)
 
         // 4th sync still polls from same timestamp because last sync has failed!
-        val pollFrom4thSync = parseBody<ChangeLogSearchRequest>(loggedRequests[3]).fromTime
+        val pollFrom4thSync = parseBody<ChangeLogSearchRequest>(loggedRequests[3]).timestampAfter
         Assertions.assertThat(pollFrom4thSync).isEqualTo(pollFrom2ndSync)
 
         // 5th sync polls from around timestamp of 2nd successful sync
-        val pollFrom5thSync = parseBody<ChangeLogSearchRequest>(loggedRequests[4]).fromTime
+        val pollFrom5thSync = parseBody<ChangeLogSearchRequest>(loggedRequests[4]).timestampAfter
         Assertions.assertThat(pollFrom5thSync).isBetween(tsBefore2ndSuccessfulSync, tsAfter2ndSuccessfulSync)
     }
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/ChangelogType.java
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/ChangelogType.java
@@ -17,20 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model.request
+package org.eclipse.tractusx.bpdm.gate.api.model;
 
-import io.swagger.v3.oas.annotations.Parameter
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
-import java.time.Instant
-
-data class ChangeLogSearchRequest(
-
-    @field:Parameter(description = "From when to search changelog entries", example = "2023-03-20T10:23:28.194Z", required = false)
-    val timestampAfter: Instant? = null,
-
-    @field:Parameter(description = "External-IDs of business partners for which to search changelog entries. Ignored if empty", required = false)
-    val externalIds: Set<String>? = emptySet(),
-
-    @field:Parameter(description = "Business partner types for which to search changelog entries. Ignored if empty", required = false)
-    val businessPartnerTypes: Set<BusinessPartnerType>? = emptySet()
-)
+public enum ChangelogType {
+    CREATE,
+    UPDATE
+}

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ChangelogGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ChangelogGateDto.kt
@@ -21,14 +21,21 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.gate.api.model.ChangelogType
 import java.time.Instant
 
 @Schema(name = "ChangelogGateDto", description = "Changelog entry for a business partner")
 data class ChangelogGateDto(
+
     @Schema(description = "External ID of the changelog entry")
     val externalId: String,
-    @Schema(description = "The type of the change")
+
+    @Schema(description = "The type of the business partner this change refers to")
     val businessPartnerType: BusinessPartnerType,
+
     @Schema(description = "The timestamp of the operation")
-    val modifiedAt: Instant
+    val timestamp: Instant,
+
+    @Schema(description = "The type of the change")
+    val changelogType: ChangelogType
 )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
@@ -42,8 +42,8 @@ class ChangelogController(
     ): PageChangeLogDto<ChangelogGateDto> {
         return changelogService.getChangeLogEntries(
             searchRequest.externalIds,
-            searchRequest.businessPartnerType,
-            searchRequest.fromTime,
+            searchRequest.businessPartnerTypes,
+            searchRequest.timestampAfter,
             OutputInputEnum.Input,
             paginationRequest.page,
             paginationRequest.size
@@ -57,8 +57,8 @@ class ChangelogController(
     ): PageChangeLogDto<ChangelogGateDto> {
         return changelogService.getChangeLogEntries(
             searchRequest.externalIds,
-            searchRequest.businessPartnerType,
-            searchRequest.fromTime,
+            searchRequest.businessPartnerTypes,
+            searchRequest.timestampAfter,
             OutputInputEnum.Output,
             paginationRequest.page,
             paginationRequest.size

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/ChangelogEntry.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/ChangelogEntry.kt
@@ -23,7 +23,7 @@ import jakarta.persistence.*
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
-
+import org.eclipse.tractusx.bpdm.gate.api.model.ChangelogType
 
 @Entity
 @Table(name = "changelog_entries")
@@ -31,15 +31,17 @@ class ChangelogEntry(
 
     @Column(name = "external_id", nullable = false, updatable = false)
     val externalId: String,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "business_partner_type", nullable = false, updatable = false)
     val businessPartnerType: BusinessPartnerType,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "changelog_type", nullable = false, updatable = false)
+    val changelogType: ChangelogType,
+
     @Column(name = "data_type")
     @Enumerated(EnumType.STRING)
     var dataType: OutputInputEnum
 
-
 ) : BaseEntity()
-
-
-

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/AddressService.kt
@@ -19,8 +19,6 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
-import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.OutputInputEnum
@@ -28,10 +26,7 @@ import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateOutputDto
-import org.eclipse.tractusx.bpdm.gate.config.BpnConfigProperties
-import org.eclipse.tractusx.bpdm.gate.entity.ChangelogEntry
 import org.eclipse.tractusx.bpdm.gate.entity.LogisticAddress
-import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository
 import org.eclipse.tractusx.bpdm.gate.repository.GateAddressRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -39,13 +34,10 @@ import org.springframework.stereotype.Service
 
 @Service
 class AddressService(
-    private val bpnConfigProperties: BpnConfigProperties,
-    private val changelogRepository: ChangelogRepository,
     private val addressPersistenceService: AddressPersistenceService,
     private val addressRepository: GateAddressRepository,
     private val sharingStateService: SharingStateService
 ) {
-    private val logger = KotlinLogging.logger { }
 
     fun getAddresses(page: Int, size: Int, externalIds: Collection<String>? = null): PageDto<AddressGateInputDto> {
 
@@ -110,12 +102,6 @@ class AddressService(
      * Upsert addresses input to the database
      **/
     fun upsertAddresses(addresses: Collection<AddressGateInputRequest>) {
-
-        // create changelog entry if all goes well from saasClient
-        addresses.forEach { address ->
-            changelogRepository.save(ChangelogEntry(address.externalId, BusinessPartnerType.ADDRESS, OutputInputEnum.Input))
-        }
-
         addressPersistenceService.persistAddressBP(addresses, OutputInputEnum.Input)
     }
 
@@ -123,14 +109,7 @@ class AddressService(
      * Upsert addresses output to the database
      **/
     fun upsertOutputAddresses(addresses: Collection<AddressGateOutputRequest>) {
-
-        // create changelog entry if all goes well from saasClient
-        addresses.forEach { address ->
-            changelogRepository.save(ChangelogEntry(address.externalId, BusinessPartnerType.ADDRESS, OutputInputEnum.Output))
-        }
-
         addressPersistenceService.persistOutputAddressBP(addresses, OutputInputEnum.Output)
-
     }
 
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -139,7 +139,7 @@ fun SiteGateInputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputIn
 
     val addressInputRequest = AddressGateInputRequest(
         address = mainAddress,
-        externalId = getMainAddressForSiteExternalId(externalId),
+        externalId = getMainAddressExternalIdForSiteExternalId(externalId),
         siteExternalId = externalId
     )
 
@@ -162,7 +162,7 @@ fun SiteGateOutputRequest.toSiteGate(legalEntity: LegalEntity, datatype: OutputI
 
     val addressOutputRequest = AddressGateOutputRequest(
         address = mainAddress.address,
-        externalId = getMainAddressForSiteExternalId(externalId),
+        externalId = getMainAddressExternalIdForSiteExternalId(externalId),
         legalEntityExternalId = externalId,
         bpn = mainAddress.bpn
     )
@@ -191,7 +191,8 @@ fun ChangelogEntry.toGateDto(): ChangelogGateDto {
     return ChangelogGateDto(
         externalId = externalId,
         businessPartnerType = businessPartnerType,
-        modifiedAt = createdAt
+        timestamp = createdAt,
+        changelogType = changelogType
     )
 }
 
@@ -199,7 +200,7 @@ fun LegalEntityGateInputRequest.toLegalEntity(datatype: OutputInputEnum): LegalE
 
     val addressInputRequest = AddressGateInputRequest(
         address = legalAddress,
-        externalId = getMainAddressForLegalEntityExternalId(externalId),
+        externalId = getLegalAddressExternalIdForLegalEntityExternalId(externalId),
         legalEntityExternalId = externalId
     )
 
@@ -225,7 +226,7 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: OutputInputEnum): Legal
 
     val addressOutputRequest = AddressGateOutputRequest(
         address = legalAddress.address,
-        externalId = getMainAddressForLegalEntityExternalId(externalId),
+        externalId = getLegalAddressExternalIdForLegalEntityExternalId(externalId),
         legalEntityExternalId = externalId,
         bpn = legalAddress.bpn
     )
@@ -269,12 +270,12 @@ fun toEntityIdentifiers(dto: LegalEntityIdentifierDto, legalEntity: LegalEntity)
     return LegalEntityIdentifier(dto.value, dto.type, dto.issuingBody, legalEntity)
 }
 
-fun getMainAddressForSiteExternalId(siteExternalId: String): String {
+fun getMainAddressExternalIdForSiteExternalId(siteExternalId: String): String {
     return siteExternalId + "_site"
 }
 
-fun getMainAddressForLegalEntityExternalId(siteExternalId: String): String {
-    return siteExternalId + "_legalAddress"
+fun getLegalAddressExternalIdForLegalEntityExternalId(legalEntityExternalId: String): String {
+    return legalEntityExternalId + "_legalAddress"
 }
 
 //Logistic Address mapping to AddressGateInputResponse

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_12__add_changelog_type.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_12__add_changelog_type.sql
@@ -1,0 +1,2 @@
+alter table changelog_entries
+    add changelog_type varchar(255) default 'UPDATE';

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
@@ -47,6 +47,7 @@ import org.assertj.core.api.RecursiveComparisonAssert
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.api.exception.ChangeLogOutputError
+import org.eclipse.tractusx.bpdm.gate.api.model.ChangelogType
 import org.eclipse.tractusx.bpdm.gate.api.model.request.ChangeLogSearchRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogGateDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ErrorInfo
@@ -103,8 +104,8 @@ internal class ChangeLogControllerIT @Autowired constructor(
         val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content)
-            .ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::modifiedAt.name}")
-            .isEqualTo(listOf(ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant)))
+            .ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
+            .isEqualTo(listOf(ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE)))
     }
 
 
@@ -151,13 +152,12 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog by external id and timeStamp`() {
 
-        val searchRequest = ChangeLogSearchRequest(externalIds = setOf(CommonValues.externalIdAddress1), fromTime = instant)
+        val searchRequest = ChangeLogSearchRequest(externalIds = setOf(CommonValues.externalIdAddress1), timestampAfter = instant)
 
         val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
-
-        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::modifiedAt.name}")
-            .isEqualTo(listOf(ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant)))
+        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
+            .isEqualTo(listOf(ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE)))
     }
 
     /**
@@ -168,15 +168,15 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog by businessPartnerType`() {
 
-        val searchRequest = ChangeLogSearchRequest(businessPartnerType = setOf(businessPartnerTypeParamAddress))
+        val searchRequest = ChangeLogSearchRequest(businessPartnerTypes = setOf(businessPartnerTypeParamAddress))
 
         val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
-        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::modifiedAt.name}")
+        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
             .isEqualTo(
                 listOf(
-                    ChangelogGateDto(CommonValues.legalEntityAddressId, businessPartnerTypeParamAddress, instant),
-                    ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant)
+                    ChangelogGateDto(CommonValues.legalEntityAddressId, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE),
+                    ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE)
                 )
             )
     }
@@ -189,7 +189,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
     @Test
     fun `get changeLog by businessPartnerType not found`() {
-        val searchRequest = ChangeLogSearchRequest(businessPartnerType = setOf(businessPartnerTypeParamNotFound))
+        val searchRequest = ChangeLogSearchRequest(businessPartnerTypes = setOf(businessPartnerTypeParamNotFound))
 
         val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
@@ -204,15 +204,15 @@ internal class ChangeLogControllerIT @Autowired constructor(
      */
     @Test
     fun `get changeLog by businessPartnerType and timeStamp`() {
-        val searchRequest = ChangeLogSearchRequest(businessPartnerType = setOf(businessPartnerTypeParamAddress), fromTime = instant)
+        val searchRequest = ChangeLogSearchRequest(businessPartnerTypes = setOf(businessPartnerTypeParamAddress), timestampAfter = instant)
 
         val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
 
-        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::modifiedAt.name}")
+        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
             .isEqualTo(
                 listOf(
-                    ChangelogGateDto(CommonValues.legalEntityAddressId, businessPartnerTypeParamAddress, instant),
-                    ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant)
+                    ChangelogGateDto(CommonValues.legalEntityAddressId, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE),
+                    ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE)
                 )
             )
     }
@@ -225,16 +225,16 @@ internal class ChangeLogControllerIT @Autowired constructor(
     @Test
     fun `get changeLog from timeStamp`() {
 
-        val searchRequest = ChangeLogSearchRequest(businessPartnerType = emptySet(), fromTime = instant)
+        val searchRequest = ChangeLogSearchRequest(businessPartnerTypes = emptySet(), timestampAfter = instant)
 
         val searchResult = gateClient.changelog().getInputChangelog(paginationRequest = PaginationRequest(), searchRequest)
 
-        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::modifiedAt.name}")
+        assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
             .isEqualTo(
                 listOf(
-                    ChangelogGateDto(CommonValues.legalEntityAddressId, businessPartnerTypeParamAddress, instant),
-                    ChangelogGateDto(CommonValues.externalId1, businessPartnerTypeParamLegalEntity, instant),
-                    ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant)
+                    ChangelogGateDto(CommonValues.legalEntityAddressId, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE),
+                    ChangelogGateDto(CommonValues.externalId1, businessPartnerTypeParamLegalEntity, instant, ChangelogType.CREATE),
+                    ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE)
                 )
             )
     }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/ChangelogSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/ChangelogSearchRequest.kt
@@ -26,8 +26,9 @@ import java.time.Instant
 
 @Schema(name = "ChangeLogSearchRequest", description = "Request for searching and filtering the business partner changelog")
 data class ChangelogSearchRequest(
+
     @Schema(description = "Changelog entries should be created after this time", example = "2023-03-20T10:23:28.194Z")
-    val fromTime: Instant? = null,
+    val timestampAfter: Instant? = null,
 
     @Schema(description = "Only show changelog entries for business partners with the given BPNs. Empty means no restriction.")
     val bpns: Set<String>? = null,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/ChangelogEntryVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/ChangelogEntryVerboseDto.kt
@@ -30,12 +30,12 @@ data class ChangelogEntryVerboseDto(
     @Schema(description = "Business Partner Number of the changelog entry")
     val bpn: String,
 
-    @Schema(description = "The type of the change")
-    val changelogType: ChangelogType,
+    @Schema(description = "The type of the business partner this change refers to")
+    val businessPartnerType: BusinessPartnerType,
 
     @Schema(description = "The timestamp of the change")
     val timestamp: Instant,
 
-    @Schema(description = "The type of the business partner this change refers to")
-    val businessPartnerType: BusinessPartnerType
+    @Schema(description = "The type of the change")
+    val changelogType: ChangelogType
 )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
@@ -51,7 +51,7 @@ class ChangelogController(
         return partnerChangelogService.getChangeLogEntries(
             changelogSearchRequest.bpns,
             changelogSearchRequest.businessPartnerTypes,
-            changelogSearchRequest.fromTime,
+            changelogSearchRequest.timestampAfter,
             paginationRequest.page,
             paginationRequest.size
         )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/ChangelogEntryCreateRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/ChangelogEntryCreateRequest.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.dto
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 
-data class ChangelogEntryVerboseDto(
+data class ChangelogEntryCreateRequest(
     val bpn: String,
     val changelogType: ChangelogType,
     val businessPartnerType: BusinessPartnerType

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/PartnerChangelogEntry.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/PartnerChangelogEntry.kt
@@ -27,13 +27,16 @@ import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 @Entity
 @Table(name = "partner_changelog_entries")
 class PartnerChangelogEntry(
-    @Enumerated(EnumType.STRING)
-    @Column(name = "changelog_type", nullable = false, updatable = false)
-    val changelogType: ChangelogType,
+
     @Column(name = "bpn", nullable = false, updatable = false)
     val bpn: String,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "business_partner_type", nullable = false, updatable = false)
-    val businessPartnerType: BusinessPartnerType
+    val businessPartnerType: BusinessPartnerType,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "changelog_type", nullable = false, updatable = false)
+    val changelogType: ChangelogType
+
 ) : BaseEntity()

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -26,7 +26,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 import org.eclipse.tractusx.bpdm.pool.api.model.request.*
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.eclipse.tractusx.bpdm.pool.dto.AddressMetadataDto
-import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryVerboseDto
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
 import org.eclipse.tractusx.bpdm.pool.dto.LegalEntityMetadataDto
 import org.eclipse.tractusx.bpdm.pool.entity.*
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
@@ -82,13 +82,11 @@ class BusinessPartnerBuildService(
 
         val legalEntities = requestsByLegalEntities.keys
 
-        changelogService.createChangelogEntries(legalEntities.map { ChangelogEntryVerboseDto(it.bpn, ChangelogType.CREATE, BusinessPartnerType.LEGAL_ENTITY) })
         changelogService.createChangelogEntries(legalEntities.map {
-            ChangelogEntryVerboseDto(
-                it.legalAddress.bpn,
-                ChangelogType.CREATE,
-                BusinessPartnerType.ADDRESS
-            )
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.CREATE, BusinessPartnerType.LEGAL_ENTITY)
+        })
+        changelogService.createChangelogEntries(legalEntities.map {
+            ChangelogEntryCreateRequest(it.legalAddress.bpn, ChangelogType.CREATE, BusinessPartnerType.ADDRESS)
         })
 
         legalEntityRepository.saveAll(legalEntities)
@@ -126,8 +124,12 @@ class BusinessPartnerBuildService(
 
         val sites = requestsBySites.keys
 
-        changelogService.createChangelogEntries(sites.map { ChangelogEntryVerboseDto(it.bpn, ChangelogType.CREATE, BusinessPartnerType.SITE) })
-        changelogService.createChangelogEntries(sites.map { ChangelogEntryVerboseDto(it.mainAddress.bpn, ChangelogType.CREATE, BusinessPartnerType.ADDRESS) })
+        changelogService.createChangelogEntries(sites.map {
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.CREATE, BusinessPartnerType.SITE)
+        })
+        changelogService.createChangelogEntries(sites.map {
+            ChangelogEntryCreateRequest(it.mainAddress.bpn, ChangelogType.CREATE, BusinessPartnerType.ADDRESS)
+        })
 
         siteRepository.saveAll(sites)
 
@@ -159,11 +161,7 @@ class BusinessPartnerBuildService(
             .plus(createAddressesForLegalEntity(legalEntityRequests, metadataMap))
 
         changelogService.createChangelogEntries(addressResponses.map {
-            ChangelogEntryVerboseDto(
-                it.address.bpna,
-                ChangelogType.CREATE,
-                BusinessPartnerType.ADDRESS
-            )
+            ChangelogEntryCreateRequest(it.address.bpna, ChangelogType.CREATE, BusinessPartnerType.ADDRESS)
         })
 
         return AddressPartnerCreateResponseWrapper(addressResponses, errors)
@@ -187,13 +185,11 @@ class BusinessPartnerBuildService(
         val legalEntities = legalEntityRepository.findDistinctByBpnIn(bpnsToFetch)
         businessPartnerFetchService.fetchDependenciesWithLegalAddress(legalEntities)
 
-        changelogService.createChangelogEntries(legalEntities.map { ChangelogEntryVerboseDto(it.bpn, ChangelogType.UPDATE, BusinessPartnerType.LEGAL_ENTITY) })
         changelogService.createChangelogEntries(legalEntities.map {
-            ChangelogEntryVerboseDto(
-                it.legalAddress.bpn,
-                ChangelogType.UPDATE,
-                BusinessPartnerType.ADDRESS
-            )
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.UPDATE, BusinessPartnerType.LEGAL_ENTITY)
+        })
+        changelogService.createChangelogEntries(legalEntities.map {
+            ChangelogEntryCreateRequest(it.legalAddress.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS)
         })
 
         val requestsByBpn = validRequests.associateBy { it.bpnl }
@@ -222,8 +218,12 @@ class BusinessPartnerBuildService(
         val bpnsToFetch = validRequests.map { it.bpns }
         val sites = siteRepository.findDistinctByBpnIn(bpnsToFetch)
 
-        changelogService.createChangelogEntries(sites.map { ChangelogEntryVerboseDto(it.bpn, ChangelogType.UPDATE, BusinessPartnerType.SITE) })
-        changelogService.createChangelogEntries(sites.map { ChangelogEntryVerboseDto(it.mainAddress.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS) })
+        changelogService.createChangelogEntries(sites.map {
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.UPDATE, BusinessPartnerType.SITE)
+        })
+        changelogService.createChangelogEntries(sites.map {
+            ChangelogEntryCreateRequest(it.mainAddress.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS)
+        })
 
         val requestByBpnMap = validRequests.associateBy { it.bpns }
         val updatedSites = sites.map {
@@ -248,10 +248,12 @@ class BusinessPartnerBuildService(
         val addresses = logisticAddressRepository.findDistinctByBpnIn(validRequests.map { it.bpna })
         val metadataMap = metadataService.getMetadata(validRequests.map { it.address }).toMapping()
 
-        changelogService.createChangelogEntries(addresses.map { ChangelogEntryVerboseDto(it.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS) })
+        changelogService.createChangelogEntries(addresses.map {
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS)
+        })
 
         val requestsByBpn = validRequests.associateBy { it.bpna }
-        val updatedAddresses = addresses.map{ address ->
+        val updatedAddresses = addresses.map { address ->
             updateLogisticAddress(address, requestsByBpn[address.bpn]!!.address, metadataMap)
             logisticAddressRepository.save(address)
         }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/PartnerChangelogService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/PartnerChangelogService.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.service
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
-import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryVerboseDto
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
 import org.eclipse.tractusx.bpdm.pool.entity.PartnerChangelogEntry
 import org.eclipse.tractusx.bpdm.pool.repository.PartnerChangelogEntryRepository
 import org.eclipse.tractusx.bpdm.pool.repository.PartnerChangelogEntryRepository.Specs.byBpnsIn
@@ -49,7 +49,7 @@ class PartnerChangelogService(
     private val logger = KotlinLogging.logger { }
 
     @Transactional
-    fun createChangelogEntries(changelogEntries: Collection<ChangelogEntryVerboseDto>): List<PartnerChangelogEntry> {
+    fun createChangelogEntries(changelogEntries: Collection<ChangelogEntryCreateRequest>): List<PartnerChangelogEntry> {
         logger.debug { "Create ${changelogEntries.size} new change log entries" }
         val entities = changelogEntries.map { it.toEntity() }
         return partnerChangelogEntryRepository.saveAll(entities)
@@ -81,7 +81,7 @@ class PartnerChangelogService(
         return page.toDto(page.content.map { it.toDto() })
     }
 
-    private fun ChangelogEntryVerboseDto.toEntity(): PartnerChangelogEntry {
-        return PartnerChangelogEntry(this.changelogType, this.bpn, this.businessPartnerType)
+    private fun ChangelogEntryCreateRequest.toEntity(): PartnerChangelogEntry {
+        return PartnerChangelogEntry(this.bpn, this.businessPartnerType, this.changelogType)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -281,7 +281,7 @@ fun SyncRecord.toDto(): SyncDto {
 }
 
 fun PartnerChangelogEntry.toDto(): ChangelogEntryVerboseDto {
-    return ChangelogEntryVerboseDto(bpn, changelogType, createdAt, businessPartnerType)
+    return ChangelogEntryVerboseDto(bpn, businessPartnerType, createdAt, changelogType)
 }
 
 fun Region.toDto(): RegionDto {

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
@@ -89,14 +89,14 @@ class ChangelogControllerIT @Autowired constructor(
 
         //Log entry for the created legal entities and their legal addresses should be there
         val expectedChangelogEntries = listOf(
-            ChangelogEntryVerboseDto(bpnL1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnL2, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnA1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnA2, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnL1, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnL2, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnA1, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnA2, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.ADDRESS)
+            ChangelogEntryVerboseDto(bpnL1, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnL2, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnA1, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnA2, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnL1, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.UPDATE),
+            ChangelogEntryVerboseDto(bpnL2, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.UPDATE),
+            ChangelogEntryVerboseDto(bpnA1, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.UPDATE),
+            ChangelogEntryVerboseDto(bpnA2, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.UPDATE)
         )
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
@@ -148,16 +148,16 @@ class ChangelogControllerIT @Autowired constructor(
 
         //Log entry for the created sites and their main address should be there
         val expectedChangelogEntries = listOf(
-            ChangelogEntryVerboseDto(bpnL, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnS1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.SITE),
-            ChangelogEntryVerboseDto(bpnS2, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.SITE),
-            ChangelogEntryVerboseDto(bpnLegalAddress, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnMainAddress1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnMainAddress2, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnS1, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.SITE),
-            ChangelogEntryVerboseDto(bpnS2, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.SITE),
-            ChangelogEntryVerboseDto(bpnMainAddress1, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnMainAddress2, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.ADDRESS)
+            ChangelogEntryVerboseDto(bpnL, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnS1, BusinessPartnerType.SITE, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnS2, BusinessPartnerType.SITE, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnLegalAddress, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnMainAddress1, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnMainAddress2, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnS1, BusinessPartnerType.SITE, timeAfterUpdate, ChangelogType.UPDATE),
+            ChangelogEntryVerboseDto(bpnS2, BusinessPartnerType.SITE, timeAfterUpdate, ChangelogType.UPDATE),
+            ChangelogEntryVerboseDto(bpnMainAddress1, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.UPDATE),
+            ChangelogEntryVerboseDto(bpnMainAddress2, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.UPDATE)
         )
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
@@ -207,14 +207,14 @@ class ChangelogControllerIT @Autowired constructor(
 
         //Log entry for the created addresses including legal and main address
         val expectedChangelogEntries = listOf(
-            ChangelogEntryVerboseDto(bpnL, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnS1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.SITE),
-            ChangelogEntryVerboseDto(bpnLegalAddress, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnMainAddress, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnA1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnA2, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnA1, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnA2, ChangelogType.UPDATE, timeAfterUpdate, BusinessPartnerType.ADDRESS)
+            ChangelogEntryVerboseDto(bpnL, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnS1, BusinessPartnerType.SITE, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnLegalAddress, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnMainAddress, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnA1, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnA2, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnA1, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.UPDATE),
+            ChangelogEntryVerboseDto(bpnA2, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.UPDATE)
         )
 
 
@@ -254,12 +254,12 @@ class ChangelogControllerIT @Autowired constructor(
         val timeAfterUpdate = Instant.now()
 
         val expectedEntriesFirstPage = listOf(
-            ChangelogEntryVerboseDto(bpnL1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnL2, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY)
+            ChangelogEntryVerboseDto(bpnL1, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnL2, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE)
         )
 
         val expectedEntriesSecondPage = listOf(
-            ChangelogEntryVerboseDto(bpnL3, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY)
+            ChangelogEntryVerboseDto(bpnL3, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE)
         )
 
         val expectedFirstPage = PageDto(3, 2, 0, expectedEntriesFirstPage.size, expectedEntriesFirstPage)
@@ -307,16 +307,16 @@ class ChangelogControllerIT @Autowired constructor(
         val timeAfterUpdate = Instant.now()
 
         val expectedLegalEntityEntries = listOf(
-            ChangelogEntryVerboseDto(bpnL, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY)
+            ChangelogEntryVerboseDto(bpnL, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE)
         )
 
         val expectedSiteEntries = listOf(
-            ChangelogEntryVerboseDto(bpnS, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.SITE)
+            ChangelogEntryVerboseDto(bpnS, BusinessPartnerType.SITE, timeAfterUpdate, ChangelogType.CREATE)
         )
 
         val expectedAddressEntries = listOf(
-            ChangelogEntryVerboseDto(bpnLegalAddress, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS),
-            ChangelogEntryVerboseDto(bpnMainAddress, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.ADDRESS)
+            ChangelogEntryVerboseDto(bpnLegalAddress, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnMainAddress, BusinessPartnerType.ADDRESS, timeAfterUpdate, ChangelogType.CREATE)
         )
 
         val expectedLegalEntitiesPage =
@@ -368,8 +368,8 @@ class ChangelogControllerIT @Autowired constructor(
 
         //Log entry for the created legal entities and their legal addresses should be there
         val expectedChangelogEntries = listOf(
-            ChangelogEntryVerboseDto(bpnL1, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnL2, ChangelogType.CREATE, timeAfterUpdate, BusinessPartnerType.LEGAL_ENTITY)
+            ChangelogEntryVerboseDto(bpnL1, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnL2, BusinessPartnerType.LEGAL_ENTITY, timeAfterUpdate, ChangelogType.CREATE)
         )
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
@@ -413,14 +413,14 @@ class ChangelogControllerIT @Autowired constructor(
 
         //Log entry for the created legal entities and their legal addresses should be there
         val expectedChangelogEntries = listOf(
-            ChangelogEntryVerboseDto(bpnL1, ChangelogType.CREATE, timeAfterSecondInsert, BusinessPartnerType.LEGAL_ENTITY),
-            ChangelogEntryVerboseDto(bpnL2, ChangelogType.CREATE, timeAfterSecondInsert, BusinessPartnerType.LEGAL_ENTITY)
+            ChangelogEntryVerboseDto(bpnL1, BusinessPartnerType.LEGAL_ENTITY, timeAfterSecondInsert, ChangelogType.CREATE),
+            ChangelogEntryVerboseDto(bpnL2, BusinessPartnerType.LEGAL_ENTITY, timeAfterSecondInsert, ChangelogType.CREATE)
         )
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
         val actualChangelog = poolClient.changelogs().getChangelogEntries(
-            ChangelogSearchRequest(fromTime = timeAfterFirstInsert, businessPartnerTypes = setOf(BusinessPartnerType.LEGAL_ENTITY)),
+            ChangelogSearchRequest(timestampAfter = timeAfterFirstInsert, businessPartnerTypes = setOf(BusinessPartnerType.LEGAL_ENTITY)),
             PaginationRequest()
         )
 

--- a/docs/postman/BPDM Gate.postman_collection.json
+++ b/docs/postman/BPDM Gate.postman_collection.json
@@ -641,7 +641,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"fromTime\": \"2020-12-16T05:54:48.942Z\",\n  \"externalIds\": [\n    \"12044444\"\n  ],\n  \"businessPartnerTypes\": [\n    \"LEGAL_ENTITY\"\n  ]\n}",
+              "raw": "{\n  \"timestampAfter\": \"2020-12-16T05:54:48.942Z\",\n  \"externalIds\": [\n    \"12044444\"\n  ],\n  \"businessPartnerTypes\": [\n    \"LEGAL_ENTITY\"\n  ]\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -681,7 +681,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"fromTime\": \"2020-12-16T05:54:48.942Z\",\n  \"externalIds\": [\n    \"12044444\"\n  ],\n  \"businessPartnerTypes\": [\n    \"LEGAL_ENTITY\"\n  ]\n}",
+              "raw": "{\n  \"timestampAfter\": \"2020-12-16T05:54:48.942Z\",\n  \"externalIds\": [\n    \"12044444\"\n  ],\n  \"businessPartnerTypes\": [\n    \"LEGAL_ENTITY\"\n  ]\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/docs/postman/BPDM Pool.postman_collection.json
+++ b/docs/postman/BPDM Pool.postman_collection.json
@@ -910,7 +910,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"fromTime\": \"2023-03-21T09:00:25.298594Z\",\n  \"bpns\": [\n    \"BPNL000000000001\"\n  ],\n  \"businessPartnerTypes\": [\n    \"LEGAL_ENTITY\"\n  ]\n}",
+              "raw": "{\n  \"timestampAfter\": \"2023-03-21T09:00:25.298594Z\",\n  \"bpns\": [\n    \"BPNL000000000001\"\n  ],\n  \"businessPartnerTypes\": [\n    \"LEGAL_ENTITY\"\n  ]\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
- Rename **fromTime** and **modifiedAt** in changelog reponse to **timestamp**
- Rename query parameter to **timestampAfter**
- For Gate add changelogType to entry & response to be consistent with Pool
- Make Gate changelog request parameters optional

Fixes #353
