### PR TITLE
fix(bpdm): TRG quality gate issue

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,3 +174,10 @@ The Swagger login uses the client specified in the property `springdoc.swagger-u
 
 This repository contains Helm files for deploying the BPDM Bridge Dummy to a Kubernetes environment.
 See the [BPDM Bridge Dummy Helm README](/charts/bpdm/charts/bpdm-bridge-dummy/README.md) for details.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/bpdm-bridge-dummy/pom.xml
+++ b/bpdm-bridge-dummy/pom.xml
@@ -176,6 +176,15 @@
                     <exclude>*.properties</exclude>
                 </excludes>
             </resource>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
         </resources>
 
         <plugins>

--- a/bpdm-gate/pom.xml
+++ b/bpdm-gate/pom.xml
@@ -172,6 +172,15 @@
                     <exclude>*.properties</exclude>
                 </excludes>
             </resource>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES</include>
+                </includes>
+                <targetPath>META-INF/</targetPath>
+            </resource>
         </resources>
         <plugins>
             <plugin>

--- a/bpdm-pool/pom.xml
+++ b/bpdm-pool/pom.xml
@@ -175,6 +175,15 @@
                     <exclude>*.properties</exclude>
                 </excludes>
             </resource>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES</include>
+                </includes>
+                <targetPath>META-INF/</targetPath>
+            </resource>
         </resources>
         <plugins>
             <plugin>


### PR DESCRIPTION

## Description
In this pull request, added support to include LICENSE, NOTICE and DEPENDENCIES files in the META-INF directory of generated jars as per the  TRG 7.05. Also, added notice section to INSTALL.md as per the TRG 7.07.

