### PR TITLE
Feat: Add Orchestrator API Endpoint for Requesting Cleaning Tasks

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -48,9 +48,6 @@ interface IBaseBusinessPartnerDto {
     @get:Schema(description = "Address of the official seat of this business partner.")
     val postalAddress: IBaseBusinessPartnerPostalAddressDto
 
-    @get:Schema(name = "isOwner", description = "True if the sharing member declares itself as the owner of the business partner.")
-    val isOwner: Boolean
-
     @get:Schema(description = "BPNL")
     val bpnL: String?
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/exception/BpdmUpsertLimitException.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/exception/BpdmUpsertLimitException.kt
@@ -17,19 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.bpdm.common.exception
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class BpdmUpsertLimitException(
+    actualSize: Int,
+    limit: Int
+) : RuntimeException("The number of upsertable items ($actualSize) surpasses the upsert limit of $limit")

--- a/bpdm-orchestrator-api/pom.xml
+++ b/bpdm-orchestrator-api/pom.xml
@@ -19,58 +19,58 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<artifactId>bpdm-orchestrator-api</artifactId>
-	<name>orchestrator-api</name>
-	<description>Business Partner Data Management Orchestrator Api</description>
-	<packaging>jar</packaging>
+    <artifactId>bpdm-orchestrator-api</artifactId>
+    <name>Business Partner Data Management Orchestrator Api</name>
+    <description>API definition and client logic for the BPDM Orchestrator</description>
+    <packaging>jar</packaging>
 
-	<parent>
-		<groupId>org.eclipse.tractusx</groupId>
-		<artifactId>bpdm-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>org.eclipse.tractusx</groupId>
+        <artifactId>bpdm-parent</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+    </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
-
-	<dependencies>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>bpdm-common</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.module</groupId>
-			<artifactId>jackson-module-kotlin</artifactId>
-		</dependency>
-
-	</dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
 
-	<build>
-		<sourceDirectory>src/main/kotlin</sourceDirectory>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bpdm-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
 
-		<plugins>
-			<plugin>
-				<groupId>org.jetbrains.kotlin</groupId>
-				<artifactId>kotlin-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	<distributionManagement>
-		<repository>
-			<id>github</id>
-			<name>GitHub CatenaX-NG Apache Maven Packages</name>
-			<url>https://maven.pkg.github.com/catenax-ng/tx-bpdm</url>
-		</repository>
-	</distributionManagement>
+    </dependencies>
+
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub CatenaX-NG Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/catenax-ng/tx-bpdm</url>
+        </repository>
+    </distributionManagement>
 
 </project>

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.orchestrator.api.model.TaskCreateRequest
+import org.eclipse.tractusx.orchestrator.api.model.TaskCreateResponse
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PostExchange
+
+@RequestMapping("/api/cleaning-tasks", produces = [MediaType.APPLICATION_JSON_VALUE])
+@HttpExchange("/api/cleaning-tasks")
+interface CleaningTaskApi {
+
+    @Operation(
+        summary = "Create new cleaning tasks for given business partner data",
+        description = "Create cleaning tasks for given business partner data in given cleaning mode. " +
+                "The mode decides through which cleaning steps the given business partner data will go through. " +
+                "The response contains the states of the created cleaning tasks in the order of given business partner data." +
+                "If there is an error in the request no cleaning tasks are created (all or nothing). " +
+                "For a single request, the maximum number of business partners in the request is limited to \${bpdm.api.upsert-limit} entries."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The states of successfully created cleaning tasks including the task identifier for tracking purposes."
+            ),
+            ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
+        ]
+    )
+    @Tag(name = "Requester")
+    @PostMapping
+    @PostExchange
+    fun createCleaningTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
+
+
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/OrchestrationApiClient.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/OrchestrationApiClient.kt
@@ -19,5 +19,10 @@
 
 package org.eclipse.tractusx.orchestrator.api.client
 
+import org.eclipse.tractusx.orchestrator.api.CleaningTaskApi
+
 interface OrchestrationApiClient {
+
+    val cleaningTasks: CleaningTaskApi
+
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AlternativePostalAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AlternativePostalAddressDto.kt
@@ -17,19 +17,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.dto.IBaseAlternativePostalAddressDto
+import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
+data class AlternativePostalAddressDto(
+    override val geographicCoordinates: GeoCoordinateDto? = null,
+    override val country: CountryCode? = null,
+    override val administrativeAreaLevel1: String? = null,
+    override val postalCode: String? = null,
+    override val city: String? = null,
+    override val deliveryServiceType: DeliveryServiceType? = null,
+    override val deliveryServiceQualifier: String? = null,
+    override val deliveryServiceNumber: String? = null
 
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+) : IBaseAlternativePostalAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerDto.kt
@@ -17,17 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model
+package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.*
 
-interface IBaseBusinessPartnerGateDto : IBaseBusinessPartnerDto {
 
-    @get:Schema(description = CommonDescription.externalId)
-    val externalId: String
-
-    @get:Schema(name = "isOwner", description = "True if the sharing member declares itself as the owner of the business partner.")
-    val isOwner: Boolean
-}
+data class BusinessPartnerDto(
+    override val nameParts: List<String> = emptyList(),
+    override val shortName: String? = null,
+    override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
+    override val legalForm: String? = null,
+    override val states: Collection<BusinessPartnerStateDto> = emptyList(),
+    override val classifications: Collection<ClassificationDto> = emptyList(),
+    override val roles: Collection<BusinessPartnerRole> = emptyList(),
+    override val postalAddress: PostalAddressDto = PostalAddressDto(),
+    override val bpnL: String? = null,
+    override val bpnS: String? = null,
+    override val bpnA: String? = null,
+    @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
+    val ownerBpnl: String? = null
+) : IBaseBusinessPartnerDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningStep.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningStep.kt
@@ -17,19 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
+enum class CleaningStep {
+    CleanAndSync,
+    PoolSync,
+    Clean
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PhysicalPostalAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PhysicalPostalAddressDto.kt
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.model
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.dto.IBasePhysicalPostalAddressDto
+
+data class PhysicalPostalAddressDto(
+    override val geographicCoordinates: GeoCoordinateDto? = null,
+    override val country: CountryCode? = null,
+    override val administrativeAreaLevel1: String? = null,
+    override val administrativeAreaLevel2: String? = null,
+    override val administrativeAreaLevel3: String? = null,
+    override val postalCode: String? = null,
+    override val city: String? = null,
+    override val district: String? = null,
+    override val street: StreetDto? = null,
+    override val companyPostalCode: String? = null,
+    override val industrialZone: String? = null,
+    override val building: String? = null,
+    override val floor: String? = null,
+    override val door: String? = null
+
+) : IBasePhysicalPostalAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PostalAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PostalAddressDto.kt
@@ -17,19 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerPostalAddressDto
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
+data class PostalAddressDto(
+    override val addressType: AddressType? = null,
+    override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
+    override val alternativePostalAddress: AlternativePostalAddressDto? = null
 
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+) : IBaseBusinessPartnerPostalAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ReservationState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ReservationState.kt
@@ -17,19 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
+enum class ReservationState {
+    Queued,
+    Reserved
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ResultState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ResultState.kt
@@ -17,19 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
+enum class ResultState {
+    Pending,
+    Success,
+    Error
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/StreetDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/StreetDto.kt
@@ -17,19 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import org.eclipse.tractusx.bpdm.common.dto.IStreetDetailedDto
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
+data class StreetDto(
+    override val name: String? = null,
+    override val houseNumber: String? = null,
+    override val milestone: String? = null,
+    override val direction: String? = null,
+    override val namePrefix: String? = null,
+    override val additionalNamePrefix: String? = null,
+    override val nameSuffix: String? = null,
+    override val additionalNameSuffix: String? = null
 
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+) : IStreetDetailedDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateRequest.kt
@@ -17,19 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
+data class TaskCreateRequest(
+    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
+    val mode: TaskMode,
+    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
+    val businessPartners: List<BusinessPartnerDto>
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateResponse.kt
@@ -17,19 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import io.swagger.v3.oas.annotations.media.Schema
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
+@Schema(description = "Response object for giving a list of created cleaning tasks")
+data class TaskCreateResponse(
+    val createdTasks: List<TaskRequesterState>
+) {
 
 }
+
+

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskError.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskError.kt
@@ -17,19 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import io.swagger.v3.oas.annotations.media.Schema
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+@Schema(description = "Describes an error that happened during processing of a cleaning task")
+data class TaskError(
+    @get:Schema(description = "The type of error that occurred", required = true)
+    val type: TaskErrorType,
+    @get:Schema(description = "The free text, detailed description of the error", required = true)
+    val description: String
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorType.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorType.kt
@@ -17,19 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
+enum class TaskErrorType {
+    Timeout,
+    Unspecified
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskMode.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskMode.kt
@@ -17,19 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
+enum class TaskMode {
+    UpdateFromSharingMember,
+    UpdateFromPool
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskProcessingStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskProcessingStateDto.kt
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "Contains detail information about the current processing state of a cleaning task")
+data class TaskProcessingStateDto(
+    @get:Schema(description = "The last cleaning step this cleaning task has entered", required = true)
+    val cleaningStep: CleaningStep,
+    @get:Schema(description = "Whether the cleaning task is queued or already reserved in the latest cleaning step", required = true)
+    val reservationState: ReservationState,
+    @get:Schema(description = "The processing result of the cleaning task, can also still be pending", required = true)
+    val resultState: ResultState,
+    @get:Schema(
+        description = "The actual errors that happened during processing if the cleaning task has an error result state. " +
+                "The errors refer to the latest cleaning step.", required = true
+    )
+    val errors: List<TaskError> = emptyList(),
+    @get:Schema(description = "When the cleaning task has been created", required = true)
+    val createdAt: Instant,
+    @get:Schema(description = "When the cleaning task has last been modified", required = true)
+    val modifiedAt: Instant
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskRequesterState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskRequesterState.kt
@@ -17,19 +17,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import io.swagger.v3.oas.annotations.media.Schema
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
 
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+@Schema(description = "The cleaning task's processing state together with optional business partner data in case processing is done")
+data class TaskRequesterState(
+    @get:Schema(required = true)
+    val taskId: String,
+    val businessPartnerResult: BusinessPartnerDto?,
+    @get:Schema(required = true)
+    val processingState: TaskProcessingStateDto
+)

--- a/bpdm-orchestrator/pom.xml
+++ b/bpdm-orchestrator/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>bpdm-orchestrator</artifactId>
     <name>Business Partner Data Management Orchestrator</name>
-    <description>Orchestrator component acts as a passive component and offers for each processing steps individual endpoints </description>
+    <description>Orchestrator component acts as a passive component and offers for each processing steps individual endpoints</description>
     <packaging>jar</packaging>
 
     <parent>
@@ -38,6 +38,11 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>bpdm-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bpdm-orchestrator-api</artifactId>
         </dependency>
 
         <dependency>

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/Application.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/Application.kt
@@ -17,14 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package com.catenax.bpdm.orchestrator
+package org.eclipse.tractusx.bpdm.orchestrator
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
-@SpringBootApplication(exclude=[DataSourceAutoConfiguration::class])
+
+@SpringBootApplication(exclude = [DataSourceAutoConfiguration::class])
 @ConfigurationPropertiesScan
 class Application
 

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/ApiConfigProperties.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/ApiConfigProperties.kt
@@ -17,19 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.bpdm.orchestrator.config
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import org.springframework.boot.context.properties.ConfigurationProperties
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
-    }
-
-}
+@ConfigurationProperties(prefix = "bpdm.api")
+data class ApiConfigProperties(
+    val upsertLimit: Int = 100,
+)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.controller
+
+import org.eclipse.tractusx.bpdm.common.exception.BpdmUpsertLimitException
+import org.eclipse.tractusx.bpdm.orchestrator.config.ApiConfigProperties
+import org.eclipse.tractusx.orchestrator.api.CleaningTaskApi
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+class CleaningTaskController(
+    val apiConfigProperties: ApiConfigProperties
+) : CleaningTaskApi {
+
+    //While we don't have an implementation use a dummy response for the endpoints
+    val dummyResponseCreateTask =
+        TaskCreateResponse(
+            listOf(
+                TaskRequesterState(
+                    taskId = "0",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.CleanAndSync,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                ),
+                TaskRequesterState(
+                    taskId = "1",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.CleanAndSync,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                )
+            )
+        )
+
+
+    override fun createCleaningTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
+        if (createRequest.businessPartners.size > apiConfigProperties.upsertLimit)
+            throw BpdmUpsertLimitException(createRequest.businessPartners.size, apiConfigProperties.upsertLimit)
+
+        //ToDo: Replace with service logic
+        return dummyResponseCreateTask
+    }
+}

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/OrchestratorClientConfig.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/OrchestratorClientConfig.kt
@@ -17,19 +17,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.orchestrator
+package org.eclipse.tractusx.bpdm.orchestrator.config
 
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClientImpl
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class ApplicationTests {
-
-    @Test
-    fun contextLoads() {
-
+@Configuration
+class OrchestratorClientConfig {
+    @Bean
+    fun orchestratorClient(webServerAppCtxt: ServletWebServerApplicationContext): OrchestrationApiClient {
+        return OrchestrationApiClientImpl { WebClient.create("http://localhost:${webServerAppCtxt.webServer.port}") }
     }
 
 }

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskControllerIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskControllerIT.kt
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.controller
+
+import org.assertj.core.api.Assertions
+import org.eclipse.tractusx.bpdm.orchestrator.util.TestValues
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskCreateRequest
+import org.eclipse.tractusx.orchestrator.api.model.TaskMode
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["bpdm.api.upsert-limit=3"])
+class CleaningTaskControllerIT @Autowired constructor(
+    val orchestratorClient: OrchestrationApiClient,
+    val cleaningTaskController: CleaningTaskController
+) {
+
+    /**
+     * Validate create cleaning task endpoint is invokable with request body and returns dummy response
+     */
+    @Test
+    fun `request cleaning task and expect dummy response`() {
+        val request = TaskCreateRequest(
+            mode = TaskMode.UpdateFromSharingMember,
+            businessPartners = listOf(TestValues.businessPartner1, TestValues.businessPartner2)
+        )
+
+        val expected = cleaningTaskController.dummyResponseCreateTask
+
+        val response = orchestratorClient.cleaningTasks.createCleaningTasks(request)
+
+        Assertions.assertThat(response).isEqualTo(expected)
+    }
+
+    /**
+     * When requesting cleaning of too many business partners (over the upsert limit)
+     * Then throw exception
+     */
+    @Test
+    fun `expect exception on surpassing upsert limit`() {
+
+        //Create entries above the upsert limit of 3
+        val request = TaskCreateRequest(
+            mode = TaskMode.UpdateFromPool,
+            businessPartners = listOf(
+                TestValues.businessPartner1,
+                TestValues.businessPartner1,
+                TestValues.businessPartner1,
+                TestValues.businessPartner1
+            )
+        )
+
+        Assertions.assertThatThrownBy {
+            orchestratorClient.cleaningTasks.createCleaningTasks(request)
+        }.isInstanceOf(WebClientResponseException::class.java)
+    }
+
+}

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/TestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/TestValues.kt
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.util
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
+import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.eclipse.tractusx.orchestrator.api.model.AlternativePostalAddressDto
+import org.eclipse.tractusx.orchestrator.api.model.PhysicalPostalAddressDto
+import org.eclipse.tractusx.orchestrator.api.model.StreetDto
+import java.time.LocalDateTime
+
+/**
+ * Contains complex test values that can be used as templates by the test classes
+ * Test values here should have as many unique values as possible to reduce the probability of finding matching errors
+ */
+object TestValues {
+
+    //Business Partner with two entries in every collection
+    val businessPartner1 = BusinessPartnerDto(
+        nameParts = listOf("NamePart1", "NamePart2"),
+        shortName = "shortname",
+        identifiers = listOf(
+            BusinessPartnerIdentifierDto(
+                type = "identifier-type-1",
+                value = "identifier-value-1",
+                issuingBody = "issuingBody-1"
+            ),
+            BusinessPartnerIdentifierDto(
+                type = "identifier-type-2",
+                value = "identifier-value-2",
+                issuingBody = "issuingBody-2"
+            ),
+        ),
+        legalForm = "legal-form",
+        states = listOf(
+            BusinessPartnerStateDto(
+                validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
+                validTo = LocalDateTime.of(2023, 10, 23, 16, 40),
+                type = BusinessStateType.INACTIVE,
+                description = "business-state-description-1"
+            ),
+            BusinessPartnerStateDto(
+                validFrom = LocalDateTime.of(2000, 8, 21, 14, 30),
+                validTo = LocalDateTime.of(2020, 9, 22, 15, 50),
+                type = BusinessStateType.ACTIVE,
+                description = "business-state-description-2"
+            )
+        ),
+        classifications = listOf(
+            ClassificationDto(
+                type = ClassificationType.NACE,
+                code = "code-1",
+                value = "value-1"
+            ),
+            ClassificationDto(
+                type = ClassificationType.NAF,
+                code = "code-2",
+                value = "value-2"
+            ),
+        ),
+        roles = listOf(
+            BusinessPartnerRole.CUSTOMER,
+            BusinessPartnerRole.SUPPLIER
+        ),
+        postalAddress = PostalAddressDto(
+            addressType = AddressType.AdditionalAddress,
+            physicalPostalAddress = PhysicalPostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),
+                country = CountryCode.DE,
+                administrativeAreaLevel1 = "DE-BW",
+                administrativeAreaLevel2 = "bw-admin-level-2",
+                administrativeAreaLevel3 = "bw-admin-level-3",
+                postalCode = "phys-postal-code",
+                city = "city",
+                district = "district",
+                street = StreetDto(
+                    name = "name",
+                    houseNumber = "house-number",
+                    milestone = "milestone",
+                    direction = "direction",
+                    namePrefix = "name-prefix",
+                    additionalNamePrefix = "add-name-prefix",
+                    nameSuffix = "name-suffix",
+                    additionalNameSuffix = "add-name-suffix"
+
+                ),
+                companyPostalCode = "comp-postal-code",
+                industrialZone = "industrial-zone",
+                building = "building",
+                floor = "floor",
+                door = "door"
+            ),
+            alternativePostalAddress = AlternativePostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(0.6f, 0.6f, 0.6f),
+                country = CountryCode.DE,
+                administrativeAreaLevel1 = "DE-BY",
+                postalCode = "alt-post-code",
+                city = "alt-city",
+                deliveryServiceNumber = "delivery-service-number",
+                deliveryServiceQualifier = "delivery-service-qualifier",
+                deliveryServiceType = DeliveryServiceType.PO_BOX
+            )
+        ),
+        ownerBpnl = null,
+        bpnL = "BPNLTEST",
+        bpnS = "BPNSTEST",
+        bpnA = "BPNATEST"
+    )
+
+    //Business Partner with single entry in every collection
+    val businessPartner2 = BusinessPartnerDto(
+        nameParts = listOf("name-part-2"),
+        shortName = "shortname-2",
+        identifiers = listOf(
+            BusinessPartnerIdentifierDto(
+                type = "identifier-type-2",
+                value = "identifier-value-2",
+                issuingBody = "issuingBody-2"
+            )
+        ),
+        legalForm = "legal-form-2",
+        states = listOf(
+            BusinessPartnerStateDto(
+                validFrom = LocalDateTime.of(1988, 10, 4, 22, 30),
+                validTo = LocalDateTime.of(2023, 1, 1, 10, 10),
+                type = BusinessStateType.ACTIVE,
+                description = "business-state-description-2"
+            )
+        ),
+        classifications = listOf(
+            ClassificationDto(
+                type = ClassificationType.SIC,
+                code = "code-2",
+                value = "value-2"
+            )
+        ),
+        roles = listOf(
+            BusinessPartnerRole.CUSTOMER
+        ),
+        postalAddress = PostalAddressDto(
+            addressType = AddressType.LegalAddress,
+            physicalPostalAddress = PhysicalPostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(0.4f, 0.4f, 0.4f),
+                country = CountryCode.FR,
+                administrativeAreaLevel1 = "FR-ARA",
+                administrativeAreaLevel2 = "fr-admin-level-2",
+                administrativeAreaLevel3 = "fr-admin-level-3",
+                postalCode = "phys-postal-code-2",
+                city = "city-2",
+                district = "district-2",
+                street = StreetDto(
+                    name = "name-2",
+                    houseNumber = "house-number-2",
+                    milestone = "milestone-2",
+                    direction = "direction-2",
+                    namePrefix = "name-prefix-2",
+                    additionalNamePrefix = "add-name-prefix-2",
+                    nameSuffix = "name-suffix-2",
+                    additionalNameSuffix = "add-name-suffix-2"
+
+                ),
+                companyPostalCode = "comp-postal-code-2",
+                industrialZone = "industrial-zone-2",
+                building = "building-2",
+                floor = "floor-2",
+                door = "door-2"
+            ),
+            alternativePostalAddress = AlternativePostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(0.2f, 0.2f, 0.2f),
+                country = CountryCode.FR,
+                administrativeAreaLevel1 = "FR-BFC",
+                postalCode = "alt-post-code-2",
+                city = "alt-city-2",
+                deliveryServiceNumber = "delivery-service-number-2",
+                deliveryServiceQualifier = "delivery-service-qualifier-2",
+                deliveryServiceType = DeliveryServiceType.BOITE_POSTALE
+            )
+        ),
+        ownerBpnl = "BPNLTEST-2",
+        bpnL = "BPNLTEST-2",
+        bpnS = "BPNSTEST-2",
+        bpnA = "BPNATEST-2"
+    )
+
+}

--- a/bpdm-orchestrator/src/test/resources/application-test.properties
+++ b/bpdm-orchestrator/src/test/resources/application-test.properties
@@ -16,31 +16,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-bpdm.name=@project.name@
-bpdm.description=@project.description@
-bpdm.version=@project.version@
-##
-# Change default port
-server.port=8085
-##
-# Logging Configuration
-bpdm.logging.unknown-user=Anonymous
-##
-# Api Request Restrictions
-bpdm.api.upsert-limit=100
-##
-#Springdoc swagger configuration
-springdoc.api-docs.enabled=true
-springdoc.api-docs.path=/docs/api-docs
-springdoc.swagger-ui.disable-swagger-default-url=true
-springdoc.swagger-ui.path=/ui/swagger-ui
-springdoc.swagger-ui.show-common-extensions=true
-springdoc.swagger-ui.csrf.enabled=true
-##
-#Enable actuator endpoints
-management.endpoint.health.probes.enabled=true
-management.health.livenessState.enabled=true
-management.health.readinessState.enabled=true
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>bpdm-orchestrator-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>bpdm-cleaning-service-dummy</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
## Description

This pull request adds the first endpoint to the orchestrator API and implements a dummy return value for that endpoint. 

As always the endpoint comes with client functionality which is validated through tests.

The DTO model for the endpoint is based on the BusinessPartner interfaces in the common module, by this connecting it to the other API models while still having its own DTO implementations.

This pull request solves issue #425 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
