### PR TITLE
Feat: Add Orchestrator Helm chart to the existing BPDM Charts

### DIFF
--- a/.github/workflows/build-docker-all.yaml
+++ b/.github/workflows/build-docker-all.yaml
@@ -29,6 +29,7 @@ on:
       - bpdm-gate-api/**
       - bpdm-bridge-dummy/**
       - bpdm-cleaning-service-dummy/**
+      - bpdm-orchestrator/**
       - .github/workflows/**
     tags:
       - 'v*.*.*'

--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -56,5 +56,5 @@ jobs:
       # install the chart to the kind cluster and run helm test
       # define charts to test with the --charts parameter
       - name: Run chart-testing (install)
-        run: ct install --charts charts/bpdm,charts/bpdm/charts/bpdm-pool,charts/bpdm/charts/bpdm-gate,charts/bpdm/charts/bpdm-bridge-dummy,charts/bpdm/charts/bpdm-cleaning-service-dummy --config charts/config/chart-testing-config.yaml
+        run: ct install --charts charts/bpdm,charts/bpdm/charts/bpdm-pool,charts/bpdm/charts/bpdm-gate,charts/bpdm/charts/bpdm-bridge-dummy,charts/bpdm/charts/bpdm-cleaning-service-dummy,charts/bpdm/charts/bpdm-orchestrator --config charts/config/chart-testing-config.yaml
         if: ${{ env.CHART_CHANGED == 'true' }}

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the gate and pool applications
-version: 3.1.0-alpha.3
+version: 3.1.0-alpha.4
 appVersion: "4.1.0-alpha.3"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -48,6 +48,10 @@ dependencies:
     version: 1.0.0-alpha.2
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
+  - name: bpdm-orchestrator
+    version: 1.0.0-alpha.0
+    alias: bpdm-orchestrator
+    condition: bpdm-orchestrator.enabled
   - name: opensearch
     version: 2.12.2
     repository: https://opensearch-project.github.io/helm-charts/

--- a/charts/bpdm/charts/bpdm-orchestrator/.helmignore
+++ b/charts/bpdm/charts/bpdm-orchestrator/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Accept only values.yaml
+values-*.yaml
+values-*.yml

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
+
+## [1.0.0] - tbr
+
+### Added
+
+- Added new microservice deployment ( orchestrator )

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -1,0 +1,32 @@
+---
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+apiVersion: v2
+type: application
+name: bpdm-orchestrator
+appVersion: "4.1.0-alpha.3"
+version: 1.0.0-alpha.0
+description: A Helm chart for deploying the BPDM Orchestrator service
+home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
+sources:
+  - https://github.com/eclipse-tractusx/bpdm
+maintainers:
+  - name: Nico Koprowski
+  - name: Fabio D. Mota

--- a/charts/bpdm/charts/bpdm-orchestrator/LICENSE
+++ b/charts/bpdm/charts/bpdm-orchestrator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Catena-X
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/bpdm/charts/bpdm-orchestrator/README.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/README.md
@@ -1,0 +1,85 @@
+# BPDM Orchestrator Helm Chart
+
+This Helm Chart deploys the BPDM service to a Kubernetes environment.
+
+## Prerequisites
+
+* [Kubernetes Cluster](https://kubernetes.io)
+* [Helm](https://helm.sh/docs/)
+
+In an existing Kubernetes cluster the application can be deployed with the following command:
+
+```bash
+helm install release_name ./charts/bpdm-orchestrator --namespace your_namespace -f /path/to/my_release-values.yaml
+```
+
+This will install a new release of the BPDM Orchestrator Service in the given namespace.
+On default values this release deploys the latest image tagged as `main` from the repository's GitHub Container Registry.
+
+By giving your own values file you can configure the Helm deployment of the BPDM Orchestrator Service freely.
+In the following sections you can have a look at the most important configuration options.
+
+## Image Tag
+
+Per default, the Helm deployment references the latest BPDM Orchestrator Service release tagged as `main`.
+This tag follows the latest version of the Orchestrator Service and contains the newest features and bug fixes.
+You might want to switch to a more stable release tag instead for your deployment.
+In your values file you can overwrite the default tag:
+
+```yaml
+image:
+  tag: "latest"
+```
+
+## Profiles
+
+You can also activate Spring profiles in which the BPDM Orchestrator Service should be run.
+In case you want to run the Orchestrator Service with authorization enabled you can write the following:
+
+```yaml
+springProfiles:
+  - auth
+```
+
+## Ingress
+
+You can specify your own ingress configuration for the Helm deployment to make the BPDM Orchestrator Service available over Ingress.
+Note that you need to have the appropriate Ingress controller installed in your cluster first.
+For example, consider a Kubernetes cluster with an [Ingress-Nginx](https://kubernetes.github.io/ingress-nginx/) installed.
+An Ingress configuration for the Orchestrator Service deployment could somehow look like this:
+
+```yaml
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+  hosts:
+    - host: business-partners.your-domain.net
+      paths:
+        - path: /orchestrator
+          pathType: Prefix
+```
+
+## Orchestrator Service Configuration
+
+For the default deployment you already need to overwrite the configuration properties of the application.
+The Helm deployment comes with the ability to configure the BPDM Orchestrator Service application directly over the values file.
+This way you are able to overwrite any configuration property of the `application.properties` and `application-auth.properties` files.
+Consider that you would need to turn on `auth` profile first before overwriting any property in the corresponding properties file could take
+effect.
+
+Entries in the "applicationConfig" value are written directly to a configMap that is part of the Helm deployment.
+This can be a problem if you want to overwrite configuration properties with secrets.
+Therefore, you can specify secret configuration values in a different Helm value `applicationSecrets`.
+Content of this value is written in a Kubernetes secret instead.
+If you want to specify a keycloak client secret for example:
+
+```yaml
+applicationSecrets:
+  bpdm:
+    security:
+      credentials:
+        secret: your_client_secret
+```
+

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/NOTES.txt
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "bpdm.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "bpdm.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "bpdm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "bpdm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/_helpers.tpl
@@ -1,0 +1,130 @@
+{{/*
+Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bpdm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bpdm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bpdm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bpdm.labels" -}}
+helm.sh/chart: {{ include "bpdm.chart" . }}
+{{ include "bpdm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "bpdm-orchestrator.poolServiceName" -}}
+{{- $config := .Values.applicationConfig -}}
+{{- if and $config (not (empty $config.bpdm)) -}}
+    {{- $bpdm := $config.bpdm -}}
+    {{- if and $bpdm (not (empty $bpdm.pool)) -}}
+        {{- $pool := $bpdm.pool -}}
+        {{- if and $pool (not (empty (index $pool "base-url"))) -}}
+            {{- index $pool "base-url" -}}
+        {{- else -}}
+            {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
+    {{- end -}}
+{{- else -}}
+    {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "bpdm-orchestrator.gateServiceName" -}}
+{{- $config := .Values.applicationConfig -}}
+{{- if and $config (not (empty $config.bpdm)) -}}
+    {{- $bpdm := $config.bpdm -}}
+    {{- if and $bpdm (not (empty $bpdm.gate)) -}}
+        {{- $gate := $bpdm.gate -}}
+        {{- if and $gate (not (empty (index $gate "base-url"))) -}}
+            {{- index $gate "base-url" -}}
+        {{- else -}}
+            {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
+    {{- end -}}
+{{- else -}}
+    {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
+{{- end -}}
+{{- end }}
+
+
+
+{{/*
+Selector labels
+*/}}
+{{- define "bpdm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bpdm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create name of application secret
+*/}}
+{{- define "bpdm.applicationSecret.name" -}}
+{{- printf "%s-application" (include "bpdm.fullname" .) }}
+{{- end }}
+
+
+
+
+{{/*
+Invoke include on given definition with postgresql dependency context
+Usage: include "includeWithPostgresContext" (list $ "your_include_function_here")
+*/}}
+{{- define "includeWithPostgresContext" -}}
+{{- $ := index . 0 }}
+{{- $function := index . 1 }}
+{{- include $function (dict "Values" $.Values.postgres "Chart" (dict "Name" "postgres") "Release" $.Release) }}
+{{- end }}

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/configMap.yaml
@@ -1,0 +1,35 @@
+---
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{include "bpdm.fullname" .}}
+  labels:
+    {{- include "bpdm.labels" . | nindent 4}}
+data:
+  deployment.yml: |-
+    # Place for putting standard deployment configuration
+    # which can be overwritten by external.yml
+  external.yml: |-
+    # External properties for overwriting application config
+    {{- if .Values.applicationConfig }}
+    {{- .Values.applicationConfig | toYaml | nindent 4 }}
+    {{- end }}

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
@@ -1,0 +1,97 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "bpdm.fullname" .}}
+  labels:
+    {{- include "bpdm.labels" . | nindent 4}}
+spec:
+  {{- if not .Values.autoscaling.enabled}}
+  replicas: {{.Values.replicaCount}}
+  {{- end}}
+  selector:
+    matchLabels:
+      {{- include "bpdm.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations}}
+      annotations:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      labels:
+        {{- include "bpdm.selectorLabels" . | nindent 8}}
+    spec:
+      {{- with .Values.imagePullSecrets}}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      # @url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8}}
+      containers:
+        - name: {{.Chart.Name}}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12}}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: {{.Values.springProfiles | join ","  }}
+            - name: SPRING_CONFIG_IMPORT
+              value: "/etc/conf/deployment.yml,/etc/conf/external.yml,/etc/conf/secrets.yml"
+          ports:
+            - name: http
+              containerPort: 8085
+              protocol: TCP
+          # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12}}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12}}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+          volumeMounts:
+            - mountPath: /etc/conf
+              name: config
+              readOnly: true
+      {{- with .Values.nodeSelector}}
+      nodeSelector:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      {{- with .Values.affinity}}
+      affinity:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      {{- with .Values.tolerations}}
+      tolerations:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{include "bpdm.fullname" .}}
+              - secret:
+                  name: {{include "bpdm.fullname" .}}

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/ingress.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/ingress.yaml
@@ -1,0 +1,82 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ################################################################################
+
+  {{if .Values.ingress.enabled}}
+
+
+  {{- $fullName := include "bpdm.fullname" . -}}
+  {{- $svcPort := .Values.service.port -}}
+  {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion))}}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")}}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end}}
+  {{- end}}
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+  {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
+apiVersion: extensions/v1beta1
+  {{- end}}
+kind: Ingress
+metadata:
+  name: {{$fullName}}
+  labels:
+    {{- include "bpdm.labels" . | nindent 4}}
+  {{- with .Values.ingress.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)}}
+  ingressClassName: {{.Values.ingress.className}}
+  {{- end}}
+  {{- if .Values.ingress.tls}}
+  tls:
+    {{- range .Values.ingress.tls}}
+    - hosts:
+        {{- range .hosts}}
+        - {{. | quote}}
+        {{- end}}
+      secretName: {{.secretName}}
+    {{- end}}
+  {{- end}}
+  rules:
+    {{- range .Values.ingress.hosts}}
+    - host: {{.host | quote}}
+      http:
+        paths:
+          {{- range .paths}}
+          - path: {{.path}}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)}}
+            pathType: {{.pathType}}
+            {{- end}}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion}}
+              service:
+                name: {{$fullName}}
+                port:
+                  number: {{$svcPort}}
+              {{- else}}
+              serviceName: {{$fullName}}
+              servicePort: {{$svcPort}}
+              {{- end}}
+          {{- end}}
+    {{- end}}
+  {{- end}}

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/secret.yaml
@@ -1,0 +1,30 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{include "bpdm.fullname" .}}
+type: Opaque
+stringData:
+  secrets.yml: |-
+    # Secret properties for overwriting application config
+    {{- if .Values.applicationSecrets }}
+    {{- .Values.applicationSecrets | toYaml | nindent 4 }}
+    {{- end }}

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/service.yaml
@@ -1,0 +1,32 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "bpdm.fullname" .}}
+  labels:
+    {{- include "bpdm.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: {{.Values.service.targetPort}}
+  selector:
+    {{- include "bpdm.selectorLabels" . | nindent 4}}

--- a/charts/bpdm/charts/bpdm-orchestrator/values.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/values.yaml
@@ -25,7 +25,7 @@ replicaCount: 1
 
 image:
   registry: docker.io
-  repository: tractusx/bpdm-cleaning-service-dummy
+  repository: tractusx/bpdm-orchestrator
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -49,7 +49,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 8080
-  targetPort: 8084
+  targetPort: 8085
 
 autoscaling:
   enabled: false
@@ -62,11 +62,11 @@ ingress:
 
 resources:
   limits:
-    cpu: 500m
-    memory: 512Mi
+    cpu: 1000m
+    memory: 1Gi
   requests:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 200m
+    memory: 1Gi
 
 nodeSelector: {}
 
@@ -86,7 +86,7 @@ affinity:
 livenessProbe:
   httpGet:
     path: "/actuator/health/liveness"
-    port: 8084
+    port: 8085
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 5
@@ -96,7 +96,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: "/actuator/health/readiness"
-    port: 8084
+    port: 8085
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 5
@@ -106,7 +106,7 @@ readinessProbe:
 startupProbe:
   httpGet:
     path: "/actuator/health/readiness"
-    port: 8084
+    port: 8085
     scheme: HTTP
   initialDelaySeconds: 60
   failureThreshold: 20
@@ -116,13 +116,13 @@ startupProbe:
 # Used to overwrite the default property values of the application configuration
 applicationConfig:
 #  bpdm:
-#    pool:
-#      base-url: ...
+#    api:
+#      upsert-limit: ...
 
 # Used to overwrite the secret property values of the application configuration
 applicationSecrets:
 #  bpdm:
-#    saas:
-#     api-key: ...
+#    security:
+#     client-id: ...
 
 

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -23,6 +23,9 @@ bpdm-bridge-dummy:
 bpdm-cleaning-service-dummy:
   enabled: true
 
+bpdm-orchestrator:
+  enabled: true
+
 
 opensearch:
   masterService: ""


### PR DESCRIPTION
<!-- 

feat: Add new Helm Chart Structure for Orchestrator Service

-->

## Description

We added a new helm chart to the existing structure to be able to deploy the new Orchestrator service module.

issue: https://github.com/eclipse-tractusx/bpdm/issues/461

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
