### PR TITLE
Fix: Mapping AddressType from Generic entity to Output DTO in Gate

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -115,7 +115,7 @@ class BusinessPartnerMappings {
 
     private fun toPostalAddressOutputDto(entity: PostalAddress) =
         BusinessPartnerPostalAddressOutputDto(
-            addressType = entity.addressType,
+            addressType = entity.addressType!!, //An entity of stage output is expected to have a non-null addressType
             physicalPostalAddress = entity.physicalPostalAddress.let(::toPhysicalPostalAddressDto),
             alternativePostalAddress = entity.alternativePostalAddress?.let(::toAlternativePostalAddressDto)
         )


### PR DESCRIPTION
## Description

This pull request fixes a bug in which an incorrect mapping between generic business partner entity and its output DTO leads to nullable/non-nullable type mismatch breaking the build of the Gate.

The culprit is the addressType field in the PostalAddress which is nullable in the entity and non-nullable in the output DTO. Since we always map from the output stage of entity to the output DTO we can expect the entity to have a non-null address type. Therefore, I casted the addressType field to non-null when assigning it to its output DTO counterpart.

## How to Test

Compile the BPDM Gate module and it should succeed without any errors.

Fixes #465 
