### PR TITLE
Feat(Orchestrator): Add taskId search Api

### DIFF
--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
@@ -26,6 +26,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.orchestrator.api.model.TaskCreateRequest
 import org.eclipse.tractusx.orchestrator.api.model.TaskCreateResponse
+import org.eclipse.tractusx.orchestrator.api.model.TaskStateRequest
+import org.eclipse.tractusx.orchestrator.api.model.TaskStateResponse
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -59,5 +61,21 @@ interface CleaningTaskApi {
     @PostExchange
     fun createCleaningTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
 
+
+    @Operation(
+        summary = "Search for the state of cleaning tasks by task identifiers",
+        description = "Returns the state of finished cleaning tasks based on the provided task identifiers."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The state of the finished cleaning tasks for the provided task identifiers."
+            ),
+            ApiResponse(responseCode = "400", description = "On malformed task search requests", content = [Content()]),
+        ]
+    )
+    @PostMapping("/cleaning-tasks/state/search")
+    fun searchCleaningTaskState(@RequestBody searchTaskIdRequest: TaskStateRequest): TaskStateResponse
 
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateRequest.kt
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request object for giving a list of tasks to search")
+data class TaskStateRequest(
+    val taskList: List<String>
+) {
+
+}
+
+

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateResponse.kt
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Response object for a given a list of tasks to search")
+data class TaskStateResponse(
+    val createdTasks: List<TaskRequesterState>
+) {
+
+}
+
+

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
@@ -62,6 +62,37 @@ class CleaningTaskController(
             )
         )
 
+    //While we don't have an implementation use a dummy response for the endpoints
+    val dummyResponseTaskState =
+        TaskStateResponse(
+            listOf(
+                TaskRequesterState(
+                    taskId = "0",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.CleanAndSync,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                ),
+                TaskRequesterState(
+                    taskId = "1",
+                    businessPartnerResult = null,
+                    processingState = TaskProcessingStateDto(
+                        cleaningStep = CleaningStep.Clean,
+                        reservationState = ReservationState.Queued,
+                        resultState = ResultState.Pending,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now()
+                    )
+                )
+            )
+        )
+
 
     override fun createCleaningTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
         if (createRequest.businessPartners.size > apiConfigProperties.upsertLimit)
@@ -70,4 +101,11 @@ class CleaningTaskController(
         //ToDo: Replace with service logic
         return dummyResponseCreateTask
     }
+
+
+    override fun searchCleaningTaskState(searchTaskIdRequest: TaskStateRequest): TaskStateResponse {
+        // ToDo: Replace with service logic
+        return dummyResponseTaskState
+    }
+
 }

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskControllerIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskControllerIT.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.orchestrator.util.TestValues
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
 import org.eclipse.tractusx.orchestrator.api.model.TaskCreateRequest
 import org.eclipse.tractusx.orchestrator.api.model.TaskMode
+import org.eclipse.tractusx.orchestrator.api.model.TaskStateRequest
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -74,6 +75,25 @@ class CleaningTaskControllerIT @Autowired constructor(
         Assertions.assertThatThrownBy {
             orchestratorClient.cleaningTasks.createCleaningTasks(request)
         }.isInstanceOf(WebClientResponseException::class.java)
+    }
+
+    /**
+     * Search for taskId and get dummy response on the test
+     */
+
+    @Test
+    fun `search cleaning task state and expect dummy response`() {
+
+        val request = TaskStateRequest(listOf("0", "1"))
+
+
+        val expected = cleaningTaskController.dummyResponseTaskState
+
+
+        val response = cleaningTaskController.searchCleaningTaskState(request)
+
+        // Assert that the response matches the expected value
+        Assertions.assertThat(response).isEqualTo(expected)
     }
 
 }


### PR DESCRIPTION
## Description

Introduced a new endpoint in the CleaningTaskApi interface for querying the state of finished cleaning tasks by task identifiers. The endpoint is defined as a POST request to /cleaning-tasks/state/search.
Implemented the above endpoint in the CleaningTaskController class. 
Currently, it returns dummy data as a placeholder.
Created a unit test for the CleaningTaskController to verify that the new endpoint is reachable and returns the expected dummy data.

This pull request solves issue (https://github.com/eclipse-tractusx/bpdm/issues/426)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
