### PR TITLE
feat(charts): Remove Unused Datasource Environment Variable from Deployment

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the gate and pool applications
-version: 3.0.2
+version: 3.0.3
 appVersion: "4.0.0"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -1,21 +1,24 @@
 bpdm-gate:
   enabled: true
   postgres:
-    enabled: false
+    # use the name that was override on postgres.fullnameOverride to be used by the application on connection
+    fullnameOverride: ""
 
 bpdm-pool:
   enabled: true
   opensearch:
-    enabled: false
+    enabled: true
     masterService: ""
     fullnameOverride: "bpdm-pool-opensearch"
   postgres:
-    enabled: false
+    # use the name that was override on postgres.fullnameOverride to be used by the application on connection
+    fullnameOverride: ""
 
 bpdm-bridge-dummy:
   enabled: true
   postgres:
-    enabled: false
+    # use the name that was override on postgres.fullnameOverride to be used by the application on connection
+    fullnameOverride: ""
 
 opensearch:
   masterService: ""
@@ -63,6 +66,8 @@ opensearch:
         privileged: true
 
 postgres:
+  # override the name of the postgres deploy
+  fullnameOverride: ""
   enabled: true
   auth:
     database: bpdm


### PR DESCRIPTION
title description: '(fix): Remove Unused Datasource Environment Variable from Deployment'

## Description

 The changes include disabling certain components (bpdm-pool, bpdm-bridge-dummy, opensearch) and updating the Postgres configuration to override the name of the Postgres deploy. The changes aim to streamline the deployment configuration and remove unnecessary elements.

fix # https://github.com/eclipse-tractusx/bpdm/issues/381

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
