### PR TITLE
Fix: Error on Invoking Authorised PUT Address Output Endpoint

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
@@ -84,7 +84,7 @@ class AddressController(
         return addressService.getAddressesOutput(externalIds = externalIds, page = paginationRequest.page, size = paginationRequest.size)
     }
 
-    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.gateSecurityConfigProperties.getChangeCompanyOutputDataAsRole())")
+    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getChangeCompanyOutputDataAsRole())")
     override fun putAddressesOutput(addresses: Collection<AddressGateOutputRequest>): ResponseEntity<Unit> {
         if (addresses.size > apiConfigProperties.upsertLimit || addresses.map { it.externalId }.containsDuplicates()) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
## Description

This pull request fixes a bug on invoking the authorised BPDM Gate PUT Address Output endpoint.  Basically, the Pre-Authorize annotation on the respective controller method was fault as it references a non-existing bean path. Fixed the path and the error is gone.

Fixes #373

## How to Test

Create a local configuration for the BPDM Gate with security enabled connecting to an openId server for token validation. Invoke the PUT Address Output endpoint with a valid token and a valid address business partner request. You should receive a 200 OK response. Before, performing these steps lead to a 500 response.
