### PR TITLE
fix(bridge): Sync Endpoint Auth Leads to 500

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/config/BridgeAuthProperties.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/config/BridgeAuthProperties.kt
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package com.catenax.bpdm.bridge.dummy.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "bpdm.bridge")
+class BridgeAuthProperties {
+    var syncAuthorities: List<String> = listOf()
+
+    val syncAuthority: String
+        get() = syncAuthorities.joinToString(", ") { "ROLE_$it" }
+}


### PR DESCRIPTION
created class BridgeAuthProperties to validate sync authorities for bridge sync endpoint

Fixes #334 

