### PR TITLE
feat: Added Client Credentials Flow to Swagger and Updated Role Configuration

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
@@ -71,6 +71,8 @@ class OpenApiConfig(
                                 .tokenUrl(securityProperties.tokenUrl)
                                 .refreshUrl(securityProperties.refreshUrl)
                                 .scopes(Scopes())
+                        ).clientCredentials(
+                            OAuthFlow().tokenUrl(securityProperties.tokenUrl)
                         )
                     )
                 )


### PR DESCRIPTION
title: '(feat): Added Client Credentials Flow to Swagger and Updated Role Configuration'


## Description

This PR introduces a new feature
It adds the Client Credentials Flow to the Swagger configuration to make possible new ways of authentication

## Pre-review checks

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
