### PR TITLE
Feat: Implement generic business partner service logic in Gate

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AlternativePostalAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AlternativePostalAddressDto.kt
@@ -27,7 +27,10 @@ import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(description = PostalAddressDescription.headerAlternative)
+@Schema(
+    description = PostalAddressDescription.headerAlternative,
+    requiredProperties = ["country", "city", "deliveryServiceType", "deliveryServiceNumber"]
+)
 data class AlternativePostalAddressDto(
 
     override val geographicCoordinates: GeoCoordinateDto?,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/CommonMappings.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/CommonMappings.kt
@@ -21,10 +21,14 @@ package org.eclipse.tractusx.bpdm.common.service
 
 import com.neovisionaries.i18n.CountryCode
 import com.neovisionaries.i18n.LanguageCode
+import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.NamedType
 import org.eclipse.tractusx.bpdm.common.model.NamedUrlType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 
 fun <T : NamedUrlType> T.toDto(): TypeKeyNameUrlDto<T> {
     return TypeKeyNameUrlDto(this, getTypeName(), getUrl())
@@ -41,3 +45,15 @@ fun LanguageCode.toDto(): TypeKeyNameVerboseDto<LanguageCode> {
 fun CountryCode.toDto(): TypeKeyNameVerboseDto<CountryCode> {
     return TypeKeyNameVerboseDto(this, getName())
 }
+
+fun PaginationRequest.toPageRequest() =
+    PageRequest.of(page, size)
+
+fun <T, R> Page<T>.toPageDto(contentMapper: (T) -> R): PageDto<R> =
+    PageDto(
+        page = number,
+        totalElements = totalElements,
+        totalPages = totalPages,
+        contentSize = content.size,
+        content = content.map(contentMapper)
+    )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateBusinessPartnerApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateBusinessPartnerApi.kt
@@ -31,6 +31,7 @@ import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -58,7 +59,7 @@ interface GateBusinessPartnerApi {
     )
     @PutMapping("/input/business-partners")
     @PutExchange("/input/business-partners")
-    fun upsertBusinessPartnersInput(@RequestBody businessPartners: Collection<BusinessPartnerInputRequest>): Collection<BusinessPartnerInputDto>
+    fun upsertBusinessPartnersInput(@RequestBody businessPartners: Collection<BusinessPartnerInputRequest>): ResponseEntity<Collection<BusinessPartnerInputDto>>
 
     @Operation(
         summary = "Search business partner by external ID. An empty external ID list returns a paginated list of all business partners.",
@@ -72,9 +73,9 @@ interface GateBusinessPartnerApi {
     )
     @PostMapping("/input/business-partners/search")
     @PostExchange("/input/business-partners/search")
-    fun getBusinessPartnersInputByExternalIds(
-        @ParameterObject @Valid paginationRequest: PaginationRequest,
-        @RequestBody externalIds: Collection<String>
+    fun getBusinessPartnersInput(
+        @RequestBody externalIds: Collection<String>? = null,
+        @ParameterObject @Valid paginationRequest: PaginationRequest = PaginationRequest()
     ): PageDto<BusinessPartnerInputDto>
 
 
@@ -92,8 +93,8 @@ interface GateBusinessPartnerApi {
     @PostMapping("/output/business-partners/search")
     @PostExchange("/output/business-partners/search")
     fun getBusinessPartnersOutput(
-        @ParameterObject @Valid paginationRequest: PaginationRequest,
-        @RequestBody(required = false) externalIds: Collection<String>?
+        @RequestBody externalIds: Collection<String>? = null,
+        @ParameterObject @Valid paginationRequest: PaginationRequest = PaginationRequest()
     ): PageDto<BusinessPartnerOutputDto>
 
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClient.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClient.kt
@@ -23,6 +23,8 @@ import org.eclipse.tractusx.bpdm.gate.api.*
 
 interface GateClient {
 
+    fun businessParters(): GateBusinessPartnerApi
+
     fun addresses(): GateAddressApi
 
     fun legalEntities(): GateLegalEntityApi

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClientImpl.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClientImpl.kt
@@ -38,11 +38,14 @@ class GateClientImpl(
             .build()
     }
 
+    private val gateClientBusinessPartner by lazy { httpServiceProxyFactory.createClient(GateBusinessPartnerApi::class.java) }
     private val gateClientAddress by lazy { httpServiceProxyFactory.createClient(GateAddressApi::class.java) }
     private val gateClientLegalEntity by lazy { httpServiceProxyFactory.createClient(GateLegalEntityApi::class.java) }
     private val gateClientSite by lazy { httpServiceProxyFactory.createClient(GateSiteApi::class.java) }
     private val gateClientChangelog by lazy { httpServiceProxyFactory.createClient(GateChangelogApi::class.java) }
     private val gateClientSharingState by lazy { httpServiceProxyFactory.createClient(GateSharingStateApi::class.java) }
+
+    override fun businessParters() = gateClientBusinessPartner
 
     override fun addresses() = gateClientAddress
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerIdentifierDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerIdentifierDto.kt
@@ -21,14 +21,17 @@ package org.eclipse.tractusx.bpdm.gate.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Identifier record for a business partner", requiredProperties = ["type"])
+@Schema(
+    description = "Identifier record for a business partner",
+    requiredProperties = ["type", "value"]
+)
 data class BusinessPartnerIdentifierDto(
-
-    @get:Schema(description = "Value of the identifier")
-    val value: String?,
 
     @get:Schema(description = "Technical key of the type to which this identifier belongs to")
     val type: String,
+
+    @get:Schema(description = "Value of the identifier")
+    val value: String,
 
     @get:Schema(description = "Body which issued the identifier")
     val issuingBody: String?

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/PhysicalPostalAddressGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/PhysicalPostalAddressGateDto.kt
@@ -28,7 +28,10 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDesc
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(description = PostalAddressDescription.headerPhysical)
+@Schema(
+    description = PostalAddressDescription.headerPhysical,
+    requiredProperties = ["country", "city"]
+)
 data class PhysicalPostalAddressGateDto(
 
     override val geographicCoordinates: GeoCoordinateDto?,

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
@@ -24,11 +24,14 @@ import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 
 
-@Schema(description = "Generic business partner with external id", requiredProperties = ["externalId", "postalAddress"])
+@Schema(
+    description = "Generic business partner with external id",
+    requiredProperties = ["externalId", "postalAddress"]
+)
 data class BusinessPartnerInputRequest(
     override val externalId: String,
     override val nameParts: List<String> = emptyList(),
-    override val shortName: String?,
+    override val shortName: String? = null,
     override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
     override val legalForm: String? = null,
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
@@ -38,6 +41,6 @@ data class BusinessPartnerInputRequest(
     @get:Schema(description = "Address of the official seat of this business partner.")
     val postalAddress: BusinessPartnerPostalAddressInputDto,
 
-    override val isOwner: Boolean
+    override val isOwner: Boolean = false
 
 ) : IBaseBusinessPartnerDto

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerController.kt
@@ -21,29 +21,47 @@ package org.eclipse.tractusx.bpdm.gate.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
+import org.eclipse.tractusx.bpdm.common.service.toPageRequest
 import org.eclipse.tractusx.bpdm.gate.api.GateBusinessPartnerApi
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
+import org.eclipse.tractusx.bpdm.gate.config.ApiConfigProperties
+import org.eclipse.tractusx.bpdm.gate.containsDuplicates
+import org.eclipse.tractusx.bpdm.gate.service.BusinessPartnerService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class BusinessPartnerController() : GateBusinessPartnerApi {
+class BusinessPartnerController(
+    val businessPartnerService: BusinessPartnerService,
+    val apiConfigProperties: ApiConfigProperties
+) : GateBusinessPartnerApi {
 
-    override fun upsertBusinessPartnersInput(businessPartners: Collection<BusinessPartnerInputRequest>): Collection<BusinessPartnerInputDto> {
-        TODO("Not yet implemented")
+    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getChangeCompanyInputDataAsRole())")
+    override fun upsertBusinessPartnersInput(businessPartners: Collection<BusinessPartnerInputRequest>): ResponseEntity<Collection<BusinessPartnerInputDto>> {
+        if (businessPartners.size > apiConfigProperties.upsertLimit || businessPartners.map { it.externalId }.containsDuplicates()) {
+            return ResponseEntity(HttpStatus.BAD_REQUEST)
+        }
+        val result = businessPartnerService.upsertBusinessPartnersInput(businessPartners)
+        return ResponseEntity.ok(result)
     }
 
-    override fun getBusinessPartnersInputByExternalIds(
-        paginationRequest: PaginationRequest,
-        externalIds: Collection<String>
+    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyInputDataAsRole())")
+    override fun getBusinessPartnersInput(
+        externalIds: Collection<String>?,
+        paginationRequest: PaginationRequest
     ): PageDto<BusinessPartnerInputDto> {
-        TODO("Not yet implemented")
+        return businessPartnerService.getBusinessPartnersInput(paginationRequest.toPageRequest(), externalIds)
     }
 
-    override fun getBusinessPartnersOutput(paginationRequest: PaginationRequest, externalIds: Collection<String>?): PageDto<BusinessPartnerOutputDto> {
-        TODO("Not yet implemented")
+    @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getReadCompanyOutputDataAsRole())")
+    override fun getBusinessPartnersOutput(
+        externalIds: Collection<String>?,
+        paginationRequest: PaginationRequest
+    ): PageDto<BusinessPartnerOutputDto> {
+        return businessPartnerService.getBusinessPartnersOutput(paginationRequest.toPageRequest(), externalIds)
     }
-
-
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/BusinessPartnerRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/BusinessPartnerRepository.kt
@@ -19,9 +19,20 @@
 
 package org.eclipse.tractusx.bpdm.gate.repository.generic
 
+import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.entity.generic.BusinessPartner
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface BusinessPartnerRepository : JpaRepository<BusinessPartner, Long>
+interface BusinessPartnerRepository : JpaRepository<BusinessPartner, Long>, CrudRepository<BusinessPartner, Long> {
+
+    fun findByStageAndExternalIdIn(stage: StageType, externalId: Collection<String>): Set<BusinessPartner>
+
+    fun findByStageAndExternalIdIn(stage: StageType, externalId: Collection<String>, pageable: Pageable): Page<BusinessPartner>
+
+    fun findByStage(stage: StageType, pageable: Pageable): Page<BusinessPartner>
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -1,0 +1,243 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.service
+
+import org.eclipse.tractusx.bpdm.common.dto.AlternativePostalAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.model.StageType
+import org.eclipse.tractusx.bpdm.common.util.replace
+import org.eclipse.tractusx.bpdm.gate.api.model.*
+import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
+import org.eclipse.tractusx.bpdm.gate.entity.AlternativePostalAddress
+import org.eclipse.tractusx.bpdm.gate.entity.GeographicCoordinate
+import org.eclipse.tractusx.bpdm.gate.entity.PhysicalPostalAddress
+import org.eclipse.tractusx.bpdm.gate.entity.Street
+import org.eclipse.tractusx.bpdm.gate.entity.generic.*
+import org.springframework.stereotype.Service
+
+@Service
+class BusinessPartnerMappings {
+
+    fun toBusinessPartnerInputDto(entity: BusinessPartner): BusinessPartnerInputDto {
+        return BusinessPartnerInputDto(
+            externalId = entity.externalId,
+            nameParts = entity.nameParts,
+            shortName = entity.shortName,
+            legalForm = entity.legalForm,
+            identifiers = entity.identifiers.map(::toIdentifierDto),
+            states = entity.states.map(::toStateDto),
+            classifications = entity.classifications.map(::toClassificationDto),
+            roles = entity.roles,
+            postalAddress = toPostalAddressInputDto(entity.postalAddress),
+            isOwner = entity.isOwner ?: false,      // TODO should be mandatory in entity
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+
+    fun toBusinessPartnerOutputDto(entity: BusinessPartner): BusinessPartnerOutputDto {
+        return BusinessPartnerOutputDto(
+            externalId = entity.externalId,
+            nameParts = entity.nameParts,
+            shortName = entity.shortName,
+            legalForm = entity.legalForm,
+            identifiers = entity.identifiers.map(::toIdentifierDto),
+            states = entity.states.map(::toStateDto),
+            classifications = entity.classifications.map(::toClassificationDto),
+            roles = entity.roles,
+            postalAddress = toPostalAddressOutputDto(entity.postalAddress),
+            isOwner = entity.isOwner ?: false,      // TODO should be mandatory in entity
+            bpnl = entity.bpnL ?: throw NullPointerException("bpnL is null"),
+            bpns = entity.bpnS,
+            bpna = entity.bpnA ?: throw NullPointerException("bpnA is null"),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+
+    fun toBusinessPartner(dto: BusinessPartnerInputRequest, stage: StageType): BusinessPartner {
+        return BusinessPartner(
+            stage = stage,
+            externalId = dto.externalId,
+            nameParts = dto.nameParts.toMutableList(),
+            roles = dto.roles.toSortedSet(),
+            identifiers = dto.identifiers.map(::toIdentifier).toSortedSet(),
+            states = dto.states.map(::toState).toSortedSet(),
+            classifications = dto.classifications.map(::toClassification).toSortedSet(),
+            shortName = dto.shortName,
+            legalForm = dto.legalForm,
+            isOwner = dto.isOwner,
+            bpnL = null,
+            bpnS = null,
+            bpnA = null,
+            postalAddress = toPostalAddress(dto.postalAddress)
+        )
+    }
+
+    fun updateBusinessPartner(entity: BusinessPartner, dto: BusinessPartnerInputRequest) {
+        entity.nameParts.replace(dto.nameParts)
+        entity.roles.replace(dto.roles)
+        entity.identifiers.replace(dto.identifiers.map(::toIdentifier))
+        entity.states.replace(dto.states.map(::toState))
+        entity.classifications.replace(dto.classifications.map(::toClassification))
+        entity.shortName = dto.shortName
+        entity.legalForm = dto.legalForm
+        entity.isOwner = dto.isOwner
+        updatePostalAddress(entity.postalAddress, dto.postalAddress)
+    }
+
+    private fun toPostalAddressInputDto(entity: PostalAddress) =
+        BusinessPartnerPostalAddressInputDto(
+            addressType = entity.addressType,
+            physicalPostalAddress = entity.physicalPostalAddress.let(::toPhysicalPostalAddressDto),
+            alternativePostalAddress = entity.alternativePostalAddress?.let(::toAlternativePostalAddressDto)
+        )
+
+    private fun toPostalAddressOutputDto(entity: PostalAddress) =
+        BusinessPartnerPostalAddressOutputDto(
+            addressType = entity.addressType,
+            physicalPostalAddress = entity.physicalPostalAddress.let(::toPhysicalPostalAddressDto),
+            alternativePostalAddress = entity.alternativePostalAddress?.let(::toAlternativePostalAddressDto)
+        )
+
+    private fun toPostalAddress(dto: BusinessPartnerPostalAddressInputDto) =
+        PostalAddress(
+            addressType = dto.addressType ?: AddressType.AdditionalAddress,     // TODO should be optional in entity
+            physicalPostalAddress = dto.physicalPostalAddress.let(::toPhysicalPostalAddress),
+            alternativePostalAddress = dto.alternativePostalAddress?.let(::toAlternativePostalAddress)
+        )
+
+    private fun updatePostalAddress(entity: PostalAddress, dto: BusinessPartnerPostalAddressInputDto) {
+        entity.addressType = dto.addressType ?: AddressType.AdditionalAddress
+        entity.physicalPostalAddress = dto.physicalPostalAddress.let(::toPhysicalPostalAddress)
+        entity.alternativePostalAddress = dto.alternativePostalAddress?.let(::toAlternativePostalAddress)
+    }
+
+    private fun toPhysicalPostalAddressDto(entity: PhysicalPostalAddress) =
+        PhysicalPostalAddressGateDto(
+            geographicCoordinates = entity.geographicCoordinates?.let(::toGeoCoordinateDto),
+            country = entity.country,
+            administrativeAreaLevel1 = entity.administrativeAreaLevel1,
+            administrativeAreaLevel2 = entity.administrativeAreaLevel2,
+            administrativeAreaLevel3 = entity.administrativeAreaLevel3,
+            postalCode = entity.postalCode,
+            city = entity.city,
+            district = entity.district,
+            street = entity.street?.let(::toStreetDto),
+            companyPostalCode = entity.companyPostalCode,
+            industrialZone = entity.industrialZone,
+            building = entity.building,
+            floor = entity.floor,
+            door = entity.door
+        )
+
+    private fun toPhysicalPostalAddress(dto: PhysicalPostalAddressGateDto) =
+        PhysicalPostalAddress(
+            geographicCoordinates = dto.geographicCoordinates?.let(::toGeographicCoordinate),
+            country = dto.country,
+            administrativeAreaLevel1 = dto.administrativeAreaLevel1,
+            administrativeAreaLevel2 = dto.administrativeAreaLevel2,
+            administrativeAreaLevel3 = dto.administrativeAreaLevel3,
+            postalCode = dto.postalCode,
+            city = dto.city,
+            district = dto.district,
+            street = dto.street?.let(::toStreet),
+            companyPostalCode = dto.companyPostalCode,
+            industrialZone = dto.industrialZone,
+            building = dto.building,
+            floor = dto.floor,
+            door = dto.door
+        )
+
+    private fun toAlternativePostalAddressDto(entity: AlternativePostalAddress) =
+        AlternativePostalAddressDto(
+            geographicCoordinates = entity.geographicCoordinates?.let(::toGeoCoordinateDto),
+            country = entity.country,
+            administrativeAreaLevel1 = entity.administrativeAreaLevel1,
+            postalCode = entity.postalCode,
+            city = entity.city,
+            deliveryServiceType = entity.deliveryServiceType,
+            deliveryServiceQualifier = entity.deliveryServiceQualifier,
+            deliveryServiceNumber = entity.deliveryServiceNumber
+        )
+
+    private fun toAlternativePostalAddress(dto: AlternativePostalAddressDto) =
+        AlternativePostalAddress(
+            geographicCoordinates = dto.geographicCoordinates?.let(::toGeographicCoordinate),
+            country = dto.country,
+            administrativeAreaLevel1 = dto.administrativeAreaLevel1,
+            postalCode = dto.postalCode,
+            city = dto.city,
+            deliveryServiceType = dto.deliveryServiceType,
+            deliveryServiceQualifier = dto.deliveryServiceQualifier,
+            deliveryServiceNumber = dto.deliveryServiceNumber
+        )
+
+    private fun toStreetDto(entity: Street) =
+        StreetGateDto(
+            name = entity.name,
+            houseNumber = entity.houseNumber,
+            milestone = entity.milestone,
+            direction = entity.direction,
+            namePrefix = entity.namePrefix,
+            additionalNamePrefix = entity.additionalNamePrefix,
+            nameSuffix = entity.nameSuffix,
+            additionalNameSuffix = entity.additionalNameSuffix
+        )
+
+    private fun toStreet(dto: StreetGateDto) =
+        Street(
+            name = dto.name,
+            houseNumber = dto.houseNumber,
+            milestone = dto.milestone,
+            direction = dto.direction,
+            namePrefix = dto.namePrefix,
+            additionalNamePrefix = dto.additionalNamePrefix,
+            nameSuffix = dto.nameSuffix,
+            additionalNameSuffix = dto.additionalNameSuffix
+        )
+
+    private fun toIdentifierDto(entity: Identifier) =
+        BusinessPartnerIdentifierDto(type = entity.type, value = entity.value, issuingBody = entity.issuingBody)
+
+    private fun toIdentifier(dto: BusinessPartnerIdentifierDto) =
+        Identifier(type = dto.type, value = dto.value, issuingBody = dto.issuingBody)
+
+    private fun toStateDto(entity: State) =
+        BusinessPartnerStateDto(type = entity.type, validFrom = entity.validFrom, validTo = entity.validTo, description = entity.description)
+
+    private fun toState(dto: BusinessPartnerStateDto) =
+        State(type = dto.type, validFrom = dto.validFrom, validTo = dto.validTo, description = dto.description)
+
+    private fun toClassificationDto(entity: Classification) =
+        ClassificationDto(type = entity.type, code = entity.code, value = entity.value)
+
+    private fun toClassification(dto: ClassificationDto) =
+        Classification(type = dto.type, code = dto.code, value = dto.value)
+
+    private fun toGeoCoordinateDto(entity: GeographicCoordinate) =
+        GeoCoordinateDto(latitude = entity.latitude, longitude = entity.longitude, altitude = entity.altitude)
+
+    private fun toGeographicCoordinate(dto: GeoCoordinateDto) =
+        GeographicCoordinate(latitude = dto.latitude, longitude = dto.longitude, altitude = dto.altitude)
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.service
+
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
+import org.eclipse.tractusx.bpdm.common.model.StageType
+import org.eclipse.tractusx.bpdm.common.service.toPageDto
+import org.eclipse.tractusx.bpdm.gate.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.gate.api.model.IBaseBusinessPartnerDto
+import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
+import org.eclipse.tractusx.bpdm.gate.entity.ChangelogEntry
+import org.eclipse.tractusx.bpdm.gate.entity.generic.BusinessPartner
+import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository
+import org.eclipse.tractusx.bpdm.gate.repository.generic.BusinessPartnerRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class BusinessPartnerService(
+    private val businessPartnerRepository: BusinessPartnerRepository,
+    private val businessPartnerMappings: BusinessPartnerMappings,
+    private val sharingStateService: SharingStateService,
+    private val changelogRepository: ChangelogRepository
+) {
+
+    @Transactional
+    fun upsertBusinessPartnersInput(dtos: Collection<BusinessPartnerInputRequest>): Collection<BusinessPartnerInputDto> {
+        val existingEntitiesByExternalId = getExistingEntityByExternalId(dtos, StageType.Input)
+
+        val savedEntities = dtos.map { dto ->
+            existingEntitiesByExternalId[dto.externalId]
+                ?.let { existingEntity -> updateBusinessPartnerInput(existingEntity, dto) }
+                ?: run { insertBusinessPartnerInput(dto) }
+        }
+
+        return savedEntities.map(businessPartnerMappings::toBusinessPartnerInputDto)
+    }
+
+    private fun insertBusinessPartnerInput(dto: BusinessPartnerInputRequest): BusinessPartner {
+        val newEntity = businessPartnerMappings.toBusinessPartner(dto, StageType.Input)
+        return businessPartnerRepository.save(newEntity)
+            .also {
+                saveChangelog(dto.externalId, ChangelogType.CREATE, StageType.Input)
+                initSharingState(dto)
+            }
+    }
+
+    private fun updateBusinessPartnerInput(existingEntity: BusinessPartner, dto: BusinessPartnerInputRequest): BusinessPartner {
+        businessPartnerMappings.updateBusinessPartner(existingEntity, dto)
+        return businessPartnerRepository.save(existingEntity)
+            .also {
+                saveChangelog(dto.externalId, ChangelogType.UPDATE, StageType.Input)
+            }
+    }
+
+    fun getBusinessPartnersInput(pageRequest: PageRequest, externalIds: Collection<String>?): PageDto<BusinessPartnerInputDto> {
+        val stage = StageType.Input
+        val page = when {
+            externalIds.isNullOrEmpty() -> businessPartnerRepository.findByStage(stage, pageRequest)
+            else -> businessPartnerRepository.findByStageAndExternalIdIn(stage, externalIds, pageRequest)
+        }
+        return page.toPageDto(businessPartnerMappings::toBusinessPartnerInputDto)
+    }
+
+    fun getBusinessPartnersOutput(pageRequest: PageRequest, externalIds: Collection<String>?): PageDto<BusinessPartnerOutputDto> {
+        val stage = StageType.Output
+        val page = when {
+            externalIds.isNullOrEmpty() -> businessPartnerRepository.findByStage(stage, pageRequest)
+            else -> businessPartnerRepository.findByStageAndExternalIdIn(stage, externalIds, pageRequest)
+        }
+        return page.toPageDto(businessPartnerMappings::toBusinessPartnerOutputDto)
+    }
+
+    private fun getExistingEntityByExternalId(
+        dtos: Collection<IBaseBusinessPartnerDto>,
+        stage: StageType
+    ): Map<String, BusinessPartner> {
+        val externalIds = dtos.map { it.externalId }.toSet()
+        return businessPartnerRepository.findByStageAndExternalIdIn(stage, externalIds)
+            .associateBy { it.externalId }
+    }
+
+    private fun initSharingState(dto: IBaseBusinessPartnerDto) {
+        // TODO make businessPartnerType optional
+        sharingStateService.upsertSharingState(SharingStateDto(BusinessPartnerType.ADDRESS, dto.externalId))
+    }
+
+    private fun saveChangelog(externalId: String, changelogType: ChangelogType, stage: StageType) {
+        // TODO make businessPartnerType optional
+        changelogRepository.save(ChangelogEntry(externalId, BusinessPartnerType.ADDRESS, changelogType, stage))
+    }
+}


### PR DESCRIPTION
This implements the logic for persisting generic business partners and querying for existing BPs (stage input and output). This involves mapping between DTO and entity model. Some small changes to the DTO model were needed.

Solves #456