### PR TITLE
Feat: Setup new Maven Module for CleaningServiceDummy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Source:
 
 * [BPDM Pool](./bpdm-pool/DOCKER_NOTICE.md)
 * [BPDM Gate](./bpdm-gate/DOCKER_NOTICE.md)
+* [BPDM Cleaning Service Dummy](./bpdm-cleaning-service-dummy/DOCKER_NOTICE.md)
 * [BPDM Bridge Dummy](./bpdm-bridge-dummy/DOCKER_NOTICE.md)
 
 ## GitHub Workflows

--- a/bpdm-cleaning-service-dummy/DOCKER_NOTICE.md
+++ b/bpdm-cleaning-service-dummy/DOCKER_NOTICE.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+**BPDM Cleaning Service Dummy**
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/bpdm 
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Cleaning Service Dummy Dockerfile: https://github.com/eclipse-tractusx/bpdm/blob/main/bpdm-cleaning-service-dummy/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/bpdm/blob/main/LICENSE)
+
+
+**Used base image**
+
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/bpdm-cleaning-service-dummy/Dockerfile
+++ b/bpdm-cleaning-service-dummy/Dockerfile
@@ -1,0 +1,17 @@
+FROM maven:3.8.7-eclipse-temurin-17 AS build
+COPY . /home/app
+WORKDIR /home/app
+RUN mvn -B -U clean package -pl bpdm-cleaning-service-dummy -am -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+COPY --from=build /home/app/bpdm-cleaning-service-dummy/target/bpdm-cleaning-service-dummy.jar /usr/local/lib/bpdm/app.jar
+RUN apk update && apk upgrade libssl3 libcrypto3
+ARG USERNAME=bpdm
+ARG USERID=10001
+ARG GID=3000
+RUN addgroup -g $GID -S $USERNAME
+RUN adduser -u $USERID -S $USERNAME $USERNAME
+USER $USERNAME
+WORKDIR /usr/local/lib/bpdm
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/bpdm-cleaning-service-dummy/pom.xml
+++ b/bpdm-cleaning-service-dummy/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Apache License, Version 2.0 which is available at
+  ~ https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>bpdm-cleaning-service-dummy</artifactId>
+    <name>Business Partner Data Management Cleaning Service Dummy</name>
+    <description>Place holder for the cleaning service provider</description>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.eclipse.tractusx</groupId>
+        <artifactId>bpdm-parent</artifactId>
+        <version>4.0.2-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bpdm-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bpdm-pool-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microutils</groupId>
+            <artifactId>kotlin-logging-jvm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+           <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- in kotlin, use mockk instead of mockito -->
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- Name jar without version to make it easier to reference it during CI/CD -->
+        <finalName>bpdm-cleaning-service-dummy</finalName>
+
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <includes>
+                    <include>*.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <filtering>false</filtering>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <excludes>
+                    <exclude>*.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub CatenaX-NG Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/catenax-ng/tx-bpdm</url>
+        </repository>
+    </distributionManagement>
+</project>

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/Application.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/Application.kt
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.cleaning
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+
+@SpringBootApplication(exclude=[DataSourceAutoConfiguration::class])
+@ConfigurationPropertiesScan
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}

--- a/bpdm-cleaning-service-dummy/src/main/resources/application.properties
+++ b/bpdm-cleaning-service-dummy/src/main/resources/application.properties
@@ -1,0 +1,42 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+bpdm.name=@project.name@
+bpdm.description=@project.description@
+bpdm.version=@project.version@
+##
+# Change default port
+server.port=8084
+##
+# Logging Configuration
+bpdm.logging.unknown-user=Anonymous
+
+##
+#Springdoc swagger configuration
+springdoc.api-docs.enabled=true
+springdoc.api-docs.path=/docs/api-docs
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.path=/ui/swagger-ui
+springdoc.swagger-ui.show-common-extensions=true
+springdoc.swagger-ui.csrf.enabled=true
+##
+#Enable actuator endpoints
+management.endpoint.health.probes.enabled=true
+management.health.livenessState.enabled=true
+management.health.readinessState.enabled=true
+

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/ApplicationTests.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/ApplicationTests.kt
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.cleaning
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ApplicationTests {
+
+	@Test
+	fun contextLoads() {
+
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>bpdm-gate-api</module>
         <module>bpdm-gate</module>
         <module>bpdm-bridge-dummy</module>
+        <module>bpdm-cleaning-service-dummy</module>
     </modules>
 
     <properties>
@@ -79,6 +80,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>bpdm-cleaning-service-dummy</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>bpdm-common</artifactId>


### PR DESCRIPTION
## Description

Create maven module for the Cleaning Service Dummy.
I used org.eclipse.tractusx.bpdm.cleaning as base package name because org.eclipse.tractusx.bpdm.cleaning-service-dummy seems a little bit long.
At the moment no persistence to a database is configured.

### Solves
#421 