### PR TITLE
Refactor: Simplify Gate/Pool API clients

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
@@ -46,7 +46,7 @@ class GateQueryService(
         val content = mutableListOf<ChangelogGateDto>()
 
         do {
-            val pageResponse = gateClient.changelog().getInputChangelog(
+            val pageResponse = gateClient.changelog.getInputChangelog(
                 searchRequest = ChangelogSearchRequest(timestampAfter = modifiedAfter),
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
             )
@@ -123,7 +123,7 @@ class GateQueryService(
         val content = mutableListOf<SharingStateDto>()
 
         do {
-            val pageResponse = gateClient.sharingState().getSharingStates(
+            val pageResponse = gateClient.sharingState.getSharingStates(
                 businessPartnerType = businessPartnerType,
                 externalIds = externalIds,
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
@@ -148,7 +148,7 @@ class GateQueryService(
         val validContent = mutableListOf<LegalEntityGateInputDto>()
 
         do {
-            val pageResponse = gateClient.legalEntities().getLegalEntitiesByExternalIds(
+            val pageResponse = gateClient.legalEntities.getLegalEntitiesByExternalIds(
                 externalIds = externalIds,
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
             )
@@ -169,7 +169,7 @@ class GateQueryService(
         val validContent = mutableListOf<SiteGateInputDto>()
 
         do {
-            val pageResponse = gateClient.sites().getSitesByExternalIds(
+            val pageResponse = gateClient.sites.getSitesByExternalIds(
                 externalIds = externalIds,
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
             )
@@ -190,7 +190,7 @@ class GateQueryService(
         val validContent = mutableListOf<AddressGateInputDto>()
 
         do {
-            val pageResponse = gateClient.addresses().getAddressesByExternalIds(
+            val pageResponse = gateClient.addresses.getAddressesByExternalIds(
                 externalIds = externalIds,
                 paginationRequest = PaginationRequest(page, bridgeConfigProperties.queryPageSize)
             )

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
@@ -260,22 +260,22 @@ class GateUpdateService(
 
     private fun putLegalEntityOutput(request: LegalEntityGateOutputRequest?) =
         request?.let {
-            gateClient.legalEntities().upsertLegalEntitiesOutput(listOf(it))
+            gateClient.legalEntities.upsertLegalEntitiesOutput(listOf(it))
         }
 
     private fun putSiteOutput(request: SiteGateOutputRequest?) =
         request?.let {
-            gateClient.sites().upsertSitesOutput(listOf(it))
+            gateClient.sites.upsertSitesOutput(listOf(it))
         }
 
     private fun putAddressOutput(request: AddressGateOutputRequest?) =
         request?.let {
-            gateClient.addresses().upsertAddressesOutput(listOf(it))
+            gateClient.addresses.upsertAddressesOutput(listOf(it))
         }
 
     private fun upsertSharingState(request: SharingStateDto?) =
         request?.let {
-            gateClient.sharingState().upsertSharingState(it)
+            gateClient.sharingState.upsertSharingState(it)
         }
 
 }

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -47,7 +47,7 @@ class PoolUpdateService(
             )
         }
 
-        return poolClient.legalEntities().createBusinessPartners(createRequests)
+        return poolClient.legalEntities.createBusinessPartners(createRequests)
             .also { logger.info { "Pool accepted ${it.entityCount} new legal entities, ${it.errorCount} were refused" } }
     }
 
@@ -61,7 +61,7 @@ class PoolUpdateService(
             )
         }
 
-        return poolClient.legalEntities().updateBusinessPartners(updateRequests)
+        return poolClient.legalEntities.updateBusinessPartners(updateRequests)
             .also { logger.info { "Pool accepted ${it.entityCount} updated legal entities, ${it.errorCount} were refused" } }
     }
 
@@ -90,7 +90,7 @@ class PoolUpdateService(
                         "because some parent BPN-L entries are missing!"
             }
         }
-        return poolClient.sites().createSite(createRequests)
+        return poolClient.sites.createSite(createRequests)
             .also { logger.info { "Pool accepted ${it.entityCount} new sites, ${it.errorCount} were refused" } }
     }
 
@@ -106,7 +106,7 @@ class PoolUpdateService(
             )
         }
 
-        return poolClient.sites().updateSite(updateRequests)
+        return poolClient.sites.updateSite(updateRequests)
             .also { logger.info { "Pool accepted ${it.entityCount} updated sites, ${it.errorCount} were refused" } }
     }
 
@@ -156,7 +156,7 @@ class PoolUpdateService(
                         "because some parent BPN-L/S entries are missing!"
             }
         }
-        return poolClient.addresses().createAddresses(createRequests)
+        return poolClient.addresses.createAddresses(createRequests)
             .also { logger.info { "Pool accepted ${it.entityCount} new addresses, ${it.errorCount} were refused" } }
     }
 
@@ -187,7 +187,7 @@ class PoolUpdateService(
             )
         }
 
-        return poolClient.addresses().updateAddresses(updateRequests)
+        return poolClient.addresses.updateAddresses(updateRequests)
             .also { logger.info { "Pool accepted ${it.entityCount} updated addresses, ${it.errorCount} were refused" } }
     }
 

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -162,14 +162,14 @@ class PoolUpdateService(
 
     private fun isSiteMainAddress(it: GateAddressInfo): Boolean {
 
-        val mainAdressExternalId = it.siteExternalId?.let { it1 -> gateQueryService.gateClient.sites().getSiteByExternalId(it1).mainAddress.externalId }
+        val mainAdressExternalId = it.siteExternalId?.let { it1 -> gateQueryService.gateClient.sites.getSiteByExternalId(it1).mainAddress.externalId }
         return it.externalId == mainAdressExternalId
     }
 
     private fun isLegalAddress(it: GateAddressInfo): Boolean {
 
         val legalAdressExternalId =
-            it.legalEntityExternalId?.let { it1 -> gateQueryService.gateClient.legalEntities().getLegalEntityByExternalId(it1).legalAddress.externalId }
+            it.legalEntityExternalId?.let { it1 -> gateQueryService.gateClient.legalEntities.getLegalEntityByExternalId(it1).legalAddress.externalId }
         return it.externalId == legalAdressExternalId
     }
 

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/BridgeSyncIT.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/BridgeSyncIT.kt
@@ -69,7 +69,7 @@ class BridgeSyncIT @Autowired constructor(
     @Test
     fun `just use API clients`() {
         assertGateChangelogHasCount(0)
-        val poolChangelogResponses = poolClient.changelogs().getChangelogEntries(
+        val poolChangelogResponses = poolClient.changelogs.getChangelogEntries(
             paginationRequest = DEFAULT_PAGINATION_REQUEST, changelogSearchRequest = ChangelogSearchRequest(timestampAfter = null, bpns = null)
         )
         assertThat(poolChangelogResponses.contentSize).isZero()
@@ -101,7 +101,7 @@ class BridgeSyncIT @Autowired constructor(
 
         val gateLegalEntityRequestByBpn = gateLegalEntityRequests.associateBy { bpnByExternalId[it.externalId]!! }
 
-        val poolLegalEntityResponses = poolClient.legalEntities().getLegalEntities(
+        val poolLegalEntityResponses = poolClient.legalEntities.getLegalEntities(
             bpSearchRequest = LegalEntityPropertiesSearchRequest.EmptySearchRequest,
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         )
@@ -150,7 +150,7 @@ class BridgeSyncIT @Autowired constructor(
 
         val gateSiteRequestsByBpn = gateSiteRequests.associateBy { bpnByExternalId[it.externalId]!! }
 
-        val poolSiteResponses = poolClient.sites().searchSites(
+        val poolSiteResponses = poolClient.sites.searchSites(
             siteSearchRequest = SiteBpnSearchRequest(sites = gateSiteRequestsByBpn.keys),
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         )
@@ -201,7 +201,7 @@ class BridgeSyncIT @Autowired constructor(
 
         val gateAddressRequestsByBpn = gateAddressRequests.associateBy { bpnByExternalId[it.externalId]!! }
 
-        val poolAddressResponses = poolClient.addresses().searchAddresses(
+        val poolAddressResponses = poolClient.addresses.searchAddresses(
             addressSearchRequest = AddressPartnerBpnSearchRequest(addresses = gateAddressRequestsByBpn.keys),
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         )
@@ -298,7 +298,7 @@ class BridgeSyncIT @Autowired constructor(
         val bpnByExternalId = buildBpnByExternalIdMap(sharingStatesOkay)
         val gateSiteRequestsByBpn = gateSiteRequests.associateBy { bpnByExternalId[it.externalId]!! }
 
-        val poolSiteResponses = poolClient.sites().searchSites(
+        val poolSiteResponses = poolClient.sites.searchSites(
             siteSearchRequest = SiteBpnSearchRequest(sites = gateSiteRequestsByBpn.keys),
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         )
@@ -318,7 +318,7 @@ class BridgeSyncIT @Autowired constructor(
         )
         gateClient.sites.upsertSites(listOf(siteRquestUpdate))
         bridgeClient.bridge().triggerSync()
-        val poolSiteUpdateResponses = poolClient.sites().searchSites(
+        val poolSiteUpdateResponses = poolClient.sites.searchSites(
             siteSearchRequest = SiteBpnSearchRequest(sites = gateSiteRequestsByBpn.keys),
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         )
@@ -364,7 +364,7 @@ class BridgeSyncIT @Autowired constructor(
         val bpnByExternalId = buildBpnByExternalIdMap(readSuccessfulSharingStatesWithBpn())
         val gateAddressRequestsByBpn = gateAddressRequests.associateBy { bpnByExternalId[it.externalId]!! }
 
-        val poolAddressResponses = poolClient.addresses().searchAddresses(
+        val poolAddressResponses = poolClient.addresses.searchAddresses(
             addressSearchRequest = AddressPartnerBpnSearchRequest(addresses = gateAddressRequestsByBpn.keys),
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         ).content
@@ -385,7 +385,7 @@ class BridgeSyncIT @Autowired constructor(
             )
         gateClient.addresses.upsertAddresses(listOf(addressRequestUpdate))
         bridgeClient.bridge().triggerSync()
-        val poolAddressUpdateResponses = poolClient.addresses().searchAddresses(
+        val poolAddressUpdateResponses = poolClient.addresses.searchAddresses(
             addressSearchRequest = AddressPartnerBpnSearchRequest(addresses = gateAddressRequestsByBpn.keys),
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         ).content
@@ -402,7 +402,7 @@ class BridgeSyncIT @Autowired constructor(
     }
 
     private fun allLegalEntitiesFromPool(): Collection<LegalEntityMatchVerboseDto> {
-        val poolLegalEntityResponses = poolClient.legalEntities().getLegalEntities(
+        val poolLegalEntityResponses = poolClient.legalEntities.getLegalEntities(
             bpSearchRequest = LegalEntityPropertiesSearchRequest.EmptySearchRequest,
             paginationRequest = DEFAULT_PAGINATION_REQUEST
         )
@@ -424,7 +424,7 @@ class BridgeSyncIT @Autowired constructor(
     }
 
     private fun assertPoolChangelogHasCount(changelogCount: Int) {
-        val poolChangelogResponses = poolClient.changelogs().getChangelogEntries(
+        val poolChangelogResponses = poolClient.changelogs.getChangelogEntries(
             paginationRequest = DEFAULT_PAGINATION_REQUEST,
             changelogSearchRequest = ChangelogSearchRequest(timestampAfter = null, bpns = null)
 

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/BridgeSyncIT.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/BridgeSyncIT.kt
@@ -83,7 +83,7 @@ class BridgeSyncIT @Autowired constructor(
             GateRequestValues.legalEntityGateInputRequest2,
             GateRequestValues.legalEntityGateInputRequest3
         )
-        gateClient.legalEntities().upsertLegalEntities(gateLegalEntityRequests)
+        gateClient.legalEntities.upsertLegalEntities(gateLegalEntityRequests)
 
         assertGateChangelogHasCount(3 + 3)  // 3 LEs + 3 addresses
         assertThat(readSuccessfulSharingStatesWithBpn().size).isEqualTo(0)
@@ -126,13 +126,13 @@ class BridgeSyncIT @Autowired constructor(
             GateRequestValues.legalEntityGateInputRequest2,
             GateRequestValues.legalEntityGateInputRequest3
         )
-        gateClient.legalEntities().upsertLegalEntities(gateLegalEntityRequests)
+        gateClient.legalEntities.upsertLegalEntities(gateLegalEntityRequests)
 
         val gateSiteRequests = listOf(
             GateRequestValues.siteGateInputRequest1,
             GateRequestValues.siteGateInputRequest2
         )
-        gateClient.sites().upsertSites(gateSiteRequests)
+        gateClient.sites.upsertSites(gateSiteRequests)
 
         assertGateChangelogHasCount(3 + 2 + 3 + 2)   // 3 LEs + 2 sites + 3 le addresses + 2 site main addresses
         assertThat(readSuccessfulSharingStatesWithBpn().size).isEqualTo(0)
@@ -173,17 +173,17 @@ class BridgeSyncIT @Autowired constructor(
         val gateLegalEntityRequests = listOf(
             GateRequestValues.legalEntityGateInputRequest1,
         )
-        gateClient.legalEntities().upsertLegalEntities(gateLegalEntityRequests)
+        gateClient.legalEntities.upsertLegalEntities(gateLegalEntityRequests)
         val gateSiteRequests = listOf(
             GateRequestValues.siteGateInputRequest1,
         )
-        gateClient.sites().upsertSites(gateSiteRequests)
+        gateClient.sites.upsertSites(gateSiteRequests)
 
         val gateAddressRequests = listOf(
             addressGateInputRequest1,
             GateRequestValues.addressGateInputRequest2
         )
-        gateClient.addresses().upsertAddresses(gateAddressRequests)
+        gateClient.addresses.upsertAddresses(gateAddressRequests)
 
         assertGateChangelogHasCount(1 + 1 + 2 + 2)  // 1 LE + 1 site + 2 addresses
         assertThat(readSuccessfulSharingStatesWithBpn().size).isEqualTo(0)
@@ -225,7 +225,7 @@ class BridgeSyncIT @Autowired constructor(
             GateRequestValues.legalEntityGateInputRequest2,
             GateRequestValues.legalEntityGateInputRequest3
         )
-        gateClient.legalEntities().upsertLegalEntities(gateLegalEntityRequests)
+        gateClient.legalEntities.upsertLegalEntities(gateLegalEntityRequests)
         assertGateChangelogHasCount(3 + 3)
         // Action: Sync from Gate to Pool and BPN back to Gate
         bridgeClient.bridge().triggerSync()
@@ -249,7 +249,7 @@ class BridgeSyncIT @Autowired constructor(
                 ),
             ),
         )
-        gateClient.legalEntities().upsertLegalEntities(listOf(leRquestUpdate))
+        gateClient.legalEntities.upsertLegalEntities(listOf(leRquestUpdate))
         assertGateChangelogHasCount(4 + 4) // 3 insert + 1 update
         bridgeClient.bridge().triggerSync()
         assertPoolChangelogHasCount(4 + 4)
@@ -275,13 +275,13 @@ class BridgeSyncIT @Autowired constructor(
             GateRequestValues.legalEntityGateInputRequest2,
             GateRequestValues.legalEntityGateInputRequest3
         )
-        gateClient.legalEntities().upsertLegalEntities(gateLegalEntityRequests)
+        gateClient.legalEntities.upsertLegalEntities(gateLegalEntityRequests)
 
         val gateSiteRequests = listOf(
             GateRequestValues.siteGateInputRequest1,
             GateRequestValues.siteGateInputRequest2
         )
-        gateClient.sites().upsertSites(gateSiteRequests)
+        gateClient.sites.upsertSites(gateSiteRequests)
 
         assertGateChangelogHasCount(3 + 2 + 3 + 2)   // 3 LEs + 2 sites + 3 le addresses + 2 site main addresses
         assertThat(readSuccessfulSharingStatesWithBpn().size).isEqualTo(0)
@@ -316,7 +316,7 @@ class BridgeSyncIT @Autowired constructor(
                 ),
             )
         )
-        gateClient.sites().upsertSites(listOf(siteRquestUpdate))
+        gateClient.sites.upsertSites(listOf(siteRquestUpdate))
         bridgeClient.bridge().triggerSync()
         val poolSiteUpdateResponses = poolClient.sites().searchSites(
             siteSearchRequest = SiteBpnSearchRequest(sites = gateSiteRequestsByBpn.keys),
@@ -340,17 +340,17 @@ class BridgeSyncIT @Autowired constructor(
         val gateLegalEntityRequests = listOf(
             GateRequestValues.legalEntityGateInputRequest1,
         )
-        gateClient.legalEntities().upsertLegalEntities(gateLegalEntityRequests)
+        gateClient.legalEntities.upsertLegalEntities(gateLegalEntityRequests)
         val gateSiteRequests = listOf(
             GateRequestValues.siteGateInputRequest1,
         )
-        gateClient.sites().upsertSites(gateSiteRequests)
+        gateClient.sites.upsertSites(gateSiteRequests)
 
         val gateAddressRequests = listOf(
             addressGateInputRequest1,
             GateRequestValues.addressGateInputRequest2
         )
-        gateClient.addresses().upsertAddresses(gateAddressRequests)
+        gateClient.addresses.upsertAddresses(gateAddressRequests)
 
         assertGateChangelogHasCount(1 + 1 + 2 + 2)  // 1 LE + le address + 1 site + main address + 2 addresses
         assertThat(readSuccessfulSharingStatesWithBpn().size).isEqualTo(0)
@@ -383,7 +383,7 @@ class BridgeSyncIT @Autowired constructor(
             ),
 
             )
-        gateClient.addresses().upsertAddresses(listOf(addressRequestUpdate))
+        gateClient.addresses.upsertAddresses(listOf(addressRequestUpdate))
         bridgeClient.bridge().triggerSync()
         val poolAddressUpdateResponses = poolClient.addresses().searchAddresses(
             addressSearchRequest = AddressPartnerBpnSearchRequest(addresses = gateAddressRequestsByBpn.keys),
@@ -416,7 +416,7 @@ class BridgeSyncIT @Autowired constructor(
             .mapValues { it.value.bpn }
 
     private fun assertGateChangelogHasCount(changelogCount: Int) {
-        val gateChangelogResponses = gateClient.changelog().getInputChangelog(
+        val gateChangelogResponses = gateClient.changelog.getInputChangelog(
             paginationRequest = DEFAULT_PAGINATION_REQUEST,
             searchRequest = org.eclipse.tractusx.bpdm.gate.api.model.request.ChangelogSearchRequest(timestampAfter = null, businessPartnerTypes = emptySet())
         )
@@ -434,7 +434,7 @@ class BridgeSyncIT @Autowired constructor(
     }
 
     private fun readSuccessfulSharingStatesWithBpn(): List<SharingStateDto> {
-        val sharingStates = gateClient.sharingState().getSharingStates(
+        val sharingStates = gateClient.sharingState.getSharingStates(
             paginationRequest = DEFAULT_PAGINATION_REQUEST,
             businessPartnerType = null,
             externalIds = null

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/TestHelpers.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/util/TestHelpers.kt
@@ -73,10 +73,10 @@ class TestHelpers(
         val identifierTypeDto4 =
             IdentifierTypeDto(CommonValues.identifierTypeTechnicalKey4, IdentifierBusinessPartnerType.LEGAL_ENTITY, CommonValues.identifierTypeName4)
 
-        poolClient.metadata().createIdentifierType(identifierTypeDto1)
-        poolClient.metadata().createIdentifierType(identifierTypeDto2)
-        poolClient.metadata().createIdentifierType(identifierTypeDto3)
-        poolClient.metadata().createIdentifierType(identifierTypeDto4)
+        poolClient.metadata.createIdentifierType(identifierTypeDto1)
+        poolClient.metadata.createIdentifierType(identifierTypeDto2)
+        poolClient.metadata.createIdentifierType(identifierTypeDto3)
+        poolClient.metadata.createIdentifierType(identifierTypeDto4)
 
         val legalForm1 = LegalFormRequest(
             technicalKey = CommonValues.legalFormTechnicalKey1,
@@ -89,7 +89,7 @@ class TestHelpers(
             abbreviation = CommonValues.legalFormAbbreviation2,
         )
 
-        poolClient.metadata().createLegalForm(legalForm1)
-        poolClient.metadata().createLegalForm(legalForm2)
+        poolClient.metadata.createLegalForm(legalForm1)
+        poolClient.metadata.createLegalForm(legalForm2)
     }
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/ParameterObjectArgumentResolver.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/ParameterObjectArgumentResolver.kt
@@ -64,6 +64,11 @@ import org.springframework.web.service.invoker.HttpRequestValues
 import org.springframework.web.service.invoker.HttpServiceArgumentResolver
 import kotlin.reflect.full.memberProperties
 
+/**
+ * This handles complex parameters with ParameterObject annotation in API controller methods, e.g. PaginationRequest.
+ * For executing an API call we want all the parameter-object's properties added to the request as individual query parameters.
+ * This doesn't work out of the box, so we added this HttpServiceArgumentResolver that can be added to HttpServiceProxyFactory.
+ */
 class ParameterObjectArgumentResolver : HttpServiceArgumentResolver {
     val conversionService = DefaultFormattingConversionService()
     override fun resolve(argument: Any?, parameter: MethodParameter, requestValues: HttpRequestValues.Builder): Boolean {
@@ -76,8 +81,8 @@ class ParameterObjectArgumentResolver : HttpServiceArgumentResolver {
                     is String -> propValue
                     else -> conversionService.convert(propValue, String::class.java)
                 }
-                if(propValue != null ){
-                    requestValues.addRequestParameter (propName, propValueString)
+                if (propValue != null) {
+                    requestValues.addRequestParameter(propName, propValueString)
                 }
             }
             return true

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClient.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClient.kt
@@ -23,16 +23,15 @@ import org.eclipse.tractusx.bpdm.gate.api.*
 
 interface GateClient {
 
-    fun businessParters(): GateBusinessPartnerApi
+    val businessParters: GateBusinessPartnerApi
 
-    fun addresses(): GateAddressApi
+    val addresses: GateAddressApi
 
-    fun legalEntities(): GateLegalEntityApi
+    val legalEntities: GateLegalEntityApi
 
-    fun sites(): GateSiteApi
+    val sites: GateSiteApi
 
-    fun changelog(): GateChangelogApi
+    val changelog: GateChangelogApi
 
-    fun sharingState(): GateSharingStateApi
-
+    val sharingState: GateSharingStateApi
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClientImpl.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClientImpl.kt
@@ -26,6 +26,12 @@ import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 import java.time.Duration
 
+/**
+ * In a Spring configuration a bean of this class is instantiated passing a webClientProvider which configures the web client with e.g. OIDC configuration.
+ * A lazy HttpServiceProxyFactory private property is defined: On first access it creates a HttpServiceProxyFactory configured with the web client.
+ * Several lazy API clients are defined: On first access they are created from the HttpServiceProxyFactory for the specific API interface.
+ * All this has to be done lazily because during integration tests the web client URL may not be available yet on Spring initialization.
+ */
 class GateClientImpl(
     private val webClientProvider: () -> WebClient
 ) : GateClient {

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClientImpl.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/GateClientImpl.kt
@@ -38,26 +38,18 @@ class GateClientImpl(
             .build()
     }
 
-    private val gateClientBusinessPartner by lazy { httpServiceProxyFactory.createClient(GateBusinessPartnerApi::class.java) }
-    private val gateClientAddress by lazy { httpServiceProxyFactory.createClient(GateAddressApi::class.java) }
-    private val gateClientLegalEntity by lazy { httpServiceProxyFactory.createClient(GateLegalEntityApi::class.java) }
-    private val gateClientSite by lazy { httpServiceProxyFactory.createClient(GateSiteApi::class.java) }
-    private val gateClientChangelog by lazy { httpServiceProxyFactory.createClient(GateChangelogApi::class.java) }
-    private val gateClientSharingState by lazy { httpServiceProxyFactory.createClient(GateSharingStateApi::class.java) }
+    override val businessParters by lazy { createClient<GateBusinessPartnerApi>() }
 
-    override fun businessParters() = gateClientBusinessPartner
+    override val addresses by lazy { createClient<GateAddressApi>() }
 
-    override fun addresses() = gateClientAddress
+    override val legalEntities by lazy { createClient<GateLegalEntityApi>() }
 
-    override fun legalEntities() = gateClientLegalEntity
+    override val sites by lazy { createClient<GateSiteApi>() }
 
-    override fun sites() = gateClientSite
+    override val changelog by lazy { createClient<GateChangelogApi>() }
 
-    override fun changelog() = gateClientChangelog
+    override val sharingState by lazy { createClient<GateSharingStateApi>() }
 
-    override fun sharingState() = gateClientSharingState
-
+    private inline fun <reified T> createClient() =
+        httpServiceProxyFactory.createClient(T::class.java)
 }
-
-
-

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangeLogControllerIT.kt
@@ -101,7 +101,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangelogSearchRequest(externalIds = setOf(CommonValues.externalIdAddress1))
 
-        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog.getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content)
             .ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
@@ -119,7 +119,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangelogSearchRequest(externalIds = setOf("NONEXIST"))
 
-        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog.getInputChangelog(PaginationRequest(), searchRequest)
 
         assertThat(searchResult.content)
             .usingRecursiveComparison()
@@ -154,7 +154,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangelogSearchRequest(externalIds = setOf(CommonValues.externalIdAddress1), timestampAfter = instant)
 
-        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog.getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
             .isEqualTo(listOf(ChangelogGateDto(CommonValues.externalIdAddress1, businessPartnerTypeParamAddress, instant, ChangelogType.CREATE)))
@@ -170,7 +170,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangelogSearchRequest(businessPartnerTypes = setOf(businessPartnerTypeParamAddress))
 
-        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog.getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
             .isEqualTo(
@@ -191,7 +191,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
     fun `get changeLog by businessPartnerType not found`() {
         val searchRequest = ChangelogSearchRequest(businessPartnerTypes = setOf(businessPartnerTypeParamNotFound))
 
-        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog.getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content)
             .isEqualTo(emptyList<ChangelogEntry>())
@@ -206,7 +206,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
     fun `get changeLog by businessPartnerType and timeStamp`() {
         val searchRequest = ChangelogSearchRequest(businessPartnerTypes = setOf(businessPartnerTypeParamAddress), timestampAfter = instant)
 
-        val searchResult = gateClient.changelog().getInputChangelog(PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog.getInputChangelog(PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
             .isEqualTo(
@@ -227,7 +227,7 @@ internal class ChangeLogControllerIT @Autowired constructor(
 
         val searchRequest = ChangelogSearchRequest(businessPartnerTypes = emptySet(), timestampAfter = instant)
 
-        val searchResult = gateClient.changelog().getInputChangelog(paginationRequest = PaginationRequest(), searchRequest)
+        val searchResult = gateClient.changelog.getInputChangelog(paginationRequest = PaginationRequest(), searchRequest)
 
         assertRecursively(searchResult.content).ignoringFieldsMatchingRegexes(".*${ChangelogGateDto::timestamp.name}")
             .isEqualTo(
@@ -261,8 +261,8 @@ internal class ChangeLogControllerIT @Autowired constructor(
             RequestValues.legalEntityGateInputRequest1
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntity)
-        gateClient.addresses().upsertAddresses(addresses)
+        gateClient.legalEntities.upsertLegalEntities(legalEntity)
+        gateClient.addresses.upsertAddresses(addresses)
     }
 
 }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerInputIT.kt
@@ -83,7 +83,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.OK, e.statusCode)
         }
@@ -129,7 +129,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -147,7 +147,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -167,8 +167,8 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
             RequestValues.legalEntityGateInputRequest1
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        val legalEntity = gateClient.legalEntities().getLegalEntityByExternalId(CommonValues.externalId1)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        val legalEntity = gateClient.legalEntities.getLegalEntityByExternalId(CommonValues.externalId1)
 
         assertThat(legalEntity).usingRecursiveComparison().ignoringCollectionOrder().ignoringAllOverriddenEquals()
             .ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*").isEqualTo(expectedLegalEntity)
@@ -184,7 +184,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
     fun `get legal entity by external id, not found`() {
 
         try {
-            gateClient.legalEntities().getLegalEntityByExternalId("nonexistent-externalid123")
+            gateClient.legalEntities.getLegalEntityByExternalId("nonexistent-externalid123")
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
         }
@@ -218,8 +218,8 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
 
 
         val paginationValue = PaginationRequest(page, size)
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        val pageResponse = gateClient.legalEntities().getLegalEntities(paginationValue)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        val pageResponse = gateClient.legalEntities.getLegalEntities(paginationValue)
 
         val expectedPage = PageDto(
             totalElements,
@@ -260,11 +260,11 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
         val contentSize = 2
 
         val paginationValue = PaginationRequest(page, size)
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
 
         val listExternalIds = legalEntities.map { it.externalId }
 
-        val pageResponse = gateClient.legalEntities().getLegalEntitiesByExternalIds(paginationValue, listExternalIds)
+        val pageResponse = gateClient.legalEntities.getLegalEntitiesByExternalIds(paginationValue, listExternalIds)
 
         val expectedPage = PageDto(
             totalElements,
@@ -289,7 +289,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
 
         try {
             val paginationValue = PaginationRequest(0, 999999)
-            gateClient.legalEntities().getLegalEntities(paginationValue)
+            gateClient.legalEntities.getLegalEntities(paginationValue)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -308,7 +308,7 @@ internal class LegalEntityControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.OK, e.statusCode)
         }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/LegalEntityControllerOutputIT.kt
@@ -87,8 +87,8 @@ internal class LegalEntityControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
-            gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
+            gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.OK, e.statusCode)
         }
@@ -115,7 +115,7 @@ internal class LegalEntityControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
+            gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -154,10 +154,10 @@ internal class LegalEntityControllerOutputIT @Autowired constructor(
 
         val paginationValue = PaginationRequest(page, size)
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
 
-        val pageResponse = gateClient.legalEntities().getLegalEntitiesOutput(paginationValue, emptyList())
+        val pageResponse = gateClient.legalEntities.getLegalEntitiesOutput(paginationValue, emptyList())
 
         val expectedPage = PageDto(
             totalElements,
@@ -204,10 +204,10 @@ internal class LegalEntityControllerOutputIT @Autowired constructor(
 
         val paginationValue = PaginationRequest(page, size)
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
 
-        val pageResponse = gateClient.legalEntities().getLegalEntitiesOutput(paginationValue, listOf(CommonValues.externalId1, CommonValues.externalId2))
+        val pageResponse = gateClient.legalEntities.getLegalEntitiesOutput(paginationValue, listOf(CommonValues.externalId1, CommonValues.externalId2))
 
         val expectedPage = PageDto(
             totalElements,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerInputIT.kt
@@ -104,11 +104,11 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
             RequestValues.addressGateInputRequest1
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntity)
-        gateClient.sites().upsertSites(site)
-        gateClient.addresses().upsertAddresses(addresses)
+        gateClient.legalEntities.upsertLegalEntities(legalEntity)
+        gateClient.sites.upsertSites(site)
+        gateClient.addresses.upsertAddresses(addresses)
 
-        val valueResponse = gateClient.addresses().getAddressByExternalId(externalIdToQuery)
+        val valueResponse = gateClient.addresses.getAddressByExternalId(externalIdToQuery)
 
         assertThat(valueResponse).usingRecursiveComparison().isEqualTo(expectedAddress)
     }
@@ -122,7 +122,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
     fun `get address by external id, not found`() {
 
         try {
-            gateClient.addresses().getAddressByExternalId("NONEXISTENT_BPN")
+            gateClient.addresses.getAddressByExternalId("NONEXISTENT_BPN")
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
         }
@@ -165,12 +165,12 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         val pageValue = 0
         val contentSize = 4
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntity)
-        gateClient.sites().upsertSites(site)
-        gateClient.addresses().upsertAddresses(addresses)
+        gateClient.legalEntities.upsertLegalEntities(legalEntity)
+        gateClient.sites.upsertSites(site)
+        gateClient.addresses.upsertAddresses(addresses)
 
         val paginationValue = PaginationRequest(page, size)
-        val pageResponse = gateClient.addresses().getAddresses(paginationValue)
+        val pageResponse = gateClient.addresses.getAddresses(paginationValue)
 
         val expectedPage = PageDto(
             totalElements = totalElements,
@@ -218,12 +218,12 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
 
         val listExternalIds = addresses.map { it.externalId }
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntity)
-        gateClient.sites().upsertSites(site)
-        gateClient.addresses().upsertAddresses(addresses)
+        gateClient.legalEntities.upsertLegalEntities(legalEntity)
+        gateClient.sites.upsertSites(site)
+        gateClient.addresses.upsertAddresses(addresses)
 
         val pagination = PaginationRequest(page, size)
-        val pageResponse = gateClient.addresses().getAddressesByExternalIds(pagination, listExternalIds)
+        val pageResponse = gateClient.addresses.getAddressesByExternalIds(pagination, listExternalIds)
 
         val expectedPage = PageDto(
             totalElements = totalElements,
@@ -248,7 +248,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         val paginationRequest = PaginationRequest(page, size)
 
         try {
-            gateClient.addresses().getAddresses(paginationRequest)
+            gateClient.addresses.getAddresses(paginationRequest)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -276,9 +276,9 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntity)
-            gateClient.sites().upsertSites(site)
-            gateClient.addresses().upsertAddresses(addresses)
+            gateClient.legalEntities.upsertLegalEntities(legalEntity)
+            gateClient.sites.upsertSites(site)
+            gateClient.addresses.upsertAddresses(addresses)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.OK, e.statusCode)
         }
@@ -304,7 +304,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().upsertAddresses(addresses)
+            gateClient.addresses.upsertAddresses(addresses)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -322,7 +322,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().upsertAddresses(addresses)
+            gateClient.addresses.upsertAddresses(addresses)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -340,7 +340,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().upsertAddresses(addresses)
+            gateClient.addresses.upsertAddresses(addresses)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -361,7 +361,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().upsertAddresses(addresses)
+            gateClient.addresses.upsertAddresses(addresses)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -382,7 +382,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().upsertAddresses(addresses)
+            gateClient.addresses.upsertAddresses(addresses)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -400,7 +400,7 @@ internal class PostalAddressControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().upsertAddresses(addresses)
+            gateClient.addresses.upsertAddresses(addresses)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PostalAddressControllerOutputIT.kt
@@ -121,14 +121,14 @@ internal class PostalAddressControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntity)
-            gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntityOutput)
+            gateClient.legalEntities.upsertLegalEntities(legalEntity)
+            gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntityOutput)
 
-            gateClient.sites().upsertSites(site)
-            gateClient.sites().upsertSitesOutput(siteOutput)
+            gateClient.sites.upsertSites(site)
+            gateClient.sites.upsertSitesOutput(siteOutput)
 
-            gateClient.addresses().upsertAddresses(addresses)
-            gateClient.addresses().upsertAddressesOutput(addressesOutput)
+            gateClient.addresses.upsertAddresses(addresses)
+            gateClient.addresses.upsertAddressesOutput(addressesOutput)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.OK, e.statusCode)
         }
@@ -154,7 +154,7 @@ internal class PostalAddressControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.addresses().upsertAddressesOutput(addresses)
+            gateClient.addresses.upsertAddressesOutput(addresses)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -180,10 +180,10 @@ internal class PostalAddressControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntity)
-            gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntityOutput)
+            gateClient.legalEntities.upsertLegalEntities(legalEntity)
+            gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntityOutput)
 
-            gateClient.addresses().upsertAddressesOutput(addresses)
+            gateClient.addresses.upsertAddressesOutput(addresses)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -238,18 +238,18 @@ internal class PostalAddressControllerOutputIT @Autowired constructor(
         val pageValue = 0
         val contentSize = 4
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntity)
-        gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntityOutput)
+        gateClient.legalEntities.upsertLegalEntities(legalEntity)
+        gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntityOutput)
 
-        gateClient.sites().upsertSites(site)
-        gateClient.sites().upsertSitesOutput(siteOutput)
+        gateClient.sites.upsertSites(site)
+        gateClient.sites.upsertSitesOutput(siteOutput)
 
-        gateClient.addresses().upsertAddresses(addresses)
-        gateClient.addresses().upsertAddressesOutput(addressesOutput)
+        gateClient.addresses.upsertAddresses(addresses)
+        gateClient.addresses.upsertAddressesOutput(addressesOutput)
 
 
         val paginationValue = PaginationRequest(page, size)
-        val pageResponse = gateClient.addresses().getAddressesOutput(paginationValue, emptyList())
+        val pageResponse = gateClient.addresses.getAddressesOutput(paginationValue, emptyList())
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*processStartedAt*", ".*identifiers*").isEqualTo(
             PageDto(
@@ -308,17 +308,17 @@ internal class PostalAddressControllerOutputIT @Autowired constructor(
         val pageValue = 0
         val contentSize = 2
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntity)
-        gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntityOutput)
+        gateClient.legalEntities.upsertLegalEntities(legalEntity)
+        gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntityOutput)
 
-        gateClient.sites().upsertSites(site)
-        gateClient.sites().upsertSitesOutput(siteOutput)
+        gateClient.sites.upsertSites(site)
+        gateClient.sites.upsertSitesOutput(siteOutput)
 
-        gateClient.addresses().upsertAddresses(addresses)
-        gateClient.addresses().upsertAddressesOutput(addressesOutput)
+        gateClient.addresses.upsertAddresses(addresses)
+        gateClient.addresses.upsertAddressesOutput(addressesOutput)
 
         val paginationValue = PaginationRequest(page, size)
-        val pageResponse = gateClient.addresses().getAddressesOutput(paginationValue, listOf(CommonValues.externalIdAddress1, CommonValues.externalIdAddress2))
+        val pageResponse = gateClient.addresses.getAddressesOutput(paginationValue, listOf(CommonValues.externalIdAddress1, CommonValues.externalIdAddress2))
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*processStartedAt*", ".*identifiers*").isEqualTo(
             PageDto(

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateControllerIT.kt
@@ -126,7 +126,7 @@ class SharingStateControllerIT @Autowired constructor(
             bpn = null
         )
 
-        gateClient.sharingState().upsertSharingState(updatedAddress1)
+        gateClient.sharingState.upsertSharingState(updatedAddress1)
 
         val readUpdatedAddress = readSharingStates(BusinessPartnerType.ADDRESS, "exIdAddress1")
         assertThat(readUpdatedAddress).hasSize(1)
@@ -150,7 +150,7 @@ class SharingStateControllerIT @Autowired constructor(
             sharingProcessStarted = null,
             sharingErrorMessage = "Changed",
         )
-        gateClient.sharingState().upsertSharingState(updatedWithEmpyStarted)
+        gateClient.sharingState.upsertSharingState(updatedWithEmpyStarted)
 
         val readUpdatedAddress = readSharingStates(BusinessPartnerType.ADDRESS, "exIdAddress1")
         assertThat(readUpdatedAddress.first().sharingStateType).isEqualTo(SharingStateType.Error)
@@ -173,7 +173,7 @@ class SharingStateControllerIT @Autowired constructor(
             sharingErrorMessage = null,
             bpn = null
         )
-        gateClient.sharingState().upsertSharingState(newState)
+        gateClient.sharingState.upsertSharingState(newState)
         return newState
     }
 
@@ -191,13 +191,13 @@ class SharingStateControllerIT @Autowired constructor(
             sharingErrorMessage = "Error in $businessPartnerType with external id $externalId",
             bpn = "BPN" + externalId
         )
-        gateClient.sharingState().upsertSharingState(newState)
+        gateClient.sharingState.upsertSharingState(newState)
         return newState
     }
 
     fun readSharingStates(businessPartnerType: BusinessPartnerType?, vararg externalIds: String): Collection<SharingStateDto> {
 
-        return gateClient.sharingState().getSharingStates(PaginationRequest(), businessPartnerType, externalIds.asList()).content
+        return gateClient.sharingState.getSharingStates(PaginationRequest(), businessPartnerType, externalIds.asList()).content
     }
 
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerInputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerInputIT.kt
@@ -80,10 +80,10 @@ internal class SiteControllerInputIT @Autowired constructor(
             RequestValues.siteGateInputRequest1
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        gateClient.sites().upsertSites(sites)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        gateClient.sites.upsertSites(sites)
 
-        val site = gateClient.sites().getSiteByExternalId(CommonValues.externalIdSite1)
+        val site = gateClient.sites.getSiteByExternalId(CommonValues.externalIdSite1)
 
         assertThat(site).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*").isEqualTo(expectedSite)
     }
@@ -97,7 +97,7 @@ internal class SiteControllerInputIT @Autowired constructor(
     fun `get site by external id, not found`() {
 
         try {
-            gateClient.sites().getSiteByExternalId("nonexistent-externalid123")
+            gateClient.sites.getSiteByExternalId("nonexistent-externalid123")
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
         }
@@ -135,11 +135,11 @@ internal class SiteControllerInputIT @Autowired constructor(
             RequestValues.siteGateInputRequest2
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        gateClient.sites().upsertSites(sites)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        gateClient.sites.upsertSites(sites)
 
         val paginationValue = PaginationRequest(page, size)
-        val pageResponse = gateClient.sites().getSites(paginationValue)
+        val pageResponse = gateClient.sites.getSites(paginationValue)
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*").isEqualTo(
             PageDto(
@@ -183,13 +183,13 @@ internal class SiteControllerInputIT @Autowired constructor(
             RequestValues.siteGateInputRequest2
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        gateClient.sites().upsertSites(sites)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        gateClient.sites.upsertSites(sites)
 
         val externalIds = sites.map { it.externalId }
 
         val paginationValue = PaginationRequest(page, size)
-        val pageResponse = gateClient.sites().getSitesByExternalIds(paginationValue, externalIds)
+        val pageResponse = gateClient.sites.getSitesByExternalIds(paginationValue, externalIds)
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*").isEqualTo(
             PageDto(
@@ -212,7 +212,7 @@ internal class SiteControllerInputIT @Autowired constructor(
         val paginationValue = PaginationRequest(0, 10)
 
         try {
-            gateClient.sites().getSites(paginationValue)
+            gateClient.sites.getSites(paginationValue)
         } catch (e: WebClientResponseException) {
             val statusCode: HttpStatusCode = e.statusCode
             val statusCodeValue: Int = statusCode.value()
@@ -231,7 +231,7 @@ internal class SiteControllerInputIT @Autowired constructor(
         val paginationValue = PaginationRequest(0, 999999)
 
         try {
-            gateClient.sites().getSites(paginationValue)
+            gateClient.sites.getSites(paginationValue)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -256,8 +256,8 @@ internal class SiteControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
-            gateClient.sites().upsertSites(sites)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
+            gateClient.sites.upsertSites(sites)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.OK, e.statusCode)
         }
@@ -288,8 +288,8 @@ internal class SiteControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
-            gateClient.sites().upsertSites(sites)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
+            gateClient.sites.upsertSites(sites)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -308,7 +308,7 @@ internal class SiteControllerInputIT @Autowired constructor(
         )
 
         try {
-            gateClient.sites().upsertSites(sites)
+            gateClient.sites.upsertSites(sites)
         } catch (e: WebClientResponseException) {
             assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
         }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerOutputIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SiteControllerOutputIT.kt
@@ -96,10 +96,10 @@ internal class SiteControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
-            gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
-            gateClient.sites().upsertSites(sites)
-            gateClient.sites().upsertSitesOutput(sitesOutput)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
+            gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
+            gateClient.sites.upsertSites(sites)
+            gateClient.sites.upsertSitesOutput(sitesOutput)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.OK, e.statusCode)
         }
@@ -136,9 +136,9 @@ internal class SiteControllerOutputIT @Autowired constructor(
         )
 
         try {
-            gateClient.legalEntities().upsertLegalEntities(legalEntities)
-            gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
-            gateClient.sites().upsertSitesOutput(sitesOutput)
+            gateClient.legalEntities.upsertLegalEntities(legalEntities)
+            gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
+            gateClient.sites.upsertSitesOutput(sitesOutput)
         } catch (e: WebClientResponseException) {
             Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
         }
@@ -185,13 +185,13 @@ internal class SiteControllerOutputIT @Autowired constructor(
             RequestValues.legalEntityGateOutputRequest2,
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
-        gateClient.sites().upsertSites(sites)
-        gateClient.sites().upsertSitesOutput(sitesOutput)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
+        gateClient.sites.upsertSites(sites)
+        gateClient.sites.upsertSitesOutput(sitesOutput)
 
         val paginationValue = PaginationRequest(page, size)
-        val pageResponse = gateClient.sites().getSitesOutput(paginationValue, emptyList())
+        val pageResponse = gateClient.sites.getSitesOutput(paginationValue, emptyList())
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*", ".*processStartedAt*").isEqualTo(
             PageDto(
@@ -244,13 +244,13 @@ internal class SiteControllerOutputIT @Autowired constructor(
             RequestValues.legalEntityGateOutputRequest2,
         )
 
-        gateClient.legalEntities().upsertLegalEntities(legalEntities)
-        gateClient.legalEntities().upsertLegalEntitiesOutput(legalEntitiesOutput)
-        gateClient.sites().upsertSites(sites)
-        gateClient.sites().upsertSitesOutput(sitesOutput)
+        gateClient.legalEntities.upsertLegalEntities(legalEntities)
+        gateClient.legalEntities.upsertLegalEntitiesOutput(legalEntitiesOutput)
+        gateClient.sites.upsertSites(sites)
+        gateClient.sites.upsertSitesOutput(sitesOutput)
 
         val paginationValue = PaginationRequest(page, size)
-        val pageResponse = gateClient.sites().getSitesOutput(paginationValue, listOf(CommonValues.externalIdSite1, CommonValues.externalIdSite2))
+        val pageResponse = gateClient.sites.getSitesOutput(paginationValue, listOf(CommonValues.externalIdSite1, CommonValues.externalIdSite2))
 
         assertThat(pageResponse).usingRecursiveComparison().ignoringFieldsMatchingRegexes(".*administrativeAreaLevel1*", ".*processStartedAt*").isEqualTo(
             PageDto(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolApiClient.kt
@@ -23,19 +23,19 @@ import org.eclipse.tractusx.bpdm.pool.api.*
 
 interface PoolApiClient {
 
-    fun addresses(): PoolAddressApi
+    val addresses: PoolAddressApi
 
-    fun bpns(): PoolBpnApi
+    val bpns: PoolBpnApi
 
-    fun changelogs(): PoolChangelogApi
+    val changelogs: PoolChangelogApi
 
-    fun legalEntities(): PoolLegalEntityApi
+    val legalEntities: PoolLegalEntityApi
 
-    fun metadata(): PoolMetadataApi
+    val metadata: PoolMetadataApi
 
-    fun sites(): PoolSiteApi
+    val sites: PoolSiteApi
 
-    fun opensearch(): PoolOpenSearchApi
+    val opensearch: PoolOpenSearchApi
 
-    fun saas(): PoolSaasApi
+    val saas: PoolSaasApi
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
@@ -26,10 +26,15 @@ import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 import java.time.Duration
 
+/**
+ * In a Spring configuration a bean of this class is instantiated passing a webClientProvider which configures the web client with e.g. OIDC configuration.
+ * A lazy HttpServiceProxyFactory private property is defined: On first access it creates a HttpServiceProxyFactory configured with the web client.
+ * Several lazy API clients are defined: On first access they are created from the HttpServiceProxyFactory for the specific API interface.
+ * All this has to be done lazily because during integration tests the web client URL may not be available yet on Spring initialization.
+ */
 class PoolClientImpl(
     private val webClientProvider: () -> WebClient
 ) : PoolApiClient {
-
 
     private val httpServiceProxyFactory: HttpServiceProxyFactory by lazy {
         HttpServiceProxyFactory

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
@@ -39,29 +39,22 @@ class PoolClientImpl(
             .build()
     }
 
+    override val addresses by lazy { createClient<PoolAddressApi>() }
 
-    private val poolClientAddress by lazy { httpServiceProxyFactory.createClient(PoolAddressApi::class.java) }
-    private val poolClientBpn by lazy { httpServiceProxyFactory.createClient(PoolBpnApi::class.java) }
-    private val poolClientChangelog by lazy { httpServiceProxyFactory.createClient(PoolChangelogApi::class.java) }
-    private val poolClientLegalEntity by lazy { httpServiceProxyFactory.createClient(PoolLegalEntityApi::class.java) }
-    private val poolClientMetadata by lazy { httpServiceProxyFactory.createClient(PoolMetadataApi::class.java) }
-    private val poolClientSite by lazy { httpServiceProxyFactory.createClient(PoolSiteApi::class.java) }
-    private val poolClientOpenSearch by lazy { httpServiceProxyFactory.createClient(PoolOpenSearchApi::class.java) }
-    private val poolClientSaas by lazy { httpServiceProxyFactory.createClient(PoolSaasApi::class.java) }
+    override val bpns by lazy { createClient<PoolBpnApi>() }
 
-    override fun addresses() = poolClientAddress
+    override val changelogs by lazy { createClient<PoolChangelogApi>() }
 
-    override fun bpns() = poolClientBpn
+    override val legalEntities by lazy { createClient<PoolLegalEntityApi>() }
 
-    override fun changelogs() = poolClientChangelog
+    override val metadata by lazy { createClient<PoolMetadataApi>() }
 
-    override fun legalEntities() = poolClientLegalEntity
+    override val sites by lazy { createClient<PoolSiteApi>() }
 
-    override fun metadata() = poolClientMetadata
+    override val opensearch by lazy { createClient<PoolOpenSearchApi>() }
 
-    override fun sites() = poolClientSite
+    override val saas by lazy { createClient<PoolSaasApi>() }
 
-    override fun opensearch() = poolClientOpenSearch
-
-    override fun saas() = poolClientSaas
+    private inline fun <reified T> createClient() =
+        httpServiceProxyFactory.createClient(T::class.java)
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/InvalidIndexStartupIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/InvalidIndexStartupIT.kt
@@ -113,7 +113,7 @@ class InvalidIndexStartupIT @Autowired constructor(
         //export to index and check whether the imported business partner can be found as normal
         testHelpers.startSyncAndAwaitSuccess(webTestClient, EndpointValues.OPENSEARCH_SYNC_PATH)
 
-        val searchResult = poolClient.legalEntities().getLegalEntities(
+        val searchResult = poolClient.legalEntities.getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
             PaginationRequest()
         )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/ValidIndexStartupIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/ValidIndexStartupIT.kt
@@ -61,7 +61,7 @@ class ValidIndexStartupIT @Autowired constructor(
         testHelpers.createTestMetadata()
         //Clear and set up a fresh valid OpenSearch context
         // webTestClient.invokeDeleteEndpointWithoutResponse(EndpointValues.OPENSEARCH_SYNC_PATH)
-        poolClient.opensearch().clear()
+        poolClient.opensearch.clear()
 
         //Import values to DB
         testHelpers.createBusinessPartnerStructure(
@@ -81,7 +81,7 @@ class ValidIndexStartupIT @Autowired constructor(
         //Export to OpenSearch index
         testHelpers.startSyncAndAwaitSuccess(webTestClient, EndpointValues.OPENSEARCH_SYNC_PATH)
         //Make sure entries are indeed there
-        val searchResult = poolClient.legalEntities().getLegalEntities(
+        val searchResult = poolClient.legalEntities.getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
             PaginationRequest()
         )
@@ -98,7 +98,7 @@ class ValidIndexStartupIT @Autowired constructor(
     @Order(1)
     fun acceptValidIndexOnStartup() {
 
-        val searchResult = poolClient.legalEntities().getLegalEntities(
+        val searchResult = poolClient.legalEntities.getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
             PaginationRequest()
         )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/component/opensearch/controller/OpenSearchControllerIT.kt
@@ -144,7 +144,7 @@ class OpenSearchControllerIT @Autowired constructor(
         assertSearchableByNames(names)
 
         //clear the index
-        poolClient.opensearch().clear()
+        poolClient.opensearch.clear()
 
         //check that the partners can really not be searched anymore
         names.forEach { assertThat(searchBusinessPartnerByName(it)).matches { it.contentSize == 0 } }
@@ -163,7 +163,7 @@ class OpenSearchControllerIT @Autowired constructor(
 
 
         //clear the index
-        poolClient.opensearch().clear()
+        poolClient.opensearch.clear()
 
 
         //export partners again
@@ -176,7 +176,7 @@ class OpenSearchControllerIT @Autowired constructor(
 
     private fun searchBusinessPartnerByName(name: String): PageDto<LegalEntityMatchVerboseDto> {
 
-        return poolClient.legalEntities().getLegalEntities(
+        return poolClient.legalEntities.getLegalEntities(
             LegalEntityPropertiesSearchRequest(name),
             PaginationRequest()
         )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
@@ -125,7 +125,7 @@ class AddressControllerIT @Autowired constructor(
 
         val searchRequest = AddressPartnerBpnSearchRequest(addresses = listOf(bpnA1, bpnA2))
         val searchResult =
-            poolClient.addresses().searchAddresses(searchRequest, PaginationRequest())
+            poolClient.addresses.searchAddresses(searchRequest, PaginationRequest())
 
         val expected = listOf(
             ResponseValues.addressPartner1,
@@ -158,7 +158,7 @@ class AddressControllerIT @Autowired constructor(
         val bpnL2 = createdStructures[1].legalEntity.legalEntity.bpnl
 
         val searchRequest = AddressPartnerBpnSearchRequest(legalEntities = listOf(bpnL2))
-        val searchResult = poolClient.addresses().searchAddresses(searchRequest, PaginationRequest())
+        val searchResult = poolClient.addresses.searchAddresses(searchRequest, PaginationRequest())
 
         val expected = listOf(
             ResponseValues.addressPartner2.copy(isLegalAddress = true),
@@ -203,7 +203,7 @@ class AddressControllerIT @Autowired constructor(
 
         // search for site1 -> main address and 2 regular addresses
         AddressPartnerBpnSearchRequest(sites = listOf(bpnS1))
-            .let { poolClient.addresses().searchAddresses(it, PaginationRequest()) }
+            .let { poolClient.addresses.searchAddresses(it, PaginationRequest()) }
             .let {
                 assertAddressesAreEqual(
                     it.content, listOf(
@@ -216,7 +216,7 @@ class AddressControllerIT @Autowired constructor(
 
         // search for site2 -> main address and 1 regular address
         AddressPartnerBpnSearchRequest(sites = listOf(bpnS2))       // search for site2
-            .let { poolClient.addresses().searchAddresses(it, PaginationRequest()) }
+            .let { poolClient.addresses.searchAddresses(it, PaginationRequest()) }
             .let {
                 assertAddressesAreEqual(
                     it.content, listOf(
@@ -228,7 +228,7 @@ class AddressControllerIT @Autowired constructor(
 
         // search for site1 and site2 -> 2 main addresses and 3 regular addresses
         AddressPartnerBpnSearchRequest(sites = listOf(bpnS2, bpnS1))    // search for site1 and site2
-            .let { poolClient.addresses().searchAddresses(it, PaginationRequest()) }
+            .let { poolClient.addresses.searchAddresses(it, PaginationRequest()) }
             .let {
                 assertAddressesAreEqual(
                     it.content, listOf(
@@ -276,7 +276,7 @@ class AddressControllerIT @Autowired constructor(
             RequestValues.addressPartnerCreate3.copy(bpnParent = bpnS)
         )
 
-        val response = poolClient.addresses().createAddresses(toCreate)
+        val response = poolClient.addresses.createAddresses(toCreate)
 
         assertCreatedAddressesAreEqual(response.entities, expected)
 //        response.entities.forEach { assertThat(it.address.bpn).matches(testHelpers.bpnAPattern) }
@@ -294,7 +294,7 @@ class AddressControllerIT @Autowired constructor(
     @Test
     fun `create new addresses and get duplicate error`() {
 
-        poolClient.metadata().createIdentifierType(
+        poolClient.metadata.createIdentifierType(
             IdentifierTypeDto(
                 technicalKey = addressIdentifier.type,
                 businessPartnerType = IdentifierBusinessPartnerType.ADDRESS, name = addressIdentifier.value
@@ -316,7 +316,7 @@ class AddressControllerIT @Autowired constructor(
         val toCreate = RequestValues.addressPartnerCreate5.copy(bpnParent = bpnL)
         val secondCreate = RequestValues.addressPartnerCreate5.copy(bpnParent = bpnL, index = CommonValues.index4)
 
-        val response = poolClient.addresses().createAddresses(listOf(toCreate, secondCreate))
+        val response = poolClient.addresses.createAddresses(listOf(toCreate, secondCreate))
 
 
         assertThat(response.errorCount).isEqualTo(2)
@@ -335,7 +335,7 @@ class AddressControllerIT @Autowired constructor(
     @Test
     fun `update address entities and get duplicate identifier error`() {
 
-        poolClient.metadata().createIdentifierType(
+        poolClient.metadata.createIdentifierType(
             IdentifierTypeDto(
                 technicalKey = addressIdentifier.type,
                 businessPartnerType = IdentifierBusinessPartnerType.ADDRESS, name = addressIdentifier.value
@@ -376,7 +376,7 @@ class AddressControllerIT @Autowired constructor(
             RequestValues.addressPartnerUpdate3.copy(bpna = bpnA1, address = RequestValues.logisticAddress5)
         )
 
-        val response = poolClient.addresses().updateAddresses(toUpdate)
+        val response = poolClient.addresses.updateAddresses(toUpdate)
 
         assertThat(response.errorCount).isEqualTo(3)
         assertThat(response.entityCount).isEqualTo(0)
@@ -393,7 +393,7 @@ class AddressControllerIT @Autowired constructor(
      */
     @Test
     fun `don't create addresses with non-existent parent`() {
-        val bpnL = poolClient.legalEntities().createBusinessPartners(listOf(RequestValues.legalEntityCreate1))
+        val bpnL = poolClient.legalEntities.createBusinessPartners(listOf(RequestValues.legalEntityCreate1))
             .entities.single().legalEntity.bpnl
 
         val expected = listOf(
@@ -415,7 +415,7 @@ class AddressControllerIT @Autowired constructor(
             RequestValues.addressPartnerCreate3.copy(bpnParent = completelyInvalidBpn),
         )
 
-        val response = poolClient.addresses().createAddresses(toCreate)
+        val response = poolClient.addresses.createAddresses(toCreate)
         assertCreatedAddressesAreEqual(response.entities, expected)
 //        response.entities.forEach { assertThat(it.address.bpn).matches(testHelpers.bpnAPattern) }
 //        testHelpers.assertRecursively(response.entities).ignoringFields(LogisticAddressResponse::bpn.name).isEqualTo(expected)
@@ -467,7 +467,7 @@ class AddressControllerIT @Autowired constructor(
             RequestValues.addressPartnerUpdate3.copy(bpna = bpnA1)
         )
 
-        val response = poolClient.addresses().updateAddresses(toUpdate)
+        val response = poolClient.addresses.updateAddresses(toUpdate)
 
         assertAddressesAreEqual(response.entities, expected)
         assertThat(response.errorCount).isEqualTo(0)
@@ -508,7 +508,7 @@ class AddressControllerIT @Autowired constructor(
             RequestValues.addressPartnerUpdate3.copy(bpna = secondInvalidBpn)
         )
 
-        val response = poolClient.addresses().updateAddresses(toUpdate)
+        val response = poolClient.addresses.updateAddresses(toUpdate)
 
         assertAddressesAreEqual(response.entities, expected)
 
@@ -541,9 +541,9 @@ class AddressControllerIT @Autowired constructor(
             .isEqualTo(expected)
     }
 
-    private fun requestAddress(bpnAddress: String) = poolClient.addresses().getAddress(bpnAddress)
+    private fun requestAddress(bpnAddress: String) = poolClient.addresses.getAddress(bpnAddress)
 
     private fun requestAddressesOfLegalEntity(bpn: String) =
-        poolClient.legalEntities().getAddresses(bpn, PaginationRequest())
+        poolClient.legalEntities.getAddresses(bpn, PaginationRequest())
 
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
@@ -83,7 +83,7 @@ class AddressControllerSearchIT @Autowired constructor(
     fun beforeEach() {
         testHelpers.truncateDbTables()
 
-        poolClient.opensearch().clear()
+        poolClient.opensearch.clear()
         testHelpers.createTestMetadata()
 
 
@@ -111,7 +111,7 @@ class AddressControllerSearchIT @Autowired constructor(
         val addressSearchRequest = AddressPartnerSearchRequest()
         addressSearchRequest.name = RequestValues.addressPartnerCreate4.address.name
 
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
+        val pageResponse = poolClient.addresses.getAddresses(addressSearchRequest, PaginationRequest())
 
         assertPageEquals(pageResponse, expected)
     }
@@ -131,7 +131,7 @@ class AddressControllerSearchIT @Autowired constructor(
         val addressSearchRequest = AddressPartnerSearchRequest()
         addressSearchRequest.name = "NONEXISTENT"
 
-        val pageResponse = poolClient.addresses().getAddresses(addressSearchRequest, PaginationRequest())
+        val pageResponse = poolClient.addresses.getAddresses(addressSearchRequest, PaginationRequest())
 
         assertPageEquals(pageResponse, expected)
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
@@ -85,7 +85,7 @@ class BpnControllerIT @Autowired constructor(
         val identifiersSearchRequest =
             IdentifiersSearchRequest(IdentifierBusinessPartnerType.LEGAL_ENTITY, identifierType, listOf(identifierValue1, identifierValue2))
 
-        val bpnIdentifierMappings = poolClient.bpns().findBpnsByIdentifiers(identifiersSearchRequest).body
+        val bpnIdentifierMappings = poolClient.bpns.findBpnsByIdentifiers(identifiersSearchRequest).body
 
         assertThat(bpnIdentifierMappings!!.map { it.idValue }).containsExactlyInAnyOrder(identifierValue1, identifierValue2)
     }
@@ -100,7 +100,7 @@ class BpnControllerIT @Autowired constructor(
         val identifiersSearchRequest =
             IdentifiersSearchRequest(IdentifierBusinessPartnerType.LEGAL_ENTITY, identifierType, listOf(identifierValue1, "someNonexistentSaasId"))
 
-        val bpnIdentifierMappings = poolClient.bpns().findBpnsByIdentifiers(identifiersSearchRequest).body
+        val bpnIdentifierMappings = poolClient.bpns.findBpnsByIdentifiers(identifiersSearchRequest).body
 
         assertThat(bpnIdentifierMappings!!.map { it.idValue }).containsExactlyInAnyOrder(identifierValue1)
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
@@ -78,7 +78,7 @@ class ChangelogControllerIT @Autowired constructor(
         val bpnA2 = createdStructures[1].legalEntity.legalAddress.bpna
 
 
-        poolClient.legalEntities().updateBusinessPartners(
+        poolClient.legalEntities.updateBusinessPartners(
             listOf(
                 RequestValues.legalEntityUpdate1.copy(bpnl = bpnL1),
                 RequestValues.legalEntityUpdate2.copy(bpnl = bpnL2)
@@ -101,7 +101,7 @@ class ChangelogControllerIT @Autowired constructor(
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
-        val actualChangelog = poolClient.changelogs().getChangelogEntries(
+        val actualChangelog = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(),
             PaginationRequest()
         )
@@ -137,7 +137,7 @@ class ChangelogControllerIT @Autowired constructor(
         val bpnMainAddress1 = createdStructures[0].siteStructures[0].site.mainAddress.bpna
         val bpnMainAddress2 = createdStructures[0].siteStructures[1].site.mainAddress.bpna
 
-        poolClient.sites().updateSite(
+        poolClient.sites.updateSite(
             listOf(
                 RequestValues.siteUpdate1.copy(bpns = bpnS1),
                 RequestValues.siteUpdate2.copy(bpns = bpnS2)
@@ -162,7 +162,7 @@ class ChangelogControllerIT @Autowired constructor(
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
-        val actualChangelog = poolClient.changelogs().getChangelogEntries(
+        val actualChangelog = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(),
             PaginationRequest()
         )
@@ -196,7 +196,7 @@ class ChangelogControllerIT @Autowired constructor(
         val bpnA1 = createdStructures[0].addresses[0].address.bpna
         val bpnA2 = createdStructures[0].siteStructures[0].addresses[0].address.bpna
 
-        poolClient.addresses().updateAddresses(
+        poolClient.addresses.updateAddresses(
             listOf(
                 RequestValues.addressPartnerUpdate1.copy(bpna = bpnA1),
                 RequestValues.addressPartnerUpdate2.copy(bpna = bpnA2)
@@ -221,7 +221,7 @@ class ChangelogControllerIT @Autowired constructor(
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
 
-        val actualChangelog = poolClient.changelogs().getChangelogEntries(
+        val actualChangelog = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(),
             PaginationRequest()
         )
@@ -266,12 +266,12 @@ class ChangelogControllerIT @Autowired constructor(
         val expectedSecondPage = PageDto(3, 2, 1, expectedEntriesSecondPage.size, expectedEntriesSecondPage)
 
 
-        val actualFirstPage = poolClient.changelogs().getChangelogEntries(
+        val actualFirstPage = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(businessPartnerTypes = setOf(BusinessPartnerType.LEGAL_ENTITY)),
             PaginationRequest(page = 0, size = 2)
         )
 
-        val actualSecondPage = poolClient.changelogs().getChangelogEntries(
+        val actualSecondPage = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(businessPartnerTypes = setOf(BusinessPartnerType.LEGAL_ENTITY)),
             PaginationRequest(page = 1, size = 2)
         )
@@ -325,15 +325,15 @@ class ChangelogControllerIT @Autowired constructor(
         val expectedAddressesPage = PageDto(expectedAddressEntries.size.toLong(), 1, 0, expectedAddressEntries.size, expectedAddressEntries)
 
 
-        val actualLegalEntityPage = poolClient.changelogs().getChangelogEntries(
+        val actualLegalEntityPage = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(businessPartnerTypes = setOf(BusinessPartnerType.LEGAL_ENTITY)),
             PaginationRequest()
         )
-        val actualSitePage = poolClient.changelogs().getChangelogEntries(
+        val actualSitePage = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(businessPartnerTypes = setOf(BusinessPartnerType.SITE)),
             PaginationRequest()
         )
-        val actualAddressPage = poolClient.changelogs().getChangelogEntries(
+        val actualAddressPage = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(businessPartnerTypes = setOf(BusinessPartnerType.ADDRESS)),
             PaginationRequest()
         )
@@ -374,7 +374,7 @@ class ChangelogControllerIT @Autowired constructor(
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
-        val actualChangelog = poolClient.changelogs().getChangelogEntries(
+        val actualChangelog = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(bpns = setOf(bpnL1, bpnL2)),
             PaginationRequest()
         )
@@ -419,7 +419,7 @@ class ChangelogControllerIT @Autowired constructor(
 
         val expectedChangelog = PageDto(expectedChangelogEntries.size.toLong(), 1, 0, expectedChangelogEntries.size, expectedChangelogEntries)
 
-        val actualChangelog = poolClient.changelogs().getChangelogEntries(
+        val actualChangelog = poolClient.changelogs.getChangelogEntries(
             ChangelogSearchRequest(timestampAfter = timeAfterFirstInsert, businessPartnerTypes = setOf(BusinessPartnerType.LEGAL_ENTITY)),
             PaginationRequest()
         )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -76,7 +76,7 @@ class LegalEntityControllerIT @Autowired constructor(
         }
 
         val toCreate = RequestValues.legalEntityCreate1
-        val response = poolClient.legalEntities().createBusinessPartners(listOf(toCreate))
+        val response = poolClient.legalEntities.createBusinessPartners(listOf(toCreate))
 
         assertThat(response.entities.size).isEqualTo(1)
         assertThat(response.entities.single())
@@ -132,7 +132,7 @@ class LegalEntityControllerIT @Autowired constructor(
         }
         val requestOkay = RequestValues.legalEntityCreate3
 
-        val response = poolClient.legalEntities().createBusinessPartners(
+        val response = poolClient.legalEntities.createBusinessPartners(
             listOf(request1, request2, request3, requestOkay)
         )
 
@@ -152,7 +152,7 @@ class LegalEntityControllerIT @Autowired constructor(
      */
     @Test
     fun `create legal entities and get duplicate identifier error on address`() {
-        poolClient.metadata().createIdentifierType(
+        poolClient.metadata.createIdentifierType(
             IdentifierTypeDto(
                 technicalKey = addressIdentifier.type,
                 businessPartnerType = IdentifierBusinessPartnerType.ADDRESS, name = addressIdentifier.value
@@ -178,7 +178,7 @@ class LegalEntityControllerIT @Autowired constructor(
             )
         }
 
-        val response = poolClient.legalEntities().createBusinessPartners(
+        val response = poolClient.legalEntities.createBusinessPartners(
             listOf(request1, request2)
         )
 
@@ -199,7 +199,7 @@ class LegalEntityControllerIT @Autowired constructor(
     fun `update legal entities and get duplicate identifier error`() {
 
         val toCreate1 = listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)
-        val response1 = poolClient.legalEntities().createBusinessPartners(toCreate1)
+        val response1 = poolClient.legalEntities.createBusinessPartners(toCreate1)
 
         assertThat(response1.errorCount).isEqualTo(0)
         val bpnList = response1.entities.map { it.legalEntity.bpnl }
@@ -230,7 +230,7 @@ class LegalEntityControllerIT @Autowired constructor(
             )
         }
 
-        val response = poolClient.legalEntities().updateBusinessPartners(
+        val response = poolClient.legalEntities.updateBusinessPartners(
             listOf(toUpdate1, toUpdate2)
         )
 
@@ -251,7 +251,7 @@ class LegalEntityControllerIT @Autowired constructor(
         val expected = listOf(ResponseValues.legalEntityUpsert1, ResponseValues.legalEntityUpsert2, ResponseValues.legalEntityUpsert3)
 
         val toCreate = listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2, RequestValues.legalEntityCreate3)
-        val response = poolClient.legalEntities().createBusinessPartners(toCreate)
+        val response = poolClient.legalEntities.createBusinessPartners(toCreate)
 
         assertThatCreatedLegalEntitiesEqual(response.entities, expected)
         assertThat(response.errorCount).isEqualTo(0)
@@ -265,11 +265,11 @@ class LegalEntityControllerIT @Autowired constructor(
     @Test
     fun `don't create legal entity with same identifier`() {
         val given = with(RequestValues.legalEntityCreate1) { copy(legalEntity = legalEntity.copy(identifiers = listOf(RequestValues.identifier1))) }
-        poolClient.legalEntities().createBusinessPartners(listOf(given))
+        poolClient.legalEntities.createBusinessPartners(listOf(given))
         val expected = listOf(ResponseValues.legalEntityUpsert2, ResponseValues.legalEntityUpsert3)
 
         val toCreate = listOf(given, RequestValues.legalEntityCreate2, RequestValues.legalEntityCreate3)
-        val response = poolClient.legalEntities().createBusinessPartners(toCreate)
+        val response = poolClient.legalEntities.createBusinessPartners(toCreate)
 
         // 2 entities created
         assertThatCreatedLegalEntitiesEqual(response.entities, expected)
@@ -285,7 +285,7 @@ class LegalEntityControllerIT @Autowired constructor(
      */
     @Test
     fun `don't create legal entity with same address identifier`() {
-        poolClient.metadata().createIdentifierType(
+        poolClient.metadata.createIdentifierType(
             IdentifierTypeDto(
                 technicalKey = addressIdentifier.type,
                 businessPartnerType = IdentifierBusinessPartnerType.ADDRESS, name = addressIdentifier.value
@@ -302,11 +302,11 @@ class LegalEntityControllerIT @Autowired constructor(
                 )
             )
         }
-        poolClient.legalEntities().createBusinessPartners(listOf(given))
+        poolClient.legalEntities.createBusinessPartners(listOf(given))
         val expected = listOf(ResponseValues.legalEntityUpsert2, ResponseValues.legalEntityUpsert3)
 
         val toCreate = listOf(given, RequestValues.legalEntityCreate2, RequestValues.legalEntityCreate3)
-        val response = poolClient.legalEntities().createBusinessPartners(toCreate)
+        val response = poolClient.legalEntities.createBusinessPartners(toCreate)
 
         // 2 entities created
         assertThatCreatedLegalEntitiesEqual(response.entities, expected)
@@ -324,7 +324,7 @@ class LegalEntityControllerIT @Autowired constructor(
     fun `update existing legal entities`() {
         val given = listOf(RequestValues.legalEntityCreate1)
 
-        val createResponse = poolClient.legalEntities().createBusinessPartners(given)
+        val createResponse = poolClient.legalEntities.createBusinessPartners(given)
             .entities.single()
         val givenBpnL = createResponse.legalEntity.bpnl
         val givenBpnA = createResponse.legalAddress.bpna
@@ -344,7 +344,7 @@ class LegalEntityControllerIT @Autowired constructor(
         val toUpdate = RequestValues.legalEntityUpdate3.copy(
             bpnl = givenBpnL
         )
-        val response = poolClient.legalEntities().updateBusinessPartners(listOf(toUpdate))
+        val response = poolClient.legalEntities.updateBusinessPartners(listOf(toUpdate))
 
         assertThatModifiedLegalEntitiesEqual(response.entities, listOf(expected))
         assertThat(response.errorCount).isEqualTo(0)
@@ -360,7 +360,7 @@ class LegalEntityControllerIT @Autowired constructor(
     fun `update existing legal entities multiple identifier`() {
         val given = listOf(RequestValues.legalEntityCreateMultipleIdentifier, RequestValues.legalEntityCreate2, RequestValues.legalEntityCreate3)
 
-        val createResponses = poolClient.legalEntities().createBusinessPartners(given)
+        val createResponses = poolClient.legalEntities.createBusinessPartners(given)
             .entities
 
         val createResponse = createResponses.filter { response ->
@@ -373,7 +373,7 @@ class LegalEntityControllerIT @Autowired constructor(
             bpnl = givenBpnL,
             legalEntity = RequestValues.legalEntityCreateMultipleIdentifier.legalEntity.copy(legalShortName = "ChangedShortNam"),
         )
-        val response = poolClient.legalEntities().updateBusinessPartners(listOf(toUpdate))
+        val response = poolClient.legalEntities.updateBusinessPartners(listOf(toUpdate))
 
         assertThat(response.errorCount).isEqualTo(0)
     }
@@ -387,7 +387,7 @@ class LegalEntityControllerIT @Autowired constructor(
     fun `ignore invalid legal entity update`() {
         val given = listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)
 
-        val createResponse = poolClient.legalEntities().createBusinessPartners(given)
+        val createResponse = poolClient.legalEntities.createBusinessPartners(given)
         val createdEntity = createResponse.entities.toList()[1]
         val bpnL = createdEntity.legalEntity.bpnl
         val bpnA = createdEntity.legalAddress.bpna
@@ -413,7 +413,7 @@ class LegalEntityControllerIT @Autowired constructor(
                 )
         }
 
-        val response = poolClient.legalEntities().updateBusinessPartners(toUpdate)
+        val response = poolClient.legalEntities.updateBusinessPartners(toUpdate)
 
         // 1 update okay
         assertThat(response.entities.size).isEqualTo(1)
@@ -441,7 +441,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .map { toLegalAddressResponse(it.legalAddress) }
 
         val bpnsToSearch = givenLegalEntities.map { it.legalEntity.bpnl }
-        val response = poolClient.legalEntities().searchLegalAddresses(bpnsToSearch)
+        val response = poolClient.legalEntities.searchLegalAddresses(bpnsToSearch)
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -470,7 +470,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .take(2)
 
         val bpnsToSearch = expected.map { it.bpnLegalEntity }.plus("NONEXISTENT")
-        val response = poolClient.legalEntities().searchLegalAddresses(bpnsToSearch)
+        val response = poolClient.legalEntities.searchLegalAddresses(bpnsToSearch)
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -499,7 +499,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .take(2) // only search for a subset of the existing legal entities
 
         val bpnsToSearch = expected.map { it.bpnl }
-        val response = poolClient.legalEntities().searchSites(bpnsToSearch).body?.map { it.legalEntity }
+        val response = poolClient.legalEntities.searchSites(bpnsToSearch).body?.map { it.legalEntity }
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -527,7 +527,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .first() // search for first
 
         val identifierToFind = expected.identifiers.first()
-        val response = poolClient.legalEntities().getLegalEntity(identifierToFind.value, identifierToFind.type.technicalKey).legalEntity
+        val response = poolClient.legalEntities.getLegalEntity(identifierToFind.value, identifierToFind.type.technicalKey).legalEntity
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -557,7 +557,7 @@ class LegalEntityControllerIT @Autowired constructor(
         var identifierToFind = expected.identifiers.first()
         identifierToFind = identifierToFind.copy(value = changeCase(identifierToFind.value))
 
-        val response = poolClient.legalEntities().getLegalEntity(identifierToFind.value, identifierToFind.type.technicalKey).legalEntity
+        val response = poolClient.legalEntities.getLegalEntity(identifierToFind.value, identifierToFind.type.technicalKey).legalEntity
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -586,7 +586,7 @@ class LegalEntityControllerIT @Autowired constructor(
 
         val bpnToFind = expected.bpnl
 
-        val response = poolClient.legalEntities().getLegalEntity(bpnToFind).legalEntity
+        val response = poolClient.legalEntities.getLegalEntity(bpnToFind).legalEntity
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -614,7 +614,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .first() // search for first
 
         val bpnToFind = changeCase(expected.bpnl)
-        val response = poolClient.legalEntities().getLegalEntity(bpnToFind).legalEntity
+        val response = poolClient.legalEntities.getLegalEntity(bpnToFind).legalEntity
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -643,7 +643,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .take(2) // only search for a subset of the existing legal entities
 
         val bpnsToSearch = expected.map { it.bpnl }.plus("NONEXISTENT") // also search for nonexistent BPN
-        val response = poolClient.legalEntities().searchSites(bpnsToSearch).body?.map { it.legalEntity }
+        val response = poolClient.legalEntities.searchSites(bpnsToSearch).body?.map { it.legalEntity }
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -661,17 +661,17 @@ class LegalEntityControllerIT @Autowired constructor(
     @Test
     fun `set business partner currentness`() {
         val given = listOf(RequestValues.legalEntityCreate1)
-        val bpnL = poolClient.legalEntities().createBusinessPartners(given)
+        val bpnL = poolClient.legalEntities.createBusinessPartners(given)
             .entities.single().legalEntity.bpnl
         val initialCurrentness = retrieveCurrentness(bpnL)
         val instantBeforeCurrentnessUpdate = Instant.now()
 
         assertThat(initialCurrentness).isBeforeOrEqualTo(instantBeforeCurrentnessUpdate)
 
-        poolClient.legalEntities().setLegalEntityCurrentness(bpnL)
+        poolClient.legalEntities.setLegalEntityCurrentness(bpnL)
 
 
-        val updatedCurrentness = poolClient.legalEntities().getLegalEntity(bpnL).legalEntity.currentness
+        val updatedCurrentness = poolClient.legalEntities.getLegalEntity(bpnL).legalEntity.currentness
         assertThat(updatedCurrentness).isBetween(instantBeforeCurrentnessUpdate, Instant.now())
     }
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
@@ -76,7 +76,7 @@ class LegalEntityControllerSearchIT @Autowired constructor(
     fun beforeEach() {
         testHelpers.truncateDbTables()
 
-        poolClient.opensearch().clear()
+        poolClient.opensearch.clear()
         testHelpers.createTestMetadata()
         val givenStructure = testHelpers.createBusinessPartnerStructure(listOf(partnerStructure1, partnerStructure2))
         givenPartner1 = with(givenStructure[0].legalEntity) { legalEntity }
@@ -168,7 +168,7 @@ class LegalEntityControllerSearchIT @Autowired constructor(
     private fun searchBusinessPartnerBySiteName(siteName: String, page: Int, size: Int): PageDto<LegalEntityMatchVerboseDto> {
         val sitePropertiesSearchRequest = SitePropertiesSearchRequest(siteName)
 
-        return poolClient.legalEntities().getLegalEntities(
+        return poolClient.legalEntities.getLegalEntities(
             LegalEntityPropertiesSearchRequest.EmptySearchRequest,
             PaginationRequest(page, size)
         )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
@@ -357,15 +357,15 @@ class MetadataControllerIT @Autowired constructor(
         val ruleDE1 = addressRuleMandatory(country = DE, field = "path1.field1")
         fieldQualityRuleRepository.saveAll(listOf(rulePL1, rulePL2, ruleDE1))
 
-        val resultPl = poolClient.metadata().getFieldQualityRules(PL).body
+        val resultPl = poolClient.metadata.getFieldQualityRules(PL).body
         assertThat(resultPl?.size).isEqualTo(2)
         assertThat(resultPl?.map { it.fieldPath }).containsExactlyInAnyOrder("path1.field1", "path1.field2")
 
-        val resultDe = poolClient.metadata().getFieldQualityRules(DE).body
+        val resultDe = poolClient.metadata.getFieldQualityRules(DE).body
         assertThat(resultDe?.size).isEqualTo(1)
         assertThat(resultDe?.map { it.fieldPath }).containsExactlyInAnyOrder("path1.field1")
 
-        val resultUs = poolClient.metadata().getFieldQualityRules(US).body
+        val resultUs = poolClient.metadata.getFieldQualityRules(US).body
         assertThat(resultUs?.size).isEqualTo(0)
     }
 
@@ -382,7 +382,7 @@ class MetadataControllerIT @Autowired constructor(
         val ruleDE1 = addressRuleMandatory(country = DE, field = "path1.field1")
         fieldQualityRuleRepository.saveAll(listOf(ruleDefault1, ruleDefault2, ruleDefault3, ruleDefault4, rulePL1, rulePL2, ruleDE1))
 
-        val resultPl = poolClient.metadata().getFieldQualityRules(PL).body
+        val resultPl = poolClient.metadata.getFieldQualityRules(PL).body
         assertThat(resultPl?.size).isEqualTo(3)
         assertThat(resultPl?.map { it.fieldPath }).containsExactlyInAnyOrder("path1.field1", "path1.field2", "path1.field3")
         assertThat(resultPl?.filter { it.fieldPath == "path1.field1" }?.map { it.qualityLevel }).describedAs("PL optional overwrites default mandatory")

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -105,7 +105,7 @@ class SiteControllerIT @Autowired constructor(
         val bpnL = createdStructures[0].legalEntity.legalEntity.bpnl
 
         val siteSearchRequest = SiteBpnSearchRequest(emptyList(), listOf(bpnS1, bpnS2))
-        val searchResult = poolClient.sites().searchSites(siteSearchRequest, PaginationRequest())
+        val searchResult = poolClient.sites.searchSites(siteSearchRequest, PaginationRequest())
 
         val expectedSiteWithReference1 = SitePoolVerboseDto(
             site = ResponseValues.site1.copy(bpnLegalEntity = bpnL),
@@ -151,7 +151,7 @@ class SiteControllerIT @Autowired constructor(
         val bpnL2 = createdStructures[1].legalEntity.legalEntity.bpnl
 
         val siteSearchRequest = SiteBpnSearchRequest(listOf(bpnL1, bpnL2))
-        val searchResult = poolClient.sites().searchSites(siteSearchRequest, PaginationRequest())
+        val searchResult = poolClient.sites.searchSites(siteSearchRequest, PaginationRequest())
 
         val expectedSiteWithReference1 =
             SitePoolVerboseDto(
@@ -187,7 +187,7 @@ class SiteControllerIT @Autowired constructor(
     fun `create new sites`() {
 
         val givenLegalEntities =
-            poolClient.legalEntities().createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
+            poolClient.legalEntities.createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
 
         val bpnL1 = givenLegalEntities.first().legalEntity.bpnl
         val bpnL2 = givenLegalEntities.last().legalEntity.bpnl
@@ -200,7 +200,7 @@ class SiteControllerIT @Autowired constructor(
             RequestValues.siteCreate3.copy(bpnlParent = bpnL2)
         )
 
-        val response = poolClient.sites().createSite(toCreate)
+        val response = poolClient.sites.createSite(toCreate)
 
         assertThatCreatedSitesEqual(response.entities, expected)
         assertThat(response.errorCount).isEqualTo(0)
@@ -214,7 +214,7 @@ class SiteControllerIT @Autowired constructor(
      */
     @Test
     fun `create sites entities and get duplicate identifier error on address`() {
-        poolClient.metadata().createIdentifierType(
+        poolClient.metadata.createIdentifierType(
             IdentifierTypeDto(
                 technicalKey = RequestValues.addressIdentifier.type,
                 businessPartnerType = IdentifierBusinessPartnerType.ADDRESS, name = RequestValues.addressIdentifier.value
@@ -222,7 +222,7 @@ class SiteControllerIT @Autowired constructor(
         )
 
         val givenLegalEntities =
-            poolClient.legalEntities().createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
+            poolClient.legalEntities.createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
 
         val request1 = with(RequestValues.siteCreate1) {
             copy(
@@ -249,7 +249,7 @@ class SiteControllerIT @Autowired constructor(
             )
         }
 
-        val response = poolClient.sites().createSite(
+        val response = poolClient.sites.createSite(
             listOf(request1, request2)
         )
 
@@ -269,7 +269,7 @@ class SiteControllerIT @Autowired constructor(
     @Test
     fun `update site entities and get duplicate identifier error`() {
 
-        poolClient.metadata().createIdentifierType(
+        poolClient.metadata.createIdentifierType(
             IdentifierTypeDto(
                 technicalKey = RequestValues.addressIdentifier.type,
                 businessPartnerType = IdentifierBusinessPartnerType.ADDRESS, name = RequestValues.addressIdentifier.value
@@ -277,10 +277,10 @@ class SiteControllerIT @Autowired constructor(
         )
 
         val givenLegalEntities =
-            poolClient.legalEntities().createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
+            poolClient.legalEntities.createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
 
         val toCreate1 = listOf(RequestValues.siteCreate1, RequestValues.siteCreate2)
-        val response1 = poolClient.sites().createSite(toCreate1)
+        val response1 = poolClient.sites.createSite(toCreate1)
 
 
         assertThat(response1.errorCount).isEqualTo(0)
@@ -320,7 +320,7 @@ class SiteControllerIT @Autowired constructor(
             )
         }
 
-        val response = poolClient.sites().updateSite(
+        val response = poolClient.sites.updateSite(
             listOf(toUpdate1, toUpdate2)
         )
 
@@ -341,7 +341,7 @@ class SiteControllerIT @Autowired constructor(
 
 
         val givenLegalEntities =
-            poolClient.legalEntities().createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
+            poolClient.legalEntities.createBusinessPartners(listOf(RequestValues.legalEntityCreate1, RequestValues.legalEntityCreate2)).entities
 
         val bpnL1 = givenLegalEntities.first().legalEntity.bpnl
         val bpnL2 = givenLegalEntities.last().legalEntity.bpnl
@@ -354,7 +354,7 @@ class SiteControllerIT @Autowired constructor(
             RequestValues.siteCreate2.copy(bpnlParent = bpnL2),
             RequestValues.siteCreate3.copy(bpnlParent = "NONEXISTENT")
         )
-        val response = poolClient.sites().createSite(toCreate)
+        val response = poolClient.sites.createSite(toCreate)
 
         // 2 entities okay
         assertThatCreatedSitesEqual(response.entities, expected)
@@ -399,7 +399,7 @@ class SiteControllerIT @Autowired constructor(
             RequestValues.siteUpdate3.copy(bpns = bpnS2)
         )
 
-        val response = poolClient.sites().updateSite(toUpdate)
+        val response = poolClient.sites.updateSite(toUpdate)
 
         assertThatCreatedSitesEqual(response.entities, expected)
         assertThat(response.errorCount).isEqualTo(0)
@@ -434,7 +434,7 @@ class SiteControllerIT @Autowired constructor(
             RequestValues.siteUpdate2.copy(bpns = bpnS1),
             RequestValues.siteUpdate3.copy(bpns = "NONEXISTENT"),
         )
-        val response = poolClient.sites().updateSite(toUpdate)
+        val response = poolClient.sites.updateSite(toUpdate)
 
         // 2 entities okay
         assertThatCreatedSitesEqual(response.entities, expected)
@@ -467,7 +467,7 @@ class SiteControllerIT @Autowired constructor(
 
         val toSearch = expected.map { it.bpnSite!! }
 
-        val response = poolClient.sites().searchMainAddresses(toSearch)
+        val response = poolClient.sites.searchMainAddresses(toSearch)
         testHelpers.assertRecursively(response).isEqualTo(expected)
     }
 
@@ -495,7 +495,7 @@ class SiteControllerIT @Autowired constructor(
 
         val toSearch = expected.map { it.bpnSite!! }.plus("NON-EXISTENT")
 
-        val response = poolClient.sites().searchMainAddresses(toSearch)
+        val response = poolClient.sites.searchMainAddresses(toSearch)
         testHelpers.assertRecursively(response).isEqualTo(expected)
     }
 
@@ -531,7 +531,7 @@ class SiteControllerIT @Autowired constructor(
             )
         )
 
-        val firstPage = poolClient.sites().getSitesPaginated(paginationRequest = PaginationRequest(0, 10))
+        val firstPage = poolClient.sites.getSitesPaginated(paginationRequest = PaginationRequest(0, 10))
 
         testHelpers.assertRecursively(firstPage).ignoringFieldsOfTypes(Instant::class.java).isEqualTo(expectedFirstPage)
 
@@ -551,8 +551,8 @@ class SiteControllerIT @Autowired constructor(
             .isEqualTo(expected)
     }
 
-    private fun requestSite(bpnSite: String) = poolClient.sites().getSite(bpnSite)
+    private fun requestSite(bpnSite: String) = poolClient.sites.getSite(bpnSite)
 
-    private fun requestSitesOfLegalEntity(bpn: String) = poolClient.legalEntities().getSites(bpn, PaginationRequest())
+    private fun requestSitesOfLegalEntity(bpn: String) = poolClient.legalEntities.getSites(bpn, PaginationRequest())
 
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
@@ -89,7 +89,7 @@ class TestHelpers(
         partnerStructures: List<LegalEntityStructureRequest>
     ): List<LegalEntityStructureResponse> {
 
-        val legalEntities = poolClient.legalEntities().createBusinessPartners(partnerStructures.map { it.legalEntity })
+        val legalEntities = poolClient.legalEntities.createBusinessPartners(partnerStructures.map { it.legalEntity })
         val indexedLegalEntities = legalEntities.entities.associateBy { it.index }
 
         val assignedSiteRequests =
@@ -98,7 +98,7 @@ class TestHelpers(
                     site.site.copy(bpnlParent = indexedLegalEntities[it.legalEntity.index]!!.legalEntity.bpnl)
                 }
             }
-        val sitesWithErrorsResponse = poolClient.sites().createSite(assignedSiteRequests)
+        val sitesWithErrorsResponse = poolClient.sites.createSite(assignedSiteRequests)
         val indexedSites = sitesWithErrorsResponse.entities.associateBy { it.index }
 
         val assignedSitelessAddresses =
@@ -114,7 +114,7 @@ class TestHelpers(
                     it.addresses.map { address -> address.copy(bpnParent = indexedSites[it.site.index]!!.site.bpns) }
                 }
 
-        val addresses = poolClient.addresses().createAddresses(assignedSitelessAddresses + assignedSiteAddresses).entities
+        val addresses = poolClient.addresses.createAddresses(assignedSitelessAddresses + assignedSiteAddresses).entities
 
         val indexedAddresses = addresses.associateBy { it.index }
 
@@ -134,7 +134,7 @@ class TestHelpers(
 
     fun `get address by bpn-a, not found`(bpn: String) {
         try {
-            val result = poolClient.addresses().getAddress(bpn)
+            val result = poolClient.addresses.getAddress(bpn)
             assertThrows<WebClientResponseException> { result }
         } catch (e: WebClientResponseException) {
             Assert.assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
@@ -143,7 +143,7 @@ class TestHelpers(
 
     fun `find bpns by identifiers, bpn request limit exceeded`(identifiersSearchRequest: IdentifiersSearchRequest) {
         try {
-            val result = poolClient.bpns().findBpnsByIdentifiers(identifiersSearchRequest)
+            val result = poolClient.bpns.findBpnsByIdentifiers(identifiersSearchRequest)
 
             assertThrows<WebClientResponseException> { result }
         } catch (e: WebClientResponseException) {
@@ -153,7 +153,7 @@ class TestHelpers(
 
     fun `find bpns by nonexistent identifier type`(identifiersSearchRequest: IdentifiersSearchRequest) {
         try {
-            val result = poolClient.bpns().findBpnsByIdentifiers(identifiersSearchRequest)
+            val result = poolClient.bpns.findBpnsByIdentifiers(identifiersSearchRequest)
             assertThrows<WebClientResponseException> { result }
         } catch (e: WebClientResponseException) {
             Assert.assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
@@ -162,7 +162,7 @@ class TestHelpers(
 
     fun `set business partner currentness using nonexistent bpn`(bpn: String) {
         try {
-            val result = poolClient.legalEntities().setLegalEntityCurrentness(bpn)
+            val result = poolClient.legalEntities.setLegalEntityCurrentness(bpn)
             assertThrows<WebClientResponseException> { result }
         } catch (e: WebClientResponseException) {
             Assert.assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
@@ -171,7 +171,7 @@ class TestHelpers(
 
     fun `get site by bpn-s, not found`(bpn: String) {
         try {
-            val result = poolClient.sites().getSite(bpn)
+            val result = poolClient.sites.getSite(bpn)
             assertThrows<WebClientResponseException> { result }
         } catch (e: WebClientResponseException) {
             Assert.assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
@@ -184,13 +184,13 @@ class TestHelpers(
      */
     fun createTestMetadata() {
 
-        poolClient.metadata().createLegalForm(RequestValues.legalForm1)
-        poolClient.metadata().createLegalForm(RequestValues.legalForm2)
-        poolClient.metadata().createLegalForm(RequestValues.legalForm3)
+        poolClient.metadata.createLegalForm(RequestValues.legalForm1)
+        poolClient.metadata.createLegalForm(RequestValues.legalForm2)
+        poolClient.metadata.createLegalForm(RequestValues.legalForm3)
 
-        poolClient.metadata().createIdentifierType(RequestValues.identifierTypeDto1)
-        poolClient.metadata().createIdentifierType(RequestValues.identifierTypeDto2)
-        poolClient.metadata().createIdentifierType(RequestValues.identifierTypeDto3)
+        poolClient.metadata.createIdentifierType(RequestValues.identifierTypeDto1)
+        poolClient.metadata.createIdentifierType(RequestValues.identifierTypeDto2)
+        poolClient.metadata.createIdentifierType(RequestValues.identifierTypeDto3)
     }
 
 


### PR DESCRIPTION
Directly expose lazy properties, not functions, for the different APIs.
This is more straight-forward in Kotlin and simplifies the API client implementations.
