### PR TITLE
Feat: Add Reservation Endpoint to Orchestrator API

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAddressIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAddressIdentifierDto.kt
@@ -17,15 +17,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressIdentifierDescription
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = AddressIdentifierDescription.header)
+interface IBaseAddressIdentifierDto : IBaseIdentifierDto {
+    @get:Schema(description = AddressIdentifierDescription.value)
+    override val value: String
+
+    @get:Schema(description = AddressIdentifierDescription.type)
+    override val type: String
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAddressStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAddressStateDto.kt
@@ -17,15 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressStateDescription
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = AddressStateDescription.header)
+interface IBaseAddressStateDto : IBusinessPartnerStateDto {
+    @get:Schema(description = AddressStateDescription.description)
+    override val description: String?
+
+    @get:Schema(description = AddressStateDescription.validFrom)
+    override val validFrom: LocalDateTime?
+
+    @get:Schema(description = AddressStateDescription.validTo)
+    override val validTo: LocalDateTime?
+
+    @get:Schema(description = AddressStateDescription.type)
+    override val type: BusinessStateType
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseClassificationDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseClassificationDto.kt
@@ -17,15 +17,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = ClassificationDescription.header)
+interface IBaseClassificationDto {
+    @get:Schema(description = ClassificationDescription.type)
+    val type: ClassificationType
+
+    @get:Schema(description = ClassificationDescription.code)
+    val code: String?
+
+    @get:Schema(description = ClassificationDescription.value)
+    val value: String?
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseIdentifierDto.kt
@@ -17,15 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+interface IBaseIdentifierDto {
+    val value: String
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+    val type: String
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.dto
+
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+
+@Schema(description = LegalEntityDescription.header)
+interface IBaseLegalEntityDto {
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers, required = false))
+    val identifiers: Collection<IBaseLegalEntityIdentifierDto>
+
+    @get:Schema(description = LegalEntityDescription.legalShortName)
+    val legalShortName: String?
+
+    @get:Schema(description = LegalEntityDescription.legalForm)
+    val legalForm: String?
+
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.states))
+    val states: Collection<IBaseLegalEntityStateDto>
+
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications, required = false))
+    val classifications: Collection<IBaseClassificationDto>
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
+    val legalAddress: IBaseLogisticAddressDto?
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityIdentifierDto.kt
@@ -17,15 +17,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = LegalEntityIdentifierDescription.header)
+interface IBaseLegalEntityIdentifierDto : IBaseIdentifierDto {
+    @get:Schema(description = LegalEntityIdentifierDescription.value)
+    override val value: String
+
+    @get:Schema(description = LegalEntityIdentifierDescription.type)
+    override val type: String
+
+    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
+    val issuingBody: String?
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityStateDto.kt
@@ -17,15 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = LegalEntityStateDescription.header)
+interface IBaseLegalEntityStateDto : IBusinessPartnerStateDto {
+    @get:Schema(description = LegalEntityStateDescription.description)
+    override val description: String?
+
+    @get:Schema(description = LegalEntityStateDescription.validFrom)
+    override val validFrom: LocalDateTime?
+
+    @get:Schema(description = LegalEntityStateDescription.validTo)
+    override val validTo: LocalDateTime?
+
+    @get:Schema(description = LegalEntityStateDescription.type)
+    override val type: BusinessStateType
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLogisticAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLogisticAddressDto.kt
@@ -17,15 +17,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = LogisticAddressDescription.header)
+interface IBaseLogisticAddressDto {
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.states))
+    val states: Collection<IBaseAddressStateDto>
+
+    @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.identifiers))
+    val identifiers: Collection<IBaseAddressIdentifierDto>
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.physicalPostalAddress)
+    val physicalPostalAddress: IBasePhysicalPostalAddressDto?
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LogisticAddressDescription.alternativePostalAddress)
+    val alternativePostalAddress: IBaseAlternativePostalAddressDto?
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
@@ -17,15 +17,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = SiteDescription.header)
+interface IBaseSiteDto {
+
+    @get:ArraySchema(arraySchema = Schema(description = SiteDescription.states))
+    val states: Collection<IBaseSiteStateDto>
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteDescription.mainAddress)
+    val mainAddress: IBaseLogisticAddressDto?
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteStateDto.kt
@@ -17,15 +17,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteStateDescription
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+@Schema(description = SiteDescription.header)
+interface IBaseSiteStateDto : IBusinessPartnerStateDto {
+    @get:Schema(description = SiteStateDescription.description)
+    override val description: String?
+
+    @get:Schema(description = SiteStateDescription.validFrom)
+    override val validFrom: LocalDateTime?
+
+    @get:Schema(description = SiteStateDescription.validTo)
+    override val validTo: LocalDateTime?
+
+    @get:Schema(description = SiteStateDescription.type)
+    override val type: BusinessStateType
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerStateDto.kt
@@ -17,15 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+interface IBusinessPartnerStateDto {
+    val description: String?
+    val validFrom: LocalDateTime?
+    val validTo: LocalDateTime?
+    val type: BusinessStateType
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
@@ -24,10 +24,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.eclipse.tractusx.orchestrator.api.model.TaskCreateRequest
-import org.eclipse.tractusx.orchestrator.api.model.TaskCreateResponse
-import org.eclipse.tractusx.orchestrator.api.model.TaskStateRequest
-import org.eclipse.tractusx.orchestrator.api.model.TaskStateResponse
+import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -75,7 +72,29 @@ interface CleaningTaskApi {
             ApiResponse(responseCode = "400", description = "On malformed task search requests", content = [Content()]),
         ]
     )
+    @Tag(name = "Requester")
     @PostMapping("/cleaning-tasks/state/search")
+    @PostExchange("/cleaning-tasks/state/search")
     fun searchCleaningTaskState(@RequestBody searchTaskIdRequest: TaskStateRequest): TaskStateResponse
 
+    @Operation(
+        summary = "Reserve the next cleaning tasks waiting in the given cleaning step",
+        description = "Reserve up to a given number of cleaning tasks enqueued in the given cleaning step. " +
+                "The cleaning tasks contain the business partner to clean which consists of the generic and L/S/A data. " +
+                "For cleaning the business partners have a time limit which is returned with the reserved tasks." +
+                "For a single request, the maximum number of reservable tasks is limited to \${bpdm.api.upsert-limit}."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The reserved cleaning tasks with their business partner data to clean."
+            ),
+            ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
+        ]
+    )
+    @Tag(name = "Cleaning Service")
+    @PostMapping("/reservations")
+    @PostExchange("/reservations")
+    fun reserveCleaningTasks(@RequestBody reservationRequest: CleaningReservationRequest): CleaningReservationResponse
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressIdentifier.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressIdentifier.kt
@@ -19,13 +19,10 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseAddressIdentifierDto
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class AddressIdentifier(
+    override val value: String,
+    override val type: String
+
+) : IBaseAddressIdentifierDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressState.kt
@@ -19,13 +19,14 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseAddressStateDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class AddressState(
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
+    override val type: BusinessStateType
+
+) : IBaseAddressStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BpnReference.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BpnReference.kt
@@ -19,13 +19,17 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
+@Schema(description = "A reference to the BPN of a business partner. Either by the BPN value itself or a BPN request identifier")
+data class BpnReference(
+    @get:Schema(description = "The value by which the BPN is referenced")
+    val referenceValue: String,
+    @get:Schema(description = "The type by which to reference the BPN with")
+    val referenceType: BpnReferenceType
 )
+
+enum class BpnReferenceType {
+    Bpn,
+    BpnRequestIdentifier
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassification.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassification.kt
@@ -19,13 +19,11 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseClassificationDto
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class BusinessPartnerClassification(
+    override val type: ClassificationType,
+    override val code: String?,
+    override val value: String?
+) : IBaseClassificationDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerFull.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerFull.kt
@@ -20,21 +20,15 @@
 package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.*
 
-
-data class BusinessPartnerDto(
-    override val nameParts: List<String> = emptyList(),
-    override val shortName: String? = null,
-    override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
-    override val legalForm: String? = null,
-    override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<ClassificationDto> = emptyList(),
-    override val roles: Collection<BusinessPartnerRole> = emptyList(),
-    override val postalAddress: PostalAddressDto = PostalAddressDto(),
-    override val bpnL: String? = null,
-    override val bpnS: String? = null,
-    override val bpnA: String? = null,
-    @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
-    val ownerBpnl: String? = null
-) : IBaseBusinessPartnerDto
+@Schema(description = "Business partner data in full representation, consisting of generic data as well as its L/S/A representation.")
+data class BusinessPartnerFull(
+    @get:Schema(description = "The business partner data in generic representation", required = true)
+    val generic: BusinessPartnerGeneric,
+    @get:Schema(description = "The legal entity part of this business partner data")
+    val legalEntity: LegalEntity? = null,
+    @get:Schema(description = "The site part of this business partner data")
+    val site: Site? = null,
+    @get:Schema(description = "The address part of this business partner data")
+    val address: LogisticAddress? = null
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGeneric.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGeneric.kt
@@ -19,13 +19,22 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.*
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+
+data class BusinessPartnerGeneric(
+    override val nameParts: List<String> = emptyList(),
+    override val shortName: String? = null,
+    override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
+    override val legalForm: String? = null,
+    override val states: Collection<BusinessPartnerStateDto> = emptyList(),
+    override val classifications: Collection<ClassificationDto> = emptyList(),
+    override val roles: Collection<BusinessPartnerRole> = emptyList(),
+    override val postalAddress: PostalAddressDto = PostalAddressDto(),
+    override val bpnL: String? = null,
+    override val bpnS: String? = null,
+    override val bpnA: String? = null,
+    @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
+    val ownerBpnL: String? = null
+) : IBaseBusinessPartnerDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningReservation.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningReservation.kt
@@ -19,13 +19,12 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
+@Schema(description = "Cleaning reservation entry")
+data class CleaningReservation(
+    @get:Schema(description = "The identifier of the reserved cleaning task")
+    val taskId: String,
+    @get:Schema(description = "The business partner data to clean")
+    val businessPartner: BusinessPartnerFull
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningReservationRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningReservationRequest.kt
@@ -19,13 +19,12 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
+@Schema(description = "Request object for reserving a number of cleaning tasks waiting in a cleaning step.")
+data class CleaningReservationRequest(
+    @get:Schema(description = "The maximum number of cleaning tasks to reserve. Can be fewer if queue is not full enough.", required = true)
+    val amount: Int = 10,
+    @get:Schema(description = "The cleaning step queue to reserve from", required = true)
+    val step: CleaningStep
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningReservationResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningReservationResponse.kt
@@ -21,11 +21,12 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
+@Schema(description = "Response object for giving a list of reserved cleaning tasks")
+data class CleaningReservationResponse(
+    @get:ArraySchema(arraySchema = Schema(description = "The reserved cleaning tasks with their business partner data to clean"))
+    val reservedTasks: List<CleaningReservation>,
+    @get:Schema(description = "The timestamp until the reservation is valid and accepts cleaning results")
+    val timeout: Instant
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntity.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntity.kt
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+
+data class LegalEntity(
+    @get:Schema(description = "A reference to the BPNL of this legal entity. Either by the BPN value itself or a BPN request identifier.")
+    val bpnLReference: BpnReference? = null,
+
+    @get:Schema(description = "Whether this legal entity data is different from its golden record counterpart in the Pool")
+    val hasChanged: Boolean? = null,
+
+    @get:Schema(description = LegalEntityDescription.legalName)
+    val legalName: String? = null,
+
+    override val legalShortName: String? = null,
+
+    override val identifiers: Collection<LegalEntityIdentifier> = emptyList(),
+
+    override val legalForm: String? = null,
+
+    override val states: Collection<LegalEntityState> = emptyList(),
+
+    override val classifications: Collection<BusinessPartnerClassification> = emptyList(),
+
+    override val legalAddress: LogisticAddress? = null,
+) : IBaseLegalEntityDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityIdentifier.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityIdentifier.kt
@@ -19,13 +19,10 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityIdentifierDto
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class LegalEntityIdentifier(
+    override val value: String,
+    override val type: String,
+    override val issuingBody: String?
+) : IBaseLegalEntityIdentifierDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityState.kt
@@ -19,13 +19,14 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityStateDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class LegalEntityState(
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
+    override val type: BusinessStateType
+
+) : IBaseLegalEntityStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddress.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddress.kt
@@ -19,13 +19,25 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class LogisticAddress(
+    @get:Schema(description = "A reference to the BPNA of this address. Either by the BPN value itself or a BPN request identifier.")
+    val bpnAReference: BpnReference? = null,
+
+    @get:Schema(description = "Whether this address data is different from its golden record counterpart in the Pool")
+    val hasChanged: Boolean? = null,
+
+    @get:Schema(description = LogisticAddressDescription.name)
+    val name: String? = null,
+
+    override val states: Collection<AddressState> = emptyList(),
+
+    override val identifiers: Collection<AddressIdentifier> = emptyList(),
+
+    override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
+
+    override val alternativePostalAddress: AlternativePostalAddressDto? = null
+) : IBaseLogisticAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/Site.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/Site.kt
@@ -19,13 +19,21 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class Site(
+    @get:Schema(description = "A reference to the BPNS of this site. Either by the BPN value itself or a BPN request identifier.")
+    val bpnSReference: BpnReference? = null,
+
+    @get:Schema(description = "Whether this site data is different from its golden record counterpart in the Pool")
+    val hasChanged: Boolean? = null,
+
+    @get:Schema(description = SiteDescription.name)
+    val name: String? = null,
+
+    override val states: Collection<SiteState> = emptyList(),
+
+    override val mainAddress: LogisticAddress? = null,
+) : IBaseSiteDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteState.kt
@@ -19,13 +19,14 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteStateDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
-data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
-    val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
-)
+data class SiteState(
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
+    override val type: BusinessStateType
+
+) : IBaseSiteStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskRequesterState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskRequesterState.kt
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class TaskRequesterState(
     @get:Schema(required = true)
     val taskId: String,
-    val businessPartnerResult: BusinessPartnerDto?,
+    val businessPartnerResult: BusinessPartnerGeneric?,
     @get:Schema(required = true)
     val processingState: TaskProcessingStateDto
 )

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
@@ -21,91 +21,41 @@ package org.eclipse.tractusx.bpdm.orchestrator.controller
 
 import org.eclipse.tractusx.bpdm.common.exception.BpdmUpsertLimitException
 import org.eclipse.tractusx.bpdm.orchestrator.config.ApiConfigProperties
+import org.eclipse.tractusx.bpdm.orchestrator.util.DummyValues
 import org.eclipse.tractusx.orchestrator.api.CleaningTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.web.bind.annotation.RestController
-import java.time.Instant
 
 @RestController
 class CleaningTaskController(
     val apiConfigProperties: ApiConfigProperties
 ) : CleaningTaskApi {
 
-    //While we don't have an implementation use a dummy response for the endpoints
-    val dummyResponseCreateTask =
-        TaskCreateResponse(
-            listOf(
-                TaskRequesterState(
-                    taskId = "0",
-                    businessPartnerResult = null,
-                    processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.CleanAndSync,
-                        reservationState = ReservationState.Queued,
-                        resultState = ResultState.Pending,
-                        errors = emptyList(),
-                        createdAt = Instant.now(),
-                        modifiedAt = Instant.now()
-                    )
-                ),
-                TaskRequesterState(
-                    taskId = "1",
-                    businessPartnerResult = null,
-                    processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.CleanAndSync,
-                        reservationState = ReservationState.Queued,
-                        resultState = ResultState.Pending,
-                        errors = emptyList(),
-                        createdAt = Instant.now(),
-                        modifiedAt = Instant.now()
-                    )
-                )
-            )
-        )
-
-    //While we don't have an implementation use a dummy response for the endpoints
-    val dummyResponseTaskState =
-        TaskStateResponse(
-            listOf(
-                TaskRequesterState(
-                    taskId = "0",
-                    businessPartnerResult = null,
-                    processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.CleanAndSync,
-                        reservationState = ReservationState.Queued,
-                        resultState = ResultState.Pending,
-                        errors = emptyList(),
-                        createdAt = Instant.now(),
-                        modifiedAt = Instant.now()
-                    )
-                ),
-                TaskRequesterState(
-                    taskId = "1",
-                    businessPartnerResult = null,
-                    processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.Clean,
-                        reservationState = ReservationState.Queued,
-                        resultState = ResultState.Pending,
-                        errors = emptyList(),
-                        createdAt = Instant.now(),
-                        modifiedAt = Instant.now()
-                    )
-                )
-            )
-        )
-
-
     override fun createCleaningTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
         if (createRequest.businessPartners.size > apiConfigProperties.upsertLimit)
             throw BpdmUpsertLimitException(createRequest.businessPartners.size, apiConfigProperties.upsertLimit)
 
         //ToDo: Replace with service logic
-        return dummyResponseCreateTask
+        return DummyValues.dummyResponseCreateTask
+    }
+
+    override fun reserveCleaningTasks(reservationRequest: CleaningReservationRequest): CleaningReservationResponse {
+        if (reservationRequest.amount > apiConfigProperties.upsertLimit) {
+            throw BpdmUpsertLimitException(reservationRequest.amount, apiConfigProperties.upsertLimit)
+        }
+
+        //ToDo: Replace with service logic
+        return when (reservationRequest.step) {
+            CleaningStep.CleanAndSync -> DummyValues.dummyCleaningReservationResponse
+            CleaningStep.PoolSync -> DummyValues.dummyPoolSyncResponse
+            CleaningStep.Clean -> DummyValues.dummyCleaningReservationResponse
+        }
     }
 
 
     override fun searchCleaningTaskState(searchTaskIdRequest: TaskStateRequest): TaskStateResponse {
         // ToDo: Replace with service logic
-        return dummyResponseTaskState
+        return DummyValues.dummyResponseTaskState
     }
 
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/DummyValues.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/DummyValues.kt
@@ -1,0 +1,237 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.util
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.orchestrator.api.model.*
+import java.time.Instant
+
+//While we don't have a service logic implementation of the API  use a dummy response for the endpoints
+object DummyValues {
+
+    val dummyResponseCreateTask =
+        TaskCreateResponse(
+            listOf(
+                TaskRequesterState(
+                    taskId = "0",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.CleanAndSync,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                ),
+                TaskRequesterState(
+                    taskId = "1",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.CleanAndSync,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                )
+            )
+        )
+
+    val dummyCleaningReservationResponse = CleaningReservationResponse(
+        timeout = Instant.now().plusSeconds(300),
+        reservedTasks = listOf(
+            CleaningReservation(
+                taskId = "0",
+                businessPartner = BusinessPartnerFull(
+                    generic = BusinessPartnerGeneric(
+                        nameParts = listOf("Dummy", "Name"),
+                        postalAddress = PostalAddressDto(
+                            physicalPostalAddress = PhysicalPostalAddressDto(
+                                country = CountryCode.DE,
+                                postalCode = "70771"
+                            )
+                        )
+                    )
+                )
+            ),
+            CleaningReservation(
+                taskId = "1",
+                businessPartner = BusinessPartnerFull(
+                    generic = BusinessPartnerGeneric(
+                        nameParts = listOf("Other", "Name"),
+                        postalAddress = PostalAddressDto(
+                            physicalPostalAddress = PhysicalPostalAddressDto(
+                                country = CountryCode.DE,
+                                postalCode = "80331"
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+
+    private val businessPartnerFull1 = BusinessPartnerFull(
+        generic = BusinessPartnerGeneric(
+            nameParts = listOf("Dummy", "Name"),
+            postalAddress = PostalAddressDto(
+                addressType = AddressType.LegalAddress,
+                physicalPostalAddress = PhysicalPostalAddressDto(
+                    country = CountryCode.DE,
+                    postalCode = "70771"
+                )
+            )
+        ),
+        legalEntity = LegalEntity(
+            legalName = "Dummy Name",
+            bpnLReference = BpnReference(
+                referenceValue = "request-id-l-1",
+                referenceType = BpnReferenceType.BpnRequestIdentifier
+            ),
+            legalAddress = LogisticAddress(
+                bpnAReference = BpnReference(
+                    referenceValue = "request-id-a-1",
+                    referenceType = BpnReferenceType.BpnRequestIdentifier
+                ),
+                physicalPostalAddress = PhysicalPostalAddressDto(
+                    country = CountryCode.DE,
+                    postalCode = "70771"
+                )
+            ),
+        ),
+        address = LogisticAddress(
+            bpnAReference = BpnReference(
+                referenceValue = "request-id-a-1",
+                referenceType = BpnReferenceType.BpnRequestIdentifier
+            ),
+            physicalPostalAddress = PhysicalPostalAddressDto(
+                country = CountryCode.DE,
+                postalCode = "70771"
+            )
+        )
+    )
+
+    private val businessPartnerFull2 = BusinessPartnerFull(
+        generic = BusinessPartnerGeneric(
+            nameParts = listOf("Other", "Name"),
+            postalAddress = PostalAddressDto(
+                addressType = AddressType.AdditionalAddress,
+                physicalPostalAddress = PhysicalPostalAddressDto(
+                    country = CountryCode.DE,
+                    postalCode = "80331"
+                )
+            )
+        ),
+        legalEntity = LegalEntity(
+            legalName = "Other Name",
+            bpnLReference = BpnReference(
+                referenceValue = "BPNL1",
+                referenceType = BpnReferenceType.Bpn
+            ),
+            legalAddress = LogisticAddress(
+                bpnAReference = BpnReference(
+                    referenceValue = "BPNA1",
+                    referenceType = BpnReferenceType.Bpn
+                ),
+                physicalPostalAddress = PhysicalPostalAddressDto(
+                    country = CountryCode.DE,
+                    postalCode = "80333"
+                )
+            )
+        ),
+        site = Site(
+            name = "Other Site Name",
+            bpnSReference = BpnReference(
+                referenceValue = "BPNS1",
+                referenceType = BpnReferenceType.Bpn
+            ),
+            mainAddress = LogisticAddress(
+                bpnAReference = BpnReference(
+                    referenceValue = "BPNA2",
+                    referenceType = BpnReferenceType.Bpn
+                ),
+                physicalPostalAddress = PhysicalPostalAddressDto(
+                    country = CountryCode.DE,
+                    postalCode = "80331"
+                )
+            )
+        ),
+        address = LogisticAddress(
+            bpnAReference = BpnReference(
+                referenceValue = "BPNA3",
+                referenceType = BpnReferenceType.Bpn
+            ),
+            physicalPostalAddress = PhysicalPostalAddressDto(
+                country = CountryCode.DE,
+                postalCode = "80331"
+            )
+        )
+    )
+
+    val dummyPoolSyncResponse = CleaningReservationResponse(
+        timeout = Instant.now().plusSeconds(300),
+        reservedTasks = listOf(
+            CleaningReservation(
+                taskId = "0",
+                businessPartner = businessPartnerFull1
+            ),
+            CleaningReservation(
+                taskId = "1",
+                businessPartner = businessPartnerFull2
+            )
+        )
+    )
+
+    val dummyResponseTaskState =
+        TaskStateResponse(
+            listOf(
+                TaskRequesterState(
+                    taskId = "0",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.CleanAndSync,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                ),
+                TaskRequesterState(
+                    taskId = "1",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.Clean,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                )
+            )
+        )
+
+
+}

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/BusinessPartnerTestValues.kt
@@ -31,13 +31,13 @@ import org.eclipse.tractusx.orchestrator.api.model.StreetDto
 import java.time.LocalDateTime
 
 /**
- * Contains complex test values that can be used as templates by the test classes
+ * Contains complex test values of business partners that can be used as templates by the test classes
  * Test values here should have as many unique values as possible to reduce the probability of finding matching errors
  */
-object TestValues {
+object BusinessPartnerTestValues {
 
     //Business Partner with two entries in every collection
-    val businessPartner1 = BusinessPartnerDto(
+    val businessPartner1 = BusinessPartnerGeneric(
         nameParts = listOf("NamePart1", "NamePart2"),
         shortName = "shortname",
         identifiers = listOf(
@@ -122,14 +122,14 @@ object TestValues {
                 deliveryServiceType = DeliveryServiceType.PO_BOX
             )
         ),
-        ownerBpnl = null,
+        ownerBpnL = "BPNL_OWNER_TEST_1",
         bpnL = "BPNLTEST",
         bpnS = "BPNSTEST",
         bpnA = "BPNATEST"
     )
 
     //Business Partner with single entry in every collection
-    val businessPartner2 = BusinessPartnerDto(
+    val businessPartner2 = BusinessPartnerGeneric(
         nameParts = listOf("name-part-2"),
         shortName = "shortname-2",
         identifiers = listOf(
@@ -197,10 +197,9 @@ object TestValues {
                 deliveryServiceType = DeliveryServiceType.BOITE_POSTALE
             )
         ),
-        ownerBpnl = "BPNLTEST-2",
+        ownerBpnL = "BPNL_OWNER_TEST_2",
         bpnL = "BPNLTEST-2",
         bpnS = "BPNSTEST-2",
         bpnA = "BPNATEST-2"
     )
-
 }


### PR DESCRIPTION
## Description

This pull request introduces an endpoint to reserve a given number of cleaning tasks from the orchestrator from a given cleaning step queue. For this I introduced interfaces for L/S/A DTOs in the common module an implemented those DTOs in the orchestrator application module, analogous to the generic business partner. 

The API endpoint is implemented in the orchestrator controller and returns dummy data on invocation.

I also added tests checking the upsert limit and whether the endpoint can be invoked.

Contributes to #458 

## Pre-review checks


Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
