### PR TITLE
chore: fix .tractusx metadata; add missing repositories key

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,4 +1,6 @@
 product: "BPDM"
 leadingRepository: "https://github.com/eclipse-tractusx/bpdm"
+repositories:
   - name: "BPDM"
     usage: "Mono-Repository for the Business Partner Data Management services"
+    url: "https://github.com/eclipse-tractusx/bpdm"


### PR DESCRIPTION
## Description

Adding the missing `repositories` key for listing connected repositories to the "BPDM" product.
File structure description in [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5), or directly in [metadata.go](https://github.com/eclipse-tractusx/tractusx-quality-checks/blob/main/pkg/product/metadata.go#L31)

Fixes #364 
