### PR TITLE
Feat: Schema overriding hook for OpenApiConfig [POC]

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
@@ -28,7 +28,10 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.*
 import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.GenericDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springdoc.core.models.GroupedOpenApi
@@ -67,7 +70,17 @@ abstract class OpenApiConfig {
     open fun getSchemaOverrides(): Collection<SchemaOverrideInfo> {
         return setOf(
             // Generic types
-            schemaOverride<TypeKeyNameVerboseDto<CountryCode>>(GenericDescription.typeKeyNameCountryCode)
+            schemaOverride<TypeKeyNameVerboseDto<CountryCode>>(GenericDescription.typeKeyNameCountryCode),
+
+            // Schema copies with alternative description
+            schemaOverride<LogisticAddressDto>(
+                LogisticAddressDescription.legalAddress,
+                LogisticAddressDescription.legalAddressAliasForLogisticAddressDto
+            ),
+            schemaOverride<LogisticAddressVerboseDto>(
+                LogisticAddressDescription.legalAddress,
+                LogisticAddressDescription.legalAddressAliasForLogisticAddressVerboseDto
+            )
         )
     }
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
@@ -19,32 +19,93 @@
 
 package org.eclipse.tractusx.bpdm.common.config
 
+import com.neovisionaries.i18n.CountryCode
+import com.nimbusds.jose.shaded.gson.reflect.TypeToken
+import io.swagger.v3.core.converter.AnnotatedType
+import io.swagger.v3.core.converter.ModelConverters
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.*
 import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.GenericDescription
+import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
+import java.lang.reflect.Type
 
 
-@Configuration
-class OpenApiConfig(
-    val securityProperties: SecurityConfigProperties,
-    val infoProperties: AppInfoProperties
-) {
+abstract class OpenApiConfig {
     private val logger = KotlinLogging.logger { }
 
-    @Bean
-    fun customOpenAPI(): OpenAPI? {
-        return OpenAPI().info(Info().title(infoProperties.name).description(infoProperties.description).version(infoProperties.version))
-            .also { if (securityProperties.enabled) it.withSecurity() }
-    }
+    abstract val securityProperties: SecurityConfigProperties
+    abstract val infoProperties: AppInfoProperties
 
     @Bean
-    fun openApiDefinition(): GroupedOpenApi {
+    open fun customOpenAPI(): OpenAPI? {
+        val info = Info()
+            .title(infoProperties.name)
+            .description(infoProperties.description)
+            .version(infoProperties.version)
+        val components = buildComponents(getSchemaOverrides())
+        return OpenAPI()
+            .info(info)
+            .components(components)
+            .also {
+                if (securityProperties.enabled)
+                    it.withSecurity()
+            }
+    }
+
+    /**
+     * This hooks allows overriding OpenAPI schema definitions.
+     * This can be used for two scenarios:
+     * - Override the schema description of a generic class with specific type parameter, as the annotated Schema description might not be specific enough.
+     * - Clone a schema, overriding its name and description, to use it for some specific field.
+     */
+    open fun getSchemaOverrides(): Collection<SchemaOverrideInfo> {
+        return setOf(
+            // Generic types
+            schemaOverride<TypeKeyNameVerboseDto<CountryCode>>(GenericDescription.typeKeyNameCountryCode)
+        )
+    }
+
+    private fun buildComponents(schemaOverrideInfos: Collection<SchemaOverrideInfo>): Components {
+        val components = Components()
+        schemaOverrideInfos.forEach {
+            val schemaCopy = copySchema(it.schemaType)
+            schemaCopy.description(it.description)
+            it.alternativeSchemaName?.let { altSchemaName ->
+                schemaCopy.name(altSchemaName)
+            }
+            components.addSchemas(schemaCopy.name, schemaCopy)
+        }
+        return components
+    }
+
+    private fun copySchema(schemaType: Type) =
+        ModelConverters.getInstance()
+            .resolveAsResolvedSchema(
+                AnnotatedType(schemaType).resolveAsRef(false)
+            )
+            .schema
+
+    inline fun <reified T> schemaOverride(description: String, alternativeSchemaName: String? = null) =
+        SchemaOverrideInfo(
+            object : TypeToken<T>() {}.type,
+            description,
+            alternativeSchemaName
+        )
+
+    data class SchemaOverrideInfo(
+        val schemaType: Type,
+        val description: String,
+        val alternativeSchemaName: String? = null
+    )
+
+    @Bean
+    open fun openApiDefinition(): GroupedOpenApi {
         return GroupedOpenApi.builder()
             .group("docs")
             .pathsToMatch("/**")
@@ -55,7 +116,9 @@ class OpenApiConfig(
 
     fun sortSchemaCustomiser(): OpenApiCustomizer {
         return OpenApiCustomizer { openApi: OpenAPI ->
-            openApi.components(with(openApi.components) { schemas(schemas?.values?.sortedBy { it.name }?.associateBy { it.name }) })
+            with(openApi.components) {
+                schemas(schemas.toSortedMap())
+            }
         }
     }
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/GenericDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/GenericDescription.kt
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.dto.openapidescription
+
+object GenericDescription {
+    const val typeKeyNameCountryCode = "Country uniquely identified by its 2-digit country code as technical key"
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LegalEntityDescription.kt
@@ -45,8 +45,6 @@ object LegalEntityDescription {
     const val legalNameParts = "The list of name parts of the legal entity to accommodate the different number of name fields in different systems."
     const val legalShortName = "The abbreviated name of the legal entity."
     const val legalForm = "The legal form of the legal entity."
-    const val legalAddress = "The official, legal correspondence address to be provided to government and tax authorities " +
-            "and used in all legal or court documents."
 
     const val identifiers = "The list of identifiers of the legal entity."
     const val states = "The list of (temporary) states of the legal entity."

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LogisticAddressDescription.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/openapidescription/LogisticAddressDescription.kt
@@ -60,4 +60,13 @@ object LogisticAddressDescription {
     const val siteExternalId = "The identifier which uniquely identifies (in the internal system landscape of the sharing member) " +
             "the business partner, representing the site, that the address belongs to."
     const val address = "Address information"
+
+    const val legalAddressAliasForAddressGateInputDto = "legalAddressAliasForAddressGateInputDto"
+    const val legalAddressAliasForAddressGateOutputDto = "legalAddressAliasForAddressGateOutputDto"
+    const val legalAddressAliasForAddressGateOutputChildRequest = "legalAddressAliasForAddressGateOutputChildRequest"
+    const val legalAddressAliasForLogisticAddressDto = "legalAddressAliasForLogisticAddressDto"
+    const val legalAddressAliasForLogisticAddressGateDto = "legalAddressAliasForLogisticAddressGateDto"
+    const val legalAddressAliasForLogisticAddressVerboseDto = "legalAddressAliasForLogisticAddressVerboseDto"
+    const val legalAddress = "The official, legal correspondence address to be provided to government and tax authorities " +
+            "and used in all legal or court documents."
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PoolLegalEntityVerboseDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PoolLegalEntityVerboseDto.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
@@ -35,7 +36,6 @@ data class PoolLegalEntityVerboseDto(
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForLogisticAddressVerboseDto)
     val legalAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/config/OpenApiGateConfig.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/config/OpenApiGateConfig.kt
@@ -22,10 +22,42 @@ package org.eclipse.tractusx.bpdm.gate.api.config
 import org.eclipse.tractusx.bpdm.common.config.AppInfoProperties
 import org.eclipse.tractusx.bpdm.common.config.OpenApiConfig
 import org.eclipse.tractusx.bpdm.common.config.SecurityConfigProperties
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
+import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputChildRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateOutputDto
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class OpenApiGateConfig(
     override val securityProperties: SecurityConfigProperties,
     override val infoProperties: AppInfoProperties
-) : OpenApiConfig()
+) : OpenApiConfig() {
+
+    override fun getSchemaOverrides(): Collection<SchemaOverrideInfo> {
+        return super.getSchemaOverrides()
+            .union(
+                setOf(
+                    // Schema copies with alternative description
+                    schemaOverride<AddressGateInputDto>(
+                        LogisticAddressDescription.legalAddress,
+                        LogisticAddressDescription.legalAddressAliasForAddressGateInputDto
+                    ),
+                    schemaOverride<AddressGateOutputDto>(
+                        LogisticAddressDescription.legalAddress,
+                        LogisticAddressDescription.legalAddressAliasForAddressGateOutputDto
+                    ),
+                    schemaOverride<AddressGateOutputChildRequest>(
+                        LogisticAddressDescription.legalAddress,
+                        LogisticAddressDescription.legalAddressAliasForAddressGateOutputChildRequest
+                    ),
+                    schemaOverride<LogisticAddressGateDto>(
+                        LogisticAddressDescription.legalAddress,
+                        LogisticAddressDescription.legalAddressAliasForLogisticAddressGateDto
+                    )
+                )
+            )
+    }
+
+}

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/config/OpenApiGateConfig.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/config/OpenApiGateConfig.kt
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.api.config
+
+import org.eclipse.tractusx.bpdm.common.config.AppInfoProperties
+import org.eclipse.tractusx.bpdm.common.config.OpenApiConfig
+import org.eclipse.tractusx.bpdm.common.config.SecurityConfigProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiGateConfig(
+    override val securityProperties: SecurityConfigProperties,
+    override val infoProperties: AppInfoProperties
+) : OpenApiConfig()

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
@@ -43,8 +44,7 @@ data class LegalEntityGateInputRequest(
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForLogisticAddressGateDto)
     val legalAddress: LogisticAddressGateDto,
 
     @get:Schema(description = CommonDescription.externalId, required = true)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputChildRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
@@ -43,8 +44,7 @@ data class LegalEntityGateOutputRequest(
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForAddressGateOutputChildRequest)
     val legalAddress: AddressGateOutputChildRequest,
 
     @get:Schema(description = CommonDescription.externalId, required = true)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 
@@ -43,8 +44,7 @@ data class LegalEntityGateInputDto(
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForAddressGateInputDto)
     val legalAddress: AddressGateInputDto,
 
     @get:Schema(description = CommonDescription.externalId, required = true)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
 
@@ -42,8 +43,7 @@ data class LegalEntityGateOutputResponse(
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForAddressGateOutputDto)
     val legalAddress: AddressGateOutputDto,
 
     @get:Schema(description = CommonDescription.externalId, required = true)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/config/OpenApiPoolConfig.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/config/OpenApiPoolConfig.kt
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.config
+
+import org.eclipse.tractusx.bpdm.common.config.AppInfoProperties
+import org.eclipse.tractusx.bpdm.common.config.OpenApiConfig
+import org.eclipse.tractusx.bpdm.common.config.SecurityConfigProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiPoolConfig(
+    override val securityProperties: SecurityConfigProperties,
+    override val infoProperties: AppInfoProperties
+) : OpenApiConfig()

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
@@ -38,8 +39,7 @@ data class LegalEntityPartnerCreateRequest(
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForLogisticAddressDto)
     val legalAddress: LogisticAddressDto,
 
     @get:Schema(description = CommonDescription.index)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
@@ -40,7 +41,6 @@ data class LegalEntityPartnerUpdateRequest(
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForLogisticAddressDto)
     val legalAddress: LogisticAddressDto,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
@@ -41,7 +42,6 @@ data class LegalEntityMatchVerboseDto(
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForLogisticAddressVerboseDto)
     val legalAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
@@ -38,8 +39,7 @@ data class LegalEntityPartnerCreateVerboseDto(
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
+    @get:Schema(ref = LogisticAddressDescription.legalAddressAliasForLogisticAddressVerboseDto)
     val legalAddress: LogisticAddressVerboseDto,
 
     @get:Schema(description = CommonDescription.index)


### PR DESCRIPTION
Adds a hook which allows overriding OpenAPI schema definitions.

This is useful for two scenarios:
- Override the schema description of a generic class with specific type parameter, as the annotated Schema description might not be specific enough.
Example: `TypeKeyNameVerboseDto<CountryCode>`
- Clone a schema, overriding its name and description, to use it for some specific field. 
This is due to OpenAPI limitations which don't allow to specify a field description for complex singular objects, see https://github.com/springdoc/springdoc-openapi/issues/1178 .
Example: legalAddress in LegalEntityPartnerCreateRequest etc.

This is just a proof-of-concept how it could be done. I don't know if it's worth it considering the effort, especially in the second case.

Proof of concept for https://github.com/eclipse-tractusx/bpdm/issues/409

https://github.com/eclipse-tractusx/bpdm/pull/398 must be merged first