### PR TITLE
fix(Pool): Fix Duplicate Identifier Validation on New Business Partners

### DIFF
--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/CommonValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/CommonValues.kt
@@ -52,6 +52,7 @@ object CommonValues {
     val index1 = "1"
     val index2 = "2"
     val index3 = "3"
+    val index4 = "4"
 
     val uuid1 = UUID.fromString("e9975a48-b190-4bf1-a7e6-73c6a1744de8")
 


### PR DESCRIPTION
<!-- 
 'fix: Duplicate Identifier Validation on New Business Partners'
-->


## Description
Added service validation when a request is made with identifier with the same values at the legal entity level.
Added unit test for testing the error return

issue: [#412](https://github.com/eclipse-tractusx/bpdm/issues/412)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
