### PR TITLE
Fix/duplicate identifier validation for address

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/CollectionUtils.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/CollectionUtils.kt
@@ -23,3 +23,8 @@ fun <T> MutableCollection<T>.replace(elements: Collection<T>) {
     clear()
     addAll(elements)
 }
+
+fun <T> Collection<T>.findDuplicates(): Set<T> =
+    this.groupBy { it }
+        .filter { it.value.size > 1 }
+        .keys

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
@@ -33,7 +33,8 @@ enum class LegalEntityCreateError : ErrorCode {
     LegalFormNotFound,
     LegalEntityIdentifierNotFound,
     LegalAddressRegionNotFound,
-    LegalAddressIdentifierNotFound
+    LegalAddressIdentifierNotFound,
+    LegalAddressDuplicateIdentifier,
 }
 
 @Schema(description = "LegalEntityUpdateError")
@@ -43,21 +44,24 @@ enum class LegalEntityUpdateError : ErrorCode {
     LegalFormNotFound,
     LegalEntityIdentifierNotFound,
     LegalAddressRegionNotFound,
-    LegalAddressIdentifierNotFound
+    LegalAddressIdentifierNotFound,
+    LegalAddressDuplicateIdentifier
 }
 
 @Schema(description = "SiteCreateError")
 enum class SiteCreateError : ErrorCode {
     LegalEntityNotFound,
     MainAddressIdentifierNotFound,
-    MainAddressRegionNotFound
+    MainAddressRegionNotFound,
+    MainAddressDuplicateIdentifier
 }
 
 @Schema(description = "SiteUpdateError")
 enum class SiteUpdateError : ErrorCode {
     SiteNotFound,
     MainAddressIdentifierNotFound,
-    MainAddressRegionNotFound
+    MainAddressRegionNotFound,
+    MainAddressDuplicateIdentifier
 }
 
 @Schema(description = "AddressCreateError")
@@ -67,12 +71,13 @@ enum class AddressCreateError : ErrorCode {
     LegalEntityNotFound,
     RegionNotFound,
     IdentifierNotFound,
-    MainAddressDuplicateIdentifier,
+    AddressDuplicateIdentifier,
 }
 
 @Schema(description = "AddressUpdateError")
 enum class AddressUpdateError : ErrorCode {
     AddressNotFound,
     RegionNotFound,
-    IdentifierNotFound
+    IdentifierNotFound,
+    AddressDuplicateIdentifier,
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
@@ -66,7 +66,8 @@ enum class AddressCreateError : ErrorCode {
     SiteNotFound,
     LegalEntityNotFound,
     RegionNotFound,
-    IdentifierNotFound
+    IdentifierNotFound,
+    MainAddressDuplicateIdentifier,
 }
 
 @Schema(description = "AddressUpdateError")

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/RequestValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/RequestValues.kt
@@ -54,6 +54,11 @@ object RequestValues {
         issuingBody = CommonValues.issuingBody3,
     )
 
+    val addressIdentifier = AddressIdentifierDto(
+        value = CommonValues.identifierValue3,
+        type = CommonValues.identifierTypeTechnicalKey3,
+    )
+
     val legalForm1 = LegalFormRequest(
         technicalKey = CommonValues.legalFormTechnicalKey1,
         name = CommonValues.legalFormName1,
@@ -164,6 +169,9 @@ object RequestValues {
         physicalPostalAddress = postalAddress1, name = CommonValues.name1
     )
 
+    val logisticAddress5 = LogisticAddressDto(
+        physicalPostalAddress = postalAddress1, identifiers = listOf(addressIdentifier)
+    )
 
     val legalEntityCreate1 = LegalEntityPartnerCreateRequest(
         legalEntity = LegalEntityDto(
@@ -314,6 +322,13 @@ object RequestValues {
         bpnParent = legalEntityUpdate3.bpnl,
         index = CommonValues.index3
     )
+
+    val addressPartnerCreate5 = AddressPartnerCreateRequest(
+        address = logisticAddress5,
+        bpnParent = legalEntityUpdate3.bpnl,
+        index = CommonValues.index3
+    )
+
 
     val addressPartnerUpdate1 = AddressPartnerUpdateRequest(
         bpna = CommonValues.bpnA1,


### PR DESCRIPTION
<!-- 
 'fix: Duplicate Identifier Validation on New Business Partners'
-->

## Description
Added service validation when a request is made with identifier with the same values at the address level.
Added unit test for testing the error return


https://github.com/eclipse-tractusx/bpdm/issues/413

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
