### PR TITLE
Fix: Generic business partner entity fields in Gate

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
@@ -62,16 +62,16 @@ class BusinessPartner(
     var legalForm: String?,
 
     @Column(name = "is_owner")
-    var isOwner: Boolean?,
+    var isOwner: Boolean,
 
-    @Column(name = "address_bpn")
-    var bpnA: String?,
-
-    @Column(name = "legal_entity_bpn")
+    @Column(name = "bpnl")
     var bpnL: String?,
 
-    @Column(name = "site_bpn")
+    @Column(name = "bpns")
     var bpnS: String?,
+
+    @Column(name = "bpna")
+    var bpnA: String?,
 
     @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "postal_address_id", unique = true)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/PostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/PostalAddress.kt
@@ -31,7 +31,7 @@ class PostalAddress(
 
     @Column(name = "address_type")
     @Enumerated(EnumType.STRING)
-    var addressType: AddressType,
+    var addressType: AddressType?,
 
     @Embedded
     var physicalPostalAddress: PhysicalPostalAddress,

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_14__generic_data_model_changes.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_14__generic_data_model_changes.sql
@@ -1,0 +1,11 @@
+-- Make field mandatory
+alter table business_partners
+    alter column is_owner set not null;
+
+-- Rename columns to bnpl/bpns/bpna for consistency
+alter table business_partners
+    rename column legal_entity_bpn to bpnl;
+alter table business_partners
+    rename column site_bpn to bpns;
+alter table business_partners
+    rename column address_bpn to bpna;


### PR DESCRIPTION
Changes to entity model (including DB migration):
- Make BusinessPartner.isOwner mandatory
- Rename DB fields for BusinessPartner.bpnL/bpnS/bpnA
- Make PostalAddress.addressType optional

Fixes for #428