### PR TITLE
feat(tests): Remote-debugging the Testcontainers

### DIFF
--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/BpdmGateContextInitializer.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/BpdmGateContextInitializer.kt
@@ -42,7 +42,7 @@ class BpdmGateContextInitializer : ApplicationContextInitializer<ConfigurableApp
     private val logger = KotlinLogging.logger { }
 
     companion object {
-        const val GATE_CONTAINER_STARTUP_TIMEOUT_SEC = 180L
+        const val GATE_CONTAINER_STARTUP_TIMEOUT_SEC = 300L
         const val BPDM_PORT = 8081
         const val DEBUG_PORT = 8051
         const val IMAGE = "maven-gate"

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/BpdmGateContextInitializer.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/BpdmGateContextInitializer.kt
@@ -23,6 +23,7 @@ package com.catenax.bpdm.bridge.dummy.util
 import com.catenax.bpdm.bridge.dummy.util.BpdmPoolContextInitializer.Companion.bpdmPoolContainer
 import com.catenax.bpdm.bridge.dummy.util.OpenSearchContextInitializer.Companion.openSearchContainer
 import com.catenax.bpdm.bridge.dummy.util.PostgreSQLContextInitializer.Companion.postgreSQLContainer
+import mu.KotlinLogging
 import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
@@ -38,18 +39,23 @@ import java.time.Duration
 
 class BpdmGateContextInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
 
+    private val logger = KotlinLogging.logger { }
+
     companion object {
         const val GATE_CONTAINER_STARTUP_TIMEOUT_SEC = 180L
         const val BPDM_PORT = 8081
+        const val DEBUG_PORT = 8051
         const val IMAGE = "maven-gate"
 
         private val bpdmGateContainer: GenericContainer<*> =
             GenericContainer(IMAGE)
                 .dependsOn(listOf<Startable>(postgreSQLContainer, openSearchContainer, bpdmPoolContainer))
                 .withNetwork(postgreSQLContainer.getNetwork())
-                .withExposedPorts(BPDM_PORT)
-
-
+                .withExposedPorts(BPDM_PORT, DEBUG_PORT)
+                .withEnv(
+                    "JAVA_OPTIONS",
+                    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:$DEBUG_PORT"
+                )
     }
 
 
@@ -73,12 +79,14 @@ class BpdmGateContextInitializer : ApplicationContextInitializer<ConfigurableApp
             )
             .withEnv(
                 "spring.datasource.password", postgreSQLContainer.password
-            ).start()
+            )
+            .start()
 
 
         TestPropertyValues.of(
             "bpdm.gate.base-url=http://localhost:${bpdmGateContainer.getMappedPort(BPDM_PORT)}",
         ).applyTo(applicationContext.environment)
 
+        logger.info { "[!!!] Gate can be remote-debugged on port ${bpdmGateContainer.getMappedPort(DEBUG_PORT)} " }
     }
 }

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/BpdmPoolContextInitializer.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/BpdmPoolContextInitializer.kt
@@ -41,7 +41,7 @@ class BpdmPoolContextInitializer : ApplicationContextInitializer<ConfigurableApp
     private val logger = KotlinLogging.logger { }
 
     companion object {
-        const val POOL_CONTAINER_STARTUP_TIMEOUT_SEC = 180L
+        const val POOL_CONTAINER_STARTUP_TIMEOUT_SEC = 300L
         const val BPDM_PORT = 8080
         const val DEBUG_PORT = 8050
         const val IMAGE = "maven-pool"
@@ -55,7 +55,6 @@ class BpdmPoolContextInitializer : ApplicationContextInitializer<ConfigurableApp
                     "JAVA_OPTIONS",
                     "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:$DEBUG_PORT"
                 )
-                .withStartupTimeout(Duration.ofSeconds(210))
     }
 
 

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/OpenSearchContextInitializer.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/OpenSearchContextInitializer.kt
@@ -35,13 +35,15 @@ import java.time.Duration
 
 class OpenSearchContextInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
     companion object {
+        const val OPENSEARCH_CONTAINER_STARTUP_TIMEOUT_SEC = 270L
         const val OPENSEARCH_PORT = 9200
+
         val openSearchContainer: GenericContainer<*> = GenericContainer("opensearchproject/opensearch:2.1.0")
             .withExposedPorts(OPENSEARCH_PORT)
             .waitingFor(HttpWaitStrategy()
                 .forPort(OPENSEARCH_PORT)
                 .forStatusCodeMatching { response -> response == 200 || response == 401 }
-                .withStartupTimeout(Duration.ofSeconds(180))
+                .withStartupTimeout(Duration.ofSeconds(OPENSEARCH_CONTAINER_STARTUP_TIMEOUT_SEC))
             )
             // based on sample docker-compose for development from https://opensearch.org/docs/latest/opensearch/install/docker
             .withEnv("cluster.name", "cdqbridge")

--- a/bpdm-gate/Dockerfile
+++ b/bpdm-gate/Dockerfile
@@ -16,4 +16,4 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","app.jar"]
+ENTRYPOINT java $JAVA_OPTIONS -jar app.jar

--- a/bpdm-pool/Dockerfile
+++ b/bpdm-pool/Dockerfile
@@ -16,4 +16,4 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","app.jar"]
+ENTRYPOINT java $JAVA_OPTIONS -jar app.jar


### PR DESCRIPTION
Adjusted BpdmPoolContextInitializer / BpdmGateContextInitializer to enable remote-debugging in the containers. The external (localhost) debug port is managed by Docker and therefore dynamic. 
So there is a log message announcing the port to connect to.

Solves #410