### PR TITLE
Feat: Add OpenAPI descriptions for Gate

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/GateLegalEntityInfo.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/GateLegalEntityInfo.kt
@@ -23,7 +23,7 @@ import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
 
 data class GateLegalEntityInfo(
-    val legalNameParts: List<String>,
+    val legalNameParts: Collection<String>,
     val legalEntity: LegalEntityDto,
     val legalAddress: AddressGateInputDto,
     val externalId: String,

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
@@ -270,7 +270,7 @@ class GateUpdateService(
 
     private fun putAddressOutput(request: AddressGateOutputRequest?) =
         request?.let {
-            gateClient.addresses().putAddressesOutput(listOf(it))
+            gateClient.addresses().upsertAddressesOutput(listOf(it))
         }
 
     private fun upsertSharingState(request: SharingStateDto?) =

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/ChangelogDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/ChangelogDescription.kt
@@ -27,4 +27,5 @@ object ChangelogDescription {
     const val timestamp = "The date and time when the changelog entry was created."
     const val businessPartnerType = "One of the types of business partners for which the changelog entry was created: legal entity, site, address."
     const val bpn = "The business partner number for which the changelog entry was created. Can be either a BPNL, BPNS or BPNA."
+    const val externalId = "The external identifier of the business partner for which the changelog entry was created."
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/CommonDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/CommonDescription.kt
@@ -20,11 +20,13 @@
 package org.eclipse.tractusx.bpdm.common.dto.openapidescription
 
 object CommonDescription {
+    const val headerEntityWithErrorsWrapper = "Holds information about successfully and failed entities after the creating/updating of several objects"
+
     const val createdAt = "The date when the data record has been created."
     const val updatedAt = "The date when the data record has been last updated."
 
     const val index = "User defined index to conveniently match this entry to the corresponding entry in the response."
     const val score = "Relative quality score of the match. The higher the better."
 
-    const val entityWithErrorsWrapperHeader = "Holds information about successfully and failed entities after the creating/updating of several objects"
+    const val externalId = "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityDescription.kt
@@ -33,7 +33,8 @@ object LegalEntityDescription {
             "identified by the BPNL."
     const val headerCreateRequest = "Request for creating new business partner record of type legal entity. $header"
     const val headerUpdateRequest = "Request for updating a business partner record of type legal entity. $header"
-    const val headerCreateResponse = "Created business partner of type legal entity. $header"
+    const val headerUpsertRequest = "Request for creating/updating a business partner record of type legal entity. $header"
+    const val headerUpsertResponse = "Created/updated business partner of type legal entity. $header"
     const val headerMatchResponse = "Match with score for a business partner record of type legal entity. $header"
 
     const val bpnl = "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), " +
@@ -41,6 +42,7 @@ object LegalEntityDescription {
     const val currentness = "The date the business partner data was last indicated to be still current."
 
     const val legalName = "The name of the legal entity according to official registers."
+    const val legalNameParts = "The list of name parts of the legal entity to accommodate the different number of name fields in different systems."
     const val legalShortName = "The abbreviated name of the legal entity."
     const val legalForm = "The legal form of the legal entity."
     const val legalAddress = "The official, legal correspondence address to be provided to government and tax authorities " +
@@ -50,4 +52,5 @@ object LegalEntityDescription {
     const val states = "The list of (temporary) states of the legal entity."
     const val classifications = "The list of classifications of the legal entity, such as a specific industry."
     const val relations = "Relations to other business partners."
+    const val roles = "Roles this business partner takes in relation to the sharing member."
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LogisticAddressDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LogisticAddressDescription.kt
@@ -32,6 +32,7 @@ object LogisticAddressDescription {
             "uniquely identified by the BPNA."
     const val headerCreateRequest = "Request for creating new business partner record of type address. $header"
     const val headerUpdateRequest = "Request for updating a business partner record of type address. $header"
+    const val headerUpsertRequest = "Request for creating/updating a business partner record of type address. $header"
     const val headerCreateResponse = "Created business partner of type address. $header"
     const val headerMatchResponse = "Match for a business partner record of type address. $header"
 
@@ -40,6 +41,8 @@ object LogisticAddressDescription {
             "It is important to note that only the BPNL must be used to uniquely identify a legal entity. " +
             "Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity."
     const val name = "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+    const val nameParts = "The list of name parts of the address to accommodate the different number of name fields in different systems. " +
+            "This is not according to official registers but according to the name the sharing member chooses."
     const val states = "The list of (temporary) states of the address."
     const val identifiers = "The list of identifiers of the address."
     const val physicalPostalAddress = "The physical postal address of the address, such as an office, warehouse, gate, etc."
@@ -49,7 +52,12 @@ object LogisticAddressDescription {
     const val bpnSite = "The BPNS of the site the address belongs to."
     const val isMainAddress = "Indicates if the address is the main address to a site. " +
             "This is where typically the main entrance or the reception is located, or where the mail is delivered to."
+    const val roles = "Roles this business partner takes in relation to the sharing member."
 
     const val bpnParent = "BPNL of the legal entity or BPNS of the site this address belongs to."
+    const val legalEntityExternalId = "The identifier which uniquely identifies (in the internal system landscape of the sharing member) " +
+            "the business partner, representing the legal entity, that owns the address."
+    const val siteExternalId = "The identifier which uniquely identifies (in the internal system landscape of the sharing member) " +
+            "the business partner, representing the site, that the address belongs to."
     const val address = "Address information"
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/SiteDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/SiteDescription.kt
@@ -31,16 +31,22 @@ object SiteDescription {
             "addresses belong to which site. A site is uniquely identified by the BPNS."
     const val headerCreateRequest = "Request for creating new business partner record of type site. $header"
     const val headerUpdateRequest = "Request for updating a business partner record of type site. $header"
-    const val headerCreateResponse = "Created business partner of type site. $header"
+    const val headerUpsertRequest = "Request for creating/updating a business partner record of type site. $header"
+    const val headerUpsertResponse = "Created/updated business partner of type site. $header"
     const val headerMatchResponse = "Match for a business partner record of type site. $header"
 
     const val bpns = "A BPNS represents and uniquely identifies a site, which is where for example a production plant, " +
             "a warehouse, or an office building is located."
     const val name = "The name of the site. This is not according to official registers but according to the name the owner chooses."
+    const val nameParts = "The list of name parts of the site to accommodate the different number of name fields in different systems. " +
+            "This is not according to official registers but according to the name the owner chooses."
     const val states = "The list of the (temporary) states of the site."
     const val bpnLegalEntity = "The BPNL of the legal entity owning the site."
     const val mainAddress = "The address, where typically the main entrance or the reception is located, or where the mail is delivered to."
+    const val roles = "Roles this business partner takes in relation to the sharing member."
 
     const val bpnlParent = "The BPNL of the legal entity owning the site."
+    const val legalEntityExternalId = "The identifier which uniquely identifies (in the internal system landscape of the sharing member) " +
+            "the business partner owning the site."
     const val site = "Site information"
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/StreetDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/StreetDescription.kt
@@ -27,4 +27,9 @@ object StreetDescription {
     const val milestone = "The number representing the exact location of an addressed object within a street without house numbers, such as within long roads."
     const val direction = "The cardinal direction describing where the exit to the location of the addressed object on large highways / " +
             "motorways is located, such as Highway 101 South."
+
+    const val namePrefix = "The street related information, which is usually printed before the official street name on an address label."
+    const val additionalNamePrefix = "The additional street related information, which is usually printed before the official street name on an address label."
+    const val nameSuffix = "The street related information, which is usually printed after the official street name on an address label."
+    const val additionalNameSuffix = "The additional street related information, which is usually printed after the official street name on an address label."
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateAddressApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateAddressApi.kt
@@ -44,12 +44,11 @@ import org.springframework.web.service.annotation.PutExchange
 @HttpExchange("/api/catena")
 interface GateAddressApi {
 
-
     @Operation(
-        summary = "Create or update addresses.",
+        summary = "Creates or updates an existing address in the input stage",
         description = "Create or update addresses. " +
-                "Updates instead of creating a new address if an already existing external id is used. " +
-                "The same external id may not occur more than once in a single request. " +
+                "Updates instead of creating a new address if an already existing external ID is used. " +
+                "The same external ID may not occur more than once in a single request. " +
                 "For a single request, the maximum number of addresses in the request is limited to \${bpdm.api.upsert-limit} entries."
     )
     @ApiResponses(
@@ -62,25 +61,23 @@ interface GateAddressApi {
     @PutExchange("/input/addresses")
     fun upsertAddresses(@RequestBody addresses: Collection<AddressGateInputRequest>): ResponseEntity<Unit>
 
-
     @Operation(
-        summary = "Get address by external identifier",
-        description = "Get address by external identifier."
+        summary = "Returns address by external ID from the input stage",
+        description = "Returns address by external ID from the input stage."
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "Found address with external identifier"),
-            ApiResponse(responseCode = "404", description = "No address found under specified external identifier", content = [Content()])
+            ApiResponse(responseCode = "200", description = "Found address with external ID"),
+            ApiResponse(responseCode = "404", description = "No address found under specified external ID", content = [Content()])
         ]
     )
-
     @GetMapping("/input/addresses/{externalId}")
     @GetExchange("/input/addresses/{externalId}")
-    fun getAddressByExternalId(@Parameter(description = "External identifier") @PathVariable externalId: String): AddressGateInputDto
+    fun getAddressByExternalId(@Parameter(description = "External ID") @PathVariable externalId: String): AddressGateInputDto
 
     @Operation(
-        summary = "Get page of addresses filtered by a collection of externalIds",
-        description = "Get page of addresses filtered by a collection of externalIds."
+        summary = "Returns addresses by an array of external IDs from the input stage",
+        description = "Returns page of addresses from the input stage. Can optionally be filtered by external IDs."
     )
     @ApiResponses(
         value = [
@@ -95,10 +92,9 @@ interface GateAddressApi {
         @RequestBody externalIds: Collection<String>
     ): PageDto<AddressGateInputDto>
 
-
     @Operation(
-        summary = "Get page of addresses",
-        description = "Get page of addresses."
+        summary = "Returns addresses from the input stage",
+        description = "Returns page of addresses from the input stage."
     )
     @ApiResponses(
         value = [
@@ -111,8 +107,8 @@ interface GateAddressApi {
     fun getAddresses(@ParameterObject @Valid paginationRequest: PaginationRequest): PageDto<AddressGateInputDto>
 
     @Operation(
-        summary = "Get page of addresses (Output)",
-        description = "Get page of addresses (Output). Can optionally be filtered by external ids."
+        summary = "Returns addresses by an array of external IDs from the output stage",
+        description = "Get page of addresses from the output stage. Can optionally be filtered by external IDs."
     )
     @ApiResponses(
         value = [
@@ -128,10 +124,10 @@ interface GateAddressApi {
     ): PageDto<AddressGateOutputDto>
 
     @Operation(
-        summary = "Create or update output addresses.",
+        summary = "Creates or updates an existing address in the output stage",
         description = "Create or update addresses (Output). " +
-                "Updates instead of creating a new address if an already existing external id is used. " +
-                "The same external id may not occur more than once in a single request. " +
+                "Updates instead of creating a new address if an already existing external ID is used. " +
+                "The same external ID may not occur more than once in a single request. " +
                 "For a single request, the maximum number of addresses in the request is limited to \${bpdm.api.upsert-limit} entries."
 
     )
@@ -143,6 +139,5 @@ interface GateAddressApi {
     )
     @PutMapping("/output/addresses")
     @PutExchange("/output/addresses")
-    fun putAddressesOutput(@RequestBody addresses: Collection<AddressGateOutputRequest>): ResponseEntity<Unit>
-
+    fun upsertAddressesOutput(@RequestBody addresses: Collection<AddressGateOutputRequest>): ResponseEntity<Unit>
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateChangelogApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateChangelogApi.kt
@@ -38,10 +38,10 @@ import org.springframework.web.service.annotation.PostExchange
 @HttpExchange("/api/catena")
 interface GateChangelogApi {
 
-
     @Operation(
-        summary = "Get business partner changelog entries for changes to the business partner input data",
-        description = "Get business partner changelog entries for changes to the business partner input data. Filter by list external id, from timestamp and/or lsa type"
+        summary = "Returns changelog entries for changes to the business partner input stage",
+        description = "Returns changelog entries as of a specified timestamp from the input stage, " +
+                "optionally filtered by timestamp, an array of external IDs and a business partner type."
     )
     @ApiResponses(
         value = [
@@ -56,10 +56,10 @@ interface GateChangelogApi {
         @RequestBody searchRequest: ChangelogSearchRequest
     ): PageChangeLogDto<ChangelogGateDto>
 
-
     @Operation(
-        summary = "Get business partner changelog entries for changes to the business partner output data",
-        description = "Get business partner changelog entries for changes to the business partner output data. Filter by list external id, from timestamp and/or lsa type"
+        summary = "Returns changelog entries for changes to the business partner output stage",
+        description = "Returns changelog entries as of a specified timestamp from the output stage, " +
+                "optionally filtered by timestamp, an array of external IDs and a business partner type."
     )
     @ApiResponses(
         value = [

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateLegalEntityApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateLegalEntityApi.kt
@@ -45,10 +45,10 @@ import org.springframework.web.service.annotation.PutExchange
 interface GateLegalEntityApi {
 
     @Operation(
-        summary = "Create or update legal entities.",
+        summary = "Creates or updates an existing legal entity in the input stage",
         description = "Create or update legal entities. " +
-                "Updates instead of creating a new legal entity if an already existing external id is used. " +
-                "The same external id may not occur more than once in a single request. " +
+                "Updates instead of creating a new legal entity if an already existing external ID is used. " +
+                "The same external ID may not occur more than once in a single request. " +
                 "For a single request, the maximum number of legal entities in the request is limited to \${bpdm.api.upsert-limit} entries."
     )
     @ApiResponses(
@@ -62,22 +62,22 @@ interface GateLegalEntityApi {
     fun upsertLegalEntities(@RequestBody legalEntities: Collection<LegalEntityGateInputRequest>): ResponseEntity<Unit>
 
     @Operation(
-        summary = "Get legal entity by external identifier",
-        description = "Get legal entity by external identifier."
+        summary = "Returns legal entity by external ID from the input stage",
+        description = "Returns legal entity by external ID from the input stage."
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "Found legal entity with external identifier"),
-            ApiResponse(responseCode = "404", description = "No legal entity found under specified external identifier", content = [Content()])
+            ApiResponse(responseCode = "200", description = "Found legal entity with external ID"),
+            ApiResponse(responseCode = "404", description = "No legal entity found under specified external ID", content = [Content()])
         ]
     )
     @GetMapping("/input/legal-entities/{externalId}")
     @GetExchange("/input/legal-entities/{externalId}")
-    fun getLegalEntityByExternalId(@Parameter(description = "External identifier") @PathVariable externalId: String): LegalEntityGateInputDto
+    fun getLegalEntityByExternalId(@Parameter(description = "External ID") @PathVariable externalId: String): LegalEntityGateInputDto
 
     @Operation(
-        summary = "Get page of legal-entities filtered by a collection of externalIds",
-        description = "Get page of legal-entities filtered by a collection of externalIds."
+        summary = "Returns legal entities by an array of external IDs from the input stage",
+        description = "Returns page of legal entities from the input stage. Can optionally be filtered by external IDs."
     )
     @ApiResponses(
         value = [
@@ -93,8 +93,8 @@ interface GateLegalEntityApi {
     ): PageDto<LegalEntityGateInputDto>
 
     @Operation(
-        summary = "Get page of legal entities",
-        description = "Get page of legal entities."
+        summary = "Returns legal entities from the input stage",
+        description = "Returns page of legal entities from the input stage."
     )
     @ApiResponses(
         value = [
@@ -107,8 +107,8 @@ interface GateLegalEntityApi {
     fun getLegalEntities(@ParameterObject @Valid paginationRequest: PaginationRequest): PageDto<LegalEntityGateInputDto>
 
     @Operation(
-        summary = "Get page of legal entities",
-        description = "Get page of legal entities. Can optionally be filtered by external ids."
+        summary = "Returns legal entities by an array of external IDs from the output stage",
+        description = "Get page of legal entities from the output stage. Can optionally be filtered by external IDs."
     )
     @ApiResponses(
         value = [
@@ -124,10 +124,10 @@ interface GateLegalEntityApi {
     ): PageDto<LegalEntityGateOutputResponse>
 
     @Operation(
-        summary = "Create or update output legal entities.",
+        summary = "Creates or updates an existing legal entity in the output stage",
         description = "Create or update legal entities (Output). " +
-                "Updates instead of creating a new legal entity if an already existing external id is used. " +
-                "The same external id may not occur more than once in a single request. " +
+                "Updates instead of creating a new legal entity if an already existing external ID is used. " +
+                "The same external ID may not occur more than once in a single request. " +
                 "For a single request, the maximum number of legal entities in the request is limited to \${bpdm.api.upsert-limit} entries."
     )
     @ApiResponses(
@@ -139,5 +139,4 @@ interface GateLegalEntityApi {
     @PutMapping("/output/legal-entities")
     @PutExchange("/output/legal-entities")
     fun upsertLegalEntitiesOutput(@RequestBody legalEntities: Collection<LegalEntityGateOutputRequest>): ResponseEntity<Unit>
-
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
@@ -41,7 +41,7 @@ import org.springframework.web.service.annotation.PutExchange
 interface GateSharingStateApi {
 
     @Operation(
-        summary = "Get sharing states (including error info and BPN) for business partners, optionally filtered by LSA type and external ID"
+        summary = "Returns sharing states of business partners, optionally filtered by a business partner type and an array of external IDs"
     )
     @ApiResponses(
         value = [
@@ -53,20 +53,19 @@ interface GateSharingStateApi {
     fun getSharingStates(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
         @Parameter(description = "Business partner type") @RequestParam(required = false) businessPartnerType: BusinessPartnerType?,
-        @Parameter(description = "External identifiers") @RequestParam(required = false) externalIds: Collection<String>?
+        @Parameter(description = "External IDs") @RequestParam(required = false) externalIds: Collection<String>?
     ): PageDto<SharingStateDto>
 
     @Operation(
-        summary = "Insert/update sharing state (including error info and BPN) for business partner with LSA type and external ID"
+        summary = "Creates or updates a sharing state of a business partner"
     )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "204", description = "Operation completed successfully"),
-            ApiResponse(responseCode = "400", description = "Invalid data (e.g. externalId)", content = [Content()])
+            ApiResponse(responseCode = "400", description = "Invalid data (e.g. external ID)", content = [Content()])
         ]
     )
     @PutMapping
     @PutExchange
     fun upsertSharingState(@RequestBody request: SharingStateDto)
-
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSiteApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSiteApi.kt
@@ -45,10 +45,10 @@ import org.springframework.web.service.annotation.PutExchange
 interface GateSiteApi {
 
     @Operation(
-        summary = "Create or update sites.",
+        summary = "Creates or updates an existing site in the input stage",
         description = "Create or update sites. " +
-                "Updates instead of creating a new site if an already existing external id is used. " +
-                "The same external id may not occur more than once in a single request. " +
+                "Updates instead of creating a new site if an already existing external ID is used. " +
+                "The same external ID may not occur more than once in a single request. " +
                 "For a single request, the maximum number of sites in the request is limited to \${bpdm.api.upsert-limit} entries."
     )
     @ApiResponses(
@@ -62,22 +62,22 @@ interface GateSiteApi {
     fun upsertSites(@RequestBody sites: Collection<SiteGateInputRequest>): ResponseEntity<Unit>
 
     @Operation(
-        summary = "Get site by external identifier",
-        description = "Get site by external identifier."
+        summary = "Returns site by external ID from the input stage",
+        description = "Returns site by external ID from the input stage."
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "Found site with external identifier"),
-            ApiResponse(responseCode = "404", description = "No site found under specified external identifier", content = [Content()])
+            ApiResponse(responseCode = "200", description = "Found site with external ID"),
+            ApiResponse(responseCode = "404", description = "No site found under specified external ID", content = [Content()])
         ]
     )
     @GetMapping("/input/sites/{externalId}")
     @GetExchange("/input/sites/{externalId}")
-    fun getSiteByExternalId(@Parameter(description = "External identifier") @PathVariable externalId: String): SiteGateInputDto
+    fun getSiteByExternalId(@Parameter(description = "External ID") @PathVariable externalId: String): SiteGateInputDto
 
     @Operation(
-        summary = "Get page of sites filtered by a collection of externalIds",
-        description = "Get page of sites filtered by a collection of externalIds."
+        summary = "Returns sites by an array of external IDs from the input stage",
+        description = "Returns page of sites from the input stage. Can optionally be filtered by external IDs."
     )
     @ApiResponses(
         value = [
@@ -93,8 +93,8 @@ interface GateSiteApi {
     ): PageDto<SiteGateInputDto>
 
     @Operation(
-        summary = "Get page of sites",
-        description = "Get page of sites."
+        summary = "Returns sites from the input stage",
+        description = "Returns page of sites from the input stage."
     )
     @ApiResponses(
         value = [
@@ -107,8 +107,8 @@ interface GateSiteApi {
     fun getSites(@ParameterObject @Valid paginationRequest: PaginationRequest): PageDto<SiteGateInputDto>
 
     @Operation(
-        summary = "Get page of sites",
-        description = "Get page of sites. Can optionally be filtered by external ids."
+        summary = "Returns sites by an array of external IDs from the output stage",
+        description = "Get page of sites from the output stage. Can optionally be filtered by external IDs."
     )
     @ApiResponses(
         value = [
@@ -124,10 +124,10 @@ interface GateSiteApi {
     ): PageDto<SiteGateOutputResponse>
 
     @Operation(
-        summary = "Create or update output sites.",
+        summary = "Creates or updates an existing site in the output stage",
         description = "Create or update sites (Output). " +
-                "Updates instead of creating a new site if an already existing external id is used. " +
-                "The same external id may not occur more than once in a single request. " +
+                "Updates instead of creating a new site if an already existing external ID is used. " +
+                "The same external ID may not occur more than once in a single request. " +
                 "For a single request, the maximum number of sites in the request is limited to \${bpdm.api.upsert-limit} entries."
     )
     @ApiResponses(
@@ -139,5 +139,4 @@ interface GateSiteApi {
     @PutMapping("/output/sites")
     @PutExchange("/output/sites")
     fun upsertSitesOutput(@RequestBody sites: Collection<SiteGateOutputRequest>): ResponseEntity<Unit>
-
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/exception/GateErrorCodes.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/exception/GateErrorCodes.kt
@@ -19,22 +19,18 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.exception
 
-import io.swagger.v3.oas.annotations.media.Schema
-
 /**
  * For every combination of possible errors a separate enum class is defined extending this marker interface.
  * We need separate enum classes in order to get the correct error codes for each endpoint in the Swagger schema.
  */
 interface ErrorCode
 
-@Schema(description = "BusinessPartnerSharingError")
 enum class BusinessPartnerSharingError : ErrorCode {
     SharingProcessError,
     SharingTimeout,
     BpnNotInPool,
 }
 
-@Schema(description = "ChangeLogOutputError")
 enum class ChangeLogOutputError : ErrorCode {
     ExternalIdNotFound,
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/AddressGateOutputChildRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/AddressGateOutputChildRequest.kt
@@ -22,17 +22,17 @@ package org.eclipse.tractusx.bpdm.gate.api.model
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "AddressGateOutputChildRequest",
-    description = "DTO for setting the output address data with BPN."
-)
+@Schema(description = LogisticAddressDescription.header)
 data class AddressGateOutputChildRequest(
+
     @field:JsonUnwrapped
     val address: LogisticAddressGateDto,
 
-    @Schema(description = "Business Partner Number")
+    // TODO rename to bpna
+    @get:Schema(description = LogisticAddressDescription.bpna)
     val bpn: String
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LogisticAddressGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LogisticAddressGateDto.kt
@@ -24,27 +24,28 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.AddressIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.AddressStateDto
 import org.eclipse.tractusx.bpdm.common.dto.AlternativePostalAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 
-
-@Schema(name = "LogisticAddressGateDto", description = "Address record for a business partner")
+@Schema(description = LogisticAddressDescription.header)
 data class LogisticAddressGateDto(
-    @get:Schema(
-        description = "Name of the logistic address of the business partner. This is not according to official\n" +
-                "registers but according to the name the uploading sharing member chooses."
-    )
+
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.nameParts))
     val nameParts: Collection<String> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "Indicates if the LogisticAddress is \"Active\" or \"Inactive\"."))
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.states))
     val states: Collection<AddressStateDto> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "List of identifiers"))
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.identifiers))
     val identifiers: Collection<AddressIdentifierDto> = emptyList(),
 
-    @get:Schema(description = "Physical postal address")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.physicalPostalAddress)
     val physicalPostalAddress: PhysicalPostalAddressGateDto,
 
-    @get:Schema(description = "Alternative postal address")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.alternativePostalAddress)
     val alternativePostalAddress: AlternativePostalAddressDto? = null,
 
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList()
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/PhysicalPostalAddressGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/PhysicalPostalAddressGateDto.kt
@@ -25,16 +25,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.AreaDistrictDto
 import org.eclipse.tractusx.bpdm.common.dto.BasePhysicalAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.BasePostalAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.StreetDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "PhysicalPostalAddressGateDto", description = "Physical Postal Address Part")
+@Schema(description = PostalAddressDescription.headerPhysical)
 data class PhysicalPostalAddressGateDto(
 
     @field:JsonUnwrapped
     val baseAddress: BasePostalAddressDto,
 
-    @get:Schema(description = "Address Street")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = StreetDescription.header)
     val street: StreetGateDto? = null,
 
     @field:JsonUnwrapped

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/SiteGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/SiteGateDto.kt
@@ -22,15 +22,17 @@ package org.eclipse.tractusx.bpdm.gate.api.model
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.SiteStateDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 
-@Schema(name = "Site", description = "Site record")
+@Schema(description = SiteDescription.header)
 data class SiteGateDto(
-    @get:Schema(description = "Parts that make up the name of that site")
+
+    @get:ArraySchema(arraySchema = Schema(description = SiteDescription.nameParts))
     val nameParts: Collection<String> = emptyList(),
 
-    @ArraySchema(arraySchema = Schema(description = "Business status"))
+    @get:ArraySchema(arraySchema = Schema(description = SiteDescription.states))
     val states: Collection<SiteStateDto> = emptyList(),
 
-    @Schema(description = "Which roles this business partner takes in relation to the sharing member")
+    @get:ArraySchema(arraySchema = Schema(description = SiteDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/StreetGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/StreetGateDto.kt
@@ -20,32 +20,32 @@
 package org.eclipse.tractusx.bpdm.gate.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.StreetDescription
 
-@Schema(name = "StreetGate", description = "A public road in a city, town, or village, typically with houses and buildings on one or both sides.")
+@Schema(description = StreetDescription.header)
 data class StreetGateDto(
 
-
-    @get:Schema(description = "Describes the official name prefix  of the Street.")
+    @get:Schema(description = StreetDescription.namePrefix)
     val namePrefix: String? = null,
 
-    @get:Schema(description = "Describes the additional name prefix of the Street.")
+    @get:Schema(description = StreetDescription.additionalNamePrefix)
     val additionalNamePrefix: String? = null,
 
-    @get:Schema(description = "Describes the Name of the Street.")
+    @get:Schema(description = StreetDescription.name)
     val name: String? = null,
 
-    @get:Schema(description = "Describes the name suffix of the Street.")
+    @get:Schema(description = StreetDescription.nameSuffix)
     val nameSuffix: String? = null,
 
-    @get:Schema(description = "Describes the additional name suffix of the Street.")
+    @get:Schema(description = StreetDescription.additionalNameSuffix)
     val additionalNameSuffix: String? = null,
 
-    @get:Schema(description = "Describes the House Number")
+    @get:Schema(description = StreetDescription.houseNumber)
     val houseNumber: String? = null,
 
-    @get:Schema(description = "The Milestone is relevant for long roads without specific house numbers.")
+    @get:Schema(description = StreetDescription.milestone)
     val milestone: String? = null,
 
-    @get:Schema(description = "Describes the direction")
+    @get:Schema(description = StreetDescription.direction)
     val direction: String? = null
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/AddressGateInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/AddressGateInputRequest.kt
@@ -22,26 +22,24 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "AddressGateInputRequest", description = "Address with legal entity or site references. " +
-            "Only one of either legal entity or site external id can be set for an address."
-)
+@Schema(description = LogisticAddressDescription.headerUpsertRequest)
 data class AddressGateInputRequest(
 
     @field:JsonUnwrapped
     val address: LogisticAddressGateDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = LogisticAddressDescription.legalEntityExternalId)
     val legalEntityExternalId: String? = null,
 
-    @Schema(description = "External id of the related site")
+    @get:Schema(description = LogisticAddressDescription.siteExternalId)
     val siteExternalId: String? = null,
-
-    )
+)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/AddressGateOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/AddressGateOutputRequest.kt
@@ -22,28 +22,28 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "AddressGateOutputRequest", description = "Address with legal entity or site references. " +
-            "Only one of either legal entity or site external id can be set for an address."
-)
+@Schema(description = LogisticAddressDescription.headerUpsertRequest)
 data class AddressGateOutputRequest(
     
     @field:JsonUnwrapped
     val address: LogisticAddressGateDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = LogisticAddressDescription.legalEntityExternalId)
     val legalEntityExternalId: String? = null,
 
-    @Schema(description = "External id of the related site")
+    @get:Schema(description = LogisticAddressDescription.siteExternalId)
     val siteExternalId: String? = null,
 
-    @Schema(description = "Business Partner Number")
+    // TODO rename to bpna
+    @get:Schema(description = LogisticAddressDescription.bpna)
     val bpn: String
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/ChangelogSearchRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/ChangelogSearchRequest.kt
@@ -19,18 +19,22 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model.request
 
-import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import java.time.Instant
 
 data class ChangelogSearchRequest(
 
-    @field:Parameter(description = "From when to search changelog entries", example = "2023-03-20T10:23:28.194Z", required = false)
+    @get:Schema(
+        description = "Only changelog entries created after this time. Ignored if empty.",
+        example = "2023-03-20T10:23:28.194Z"
+    )
     val timestampAfter: Instant? = null,
 
-    @field:Parameter(description = "External IDs of business partners for which to search changelog entries. Ignored if empty", required = false)
+    @get:ArraySchema(arraySchema = Schema(description = "Only for business partners with the given array of external IDs. Ignored if empty."))
     val externalIds: Set<String>? = emptySet(),
 
-    @field:Parameter(description = "Business partner types for which to search changelog entries. Ignored if empty", required = false)
+    @get:ArraySchema(arraySchema = Schema(description = "Only for business partners with the given array of business partner types. Ignored if empty."))
     val businessPartnerTypes: Set<BusinessPartnerType>? = emptySet()
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/ChangelogSearchRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/ChangelogSearchRequest.kt
@@ -28,7 +28,7 @@ data class ChangelogSearchRequest(
     @field:Parameter(description = "From when to search changelog entries", example = "2023-03-20T10:23:28.194Z", required = false)
     val timestampAfter: Instant? = null,
 
-    @field:Parameter(description = "External-IDs of business partners for which to search changelog entries. Ignored if empty", required = false)
+    @field:Parameter(description = "External IDs of business partners for which to search changelog entries. Ignored if empty", required = false)
     val externalIds: Set<String>? = emptySet(),
 
     @field:Parameter(description = "Business partner types for which to search changelog entries. Ignored if empty", required = false)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
@@ -21,29 +21,32 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityGateInputRequest", description = "Legal entity with external id")
+@Schema(description = LegalEntityDescription.headerUpsertRequest)
 data class LegalEntityGateInputRequest(
 
-    val legalNameParts: List<String> = emptyList(),
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
+    val legalNameParts: Collection<String> = emptyList(),
 
-    @Schema(description = "legal Entity")
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    @Schema(description = "Which roles this business partner takes in relation to the sharing member")
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: LogisticAddressGateDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from", required = true)
+    @get:Schema(description = CommonDescription.externalId, required = true)
     val externalId: String,
-
-    )
+)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
@@ -21,31 +21,36 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputChildRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityGateOutputRequest", description = "Legal entity with external id")
+@Schema(description = LegalEntityDescription.headerUpsertRequest)
 data class LegalEntityGateOutputRequest(
 
-    val legalNameParts: List<String> = emptyList(),
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
+    val legalNameParts: Collection<String> = emptyList(),
 
-    @Schema(description = "legal Enity")
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    @Schema(description = "Which roles this business partner takes in relation to the sharing member")
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: AddressGateOutputChildRequest,
 
-    @Schema(description = "ID the record has in the external system where the record originates from", required = true)
+    @get:Schema(description = CommonDescription.externalId, required = true)
     val externalId: String,
 
-    @Schema(description = "Business Partner Number")
+    // TODO rename to bpnl
+    @get:Schema(description = LegalEntityDescription.bpnl)
     val bpn: String
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/SiteGateInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/SiteGateInputRequest.kt
@@ -22,26 +22,26 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "SiteGateInputRequest", description = "Site with legal entity reference"
-)
+@Schema(description = SiteDescription.headerUpsertRequest)
 data class SiteGateInputRequest(
 
     @field:JsonUnwrapped
     val site: SiteGateDto,
 
-    @get:Schema(description = "Main address where this site resides")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteDescription.mainAddress)
     val mainAddress: LogisticAddressGateDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = SiteDescription.legalEntityExternalId)
     val legalEntityExternalId: String,
-
-    )
+)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/SiteGateOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/SiteGateOutputRequest.kt
@@ -22,28 +22,30 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputChildRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "SiteGateOutputRequest", description = "Site with legal entity reference"
-)
+@Schema(description = SiteDescription.headerUpsertRequest)
 data class SiteGateOutputRequest(
-    
+
     @field:JsonUnwrapped
     val site: SiteGateDto,
 
-    @get:Schema(description = "Main address where this site resides")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteDescription.mainAddress)
     val mainAddress: AddressGateOutputChildRequest,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = SiteDescription.legalEntityExternalId)
     val legalEntityExternalId: String,
 
-    @Schema(description = "Business Partner Number")
+    // TODO rename to bpns
+    @get:Schema(description = SiteDescription.bpns)
     val bpn: String
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/AddressGateInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/AddressGateInputDto.kt
@@ -22,26 +22,25 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 
+// TODO rename to AddressGateInputResponse
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "AddressGateInputDto", description = "Address with legal entity or site references. " +
-            "Only one of either legal entity or site external id can be set for an address."
-)
+@Schema(description = LogisticAddressDescription.header)
 data class AddressGateInputDto(
 
     @field:JsonUnwrapped
     val address: LogisticAddressGateDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = LogisticAddressDescription.legalEntityExternalId)
     val legalEntityExternalId: String? = null,
 
-    @Schema(description = "External id of the related site")
+    @get:Schema(description = LogisticAddressDescription.siteExternalId)
     val siteExternalId: String? = null,
-
-    )
+)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/AddressGateOutputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/AddressGateOutputDto.kt
@@ -22,29 +22,28 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 
+// TODO rename to AddressGateOutputResponse
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "AddressGateOutputDto", description = "Address with legal entity or site references. " +
-            "Only one of either legal entity or site external id can be set for an address."
-)
+@Schema(description = LogisticAddressDescription.header)
 data class AddressGateOutputDto(
 
     @field:JsonUnwrapped
     val address: LogisticAddressGateDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = LogisticAddressDescription.legalEntityExternalId)
     val legalEntityExternalId: String? = null,
 
-    @Schema(description = "External id of the related site")
+    @get:Schema(description = LogisticAddressDescription.siteExternalId)
     val siteExternalId: String? = null,
 
-    @Schema(description = "Business Partner Number")
+    @get:Schema(description = LogisticAddressDescription.bpna)
     val bpna: String
-
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ChangelogGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ChangelogGateDto.kt
@@ -21,21 +21,22 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ChangelogDescription
 import org.eclipse.tractusx.bpdm.gate.api.model.ChangelogType
 import java.time.Instant
 
-@Schema(name = "ChangelogGateDto", description = "Changelog entry for a business partner")
+@Schema(description = ChangelogDescription.header)
 data class ChangelogGateDto(
 
-    @Schema(description = "External ID of the changelog entry")
+    @get:Schema(description = ChangelogDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "The type of the business partner this change refers to")
+    @get:Schema(description = ChangelogDescription.businessPartnerType)
     val businessPartnerType: BusinessPartnerType,
 
-    @Schema(description = "The timestamp of the operation")
+    @get:Schema(description = ChangelogDescription.timestamp)
     val timestamp: Instant,
 
-    @Schema(description = "The type of the change")
+    @get:Schema(description = ChangelogDescription.changelogType)
     val changelogType: ChangelogType
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ErrorInfo.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ErrorInfo.kt
@@ -25,10 +25,12 @@ import org.eclipse.tractusx.bpdm.gate.api.exception.ErrorCode
 @Schema(title = "ErrorInfo", description = "Holds information about failures")
 data class ErrorInfo<out ERROR : ErrorCode>(
 
-    @Schema(description = "Error code identifying the error")
+    @get:Schema(description = "Error code identifying the error")
     val errorCode: ERROR,
-    @Schema(description = "Error message that explains the error")
+
+    @get:Schema(description = "Error message that explains the error")
     val message: String,
-    @Schema(description = "Key (externalId) of the entity that failed")
+
+    @get:Schema(description = "Key (externalId) of the entity that failed")
     val entityKey: String?
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
@@ -21,29 +21,32 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 
+// TODO rename to LegalEntityGateInputResponse
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityGateInputDto", description = "Legal entity with external id")
+@Schema(description = LegalEntityDescription.header)
 data class LegalEntityGateInputDto(
 
-    val legalNameParts: List<String> = emptyList(),
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
+    val legalNameParts: Collection<String>,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    @Schema(description = "Which roles this business partner takes in relation to the sharing member")
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: AddressGateInputDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from", required = true)
+    @get:Schema(description = CommonDescription.externalId, required = true)
     val externalId: String,
-
-    )
-
-
+)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
@@ -21,30 +21,34 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(name = "LegalEntityGateOutputResponse", description = "Legal entity with external id")
+@Schema(description = LegalEntityDescription.header)
 data class LegalEntityGateOutputResponse(
+
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
+    val legalNameParts: Collection<String>,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    val legalNameParts: Collection<String>,
-
-    @Schema(description = "Which roles this business partner takes in relation to the sharing member")
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    @get:Schema(description = "Address of the official seat of this legal entity")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: AddressGateOutputDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from", required = true)
+    @get:Schema(description = CommonDescription.externalId, required = true)
     val externalId: String,
 
-    @Schema(description = "Business Partner Number")
+    @get:Schema(description = LegalEntityDescription.bpnl)
     val bpnl: String
-
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/PageChangeLogDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/PageChangeLogDto.kt
@@ -19,25 +19,32 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model.response
 
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.gate.api.exception.ChangeLogOutputError
 
 
 @Schema(description = "Paginated collection of results")
 data class PageChangeLogDto<T>(
-    @Schema(description = "Total number of all results in all pages")
+
+    @get:Schema(description = "Total number of all results in all pages")
     val totalElements: Long,
-    @Schema(description = "Total number pages")
+
+    @get:Schema(description = "Total number pages")
     val totalPages: Int,
-    @Schema(description = "Current page number")
+
+    @get:Schema(description = "Current page number")
     val page: Int,
-    @Schema(description = "Number of results in the page")
+
+    @get:Schema(description = "Number of results in the page")
     val contentSize: Int,
-    @Schema(description = "Collection of results in the page")
+
+    @get:ArraySchema(arraySchema = Schema(description = "Collection of results in the page"))
     val content: Collection<T>,
-    @Schema(description = "Number of entries in the page that have been omitted due to being invalid (error)")
+
+    @get:Schema(description = "Number of entries in the page that have been omitted due to being invalid (error)")
     val invalidEntries: Int,
-    @Schema(description = "Infos about the entries with errors")
+
+    @get:Schema(description = "Infos about the entries with errors")
     val errors: Collection<ErrorInfo<ChangeLogOutputError>>,
 )
-

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SharingStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SharingStateDto.kt
@@ -26,27 +26,33 @@ import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import java.time.LocalDateTime
 
 @Schema(
-    name = "SharingState"
+    description = "A sharing state entry shows the progress in the sharing process and is updated each time the " +
+            "progress for a business partner changes. The business partner is identified by a combination " +
+            "of external ID and business partner type."
 )
 data class SharingStateDto(
-    @get:Schema(description = "LSA Type")
+
+    @get:Schema(description = "One of the types of business partners for which the sharing state entry was created.")
     val businessPartnerType: BusinessPartnerType,
 
-    @get:Schema(description = "External identifier")
+    @get:Schema(description = "The external identifier of the business partner for which the sharing state entry was created.")
     val externalId: String,
 
-    @get:Schema(description = "Type of sharing state")
+    @get:Schema(description = "One of the sharing state types of the current sharing state.")
     val sharingStateType: SharingStateType = SharingStateType.Initial,
 
-    @get:Schema(description = "Sharing error code (for error)")
+    @get:Schema(description = "One of the sharing error codes in case the current sharing state type is \"error\".")
     val sharingErrorCode: BusinessPartnerSharingError? = null,
 
-    @get:Schema(description = "Sharing error message (for error)")
+    @get:Schema(description = "The error message in case the current sharing state type is \"error\".")
     val sharingErrorMessage: String? = null,
 
-    @get:Schema(description = "BPN (for success)")
+    @get:Schema(
+        description = "The business partner number associated to the combination of external identifier and business partner type " +
+                "in case the sharing state type is “success”. Can be either a BPNL, BPNS or BPNA."
+    )
     val bpn: String? = null,
 
-    @get:Schema(description = "Sharing process started (not updated if null)")
+    @get:Schema(description = "The date and time when the sharing process was started.")
     val sharingProcessStarted: LocalDateTime? = null
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SiteGateInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SiteGateInputDto.kt
@@ -22,26 +22,26 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateDto
 
+// TODO rename to SiteGateInputResponse
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "SiteGateInputDto", description = "Site with legal entity reference"
-)
+@Schema(description = SiteDescription.header)
 data class SiteGateInputDto(
 
     @field:JsonUnwrapped
     val site: SiteGateDto,
 
-    @get:Schema(description = "Main address where this site resides")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteDescription.mainAddress)
     val mainAddress: AddressGateInputDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = SiteDescription.legalEntityExternalId)
     val legalEntityExternalId: String,
-
-    )
-
+)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SiteGateOutputResponse.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SiteGateOutputResponse.kt
@@ -22,27 +22,28 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(
-    name = "SiteGateOutputResponse", description = "Site with legal entity reference"
-)
+@Schema(description = SiteDescription.header)
 data class SiteGateOutputResponse(
 
     @field:JsonUnwrapped
     val site: SiteGateDto,
 
-    @get:Schema(description = "Main address where this site resides")
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteDescription.mainAddress)
     val mainAddress: AddressGateOutputDto,
 
-    @Schema(description = "ID the record has in the external system where the record originates from")
+    @get:Schema(description = CommonDescription.externalId)
     val externalId: String,
 
-    @Schema(description = "External id of the related legal entity")
+    @get:Schema(description = SiteDescription.legalEntityExternalId)
     val legalEntityExternalId: String,
 
-    @Schema(description = "Business Partner Number")
+    @get:Schema(description = SiteDescription.bpns)
     val bpns: String
 )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressController.kt
@@ -85,7 +85,7 @@ class AddressController(
     }
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getChangeCompanyOutputDataAsRole())")
-    override fun putAddressesOutput(addresses: Collection<AddressGateOutputRequest>): ResponseEntity<Unit> {
+    override fun upsertAddressesOutput(addresses: Collection<AddressGateOutputRequest>): ResponseEntity<Unit> {
         if (addresses.size > apiConfigProperties.upsertLimit || addresses.map { it.externalId }.containsDuplicates()) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)
         }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -121,7 +121,7 @@ private fun toValidSingleLegalEntity(legalEntity: LegalEntity): LegalEntityGateI
 
     return LegalEntityGateInputDto(
         legalEntity = legalEntity.toLegalEntityDto(),
-        legalNameParts = getNamePartValuesToList(legalEntity.nameParts),
+        legalNameParts = getNamePartValues(legalEntity.nameParts),
         roles = legalEntity.roles.map { it.roleName },
         legalAddress = legalEntity.legalAddress.toAddressGateInputResponse(legalEntity.legalAddress),
         externalId = legalEntity.externalId

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -306,13 +306,7 @@ fun LogisticAddress.toLogisticAddressDto(): LogisticAddressGateDto {
     return logisticAddress
 }
 
-//Collection
 fun getNamePartValues(nameparts: MutableSet<NameParts>): Collection<String> {
-    return nameparts.map { it.namePart }
-}
-
-//List
-fun getNamePartValuesToList(nameparts: MutableSet<NameParts>): List<String> {
     return nameparts.map { it.namePart }
 }
 
@@ -431,7 +425,7 @@ fun LegalEntity.toLegalEntityGateInputResponse(legalEntity: LegalEntity): LegalE
         legalAddress = legalAddress.toAddressGateInputResponse(legalAddress),
         roles = roles.map { it.roleName },
         externalId = legalEntity.externalId,
-        legalNameParts = getNamePartValuesToList(nameParts)
+        legalNameParts = getNamePartValues(nameParts)
     )
 }
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/AddressControllerOutputIT.kt
@@ -128,7 +128,7 @@ internal class AddressControllerOutputIT @Autowired constructor(
             gateClient.sites().upsertSitesOutput(siteOutput)
 
             gateClient.addresses().upsertAddresses(addresses)
-            gateClient.addresses().putAddressesOutput(addressesOutput)
+            gateClient.addresses().upsertAddressesOutput(addressesOutput)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.OK, e.statusCode)
         }
@@ -154,7 +154,7 @@ internal class AddressControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().putAddressesOutput(addresses)
+            gateClient.addresses().upsertAddressesOutput(addresses)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -183,7 +183,7 @@ internal class AddressControllerOutputIT @Autowired constructor(
             gateClient.legalEntities().upsertLegalEntities(legalEntity)
             gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntityOutput)
 
-            gateClient.addresses().putAddressesOutput(addresses)
+            gateClient.addresses().upsertAddressesOutput(addresses)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -245,7 +245,7 @@ internal class AddressControllerOutputIT @Autowired constructor(
         gateClient.sites().upsertSitesOutput(siteOutput)
 
         gateClient.addresses().upsertAddresses(addresses)
-        gateClient.addresses().putAddressesOutput(addressesOutput)
+        gateClient.addresses().upsertAddressesOutput(addressesOutput)
 
 
         val paginationValue = PaginationRequest(page, size)
@@ -315,7 +315,7 @@ internal class AddressControllerOutputIT @Autowired constructor(
         gateClient.sites().upsertSitesOutput(siteOutput)
 
         gateClient.addresses().upsertAddresses(addresses)
-        gateClient.addresses().putAddressesOutput(addressesOutput)
+        gateClient.addresses().upsertAddressesOutput(addressesOutput)
 
         val paginationValue = PaginationRequest(page, size)
         val pageResponse = gateClient.addresses().getAddressesOutput(paginationValue, listOf(CommonValues.externalIdAddress1, CommonValues.externalIdAddress2))

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/EntitiesWithErrors.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/EntitiesWithErrors.kt
@@ -36,37 +36,37 @@ open class EntitiesWithErrors<ENTITY, out ERROR : ErrorCode>(
         get() = errors.size
 }
 
-@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
 data class LegalEntityPartnerCreateResponseWrapper(
     override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<LegalEntityCreateError>>
 ) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityCreateError>(entities, errors)
 
-@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
 data class LegalEntityPartnerUpdateResponseWrapper(
     override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<LegalEntityUpdateError>>
 ) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityUpdateError>(entities, errors)
 
-@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
 data class SitePartnerCreateResponseWrapper(
     override val entities: Collection<SitePartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<SiteCreateError>>
 ) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteCreateError>(entities, errors)
 
-@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
 data class SitePartnerUpdateResponseWrapper(
     override val entities: Collection<SitePartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<SiteUpdateError>>
 ) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteUpdateError>(entities, errors)
 
-@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
 data class AddressPartnerCreateResponseWrapper(
     override val entities: Collection<AddressPartnerCreateVerboseDto>,
     override val errors: Collection<ErrorInfo<AddressCreateError>>
 ) : EntitiesWithErrors<AddressPartnerCreateVerboseDto, AddressCreateError>(entities, errors)
 
-@Schema(description = CommonDescription.entityWithErrorsWrapperHeader)
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
 data class AddressPartnerUpdateResponseWrapper(
     override val entities: Collection<LogisticAddressVerboseDto>,
     override val errors: Collection<ErrorInfo<AddressUpdateError>>

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
@@ -29,7 +29,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(description = LegalEntityDescription.headerCreateResponse)
+@Schema(description = LegalEntityDescription.headerUpsertResponse)
 data class LegalEntityPartnerCreateVerboseDto(
 
     @get:Schema(description = LegalEntityDescription.legalName)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/SitePartnerCreateVerboseDto.kt
@@ -29,16 +29,16 @@ import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(description = SiteDescription.headerCreateResponse)
+@Schema(description = SiteDescription.headerUpsertResponse)
 data class SitePartnerCreateVerboseDto(
 
     @field:JsonUnwrapped
     val site: SiteVerboseDto,
 
     // TODO OpenAPI description for complex field does not work!!
-    @Schema(description = SiteDescription.mainAddress)
+    @get:Schema(description = SiteDescription.mainAddress)
     val mainAddress: LogisticAddressVerboseDto,
 
-    @Schema(description = CommonDescription.index)
+    @get:Schema(description = CommonDescription.index)
     val index: String?
 )


### PR DESCRIPTION
- Update endpoint and DTO field description texts for Gate.
- Reused description texts are collected in appropriate *Description objects.
- Fixed @Schema annotations to @get:Schema to work with Kotlin data objects.

Part of #355

https://github.com/eclipse-tractusx/bpdm/pull/397 must be merged first