### PR TITLE
feat(Gate): Added new generic data model with migration files and uni…

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AlternativePostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/AlternativePostalAddress.kt
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 
 @Embeddable
 class AlternativePostalAddress(
+
     @Embedded
     @AttributeOverride(name = "latitude", column = Column(name = "alt_latitude"))
     @AttributeOverride(name = "longitude", column = Column(name = "alt_longitude"))
@@ -39,17 +40,18 @@ class AlternativePostalAddress(
      * Region within the country
      */
     @Column(name = "alt_admin_area_l1_region")
-    val administrativeAreaLevel1: String? = null,
+    val administrativeAreaLevel1: String?,
 
     /**
      * A postal code, also known as postcode, PIN or ZIP Code
      */
     @Column(name = "alt_postcode")
-    val postCode: String? = null,
+    val postalCode: String?,
 
     /**
      * The city of the address (Synonym: Town, village, municipality)
      */
+    // TODO Should it be optional?
     @Column(name = "alt_city")
     val city: String,
 
@@ -58,14 +60,17 @@ class AlternativePostalAddress(
      */
     @Column(name = "alt_delivery_service_type")
     @Enumerated(EnumType.STRING)
-    val deliveryServiceType: DeliveryServiceType = DeliveryServiceType.PO_BOX,
+    val deliveryServiceType: DeliveryServiceType,
 
     /**
-     * Describes the PO Box or private Bag number the delivery should be placed at.
+     * The qualifier uniquely identifies the delivery service endpoint in conjunction with the delivery service number
      */
-    @Column(name = "alt_delivery_service_number")
-    val deliveryServiceNumber: String = "",
-
     @Column(name = "alt_delivery_service_qualifier")
     val deliveryServiceQualifier: String?,
+
+    /**
+     * Describes the PO Box or private Bag number the delivery should be placed at
+     */
+    @Column(name = "alt_delivery_service_number")
+    val deliveryServiceNumber: String
 )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntity.kt
@@ -51,7 +51,7 @@ class LegalEntity(
     val states: MutableSet<LegalEntityState> = mutableSetOf()
 
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val classifications: MutableSet<Classification> = mutableSetOf()
+    val classifications: MutableSet<LegalEntityClassification> = mutableSetOf()
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(name = "legal_address_id", nullable = false)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityClassification.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/LegalEntityClassification.kt
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
+
+@Entity
+@Table(
+    name = "classifications",
+    indexes = [
+        Index(columnList = "legal_entity_id")
+    ]
+)
+class LegalEntityClassification(
+    @Column(name = "`value`")
+    val value: String?,
+
+    @Column(name = "code")
+    val code: String?,
+
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    val type: ClassificationType,
+
+    @ManyToOne
+    @JoinColumn(name = "legal_entity_id", nullable = false)
+    var legalEntity: LegalEntity
+
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
@@ -24,6 +24,7 @@ import jakarta.persistence.*
 
 @Embeddable
 class PhysicalPostalAddress(
+
     @Embedded
     @AttributeOverride(name = "latitude", column = Column(name = "phy_latitude"))
     @AttributeOverride(name = "longitude", column = Column(name = "phy_longitude"))
@@ -38,29 +39,30 @@ class PhysicalPostalAddress(
      * Region within the country
      */
     @Column(name = "phy_admin_area_l1_region")
-    val administrativeAreaLevel1: String? = null,
+    val administrativeAreaLevel1: String?,
 
     /**
      * Further possibility to describe the region/address(e.g. County)
      */
     @Column(name = "phy_admin_area_l2")
-    val administrativeAreaLevel2: String? = null,
+    val administrativeAreaLevel2: String?,
 
     /**
      * Further possibility to describe the region/address(e.g. Township)
      */
     @Column(name = "phy_admin_area_l3")
-    val administrativeAreaLevel3: String? = null,
+    val administrativeAreaLevel3: String?,
 
     /**
      * A postal code, also known as postcode, PIN or ZIP Code
      */
     @Column(name = "phy_postcode")
-    val postCode: String? = null,
+    val postalCode: String?,
 
     /**
      * The city of the address (Synonym: Town, village, municipality)
      */
+    // TODO Should it be optional?
     @Column(name = "phy_city")
     val city: String,
 
@@ -68,7 +70,7 @@ class PhysicalPostalAddress(
      * Divides the city in several smaller areas
      */
     @Column(name = "phy_district_l1")
-    val districtLevel1: String? = null,
+    val district: String?,
 
     @Embedded
     @AttributeOverride(name = "name", column = Column(name = "phy_street_name"))
@@ -79,7 +81,7 @@ class PhysicalPostalAddress(
     @AttributeOverride(name = "additionalNamePrefix", column = Column(name = "phy_additional_name_prefix"))
     @AttributeOverride(name = "nameSuffix", column = Column(name = "phy_name_suffix"))
     @AttributeOverride(name = "additionalNameSuffix", column = Column(name = "phy_additional_name_suffix"))
-    val street: Street? = null,
+    val street: Street?,
 
     // specific for PhysicalPostalAddress
 
@@ -87,30 +89,29 @@ class PhysicalPostalAddress(
      * A separate postal code for a company, also known as postcode, PIN or ZIP Code
      */
     @Column(name = "phy_company_postcode")
-    val companyPostCode: String? = null,
+    val companyPostalCode: String?,
 
     /**
      * The practice of designating an area for industrial development
      */
     @Column(name = "phy_industrial_zone")
-    val industrialZone: String? = null,
+    val industrialZone: String?,
 
     /**
      * Describes a specific building within the address
      */
     @Column(name = "phy_building")
-    val building: String? = null,
+    val building: String?,
 
     /**
      * Describes the floor/level the delivery shall take place
      */
     @Column(name = "phy_floor")
-    val floor: String? = null,
+    val floor: String?,
 
     /**
      * Describes the door/room/suite on the respective floor the delivery shall take place
      */
     @Column(name = "phy_door")
-    val door: String? = null,
-
-    )
+    val door: String?
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity.generic
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+import org.eclipse.tractusx.bpdm.common.model.StageType
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
+
+@Entity
+@Table(name = "business_partners")
+class BusinessPartner(
+
+    @Column(name = "external_id")
+    var externalId: String,
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "business_partners_name_parts", joinColumns = [JoinColumn(name = "business_partner_id")])
+    @OrderColumn(name = "name_parts_order")
+    var nameParts: MutableList<String> = mutableListOf(),
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "business_partners_roles", joinColumns = [JoinColumn(name = "business_partner_id")])
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_name")
+    var roles: MutableList<BusinessPartnerRole> = mutableListOf(),
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "business_partners_identifiers", joinColumns = [JoinColumn(name = "business_partner_id")])
+    var identifiers: MutableList<Identifier> = mutableListOf(),
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "business_partners_states", joinColumns = [JoinColumn(name = "business_partner_id")])
+    var states: MutableList<State> = mutableListOf(),
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "business_partners_classifications", joinColumns = [JoinColumn(name = "business_partner_id")])
+    var classifications: MutableList<Classification> = mutableListOf(),
+
+    @Column(name = "short_name")
+    var shortName: String?,
+
+    @Column(name = "legal_form")
+    var legalForm: String?,
+
+    @Column(name = "is_owner")
+    var isOwner: Boolean?,
+
+    @Column(name = "address_bpn")
+    var bpnA: String?,
+
+    @Column(name = "legal_entity_bpn")
+    var bpnL: String?,
+
+    @Column(name = "site_bpn")
+    var bpnS: String?,
+
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "postal_address_id", unique = true)
+    var postalAddress: PostalAddress,
+
+    @Column(name = "stage")
+    @Enumerated(EnumType.STRING)
+    var stage: StageType
+
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/Classification.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/Classification.kt
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity.generic
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
+
+
+@Embeddable
+data class Classification(
+    @Column(name = "value")
+    var value: String?,
+
+    @Column(name = "code")
+    var code: String?,
+
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    val type: ClassificationType,
+
+    )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/Identifier.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/Identifier.kt
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity.generic
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+
+@Embeddable
+data class Identifier(
+    @Column(name = "value", nullable = false)
+    var value: String,
+
+    @Column(name = "type", nullable = false)
+    var type: String,
+
+    @Column(name = "issuing_body")
+    var issuingBody: String?,
+
+    )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/PostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/PostalAddress.kt
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity.generic
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+import org.eclipse.tractusx.bpdm.gate.api.model.AddressType
+import org.eclipse.tractusx.bpdm.gate.entity.AlternativePostalAddress
+import org.eclipse.tractusx.bpdm.gate.entity.PhysicalPostalAddress
+
+@Entity
+@Table(name = "postal_addresses")
+class PostalAddress(
+
+    @Column(name = "address_type")
+    @Enumerated(EnumType.STRING)
+    var addressType: AddressType,
+
+    @Embedded
+    var physicalPostalAddress: PhysicalPostalAddress,
+
+    @Embedded
+    var alternativePostalAddress: AlternativePostalAddress?
+
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/State.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/State.kt
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity.generic
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
+
+@Embeddable
+data class State(
+
+    @Column(name = "description")
+    var description: String?,
+
+    @Column(name = "valid_from")
+    var validFrom: LocalDateTime?,
+
+    @Column(name = "valid_to")
+    var validTo: LocalDateTime?,
+
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val type: BusinessStateType,
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/BusinessPartnerRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/BusinessPartnerRepository.kt
@@ -17,32 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.entity
+package org.eclipse.tractusx.bpdm.gate.repository.generic
 
-import jakarta.persistence.*
-import org.eclipse.tractusx.bpdm.common.model.BaseEntity
-import org.eclipse.tractusx.bpdm.common.model.ClassificationType
+import org.eclipse.tractusx.bpdm.gate.entity.generic.BusinessPartner
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
-@Entity
-@Table(
-    name = "classifications",
-    indexes = [
-        Index(columnList = "legal_entity_id")
-    ]
-)
-class Classification (
-    @Column(name = "`value`")
-    val value: String?,
-
-    @Column(name = "code")
-    val code: String?,
-
-    @Column(name = "type")
-    @Enumerated(EnumType.STRING)
-    val type: ClassificationType,
-
-    @ManyToOne
-    @JoinColumn(name = "legal_entity_id", nullable = false)
-    var legalEntity: LegalEntity
-
-) : BaseEntity()
+@Repository
+interface BusinessPartnerRepository : JpaRepository<BusinessPartner, Long>

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/PostalAddressRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/PostalAddressRepository.kt
@@ -17,11 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.repository
+package org.eclipse.tractusx.bpdm.gate.repository.generic
 
-import org.eclipse.tractusx.bpdm.pool.entity.Classification
-import org.springframework.data.repository.CrudRepository
-import org.springframework.data.repository.PagingAndSortingRepository
+import org.eclipse.tractusx.bpdm.gate.entity.generic.PostalAddress
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
-interface ClassificationRepository : PagingAndSortingRepository<Classification, Long>, CrudRepository<Classification, Long> {
-}
+@Repository
+interface PostalAddressRepository : JpaRepository<PostalAddress, Long>

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -78,7 +78,7 @@ fun AlternativePostalAddressDto.toAlternativePostalAddressEntity() =
         geographicCoordinates = geographicCoordinates?.toGeographicCoordinateEntity(),
         country = country,
         administrativeAreaLevel1 = administrativeAreaLevel1,
-        postCode = postalCode,
+        postalCode = postalCode,
         city = city,
         deliveryServiceType = deliveryServiceType,
         deliveryServiceNumber = deliveryServiceNumber,
@@ -92,11 +92,11 @@ fun PhysicalPostalAddressGateDto.toPhysicalPostalAddressEntity() =
         administrativeAreaLevel1 = administrativeAreaLevel1,
         administrativeAreaLevel2 = administrativeAreaLevel2,
         administrativeAreaLevel3 = administrativeAreaLevel3,
-        postCode = postalCode,
+        postalCode = postalCode,
         city = city,
-        districtLevel1 = district,
+        district = district,
         street = street?.toStreetEntity(),
-        companyPostCode = companyPostalCode,
+        companyPostalCode = companyPostalCode,
         industrialZone = industrialZone,
         building = building,
         floor = floor,
@@ -256,8 +256,8 @@ fun toEntityState(dto: LegalEntityStateDto, legalEntity: LegalEntity): LegalEnti
     return LegalEntityState(dto.description, dto.validFrom, dto.validTo, dto.type, legalEntity)
 }
 
-fun toEntityClassification(dto: ClassificationDto, legalEntity: LegalEntity): Classification {
-    return Classification(dto.value, dto.code, dto.type, legalEntity)
+fun toEntityClassification(dto: ClassificationDto, legalEntity: LegalEntity): LegalEntityClassification {
+    return LegalEntityClassification(dto.value, dto.code, dto.type, legalEntity)
 }
 
 fun toEntityIdentifiers(dto: LegalEntityIdentifierDto, legalEntity: LegalEntity): LegalEntityIdentifier {
@@ -316,7 +316,7 @@ fun AlternativePostalAddress.toAlternativePostalAddressDto(): AlternativePostalA
         administrativeAreaLevel1 = administrativeAreaLevel1,
         geographicCoordinates = geographicCoordinates?.toGeographicCoordinateDto(),
         country = country,
-        postalCode = postCode,
+        postalCode = postalCode,
         city = city
     )
 
@@ -324,13 +324,13 @@ fun PhysicalPostalAddress.toPhysicalPostalAddress(): PhysicalPostalAddressGateDt
     PhysicalPostalAddressGateDto(
         geographicCoordinates = geographicCoordinates?.toGeographicCoordinateDto(),
         country = country,
-        postalCode = postCode,
+        postalCode = postalCode,
         city = city,
         administrativeAreaLevel1 = administrativeAreaLevel1,
         administrativeAreaLevel2 = administrativeAreaLevel2,
         administrativeAreaLevel3 = administrativeAreaLevel3,
-        district = districtLevel1,
-        companyPostalCode = companyPostCode,
+        district = district,
+        companyPostalCode = companyPostalCode,
         industrialZone = industrialZone,
         building = building,
         floor = floor,
@@ -372,7 +372,7 @@ fun mapToLegalEntityStateDto(states: MutableSet<LegalEntityState>): Collection<L
     return states.map { LegalEntityStateDto(it.description, it.validFrom, it.validTo, it.type) }
 }
 
-fun mapToLegalEntityClassificationsDto(classification: MutableSet<Classification>): Collection<ClassificationDto> {
+fun mapToLegalEntityClassificationsDto(classification: MutableSet<LegalEntityClassification>): Collection<ClassificationDto> {
     return classification.map { ClassificationDto(it.value, it.code, it.type) }
 }
 

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_13__create_generic_data_model_tables.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_13__create_generic_data_model_tables.sql
@@ -1,0 +1,116 @@
+-- Create table for Address entity
+CREATE TABLE postal_addresses
+(
+    id                             bigint                   NOT NULL,
+    created_at                     TIMESTAMP WITH time zone NOT NULL,
+    updated_at                     TIMESTAMP WITH time zone NOT NULL,
+    uuid                           UUID                     NOT NULL,
+    address_type                   varchar(255),
+    phy_latitude                   double precision,
+    phy_longitude                  double precision,
+    phy_altitude                   double precision,
+    phy_country                    varchar(255)             not null,
+    phy_admin_area_l1_region       varchar(255),
+    phy_admin_area_l2              varchar(255),
+    phy_admin_area_l3              varchar(255),
+    phy_postcode                   varchar(255),
+    phy_city                       varchar(255)             not null,
+    phy_district_l1                varchar(255),
+    phy_street_name                varchar(255),
+    phy_street_number              varchar(255),
+    phy_street_milestone           varchar(255),
+    phy_street_direction           varchar(255),
+    phy_name_prefix                varchar(255),
+    phy_additional_name_prefix     varchar(255),
+    phy_name_suffix                varchar(255),
+    phy_additional_name_suffix     varchar(255),
+    phy_company_postcode           varchar(255),
+    phy_industrial_zone            varchar(255),
+    phy_building                   varchar(255),
+    phy_floor                      varchar(255),
+    phy_door                       varchar(255),
+    alt_latitude                   double precision,
+    alt_longitude                  double precision,
+    alt_altitude                   double precision,
+    alt_country                    varchar(255),
+    alt_admin_area_l1_region       varchar(255),
+    alt_postcode                   varchar(255),
+    alt_city                       varchar(255),
+    alt_delivery_service_type      varchar(255),
+    alt_delivery_service_qualifier varchar(255),
+    alt_delivery_service_number    varchar(255),
+    PRIMARY KEY (id)
+);
+
+-- Create table for Business_Partner entity
+CREATE TABLE business_partners
+(
+    id                bigint                   NOT NULL,
+    created_at        TIMESTAMP WITH time zone NOT NULL,
+    updated_at        TIMESTAMP WITH time zone NOT NULL,
+    uuid              UUID                     NOT NULL,
+    external_id       VARCHAR(255)             NOT NULL,
+    short_name        VARCHAR(255),
+    legal_form        VARCHAR(255),
+    is_owner          BOOLEAN,
+    address_bpn       VARCHAR(255),
+    legal_entity_bpn  VARCHAR(255),
+    site_bpn          VARCHAR(255),
+    postal_address_id bigint                   NOT NULL UNIQUE,
+    stage             VARCHAR(255),
+    CONSTRAINT pk_business_partners PRIMARY KEY (id),
+    FOREIGN KEY (postal_address_id) REFERENCES postal_addresses (id)
+);
+
+-- Create table for Name Parts
+CREATE TABLE business_partners_name_parts
+(
+    name_parts_order    bigint,
+    name_parts          VARCHAR(255),
+    business_partner_id bigint NOT NULL,
+    FOREIGN KEY (business_partner_id) REFERENCES business_partners (id)
+);
+CREATE INDEX idx_business_partners_name_parts_business_partner_id ON business_partners_name_parts USING btree (business_partner_id);
+
+-- Create table for Roles entity
+CREATE TABLE business_partners_roles
+(
+    role_name           VARCHAR(255) NOT NULL,
+    business_partner_id bigint       NOT NULL,
+    FOREIGN KEY (business_partner_id) REFERENCES business_partners (id)
+);
+CREATE INDEX idx_business_partners_roles_business_partner_id ON business_partners_roles USING btree (business_partner_id);
+
+-- Create table for Identifier entity
+CREATE TABLE business_partners_identifiers
+(
+    "value"             VARCHAR(255),
+    type                VARCHAR(255),
+    issuing_body        VARCHAR(255),
+    business_partner_id bigint NOT NULL,
+    FOREIGN KEY (business_partner_id) REFERENCES business_partners (id)
+);
+CREATE INDEX idx_business_partners_identifiers_business_partner_id ON business_partners_identifiers USING btree (business_partner_id);
+
+-- Create table for State entity
+CREATE TABLE business_partners_states
+(
+    description         VARCHAR(255),
+    valid_from          timestamp(6) NULL,
+    valid_to            timestamp(6) NULL,
+    type                VARCHAR(255),
+    business_partner_id bigint       NOT NULL,
+    FOREIGN KEY (business_partner_id) REFERENCES business_partners (id)
+);
+CREATE INDEX idx_business_partners_states_business_partner_id ON business_partners_states USING btree (business_partner_id);
+
+-- Create table for Classification entity
+CREATE TABLE business_partners_classifications
+(
+    "value"             VARCHAR(255),
+    code                VARCHAR(255),
+    type                VARCHAR(255),
+    business_partner_id bigint NOT NULL,
+    FOREIGN KEY (business_partner_id) REFERENCES business_partners (id)
+);
+CREATE INDEX idx_business_partners_classifications_business_partner_id ON business_partners_classifications USING btree (business_partner_id);

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerInputIT.kt
@@ -62,7 +62,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
-internal class AddressControllerInputIT @Autowired constructor(
+internal class PostalAddressControllerInputIT @Autowired constructor(
     val gateClient: GateClient,
     private val gateAddressRepository: GateAddressRepository,
     val testHelpers: DbTestHelpers,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerOutputIT.kt
@@ -64,7 +64,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
-internal class AddressControllerOutputIT @Autowired constructor(
+internal class PostalAddressControllerOutputIT @Autowired constructor(
     val gateClient: GateClient,
     private val gateAddressRepository: GateAddressRepository,
     val testHelpers: DbTestHelpers

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -1,0 +1,246 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.entity.generic
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.model.*
+import org.eclipse.tractusx.bpdm.gate.api.model.AddressType
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.gate.entity.AlternativePostalAddress
+import org.eclipse.tractusx.bpdm.gate.entity.GeographicCoordinate
+import org.eclipse.tractusx.bpdm.gate.entity.PhysicalPostalAddress
+import org.eclipse.tractusx.bpdm.gate.entity.Street
+import org.eclipse.tractusx.bpdm.gate.repository.generic.*
+import org.eclipse.tractusx.bpdm.gate.util.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import java.time.LocalDateTime
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
+internal class BusinessPartnerIT @Autowired constructor(
+    val testHelpers: DbTestHelpers,
+) {
+
+    @Autowired
+    lateinit var businessPartnerRepository: BusinessPartnerRepository
+
+    @Autowired
+    lateinit var postalAddressRepository: PostalAddressRepository
+
+
+    companion object {
+        @RegisterExtension
+        private val wireMockServer: WireMockExtension = WireMockExtension.newInstance()
+            .options(WireMockConfiguration.wireMockConfig().dynamicPort())
+            .build()
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        wireMockServer.resetAll()
+        testHelpers.truncateDbTables()
+    }
+
+    @Test
+    fun `test save BusinessPartner`() {
+        val businessPartner = createBusinessPartner()
+
+        val savedEntity = businessPartnerRepository.save(businessPartner)
+        val foundEntity = businessPartnerRepository.findById(savedEntity.id).get()
+
+        assertNotNull(savedEntity)
+        assertEquals(savedEntity.id, foundEntity.id)
+        assertEquals(savedEntity.roles.toList(), foundEntity.roles.toList())
+        assertEquals(savedEntity.nameParts.toList(), foundEntity.nameParts.toList())
+        assertEquals(savedEntity.identifiers.toList(), foundEntity.identifiers.toList())
+        assertEquals(savedEntity.classifications.toList(), foundEntity.classifications.toList())
+        testHelpers.assertRecursively(foundEntity.states.toList()).isEqualTo(savedEntity.states.toList())
+    }
+
+
+    @Test
+    fun `test save PostalAddress`() {
+
+        val address = createPostalAddress()
+
+        val savedAddress = postalAddressRepository.save(address)
+
+        val foundAddress = postalAddressRepository.findById(savedAddress.id).get()
+        val foundPhysicalPostalAddress = foundAddress.physicalPostalAddress
+
+        assertNotNull(foundAddress)
+        assertEquals(savedAddress.id, foundAddress.id)
+        assertEquals(AddressType.LegalAddress, foundAddress.addressType)
+
+        assertEquals(10.0f, foundPhysicalPostalAddress.geographicCoordinates?.altitude)
+        assertEquals(52.0f, foundPhysicalPostalAddress.geographicCoordinates?.latitude)
+        assertEquals("Berlin", foundPhysicalPostalAddress.city)
+    }
+
+    @Test
+    fun `test save PostalAddress with alternative address`() {
+
+        val address = createPostalAddress()
+        address.alternativePostalAddress = createAlternativePostalAddress()
+
+        val savedAddress = postalAddressRepository.save(address)
+
+        val foundAddress = postalAddressRepository.findById(savedAddress.id).get()
+        val foundAlternativePostalAddress = foundAddress.alternativePostalAddress
+
+        assertNotNull(foundAddress)
+        assertEquals(savedAddress.id, foundAddress.id)
+        assertEquals(AddressType.LegalAddress, foundAddress.addressType)
+
+        assertEquals(15.0f, foundAlternativePostalAddress?.geographicCoordinates?.altitude)
+        assertEquals(52.5f, foundAlternativePostalAddress?.geographicCoordinates?.latitude)
+        assertEquals("Berlin", foundAlternativePostalAddress?.city)
+    }
+
+
+    private fun createBusinessPartner(): BusinessPartner {
+        val postalAddress = createPostalAddress()
+
+        return BusinessPartner(
+            externalId = "testExternalId",
+            nameParts = mutableListOf("testNameParts", "testNameParts2", "testNameParts3", "testNameParts4", "testNameParts5"),
+            shortName = "testShortName",
+            legalForm = "testLegalForm",
+            isOwner = true,
+            bpnA = "testAddressBpn",
+            bpnL = "testLegalEntityBpn",
+            bpnS = "testSiteBpn",
+            postalAddress = postalAddress,
+            roles = mutableListOf(BusinessPartnerRole.CUSTOMER, BusinessPartnerRole.SUPPLIER),
+            identifiers = mutableListOf(createIdentifier()),
+            states = mutableListOf(createState()),
+            classifications = mutableListOf(createClassification()),
+            stage = StageType.Input
+        )
+    }
+
+    private fun createPostalAddress(): PostalAddress {
+        return PostalAddress(
+            addressType = AddressType.LegalAddress,
+            physicalPostalAddress = createPhysicalPostalAddress(),
+            alternativePostalAddress = null
+        )
+    }
+
+    private fun createPhysicalPostalAddress() =
+        PhysicalPostalAddress(
+            geographicCoordinates = GeographicCoordinate(
+                altitude = 10.0f,
+                latitude = 52.0f,
+                longitude = 13.0f
+            ),
+            country = CountryCode.DE,
+            administrativeAreaLevel1 = "adminlevel1",
+            administrativeAreaLevel2 = "adminlevel2",
+            administrativeAreaLevel3 = "adminlevel3",
+            postalCode = "10115",
+            city = "Berlin",
+            district = "district9",
+            street = Street(
+                name = "unknown street",
+                namePrefix = "Un",
+                nameSuffix = "know",
+                additionalNamePrefix = "empty"
+            ),
+            companyPostalCode = "newCode",
+            industrialZone = "oldCode",
+            building = "3",
+            floor = "6",
+            door = "42"
+        )
+
+    private fun createAlternativePostalAddress() =
+        AlternativePostalAddress(
+            geographicCoordinates = GeographicCoordinate(
+                altitude = 15.0f,
+                latitude = 52.5f,
+                longitude = 13.5f
+            ),
+            country = CountryCode.DE,
+            administrativeAreaLevel1 = "level1",
+            postalCode = "10117",
+            city = "Berlin",
+            deliveryServiceType = DeliveryServiceType.PO_BOX,
+            deliveryServiceQualifier = "DHL Express",
+            deliveryServiceNumber = "12345"
+        )
+
+    private fun createIdentifier(): Identifier {
+
+        return Identifier(
+            value = "1234567890",
+            type = "Passport",
+            issuingBody = "Government of XYZ"
+        )
+    }
+
+    private fun createState(): State {
+        return State(
+            description = "Active",
+            type = BusinessStateType.ACTIVE,
+            validFrom = LocalDateTime.now(),
+            validTo = LocalDateTime.now().plusDays(365)
+        )
+    }
+    private fun createClassification(): Classification {
+
+        return Classification(
+            value = "A1",
+            code = "OP123",
+            type = ClassificationType.NACE
+        )
+    }
+
+}

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/DbTestHelpers.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/DbTestHelpers.kt
@@ -25,6 +25,7 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.RecursiveComparisonAssert
 import org.springframework.stereotype.Component
 import java.time.Instant
+import java.time.LocalDateTime
 
 private const val BPDM_DB_SCHEMA_NAME: String = "bpdmgate"
 
@@ -59,7 +60,7 @@ class DbTestHelpers(entityManagerFactory: EntityManagerFactory) {
             .usingRecursiveComparison()
             .ignoringCollectionOrder()
             .ignoringAllOverriddenEquals()
-            .ignoringFieldsOfTypes(Instant::class.java)
+            .ignoringFieldsOfTypes(Instant::class.java, LocalDateTime::class.java)
     }
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntity.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntity.kt
@@ -56,7 +56,7 @@ class LegalEntity(
     val sites: MutableSet<Site> = mutableSetOf()
 
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val classifications: MutableSet<Classification> = mutableSetOf()
+    val classifications: MutableSet<LegalEntityClassification> = mutableSetOf()
 
     @OneToMany(mappedBy = "startNode", cascade = [CascadeType.ALL], orphanRemoval = true)
     val startNodeRelations: MutableSet<Relation> = mutableSetOf()

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntityClassification.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntityClassification.kt
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.entity
+package org.eclipse.tractusx.bpdm.pool.entity
 
 import jakarta.persistence.*
 import org.eclipse.tractusx.bpdm.common.model.BaseEntity
@@ -30,7 +30,7 @@ import org.eclipse.tractusx.bpdm.common.model.ClassificationType
         Index(columnList = "legal_entity_id")
     ]
 )
-class Classification (
+class LegalEntityClassification(
     @Column(name = "`value`")
     val value: String?,
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityClassificationRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityClassificationRepository.kt
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.repository
+
+import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityClassification
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
+
+interface LegalEntityClassificationRepository : PagingAndSortingRepository<LegalEntityClassification, Long>, CrudRepository<LegalEntityClassification, Long> {
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -506,8 +506,8 @@ class BusinessPartnerBuildService(
         )
     }
 
-    private fun toEntity(dto: ClassificationDto, partner: LegalEntity): Classification {
-        return Classification(
+    private fun toEntity(dto: ClassificationDto, partner: LegalEntity): LegalEntityClassification {
+        return LegalEntityClassification(
             value = dto.value,
             code = dto.code,
             type = dto.type,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -255,7 +255,7 @@ fun GeographicCoordinate.toDto(): GeoCoordinateDto {
     return GeoCoordinateDto(longitude, latitude, altitude)
 }
 
-fun Classification.toDto(): ClassificationVerboseDto {
+fun LegalEntityClassification.toDto(): ClassificationVerboseDto {
     return ClassificationVerboseDto(value, code, type.toDto())
 }
 


### PR DESCRIPTION
## Description
This PR introduces generic data model entities alongside the migration files. 
The tests focus on the CRUD operations for entities like `BusinessPartner`, `Roles`, `Identifier`, `State`, `Classification`, `PostalAddress`, `PhysicalPostalAddress`, and `AlternativePostalAddress`.

The goal is to ensure that the basic functionalities for these entities are working as expected, and any future changes won't inadvertently break existing functionalities.



issue https://github.com/eclipse-tractusx/bpdm/issues/382

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
