### PR TITLE
Feat: Add OpenAPI descriptions for Pool

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AddressIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AddressIdentifierDto.kt
@@ -20,12 +20,14 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressIdentifierDescription
 
-@Schema(name = "AddressIdentifier", description = "Identifier record for a logistic address")
+@Schema(description = AddressIdentifierDescription.header)
 data class AddressIdentifierDto(
-    @get:Schema(description = "Value of the identifier")
+
+    @get:Schema(description = AddressIdentifierDescription.value)
     val value: String,
 
-    @get:Schema(description = "Technical key of the type to which this identifier belongs to")
+    @get:Schema(description = AddressIdentifierDescription.type)
     val type: String,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AddressStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AddressStateDto.kt
@@ -20,20 +20,22 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(name = "AddressState", description = "Status record for a address")
+@Schema(description = AddressStateDescription.header)
 data class AddressStateDto(
-    @get:Schema(description = "Description of the status")
+
+    @get:Schema(description = AddressStateDescription.description)
     val description: String?,
 
-    @get:Schema(description = "Since when the status is/was valid")
+    @get:Schema(description = AddressStateDescription.validFrom)
     val validFrom: LocalDateTime?,
 
-    @get:Schema(description = "Until the status was valid, if applicable")
+    @get:Schema(description = AddressStateDescription.validTo)
     val validTo: LocalDateTime?,
 
-    @get:Schema(description = "The type of this specified status")
+    @get:Schema(description = AddressStateDescription.type)
     val type: BusinessStateType
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AlternativePostalAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AlternativePostalAddressDto.kt
@@ -22,11 +22,12 @@ package org.eclipse.tractusx.bpdm.common.dto
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "AlternativePostalAddress", description = "Alternative Postal Address Part")
+@Schema(description = PostalAddressDescription.headerAlternative)
 data class AlternativePostalAddressDto(
 
     @field:JsonUnwrapped
@@ -35,12 +36,12 @@ data class AlternativePostalAddressDto(
     @field:JsonUnwrapped
     val areaPart: AreaDistrictAlternativDto,
 
-    @get:Schema(description = "Describes the PO Box or private Bag number the delivery should be placed at.")
+    @get:Schema(description = PostalAddressDescription.deliveryServiceNumber)
     val deliveryServiceNumber: String = "",
 
-    @get:Schema(description = "The type of this specified delivery")
+    @get:Schema(description = PostalAddressDescription.deliveryServiceType)
     val deliveryServiceType: DeliveryServiceType = DeliveryServiceType.PO_BOX,
 
-    @get:Schema(description = "Delivery Service Qualifier")
+    @get:Schema(description = PostalAddressDescription.deliveryServiceQualifier)
     val deliveryServiceQualifier: String?,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AreaDistrictAlternativDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AreaDistrictAlternativDto.kt
@@ -20,10 +20,10 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 
-@Schema(name = "AreaDistrictDto", description = "Record for administrativeAreaLevel and district part of an alternativ address")
 data class AreaDistrictAlternativDto(
 
-    @get:Schema(description = "Identifying code of the Region within the country (e.g. Bayern)")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
     val administrativeAreaLevel1: String? = null,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AreaDistrictDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AreaDistrictDto.kt
@@ -20,19 +20,19 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 
-@Schema(name = "AreaDistrictDto", description = "Record for administrativeAreaLevel and district part of an address")
 data class AreaDistrictDto(
 
-    @get:Schema(description = "Identifying code of the Region within the country (e.g. Bayern)")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
     val administrativeAreaLevel1: String? = null,
 
-    @get:Schema(description = "Further possibility to describe the region/address(e.g. County/Landkreis)")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel2)
     val administrativeAreaLevel2: String? = null,
 
-    @get:Schema(description = "Further possibility to describe the region/address(e.g. Township/Gemeinde)")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel3)
     val administrativeAreaLevel3: String? = null,
 
-    @get:Schema(description = "Divides the city in several smaller areas")
+    @get:Schema(description = PostalAddressDescription.district)
     val district: String? = null,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BasePhysicalAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BasePhysicalAddressDto.kt
@@ -20,22 +20,22 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 
-@Schema(name = "BasePhysicalAddressDto", description = "Address record for the basical physical address fields")
 data class BasePhysicalAddressDto(
 
-    @get:Schema(description = "A separate postal code for a company, also known as postcode, PIN or ZIP Code")
+    @get:Schema(description = PostalAddressDescription.companyPostalCode)
     val companyPostalCode: String? = null,
 
-    @get:Schema(description = "The practice of designating an area for industrial development")
+    @get:Schema(description = PostalAddressDescription.industrialZone)
     val industrialZone: String? = null,
 
-    @get:Schema(description = "Describes a specific building within the address")
+    @get:Schema(description = PostalAddressDescription.building)
     val building: String? = null,
 
-    @get:Schema(description = "Describes the floor/level the delivery shall take place")
+    @get:Schema(description = PostalAddressDescription.floor)
     val floor: String? = null,
 
-    @get:Schema(description = "Describes the  door/room/suite on the respective floor the delivery shall take place")
+    @get:Schema(description = PostalAddressDescription.door)
     val door: String? = null,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BasePostalAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BasePostalAddressDto.kt
@@ -21,20 +21,20 @@ package org.eclipse.tractusx.bpdm.common.dto
 
 import com.neovisionaries.i18n.CountryCode
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 
-@Schema(name = "PostalAdress", description = "Address record for a business partner")
 data class BasePostalAddressDto(
 
-    @get:Schema(description = "Geographic coordinates to find this location")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = PostalAddressDescription.headerGeoCoordinates)
     val geographicCoordinates: GeoCoordinateDto? = null,
 
-    @get:Schema(description = "Describes the country")
+    @get:Schema(description = PostalAddressDescription.country)
     val country: CountryCode,
 
-    @get:Schema(description = "A postal code, also known as postcode, PIN or ZIP Code")
+    @get:Schema(description = PostalAddressDescription.postalCode)
     val postalCode: String? = null,
 
-    @get:Schema(description = "The city of the address (Synonym: Town, village, municipality)")
+    @get:Schema(description = PostalAddressDescription.city)
     val city: String,
-
-    )
+)

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ClassificationDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ClassificationDto.kt
@@ -20,16 +20,18 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(name = "Classification", description = "Classification record for a business partner")
+@Schema(description = ClassificationDescription.header)
 data class ClassificationDto(
-    @get:Schema(description = "Name of the classification")
+
+    @get:Schema(description = ClassificationDescription.value)
     val value: String?,
 
-    @get:Schema(description = "Identifying code of the classification, if applicable")
+    @get:Schema(description = ClassificationDescription.code)
     val code: String?,
 
-    @get:Schema(description = "Type of specified classification")
+    @get:Schema(description = ClassificationDescription.type)
     val type: ClassificationType
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/GeoCoordinateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/GeoCoordinateDto.kt
@@ -20,8 +20,9 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 
-@Schema(name = "GeoCoordinates", description = "Geo coordinates record for an address")
+@Schema(description = PostalAddressDescription.headerGeoCoordinates)
 data class GeoCoordinateDto(
 
     @get:Schema(description = "Longitude coordinate")

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IdentifierTypeDetailDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IdentifierTypeDetailDto.kt
@@ -21,12 +21,14 @@ package org.eclipse.tractusx.bpdm.common.dto
 
 import com.neovisionaries.i18n.CountryCode
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.IdentifierTypeDescription
 
-@Schema(name = "IdentifierTypeDetailDto", description = "Identifier type validity details")
+@Schema(description = IdentifierTypeDescription.headerDetail)
 data class IdentifierTypeDetailDto(
-    @get:Schema(description = "Country in which this identifier is valid, null for universal identifiers")
+
+    @get:Schema(description = IdentifierTypeDescription.detailCountry)
     val country: CountryCode?,
 
-    @get:Schema(description = "True if identifier is mandatory in this country")
+    @get:Schema(description = IdentifierTypeDescription.detailMandatory)
     val mandatory: Boolean
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IdentifierTypeDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IdentifierTypeDto.kt
@@ -20,19 +20,20 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.IdentifierTypeDescription
 
-@Schema(name = "IdentifierTypeDto", description = "Identifier type definition for legal entity or address")
+@Schema(description = IdentifierTypeDescription.header)
 data class IdentifierTypeDto(
 
-    @get:Schema(description = "Unique key (in combination with businessPartnerType) to be used as reference")
+    @get:Schema(description = IdentifierTypeDescription.technicalKey)
     val technicalKey: String,
 
-    @get:Schema(description = "Specifies if this identifier type is valid for legal entities (L) or addresses (A)")
+    @get:Schema(description = IdentifierTypeDescription.businessPartnerType)
     val businessPartnerType: IdentifierBusinessPartnerType,
 
-    @get:Schema(description = "Full name")
+    @get:Schema(description = IdentifierTypeDescription.name)
     val name: String,
 
-    @get:Schema(description = "Validity details")
+    @get:Schema(description = IdentifierTypeDescription.details)
     val details: Collection<IdentifierTypeDetailDto> = listOf()
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityDto.kt
@@ -21,23 +21,22 @@ package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 
-@Schema(name = "LegalEntity")
+@Schema(description = LegalEntityDescription.header)
 data class LegalEntityDto(
-    @ArraySchema(arraySchema = Schema(description = "Additional identifiers (except BPN)", required = false))
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers, required = false))
     val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
-    
-    @get:Schema(description = "Abbreviated name or shorthand")
+
+    @get:Schema(description = LegalEntityDescription.legalShortName)
     val legalShortName: String?,
 
-    @get:Schema(description = "Technical key of the legal form")
+    @get:Schema(description = LegalEntityDescription.legalForm)
     val legalForm: String? = null,
 
-    @ArraySchema(arraySchema = Schema(description = "Business status"))
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.states))
     val states: Collection<LegalEntityStateDto> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "Classifications", required = false))
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications, required = false))
     val classifications: Collection<ClassificationDto> = emptyList(),
-
-
-    )
+)

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityIdentifierDto.kt
@@ -20,15 +20,17 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 
-@Schema(name = "LegalEntityIdentifier", description = "Identifier record for a legal entity")
+@Schema(description = LegalEntityIdentifierDescription.header)
 data class LegalEntityIdentifierDto(
-    @get:Schema(description = "Value of the identifier")
+
+    @get:Schema(description = LegalEntityIdentifierDescription.value)
     val value: String,
 
-    @get:Schema(description = "Technical key of the type to which this identifier belongs to")
+    @get:Schema(description = LegalEntityIdentifierDescription.type)
     val type: String,
 
-    @get:Schema(description = "Body which issued the identifier")
+    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
     val issuingBody: String?
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityStateDto.kt
@@ -20,20 +20,22 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(name = "LegalEntityState", description = "Status record of a legal entity")
+@Schema(description = LegalEntityStateDescription.header)
 data class LegalEntityStateDto(
-    @get:Schema(description = "Exact, official denotation of the status")
+
+    @get:Schema(description = LegalEntityStateDescription.description)
     val description: String?,
 
-    @get:Schema(description = "Since when the status is/was valid")
+    @get:Schema(description = LegalEntityStateDescription.validFrom)
     val validFrom: LocalDateTime?,
 
-    @get:Schema(description = "Until the status was valid, if applicable")
+    @get:Schema(description = LegalEntityStateDescription.validTo)
     val validTo: LocalDateTime?,
 
-    @get:Schema(description = "The type of this specified status")
+    @get:Schema(description = LegalEntityStateDescription.type)
     val type: BusinessStateType
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LogisticAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LogisticAddressDto.kt
@@ -21,9 +21,9 @@ package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 
-
-@Schema(name = "LogisticAddressDto", description = "Address record for a business partner")
+@Schema(description = LogisticAddressDescription.header)
 data class LogisticAddressDto(
     @get:Schema(
         description = "Name of the logistic address of the business partner. This is not according to official\n" +

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LogisticAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LogisticAddressDto.kt
@@ -25,21 +25,21 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDe
 
 @Schema(description = LogisticAddressDescription.header)
 data class LogisticAddressDto(
-    @get:Schema(
-        description = "Name of the logistic address of the business partner. This is not according to official\n" +
-                "registers but according to the name the uploading sharing member chooses."
-    )
+
+    @get:Schema(description = LogisticAddressDescription.name)
     val name: String? = null,
 
-    @ArraySchema(arraySchema = Schema(description = "Indicates if the LogisticAddress is \"Active\" or \"Inactive\"."))
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.states))
     val states: Collection<AddressStateDto> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "List of identifiers"))
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.identifiers))
     val identifiers: Collection<AddressIdentifierDto> = emptyList(),
 
-    @get:Schema(description = "Physical postal address")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.physicalPostalAddress)
     val physicalPostalAddress: PhysicalPostalAddressDto,
 
-    @get:Schema(description = "Alternative postal address")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.alternativePostalAddress)
     val alternativePostalAddress: AlternativePostalAddressDto? = null
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/PhysicalPostalAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/PhysicalPostalAddressDto.kt
@@ -22,16 +22,19 @@ package org.eclipse.tractusx.bpdm.common.dto
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.StreetDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "PhysicalPostalAddress", description = "Physical Postal Address Part")
+@Schema(description = PostalAddressDescription.headerPhysical)
 data class PhysicalPostalAddressDto(
 
     @field:JsonUnwrapped
     val baseAddress: BasePostalAddressDto,
 
-    @get:Schema(description = "Address Street")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = StreetDescription.header)
     val street: StreetDto? = null,
 
     @field:JsonUnwrapped

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/SiteDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/SiteDto.kt
@@ -21,15 +21,18 @@ package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 
-@Schema(name = "Site", description = "Site record")
+@Schema(description = SiteDescription.header)
 data class SiteDto(
-    @get:Schema(description = "Site name")
+
+    @get:Schema(description = SiteDescription.name)
     val name: String,
 
-    @ArraySchema(arraySchema = Schema(description = "Business status"))
+    @ArraySchema(arraySchema = Schema(description = SiteDescription.states))
     val states: Collection<SiteStateDto> = emptyList(),
 
-    @get:Schema(description = "Main address where this site resides")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteDescription.mainAddress)
     val mainAddress: LogisticAddressDto
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/SiteStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/SiteStateDto.kt
@@ -20,20 +20,22 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(name = "SiteState", description = "Status record of a site")
+@Schema(description = SiteStateDescription.header)
 data class SiteStateDto(
-    @get:Schema(description = "Description of the status")
+
+    @get:Schema(description = SiteStateDescription.description)
     val description: String?,
 
-    @get:Schema(description = "Since when the status is/was valid")
+    @get:Schema(description = SiteStateDescription.validFrom)
     val validFrom: LocalDateTime?,
 
-    @get:Schema(description = "Until the status was valid, if applicable")
+    @get:Schema(description = SiteStateDescription.validTo)
     val validTo: LocalDateTime?,
 
-    @get:Schema(description = "The type of this specified status")
+    @get:Schema(description = SiteStateDescription.type)
     val type: BusinessStateType
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/StreetDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/StreetDto.kt
@@ -20,18 +20,20 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.StreetDescription
 
-@Schema(name = "Street", description = "A public road in a city, town, or village, typically with houses and buildings on one or both sides.")
+@Schema(description = StreetDescription.header)
 data class StreetDto(
-    @get:Schema(description = "Describes the official Name of the Street.")
+
+    @get:Schema(description = StreetDescription.name)
     val name: String? = null,
 
-    @get:Schema(description = "Describes the House Number")
+    @get:Schema(description = StreetDescription.houseNumber)
     val houseNumber: String? = null,
 
-    @get:Schema(description = "The Milestone is relevant for long roads without specific house numbers.")
+    @get:Schema(description = StreetDescription.milestone)
     val milestone: String? = null,
 
-    @get:Schema(description = "Describes the direction")
+    @get:Schema(description = StreetDescription.direction)
     val direction: String? = null
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/AddressIdentifierDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/AddressIdentifierDescription.kt
@@ -17,22 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object AddressIdentifierDescription {
+    const val header = "An address identifier (uniquely) identifies the address, such as the Global Location Number (GLN)."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val value = "The value of the identifier like \"0847976000005\"."
+    const val type = "The type of the identifier."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/AddressStateDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/AddressStateDescription.kt
@@ -17,22 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object AddressStateDescription {
+    const val header = "An address state indicates if the address is active or inactive. " +
+            "This does not describe the relation between a sharing member and a business partner and whether they have active " +
+            "business, but it describes whether the business partner is still operating at that address."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val description = "The description from the original source indicating the state of the address."
+    const val validFrom = "The date from which the state is valid."
+    const val validTo = "The date until the state is valid."
+    const val type = "One of the state types: active, inactive."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/ChangelogDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/ChangelogDescription.kt
@@ -17,22 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object ChangelogDescription {
+    const val header = "An entry of the changelog, which is created each time a business partner is modified and " +
+            "contains data about the change. The actual new state of the business partner is not included."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val changelogType = "One of the actions for which the changelog entry was created: create, update."
+    const val timestamp = "The date and time when the changelog entry was created."
+    const val businessPartnerType = "One of the types of business partners for which the changelog entry was created: legal entity, site, address."
+    const val bpn = "The business partner number for which the changelog entry was created. Can be either a BPNL, BPNS or BPNA."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/ClassificationDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/ClassificationDescription.kt
@@ -17,22 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object ClassificationDescription {
+    const val header = "A legal entity classification is an assignment of the legal entity to an industry. It does not " +
+            "necessarily have to be the only industry the company is active in (see large companies " +
+            "operating in different industries). Multiple assignments to several industries are possible per " +
+            "classification type."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val value = "The name of the class belonging to the classification."
+    const val code = "The identifier of the class belonging to the classification."
+    const val type = "Type of classification."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/CommonDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/CommonDescription.kt
@@ -17,22 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object CommonDescription {
+    const val createdAt = "The date when the data record has been created."
+    const val updatedAt = "The date when the data record has been last updated."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
+    const val index = "User defined index to conveniently match this entry to the corresponding entry in the response."
+    const val score = "Relative quality score of the match. The higher the better."
 
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val entityWithErrorsWrapperHeader = "Holds information about successfully and failed entities after the creating/updating of several objects"
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/IdentifierTypeDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/IdentifierTypeDescription.kt
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
+
+object IdentifierTypeDescription {
+    const val header = "An identifier type defines the name or category of an identifier, such as the German " +
+            "Handelsregisternummer, VAT number, Global Location Number (GLN), etc. The identifier type " +
+            "is valid for a business partner type."
+
+    const val technicalKey = "The technical identifier (unique in combination with businessPartnerType)."
+    const val businessPartnerType = "One of the types of business partners for which the identifier type is valid."
+    const val name = "The name of the identifier type."
+    const val details = "Validity details."
+
+    const val headerDetail = "Information for which countries an identifier type is valid and mandatory."
+    const val detailCountry = "2-digit country code for which this identifier is valid; null for universal identifiers."
+    const val detailMandatory = "True if identifier is mandatory in this country."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityDescription.kt
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
+
+object LegalEntityDescription {
+    const val header = "In general, a legal entity is a juridical person that has legal rights and duties related to " +
+            "contracts, agreements, and obligations. The term especially applies to any kind of " +
+            "organization (such as an enterprise or company, university, association, etc.) established " +
+            "under the law applicable to a country." +
+            "In Catena-X, a legal entity is a type of business partner representing a legally registered " +
+            "organization with its official registration information, such as legal name (including legal form, " +
+            "if registered), legal address and tax number." +
+            "A legal entity has exactly one legal address, but it is possible to specify additional addresses " +
+            "that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity " +
+            "can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely " +
+            "identified by the BPNL."
+    const val headerCreateRequest = "Request for creating new business partner record of type legal entity. $header"
+    const val headerUpdateRequest = "Request for updating a business partner record of type legal entity. $header"
+    const val headerCreateResponse = "Created business partner of type legal entity. $header"
+    const val headerMatchResponse = "Match with score for a business partner record of type legal entity. $header"
+
+    const val bpnl = "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), " +
+            "legal address and tax number."
+    const val currentness = "The date the business partner data was last indicated to be still current."
+
+    const val legalName = "The name of the legal entity according to official registers."
+    const val legalShortName = "The abbreviated name of the legal entity."
+    const val legalForm = "The legal form of the legal entity."
+    const val legalAddress = "The official, legal correspondence address to be provided to government and tax authorities " +
+            "and used in all legal or court documents."
+
+    const val identifiers = "The list of identifiers of the legal entity."
+    const val states = "The list of (temporary) states of the legal entity."
+    const val classifications = "The list of classifications of the legal entity, such as a specific industry."
+    const val relations = "Relations to other business partners."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityIdentifierDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityIdentifierDescription.kt
@@ -17,22 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object LegalEntityIdentifierDescription {
+    const val header = "A legal entity identifier (uniquely) identifies the legal entity, such as the German " +
+            "Handelsregisternummer, a VAT number, etc."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val value = "The value of the identifier like \"DE123465789\"."
+    const val type = "The type of the identifier."
+    const val issuingBody = "The name of the official register, where the identifier is registered. " +
+            "For example, a Handelsregisternummer in Germany is only valid with its corresponding Handelsregister."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityStateDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityStateDescription.kt
@@ -17,22 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object LegalEntityStateDescription {
+    const val header = "A legal entity state indicates if the legal entity is active or inactive. " +
+            "This does not describe the relation between a sharing member and a business partner and whether they have active " +
+            "business, but it describes whether the legal entity is still operating."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val description = "The description from the original source indicating the state of the legal entity, such as from the German Handelsregister."
+    const val validFrom = "The date from which the state is valid."
+    const val validTo = "The date until the state is valid."
+    const val type = "One of the state types: active, inactive."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalFormDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalFormDescription.kt
@@ -17,22 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object LegalFormDescription {
+    const val header = "A legal form is a mandatory corporate legal framework by which companies can conduct " +
+            "business, charitable or other permissible activities."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val technicalKey = "The technical identifier of the legal form according to ISO 20275."
+    const val name = "The name of legal form according to ISO 20275."
+    const val abbreviation = "The abbreviated name of the legal form, such as AG for German Aktiengesellschaft."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LogisticAddressDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LogisticAddressDescription.kt
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
+
+object LogisticAddressDescription {
+    const val header = "In general, an address is a collection of information to describe a physical location, using a " +
+            "street name with a house number and/or a post office box as reference. In addition, an " +
+            "address consists of several postal attributes, such as country, region (state), county, township, " +
+            "city, district, or postal code, which help deliver mail." +
+            "In Catena-X, an address is a type of business partner representing the legal address of a legal " +
+            "entity, and/or the main address of a site, or any additional address of a legal entity or site " +
+            "(such as different gates)." +
+            "An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. " +
+            "An address can belong to a site. Thus, one or no site is assigned to an address. An address is " +
+            "uniquely identified by the BPNA."
+    const val headerCreateRequest = "Request for creating new business partner record of type address. $header"
+    const val headerUpdateRequest = "Request for updating a business partner record of type address. $header"
+    const val headerCreateResponse = "Created business partner of type address. $header"
+    const val headerMatchResponse = "Match for a business partner record of type address. $header"
+
+    const val bpna = "A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, " +
+            "and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). " +
+            "It is important to note that only the BPNL must be used to uniquely identify a legal entity. " +
+            "Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity."
+    const val name = "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+    const val states = "The list of (temporary) states of the address."
+    const val identifiers = "The list of identifiers of the address."
+    const val physicalPostalAddress = "The physical postal address of the address, such as an office, warehouse, gate, etc."
+    const val alternativePostalAddress = "The alternative postal address of the address, for example if the goods are to be picked up somewhere else."
+    const val bpnLegalEntity = "The BPNL of the legal entity owning the address."
+    const val isLegalAddress = "Indicates if the address is the legal address to a legal entity."
+    const val bpnSite = "The BPNS of the site the address belongs to."
+    const val isMainAddress = "Indicates if the address is the main address to a site. " +
+            "This is where typically the main entrance or the reception is located, or where the mail is delivered to."
+
+    const val bpnParent = "BPNL of the legal entity or BPNS of the site this address belongs to."
+    const val address = "Address information"
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/PostalAddressDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/PostalAddressDescription.kt
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
+
+object PostalAddressDescription {
+    const val headerPhysical = "A physical postal address describes the physical location of an office, warehouse, gate, etc."
+    const val headerAlternative = "An alternative postal address describes an alternative way of delivery for example if the goods " +
+            "are to be picked up somewhere else."
+    const val headerGeoCoordinates = "The exact location of the physical postal address in latitude, longitude, and altitude."
+
+    const val country = "The 2-digit country code of the physical postal address according to ISO 3166-1."
+    const val postalCode = "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for " +
+            "the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+    const val city = "The name of the city of the physical postal address, synonyms: town, village, municipality."
+
+    const val administrativeAreaLevel1 = "The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country."
+    const val administrativeAreaLevel2 = "The name of the locally regulated secondary country subdivision of the physical postal address, " +
+            "such as county within a country."
+    const val administrativeAreaLevel3 = "The name of the locally regulated tertiary country subdivision of the physical address, " +
+            "such as townships within a country."
+    const val district = "The name of the district of the physical postal address which divides the city in several smaller areas."
+
+    const val companyPostalCode = "The company postal code of the physical postal address, which is sometimes required for large companies."
+    const val industrialZone = "The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area."
+    const val building = "The alphanumeric identifier of the building addressed by the physical postal address."
+    const val floor = "The number of a floor in the building addressed by the physical postal address, synonym: level."
+    const val door = "The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite."
+
+    const val deliveryServiceType = "One of the alternative postal address types: P.O. box, private bag, boite postale."
+    const val deliveryServiceQualifier = "The qualifier uniquely identifying the delivery service endpoint of the alternative postal address " +
+            "in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, " +
+            "postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number " +
+            "is assigned multiple times in some cities."
+    const val deliveryServiceNumber = "The number indicating the delivery service endpoint of the alternative postal address to which the delivery is " +
+            "to be delivered, such as a P.O. box number or a private bag number."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/SiteDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/SiteDescription.kt
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
+
+object SiteDescription {
+    const val header = "In general, a site is a delimited geographical area in which an organization (such as an " +
+            "enterprise or company, university, association, etc.) conducts business. " +
+            "In Catena-X, a site is a type of business partner representing a physical location or area owned " +
+            "by a legal entity, where a production plant, a warehouse, or an office building is located. " +
+            "A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has " +
+            "exactly one main address, but it is possible to specify additional addresses (such as different " +
+            "gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be " +
+            "uploaded and modified by the owner (the legal entity), because only the owner knows which " +
+            "addresses belong to which site. A site is uniquely identified by the BPNS."
+    const val headerCreateRequest = "Request for creating new business partner record of type site. $header"
+    const val headerUpdateRequest = "Request for updating a business partner record of type site. $header"
+    const val headerCreateResponse = "Created business partner of type site. $header"
+    const val headerMatchResponse = "Match for a business partner record of type site. $header"
+
+    const val bpns = "A BPNS represents and uniquely identifies a site, which is where for example a production plant, " +
+            "a warehouse, or an office building is located."
+    const val name = "The name of the site. This is not according to official registers but according to the name the owner chooses."
+    const val states = "The list of the (temporary) states of the site."
+    const val bpnLegalEntity = "The BPNL of the legal entity owning the site."
+    const val mainAddress = "The address, where typically the main entrance or the reception is located, or where the mail is delivered to."
+
+    const val bpnlParent = "The BPNL of the legal entity owning the site."
+    const val site = "Site information"
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/SiteStateDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/SiteStateDescription.kt
@@ -17,22 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object SiteStateDescription {
+    const val header = "A site state indicates if the site is active or inactive. This does not describe the relation " +
+            "between a sharing member and a business partner and whether they have active business, " +
+            "but it describes whether the site is still operating."
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val description = "The description from the original source indicating the state of the site."
+    const val validFrom = "The date from which the state is valid."
+    const val validTo = "The date until the state is valid."
+    const val type = "One of the state types: active, inactive."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/StreetDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/StreetDescription.kt
@@ -17,22 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+object StreetDescription {
+    const val header = "The street of the physical postal address, synonyms: road, avenue, lane, boulevard, highway"
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
-
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    const val name = "The name of the street."
+    const val houseNumber = "The number representing the exact location of a building within the street."
+    const val milestone = "The number representing the exact location of an addressed object within a street without house numbers, such as within long roads."
+    const val direction = "The cardinal direction describing where the exit to the location of the addressed object on large highways / " +
+            "motorways is located, such as Highway 101 South."
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/request/AddressPartnerBpnSearchRequest.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/request/AddressPartnerBpnSearchRequest.kt
@@ -21,12 +21,15 @@ package org.eclipse.tractusx.bpdm.common.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "AddressPartnerBpnSearchRequest", description = "Request for searching business partners of type address by parent BPNs")
+@Schema(description = "Request for searching business partners of type address by parent BPNs")
 data class AddressPartnerBpnSearchRequest(
+
     @Schema(description = "Filter by Business Partner Numbers of legal entities which are at that address")
     val legalEntities: Collection<String> = emptyList(),
+
     @Schema(description = "Filter by Business Partner Numbers of sites which are at that address")
     val sites: Collection<String> = emptyList(),
+
     @Schema(description = "Filter by BPNA of addresses")
     val addresses: Collection<String> = emptyList()
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/request/PaginationRequest.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/request/PaginationRequest.kt
@@ -25,8 +25,9 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.PositiveOrZero
 
-@Schema(name = "PaginationRequest", description = "Defines pagination information for requesting collection results")
+@Schema(description = "Defines pagination information for requesting collection results")
 data class PaginationRequest (
+
     @field:Parameter(
         description = "Number of page to get results from", schema =
         Schema(defaultValue = "0"))

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressIdentifierVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressIdentifierVerboseDto.kt
@@ -20,14 +20,15 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressIdentifierDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 
-@Schema(name = "AddressIdentifierVerboseDto", description = "Identifier record of a logistic address")
+@Schema(description = AddressIdentifierDescription.header)
 data class AddressIdentifierVerboseDto(
 
-    @get:Schema(description = "Value of the identifier")
+    @get:Schema(description = AddressIdentifierDescription.value)
     val value: String,
 
-    @get:Schema(description = "Type of the identifier")
+    @get:Schema(description = AddressIdentifierDescription.type)
     val type: TypeKeyNameVerboseDto<String>,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressStateVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressStateVerboseDto.kt
@@ -20,22 +20,24 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressStateDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(name = "AddressStateVerboseDto", description = "Status record of a legal entity")
+@Schema(description = AddressStateDescription.header)
 data class AddressStateVerboseDto(
 
-    @get:Schema(description = "Exact, official denotation of the status")
+    @get:Schema(description = AddressStateDescription.description)
     val description: String?,
 
-    @get:Schema(description = "Since when the status is/was valid")
+    @get:Schema(description = AddressStateDescription.validFrom)
     val validFrom: LocalDateTime?,
 
-    @get:Schema(description = "Until the status was valid, if applicable")
+    @get:Schema(description = AddressStateDescription.validTo)
     val validTo: LocalDateTime?,
 
-    @get:Schema(description = "The type of this status")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = AddressStateDescription.type)
     val type: TypeKeyNameVerboseDto<BusinessStateType>
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AlternativePostalAddressVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AlternativePostalAddressVerboseDto.kt
@@ -22,11 +22,12 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "AlternativePostalAddressVerboseDto", description = "Alternative Postal Address Part")
+@Schema(description = PostalAddressDescription.headerAlternative)
 data class AlternativePostalAddressVerboseDto(
 
     @field:JsonUnwrapped
@@ -35,12 +36,12 @@ data class AlternativePostalAddressVerboseDto(
     @field:JsonUnwrapped
     val areaPart: AreaDistrictAlternativVerboseDto,
 
-    @get:Schema(description = "Describes the PO Box or private Bag number the delivery should be placed at.")
+    @get:Schema(description = PostalAddressDescription.deliveryServiceNumber)
     val deliveryServiceNumber: String = "",
 
-    @get:Schema(description = "The type of this specified delivery")
+    @get:Schema(description = PostalAddressDescription.deliveryServiceType)
     val deliveryServiceType: DeliveryServiceType = DeliveryServiceType.PO_BOX,
 
-    @get:Schema(description = "Delivery Service Qualifier")
+    @get:Schema(description = PostalAddressDescription.deliveryServiceQualifier)
     val deliveryServiceQualifier: String?,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AreaDistrictAlternativVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AreaDistrictAlternativVerboseDto.kt
@@ -20,10 +20,10 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 
-@Schema(name = "AreaDistrictAlternativVerboseDto", description = "Record for administrativeAreaLevel and district part of an alternativ address")
 data class AreaDistrictAlternativVerboseDto(
 
-    @get:Schema(description = "Region within the country")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
     val administrativeAreaLevel1: RegionDto? = null,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AreaDistrictVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AreaDistrictVerboseDto.kt
@@ -20,19 +20,19 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 
-@Schema(name = "AreaDistrictVerboseDto", description = "Record for administrativeAreaLevel and district part of an address")
 data class AreaDistrictVerboseDto(
 
-    @get:Schema(description = "Region within the country")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
     val administrativeAreaLevel1: RegionDto? = null,
 
-    @get:Schema(description = "Further possibility to describe the region/address(e.g. County/Landkreis)")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel2)
     val administrativeAreaLevel2: String? = null,
 
-    @get:Schema(description = "Further possibility to describe the region/address(e.g. Township/Gemeinde)")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel3)
     val administrativeAreaLevel3: String? = null,
 
-    @get:Schema(description = "Divides the city in several smaller areas")
+    @get:Schema(description = PostalAddressDescription.district)
     val district: String? = null,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/BasePostalAddressVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/BasePostalAddressVerboseDto.kt
@@ -22,21 +22,22 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 import com.neovisionaries.i18n.CountryCode
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 
-@Schema(name = "BasePostalAddressVerboseDto", description = "Address record of a business partner")
 data class BasePostalAddressVerboseDto(
 
-    @get:Schema(description = "Geographic coordinates to find this location")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = PostalAddressDescription.headerGeoCoordinates)
     val geographicCoordinates: GeoCoordinateDto? = null,
 
-    @get:Schema(description = "Describes the full name of the country")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = PostalAddressDescription.country)
     val country: TypeKeyNameVerboseDto<CountryCode>,
 
-    @get:Schema(description = "A postal code, also known as postcode, PIN or ZIP Code")
+    @get:Schema(description = PostalAddressDescription.postalCode)
     val postalCode: String? = null,
 
-    @get:Schema(description = "The city of the address (Synonym: Town, village, municipality)")
+    @get:Schema(description = PostalAddressDescription.city)
     val city: String,
-
-    )
+)

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/ClassificationVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/ClassificationVerboseDto.kt
@@ -20,18 +20,20 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(name = "ClassificationVerboseDto", description = "Classification record of a business partner")
+@Schema(description = ClassificationDescription.header)
 data class ClassificationVerboseDto(
 
-    @get:Schema(description = "Name of the classification")
+    @get:Schema(description = ClassificationDescription.value)
     val value: String? = null,
 
-    @get:Schema(description = "Identifying code of the classification, if applicable")
+    @get:Schema(description = ClassificationDescription.code)
     val code: String? = null,
 
-    @get:Schema(description = "Type of specified classification")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = ClassificationDescription.type)
     val type: TypeKeyNameVerboseDto<ClassificationType>
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityStateVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityStateVerboseDto.kt
@@ -20,22 +20,24 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(name = "LegalEntityStateVerboseDto", description = "Status record of a legal entity")
+@Schema(description = LegalEntityStateDescription.header)
 data class LegalEntityStateVerboseDto(
 
-    @get:Schema(description = "Exact, official denotation of the status")
+    @get:Schema(description = LegalEntityStateDescription.description)
     val description: String?,
 
-    @get:Schema(description = "Since when the status is/was valid")
+    @get:Schema(description = LegalEntityStateDescription.validFrom)
     val validFrom: LocalDateTime?,
 
-    @get:Schema(description = "Until the status was valid, if applicable")
+    @get:Schema(description = LegalEntityStateDescription.validTo)
     val validTo: LocalDateTime?,
 
-    @get:Schema(description = "The type of this status")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityStateDescription.type)
     val type: TypeKeyNameVerboseDto<BusinessStateType>
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityVerboseDto.kt
@@ -21,39 +21,42 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import java.time.Instant
 
 
-@Schema(name = "LegalEntityVerboseDto", description = "Legal entity record")
+@Schema(description = LegalEntityDescription.header)
 data class LegalEntityVerboseDto(
 
-    @get:Schema(description = "Business Partner Number of this legal entity")
+    @get:Schema(description = LegalEntityDescription.bpnl)
     val bpnl: String,
 
-    @ArraySchema(arraySchema = Schema(description = "All identifiers of the business partner, including BPN information"))
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers))
     val identifiers: Collection<LegalEntityIdentifierVerboseDto> = emptyList(),
 
-    @get:Schema(description = "Abbreviated name or shorthand")
+    @get:Schema(description = LegalEntityDescription.legalShortName)
     val legalShortName: String? = null,
 
-    @get:Schema(description = "Legal form of the business partner")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalForm)
     val legalForm: LegalFormDto? = null,
 
-    @ArraySchema(arraySchema = Schema(description = "Business status"))
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.states))
     val states: Collection<LegalEntityStateVerboseDto> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "Classifications"))
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications))
     val classifications: Collection<ClassificationVerboseDto> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "Relations to other business partners"))
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.relations))
     val relations: Collection<RelationVerboseDto> = emptyList(),
 
-    @get:Schema(description = "The timestamp the business partner data was last indicated to be still current")
+    @get:Schema(description = LegalEntityDescription.currentness)
     val currentness: Instant,
 
-    @get:Schema(description = "The timestamp the business partner data was created")
+    @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,
 
-    @get:Schema(description = "The timestamp the business partner data was last updated")
+    @get:Schema(description = CommonDescription.updatedAt)
     val updatedAt: Instant,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalFormDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalFormDto.kt
@@ -20,16 +20,17 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalFormDescription
 
-@Schema(name = "LegalFormDto", description = "Legal form a business partner can have")
+@Schema(description = LegalFormDescription.header)
 data class LegalFormDto(
 
-    @get:Schema(description = "Unique key to be used for reference")
+    @get:Schema(description = LegalFormDescription.technicalKey)
     val technicalKey: String,
 
-    @get:Schema(description = "Full name of the legal form")
+    @get:Schema(description = LegalFormDescription.name)
     val name: String,
 
-    @get:Schema(description = "Abbreviation of the legal form name")
+    @get:Schema(description = LegalFormDescription.abbreviation)
     val abbreviation: String? = null,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LogisticAddressVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LogisticAddressVerboseDto.kt
@@ -21,48 +21,49 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import java.time.Instant
 
 
-@Schema(name = "LogisticAddressVerboseDto", description = "Logistic address ")
+@Schema(description = LogisticAddressDescription.header)
 data class LogisticAddressVerboseDto(
 
-    @get:Schema(description = "Business Partner Number of this address")
+    @get:Schema(description = LogisticAddressDescription.bpna)
     val bpna: String,
 
-    @get:Schema(
-        description = "Name of the logistic address of the business partner. This is not according to official\n" +
-                "registers but according to the name the uploading sharing member chooses."
-    )
+    @get:Schema(description = LogisticAddressDescription.name)
     val name: String? = null,
 
-    @ArraySchema(arraySchema = Schema(description = "Address status"))
+    @ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.states))
     val states: Collection<AddressStateVerboseDto> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "All identifiers of the Address"))
+    @ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.identifiers))
     val identifiers: Collection<AddressIdentifierVerboseDto> = emptyList(),
 
-    @get:Schema(description = "Physical postal address")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.physicalPostalAddress)
     val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
 
-    @get:Schema(description = "Alternative postal address")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.alternativePostalAddress)
     val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
 
-    @get:Schema(description = "BPN of the related legal entity, if available")
+    @get:Schema(description = LogisticAddressDescription.bpnLegalEntity)
     val bpnLegalEntity: String?,
 
-    @get:Schema(name = "isLegalAddress", description = "Flag if this is the legal address of its related legal entity")
+    @get:Schema(name = "isLegalAddress", description = LogisticAddressDescription.isLegalAddress)
     val isLegalAddress: Boolean = false,
 
-    @get:Schema(description = "BPN of the related site, if available")
+    @get:Schema(description = LogisticAddressDescription.bpnSite)
     val bpnSite: String?,
 
-    @get:Schema(name = "isMainAddress", description = "Flag if this is the main address of its related site")
+    @get:Schema(name = "isMainAddress", description = LogisticAddressDescription.isMainAddress)
     val isMainAddress: Boolean = false,
 
-    @get:Schema(description = "The timestamp the business partner data was created")
+    @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,
 
-    @get:Schema(description = "The timestamp the business partner data was last updated")
+    @get:Schema(description = CommonDescription.updatedAt)
     val updatedAt: Instant
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PhysicalPostalAddressVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PhysicalPostalAddressVerboseDto.kt
@@ -24,16 +24,19 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BasePhysicalAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.StreetDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.StreetDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "PhysicalPostalAddressVerboseDto", description = "Physical Postal Address Part")
+@Schema(description = PostalAddressDescription.headerPhysical)
 data class PhysicalPostalAddressVerboseDto(
 
     @field:JsonUnwrapped
     val baseAddress: BasePostalAddressVerboseDto,
 
-    @get:Schema(description = "Street")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = StreetDescription.header)
     val street: StreetDto? = null,
 
     @field:JsonUnwrapped

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PoolLegalEntityVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PoolLegalEntityVerboseDto.kt
@@ -22,18 +22,20 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "PoolLegalEntityVerboseDto", description = "Legal entity record")
+@Schema(description = LegalEntityDescription.header)
 data class PoolLegalEntityVerboseDto(
 
-    @get:Schema(description = "Legal name the partner goes by")
+    @get:Schema(description = LegalEntityDescription.legalName)
     val legalName: String,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SiteStateVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SiteStateVerboseDto.kt
@@ -20,22 +20,24 @@
 package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteStateDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(name = "SiteStateVerboseDto", description = "Status record of a site")
+@Schema(description = SiteStateDescription.header)
 data class SiteStateVerboseDto(
 
-    @get:Schema(description = "Description of the status")
+    @get:Schema(description = SiteStateDescription.description)
     val description: String?,
 
-    @get:Schema(description = "Since when the status is/was valid")
+    @get:Schema(description = SiteStateDescription.validFrom)
     val validFrom: LocalDateTime?,
 
-    @get:Schema(description = "Until the status was valid, if applicable")
+    @get:Schema(description = SiteStateDescription.validTo)
     val validTo: LocalDateTime?,
 
-    @get:Schema(description = "The type of this status")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteStateDescription.type)
     val type: TypeKeyNameVerboseDto<BusinessStateType>
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SiteVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SiteVerboseDto.kt
@@ -21,26 +21,28 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import java.time.Instant
 
-@Schema(name = "SiteVerboseDto", description = "Site of a legal entity")
+@Schema(description = SiteDescription.header)
 data class SiteVerboseDto(
-    
-    @get:Schema(description = "Business Partner Number, main identifier value for sites")
+
+    @get:Schema(description = SiteDescription.bpns)
     val bpns: String,
 
-    @get:Schema(description = "Site name")
+    @get:Schema(description = SiteDescription.name)
     val name: String,
 
-    @ArraySchema(arraySchema = Schema(description = "Business status"))
+    @ArraySchema(arraySchema = Schema(description = SiteDescription.states))
     val states: Collection<SiteStateVerboseDto> = emptyList(),
 
-    @get:Schema(description = "Business Partner Number of the related legal entity")
+    @get:Schema(description = SiteDescription.bpnLegalEntity)
     val bpnLegalEntity: String,
 
-    @get:Schema(description = "The timestamp the business partner data was created")
+    @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,
 
-    @get:Schema(description = "The timestamp the business partner data was last updated")
+    @get:Schema(description = CommonDescription.updatedAt)
     val updatedAt: Instant
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/type/TypeKeyNameUrlDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/type/TypeKeyNameUrlDto.kt
@@ -22,10 +22,13 @@ package org.eclipse.tractusx.bpdm.common.dto.response.type
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class TypeKeyNameUrlDto<T>(
-    @Schema(description = "Unique key of this type for reference")
+
+    @get:Schema(description = "Unique key of this type for reference")
     val technicalKey: T,
-    @Schema(description = "Name or denotation of this type")
+
+    @get:Schema(description = "Name or denotation of this type")
     val name: String,
-    @Schema(description = "URL link leading to page with further information on the type")
+
+    @get:Schema(description = "URL link leading to page with further information on the type")
     val url: String?
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/type/TypeKeyNameVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/type/TypeKeyNameVerboseDto.kt
@@ -23,9 +23,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Named type uniquely identified by its technical key")
 data class TypeKeyNameVerboseDto<T>(
-    @Schema(description = "Unique key of this type for reference")
+
+    @get:Schema(description = "Unique key of this type for reference")
     val technicalKey: T,
 
-    @Schema(description = "Name or denotation of this type")
+    @get:Schema(description = "Name or denotation of this type")
     val name: String,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
@@ -46,7 +46,7 @@ import org.springframework.web.service.annotation.PutExchange
 interface PoolAddressApi {
 
     @Operation(
-        summary = "Get page of addresses matching the search criteria",
+        summary = "Returns addresses by different search parameters",
         description = "This endpoint tries to find matches among all existing business partners of type address, " +
                 "filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. " +
                 "The match of a partner is better the higher its relevancy score. " +
@@ -66,25 +66,25 @@ interface PoolAddressApi {
     ): PageDto<AddressMatchVerboseDto>
 
     @Operation(
-        summary = "Get address partners by bpna",
-        description = "Get business partners of type address by bpn-a ignoring case."
+        summary = "Returns an address by its BPNA",
+        description = "Get business partners of type address by BPNA ignoring case."
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "Found address with specified bpna"),
+            ApiResponse(responseCode = "200", description = "Found address with specified BPNA"),
             ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
-            ApiResponse(responseCode = "404", description = "No address found under specified bpna", content = [Content()])
+            ApiResponse(responseCode = "404", description = "No address found under specified BPNA", content = [Content()])
         ]
     )
     @GetMapping("/{bpna}")
     @GetExchange("/{bpna}")
     fun getAddress(
-        @Parameter(description = "Bpn value") @PathVariable bpna: String
+        @Parameter(description = "BPNA value") @PathVariable bpna: String
     ): LogisticAddressVerboseDto
 
     @Operation(
-        summary = "Search address partners by BPNs and/or parent BPNs",
-        description = "Search business partners of type address by their BPN or their parent partners BPN (BPNLs or BPNS)."
+        summary = "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
+        description = "Search business partners of type address by their BPNA or their parents' BPNL or BPNS."
     )
     @ApiResponses(
         value = [
@@ -100,7 +100,7 @@ interface PoolAddressApi {
     ): PageDto<LogisticAddressVerboseDto>
 
     @Operation(
-        summary = "Create new address business partners",
+        summary = "Creates a new address",
         description = "Create new business partners of type address by specifying the BPN of the parent each address belongs to. " +
                 "A parent can be either a site or legal entity business partner. " +
                 "If the parent cannot be found, the record is ignored." +
@@ -120,7 +120,7 @@ interface PoolAddressApi {
     ): AddressPartnerCreateResponseWrapper
 
     @Operation(
-        summary = "Update existing address business partners",
+        summary = "Updates an existing address",
         description = "Update existing business partner records of type address referenced via BPNA. " +
                 "The endpoint expects to receive the full updated record, including values that didn't change."
     )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
@@ -39,7 +39,7 @@ import org.springframework.web.service.annotation.PostExchange
 interface PoolBpnApi {
 
     @Operation(
-        summary = "Find business partner numbers by identifiers",
+        summary = "Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values",
         description = "Find business partner numbers by identifiers. " +
                 "The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. " +
                 "For a single request, the maximum number of identifier values to search for is limited to \${bpdm.bpn.search-request-limit} entries."

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolChangelogApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolChangelogApi.kt
@@ -41,8 +41,7 @@ import org.springframework.web.service.annotation.PostExchange
 interface PoolChangelogApi {
 
     @Operation(
-        summary = "Get business partner changelog entries from time, by BPN and/or LSA type",
-        description = "Get business partner changelog entries from time, by BPN and/or LSA type"
+        summary = "Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types"
     )
     @ApiResponses(
         value = [

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -44,7 +44,7 @@ import org.springframework.web.service.annotation.PutExchange
 interface PoolLegalEntityApi {
 
     @Operation(
-        summary = "Get page of legal entity business partners matching the search criteria",
+        summary = "Returns legal entities by different search parameters",
         description = "This endpoint tries to find matches among all existing business partners of type legal entity, " +
                 "filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. " +
                 "The match of a partner is better the higher its relevancy score. " +
@@ -64,7 +64,7 @@ interface PoolLegalEntityApi {
     ): PageDto<LegalEntityMatchVerboseDto>
 
     @Operation(
-        summary = "Get legal entity business partner by identifier",
+        summary = "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
         description = "This endpoint tries to find a business partner by the specified identifier. " +
                 "The identifier value is case insensitively compared but needs to be given exactly. " +
                 "By default the value given is interpreted as a BPN. " +
@@ -105,11 +105,11 @@ interface PoolLegalEntityApi {
     @PostMapping("/{bpnl}/confirm-up-to-date")
     @PostExchange("/{bpnl}/confirm-up-to-date")
     fun setLegalEntityCurrentness(
-        @Parameter(description = "Bpnl value") @PathVariable bpnl: String
+        @Parameter(description = "BPNL value") @PathVariable bpnl: String
     )
 
     @Operation(
-        summary = "Search legal entity partners by BPNLs",
+        summary = "Returns legal entities by an array of BPNL",
         description = "Search legal entity partners by their BPNLs. " +
                 "The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. " +
                 "For a single request, the maximum number of BPNLs to search for is limited to \${bpdm.bpn.search-request-limit} entries."
@@ -131,7 +131,7 @@ interface PoolLegalEntityApi {
     ): ResponseEntity<Collection<PoolLegalEntityVerboseDto>>
 
     @Operation(
-        summary = "Get site partners of a legal entity",
+        summary = "Returns all sites of a legal entity with a specific BPNL",
         description = "Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case."
     )
     @ApiResponses(
@@ -144,25 +144,25 @@ interface PoolLegalEntityApi {
     @GetMapping("/{bpnl}/sites")
     @GetExchange("/{bpnl}/sites")
     fun getSites(
-        @Parameter(description = "Bpnl value") @PathVariable bpnl: String,
+        @Parameter(description = "BPNL value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteVerboseDto>
 
     @Operation(
-        summary = "Get address partners of a legal entity",
-        description = "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's bpn ignoring case."
+        summary = "Returns all addresses of a legal entity with a specific BPNL",
+        description = "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case."
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "The addresses for the specified bpn"),
+            ApiResponse(responseCode = "200", description = "The addresses for the specified BPNL"),
             ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()]),
-            ApiResponse(responseCode = "404", description = "No business partner found for specified bpn", content = [Content()])
+            ApiResponse(responseCode = "404", description = "No business partner found for specified BPNL", content = [Content()])
         ]
     )
     @GetMapping("/{bpnl}/addresses")
     @GetExchange("/{bpnl}/addresses")
     fun getAddresses(
-        @Parameter(description = "Bpn value") @PathVariable bpnl: String,
+        @Parameter(description = "BPNL value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
@@ -184,7 +184,7 @@ interface PoolLegalEntityApi {
     ): Collection<LegalAddressVerboseDto>
 
     @Operation(
-        summary = "Create new legal entity business partners",
+        summary = "Creates a new legal entity",
         description = "Create new business partners of type legal entity. " +
                 "The given additional identifiers of a record need to be unique, otherwise they are ignored. " +
                 "For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response."
@@ -204,7 +204,7 @@ interface PoolLegalEntityApi {
 
 
     @Operation(
-        summary = "Update existing legal entity business partners",
+        summary = "Updates an existing legal entity",
         description = "Update existing business partner records of type legal entity referenced via BPNL. " +
                 "The endpoint expects to receive the full updated record, including values that didn't change."
     )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -54,7 +54,7 @@ interface PoolMetadataApi {
     }
 
     @Operation(
-        summary = "Create new identifier type",
+        summary = "Creates a new identifier type",
         description = "Create a new identifier type (including validity details) which can be referenced by business partner records. " +
                 "Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. " +
                 "The actual name of the identifier type is free to choose and doesn't need to be unique. $technicalKeyDisclaimer"
@@ -71,7 +71,7 @@ interface PoolMetadataApi {
     fun createIdentifierType(@RequestBody identifierType: IdentifierTypeDto): IdentifierTypeDto
 
     @Operation(
-        summary = "Get page of identifier types filtered by businessPartnerType and (optionally) country (specified by its ISO 3166-1 alpha-2 country code)",
+        summary = "Returns all identifier types filtered by business partner type and country.",
         description = "Lists all matching identifier types including validity details in a paginated result"
     )
     @ApiResponses(
@@ -91,7 +91,7 @@ interface PoolMetadataApi {
 
 
     @Operation(
-        summary = "Create new legal form",
+        summary = "Creates a new legal form",
         description = "Create a new legal form which can be referenced by business partner records. " +
                 "The actual name of the legal form is free to choose and doesn't need to be unique. " + technicalKeyDisclaimer
     )
@@ -107,7 +107,7 @@ interface PoolMetadataApi {
     fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormDto
 
     @Operation(
-        summary = "Get page of legal forms",
+        summary = "Returns all legal forms",
         description = "Lists all currently known legal forms in a paginated result"
     )
     @ApiResponses(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -62,24 +62,24 @@ interface PoolSiteApi {
     ): Collection<MainAddressVerboseDto>
 
     @Operation(
-        summary = "Get site partners by bpn",
-        description = "Get business partners of type site by bpn-s ignoring case."
+        summary = "Returns a site by its BPNS",
+        description = "Get business partners of type site by BPNS ignoring case."
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "Found site with specified bpn"),
+            ApiResponse(responseCode = "200", description = "Found site with specified BPNS"),
             ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
-            ApiResponse(responseCode = "404", description = "No site found under specified bpn", content = [Content()])
+            ApiResponse(responseCode = "404", description = "No site found under specified BPNS", content = [Content()])
         ]
     )
-    @GetMapping("/{bpn}")
-    @GetExchange("/{bpn}")
+    @GetMapping("/{bpns}")
+    @GetExchange("/{bpns}")
     fun getSite(
-        @Parameter(description = "Bpn value") @PathVariable bpn: String
+        @Parameter(description = "BPNS value") @PathVariable bpns: String
     ): SitePoolVerboseDto
 
     @Operation(
-        summary = "Search site partners by BPNs and/or parent BPNs",
+        summary = "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
         description = "Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities"
     )
     @ApiResponses(
@@ -96,7 +96,7 @@ interface PoolSiteApi {
     ): PageDto<SitePoolVerboseDto>
 
     @Operation(
-        summary = "Create new site business partners",
+        summary = "Creates a new site",
         description = "Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. " +
                 "If the legal entitiy cannot be found, the record is ignored." +
                 "For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response."
@@ -115,7 +115,7 @@ interface PoolSiteApi {
     ): SitePartnerCreateResponseWrapper
 
     @Operation(
-        summary = "Update existing site business partners",
+        summary = "Updates an existing site",
         description = "Update existing business partner records of type site referenced via BPNS. " +
                 "The endpoint expects to receive the full updated record, including values that didn't change."
     )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -45,7 +45,7 @@ interface PoolSiteApi {
 
 
     @Operation(
-        summary = "Search Main Addresses",
+        summary = "Search for sites' main addresses",
         description = "Search main addresses of site business partners by BPNS"
     )
     @ApiResponses(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerCreateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerCreateRequest.kt
@@ -23,17 +23,20 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "AddressPartnerCreateRequest", description = "Request for creating new business partner record of type address")
+@Schema(description = LogisticAddressDescription.headerCreateRequest)
 data class AddressPartnerCreateRequest(
+
     @field:JsonUnwrapped
     val address: LogisticAddressDto,
 
-    @Schema(description = "Business Partner Number of the legal entity or site this address belongs to")
+    @Schema(description = LogisticAddressDescription.bpnParent)
     val bpnParent: String,
 
-    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry in the response")
+    @Schema(description = CommonDescription.index)
     val index: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerSearchRequest.kt
@@ -23,8 +23,9 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 
 // TODO rename to LogisticAddressSearchRequest / adjust
-@Schema(name = "AddressPartnerSearchRequest", description = "Contains keywords used for searching in address properties")
-data class AddressPartnerSearchRequest constructor(
+@Schema(description = "Contains keywords used for searching in address properties")
+data class AddressPartnerSearchRequest(
+
     @field:Parameter(description = "Filter business partners by name")
     var name: String? = null
 ) {
@@ -32,5 +33,3 @@ data class AddressPartnerSearchRequest constructor(
         val EmptySearchRequest = AddressPartnerSearchRequest()
     }
 }
-
-

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressPartnerUpdateRequest.kt
@@ -23,12 +23,14 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "AddressPartnerUpdateRequest", description = "Request for updating a business partner record of type address")
+@Schema(description = LogisticAddressDescription.headerUpdateRequest)
 data class AddressPartnerUpdateRequest(
-    @Schema(description = "Business Partner Number of this address")
+
+    @Schema(description = LogisticAddressDescription.bpna)
     val bpna: String,
 
     @field:JsonUnwrapped

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/ChangelogSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/ChangelogSearchRequest.kt
@@ -19,20 +19,24 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model.request
 
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import java.time.Instant
 
 
-@Schema(name = "ChangeLogSearchRequest", description = "Request for searching and filtering the business partner changelog")
+@Schema(description = "Request for searching and filtering the business partner changelog")
 data class ChangelogSearchRequest(
 
-    @Schema(description = "Only changelog entries created after this time; optional", example = "2023-03-20T10:23:28.194Z")
+    @get:Schema(
+        description = "Only changelog entries created after this time. Ignored if empty.",
+        example = "2023-03-20T10:23:28.194Z"
+    )
     val timestampAfter: Instant? = null,
 
-    @Schema(description = "Only show changelog entries for business partners with the given array of BPNL/S/A; optional")
+    @get:ArraySchema(arraySchema = Schema(description = "Only for business partners with the given array of BPNL/S/A. Ignored if empty."))
     val bpns: Set<String>? = null,
 
-    @Schema(description = "Only show changelog entries for business partners with the given array of business partner types; optional")
+    @get:ArraySchema(arraySchema = Schema(description = "Only for business partners with the given array of business partner types. Ignored if empty."))
     val businessPartnerTypes: Set<BusinessPartnerType>? = null
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/ChangelogSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/ChangelogSearchRequest.kt
@@ -27,12 +27,12 @@ import java.time.Instant
 @Schema(name = "ChangeLogSearchRequest", description = "Request for searching and filtering the business partner changelog")
 data class ChangelogSearchRequest(
 
-    @Schema(description = "Changelog entries should be created after this time", example = "2023-03-20T10:23:28.194Z")
+    @Schema(description = "Only changelog entries created after this time; optional", example = "2023-03-20T10:23:28.194Z")
     val timestampAfter: Instant? = null,
 
-    @Schema(description = "Only show changelog entries for business partners with the given BPNs. Empty means no restriction.")
+    @Schema(description = "Only show changelog entries for business partners with the given array of BPNL/S/A; optional")
     val bpns: Set<String>? = null,
 
-    @Schema(description = "Only show changelog entries for business partners with the given LSA types. Empty means no restriction.")
+    @Schema(description = "Only show changelog entries for business partners with the given array of business partner types; optional")
     val businessPartnerTypes: Set<BusinessPartnerType>? = null
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
@@ -24,21 +24,24 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityPartnerCreateRequest", description = "Request for creating new business partner record of type legal entity")
+@Schema(description = LegalEntityDescription.headerCreateRequest)
 data class LegalEntityPartnerCreateRequest(
 
-    @get:Schema(description = "Legal name the partner goes by")
+    @get:Schema(description = LegalEntityDescription.legalName)
     val legalName: String,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: LogisticAddressDto,
 
-    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry in the response")
+    @get:Schema(description = CommonDescription.index)
     val index: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
@@ -24,23 +24,23 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
-
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityPartnerUpdateRequest", description = "Request for updating a business partner record of type legal entity")
+@Schema(description = LegalEntityDescription.headerUpdateRequest)
 data class LegalEntityPartnerUpdateRequest(
-    @Schema(description = "Business Partner Number")
+
+    @get:Schema(description = LegalEntityDescription.bpnl)
     val bpnl: String,
 
-    @get:Schema(description = "Legal name the partner goes by")
+    @get:Schema(description = LegalEntityDescription.legalName)
     val legalName: String,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: LogisticAddressDto,
-
-    )
-
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPropertiesSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPropertiesSearchRequest.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 
 
-@Schema(name = "LegalEntityPropertiesSearchRequest", description = "Contains keywords used for searching in legal entity properties")
+@Schema(description = "Contains keywords used for searching in legal entity properties")
 data class LegalEntityPropertiesSearchRequest constructor(
     @field:Parameter(description = "Filter legal entities by name")
     val legalName: String?
@@ -32,4 +32,3 @@ data class LegalEntityPropertiesSearchRequest constructor(
         val EmptySearchRequest = LegalEntityPropertiesSearchRequest(null)
     }
 }
-

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SitePartnerCreateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SitePartnerCreateRequest.kt
@@ -23,17 +23,20 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.SiteDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "SitePartnerCreateRequest", description = "Request for creating new business partner record of type site")
+@Schema(description = SiteDescription.headerCreateRequest)
 data class SitePartnerCreateRequest(
+
     @field:JsonUnwrapped
     val site: SiteDto,
 
-    @Schema(description = "Business Partner Number of the legal entity this site belongs to")
+    @Schema(description = SiteDescription.bpnlParent)
     val bpnlParent: String,
 
-    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry in the response")
+    @Schema(description = CommonDescription.index)
     val index: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SitePartnerUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SitePartnerUpdateRequest.kt
@@ -23,12 +23,14 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.SiteDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "SitePartnerUpdateRequest", description = "Request for updating a business partner record of type site")
+@Schema(description = SiteDescription.headerUpdateRequest)
 data class SitePartnerUpdateRequest(
-    @Schema(description = "Business Partner Number of this site")
+
+    @Schema(description = SiteDescription.bpns)
     val bpns: String,
 
     @field:JsonUnwrapped

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressMatchVerboseDto.kt
@@ -20,15 +20,18 @@
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 
 
-@Schema(name = "AddressMatchVerboseDto", description = "Match with score for a business partner record of type address")
+@Schema(description = LogisticAddressDescription.headerMatchResponse)
 data class AddressMatchVerboseDto(
 
-    @Schema(description = "Relative quality score of the match. The higher the better")
+    @get:Schema(description = CommonDescription.score)
     val score: Float,
 
-    @Schema(description = "Matched address business partner record")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.address)
     val address: LogisticAddressVerboseDto
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/AddressPartnerCreateVerboseDto.kt
@@ -22,16 +22,18 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "AddressPartnerCreateVerboseDto", description = "Created business partners of type address")
+@Schema(description = LogisticAddressDescription.headerCreateResponse)
 data class AddressPartnerCreateVerboseDto(
 
     @field:JsonUnwrapped
     val address: LogisticAddressVerboseDto,
 
-    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry from the request")
+    @Schema(description = CommonDescription.index)
     val index: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/ChangelogEntryVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/ChangelogEntryVerboseDto.kt
@@ -21,21 +21,22 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ChangelogDescription
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 import java.time.Instant
 
-@Schema(name = "ChangelogEntryVerboseDto", description = "Changelog entry for a business partner")
+@Schema(description = ChangelogDescription.header)
 data class ChangelogEntryVerboseDto(
 
-    @Schema(description = "Business Partner Number of the changelog entry")
+    @get:Schema(description = ChangelogDescription.bpn)
     val bpn: String,
 
-    @Schema(description = "The type of the business partner this change refers to")
+    @get:Schema(description = ChangelogDescription.businessPartnerType)
     val businessPartnerType: BusinessPartnerType,
 
-    @Schema(description = "The timestamp of the change")
+    @get:Schema(description = ChangelogDescription.timestamp)
     val timestamp: Instant,
 
-    @Schema(description = "The type of the change")
+    @get:Schema(description = ChangelogDescription.changelogType)
     val changelogType: ChangelogType
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/EntitiesWithErrors.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/EntitiesWithErrors.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdm.pool.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 
 open class EntitiesWithErrors<ENTITY, out ERROR : ErrorCode>(
@@ -35,59 +36,38 @@ open class EntitiesWithErrors<ENTITY, out ERROR : ErrorCode>(
         get() = errors.size
 }
 
-@Schema(
-    name = "LegalEntityCreateWrapper",
-    description = "Holds information about successfully and failed entities after the creating/updating of several objects"
-)
+@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
 data class LegalEntityPartnerCreateResponseWrapper(
     override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<LegalEntityCreateError>>
 ) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityCreateError>(entities, errors)
 
-@Schema(
-    name = "LegalEntityUpdateWrapper",
-    description = "Holds information about successfully and failed entities after the creating/updating of several objects"
-)
+@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
 data class LegalEntityPartnerUpdateResponseWrapper(
     override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<LegalEntityUpdateError>>
 ) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityUpdateError>(entities, errors)
 
-@Schema(
-    name = "SiteCreateWrapper",
-    description = "Holds information about successfully and failed entities after the creating/updating of several objects"
-)
+@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
 data class SitePartnerCreateResponseWrapper(
     override val entities: Collection<SitePartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<SiteCreateError>>
 ) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteCreateError>(entities, errors)
 
-@Schema(
-    name = "SiteUpdateWrapper",
-    description = "Holds information about successfully and failed entities after the creating/updating of several objects"
-)
+@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
 data class SitePartnerUpdateResponseWrapper(
     override val entities: Collection<SitePartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<SiteUpdateError>>
 ) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteUpdateError>(entities, errors)
 
-@Schema(
-    name = "AddressCreateWrapper",
-    description = "Holds information about successfully and failed entities after the creating/updating of several objects"
-)
+@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
 data class AddressPartnerCreateResponseWrapper(
     override val entities: Collection<AddressPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<AddressCreateError>>
 ) : EntitiesWithErrors<AddressPartnerCreateVerboseDto, AddressCreateError>(entities, errors)
 
-@Schema(
-    name = "AddressUpdateWrapper",
-    description = "Holds information about successfully and failed entities after the creating/updating of several objects"
-)
+@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
 data class AddressPartnerUpdateResponseWrapper(
     override val entities: Collection<LogisticAddressVerboseDto>,
     override val errors: Collection<ErrorInfo<AddressUpdateError>>
 ) : EntitiesWithErrors<LogisticAddressVerboseDto, AddressUpdateError>(entities, errors)
-
-
-

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
@@ -22,23 +22,26 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityMatchVerboseDto", description = "Match with score for a business partner record of type legal entity")
+@Schema(description = LegalEntityDescription.headerMatchResponse)
 data class LegalEntityMatchVerboseDto(
 
-    @Schema(description = "Relative quality score of the match. The higher the better")
+    @get:Schema(description = CommonDescription.score)
     val score: Float,
 
-    @get:Schema(description = "Legal name the partner goes by")
+    @get:Schema(description = LegalEntityDescription.legalName)
     val legalName: String,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
@@ -22,23 +22,26 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityPartnerCreateVerboseDto", description = "Created business partner of type legal entity")
+@Schema(description = LegalEntityDescription.headerCreateResponse)
 data class LegalEntityPartnerCreateVerboseDto(
 
-    @get:Schema(description = "Legal name the partner goes by")
+    @get:Schema(description = LegalEntityDescription.legalName)
     val legalName: String,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: LogisticAddressVerboseDto,
 
-    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry from the request")
+    @get:Schema(description = CommonDescription.index)
     val index: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SiteMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SiteMatchVerboseDto.kt
@@ -21,20 +21,23 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "SiteMatchVerboseDto", description = "Match with score for a business partner record of type site.")
+@Schema(description = SiteDescription.headerMatchResponse)
 data class SiteMatchVerboseDto(
 
 //    @Schema(description = "Relative quality score of the match. The higher the better")
 //    val score: Float,
 
-    @Schema(description = "Main address where this site resides")
+    // TODO OpenAPI description for complex field does not work!!
+    @Schema(description = SiteDescription.mainAddress)
     val mainAddress: LogisticAddressVerboseDto,
 
-    @Schema(description = "Site information")
+    // TODO OpenAPI description for complex field does not work!!
+    @Schema(description = SiteDescription.site)
     val site: SiteVerboseDto,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePartnerCreateVerboseDto.kt
@@ -22,20 +22,23 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "SitePartnerCreateVerboseDto", description = "Created business partner record of type site")
+@Schema(description = SiteDescription.headerCreateResponse)
 data class SitePartnerCreateVerboseDto(
 
     @field:JsonUnwrapped
     val site: SiteVerboseDto,
 
-    @Schema(description = "Main address of this site")
+    // TODO OpenAPI description for complex field does not work!!
+    @Schema(description = SiteDescription.mainAddress)
     val mainAddress: LogisticAddressVerboseDto,
 
-    @Schema(description = "User defined index to conveniently match this entry to the corresponding entry from the request")
+    @Schema(description = CommonDescription.index)
     val index: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePoolVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePoolVerboseDto.kt
@@ -22,17 +22,19 @@ package org.eclipse.tractusx.bpdm.pool.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "SitePoolVerboseDto", description = "Site with legal entity reference.")
+@Schema(description = SiteDescription.header)
 data class SitePoolVerboseDto(
 
     @field:JsonUnwrapped
     val site: SiteVerboseDto,
 
-    @Schema(description = "Main address where this site resides")
+    // TODO OpenAPI description for complex field does not work!!
+    @Schema(description = SiteDescription.mainAddress)
     val mainAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -49,9 +49,9 @@ class SiteController(
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun getSite(
-        bpn: String
+        bpns: String
     ): SitePoolVerboseDto {
-        return siteService.findByBpn(bpn.uppercase())
+        return siteService.findByBpn(bpns.uppercase())
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")


### PR DESCRIPTION
- Update endpoint and DTO field description texts for Pool.
- Reused descriptions texts are collected in appropriate *Description objects.
- Fixed @Schema annotations to @get:Schema to work with Kotlin data objects.

Part of #355

https://github.com/eclipse-tractusx/bpdm/pull/393 must be merged first