### PR TITLE
Feat: Add Endpoint for Posting Cleaning Results to Orchestrator

### DIFF
--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
@@ -100,4 +100,26 @@ interface CleaningTaskApi {
     @PostMapping("/reservations")
     @PostExchange("/reservations")
     fun reserveCleaningTasks(@RequestBody reservationRequest: CleaningReservationRequest): CleaningReservationResponse
+
+    @Operation(
+        summary = "Post cleaning results for reserved cleaning tasks in given cleaning step",
+        description = "Post business partner cleaning results for the given cleaning tasks. " +
+                "In order to post a result for a cleaning task it needs to be reserved first, has to currently be in the given cleaning step and the time limit is not exceeded." +
+                "The number of results you can post at a time does not need to match the original number of reserved tasks." +
+                "Results are accepted via strategy 'all or nothing'." +
+                "For a single request, the maximum number of postable results is limited to \${bpdm.api.upsert-limit}."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "If the results could be processed"
+            ),
+            ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
+        ]
+    )
+    @Tag(name = "Cleaning Service")
+    @PostMapping("/results")
+    @PostExchange("/results")
+    fun resolveCleaningTasks(@RequestBody resultRequest: CleaningResultRequest)
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningResultEntry.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningResultEntry.kt
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.model
+
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+
+
+@Schema(description = "A cleaning result for a cleaning task")
+data class CleaningResultEntry(
+    @get:Schema(description = "The identifier of the cleaning task for which this is a result", required = true)
+    val taskId: String,
+    @get:Schema(description = "The actual result in form of business partner data. Maybe null if an error occurred during cleaning of this task.")
+    val result: BusinessPartnerFull? = null,
+    @get:ArraySchema(arraySchema = Schema(description = "Errors that occurred during cleaning of this task"))
+    val errors: List<TaskError> = emptyList()
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningResultRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/CleaningResultRequest.kt
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.model
+
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request object for posting cleaning results")
+data class CleaningResultRequest(
+    @get:ArraySchema(arraySchema = Schema(description = "The cleaning results for previously reserved cleaning tasks"))
+    val results: List<CleaningResultEntry>
+)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskController.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.orchestrator.controller
 
 import org.eclipse.tractusx.bpdm.common.exception.BpdmUpsertLimitException
 import org.eclipse.tractusx.bpdm.orchestrator.config.ApiConfigProperties
+import org.eclipse.tractusx.bpdm.orchestrator.exception.BpdmEmptyResultException
 import org.eclipse.tractusx.bpdm.orchestrator.util.DummyValues
 import org.eclipse.tractusx.orchestrator.api.CleaningTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
@@ -49,6 +50,16 @@ class CleaningTaskController(
             CleaningStep.CleanAndSync -> DummyValues.dummyCleaningReservationResponse
             CleaningStep.PoolSync -> DummyValues.dummyPoolSyncResponse
             CleaningStep.Clean -> DummyValues.dummyCleaningReservationResponse
+        }
+    }
+
+    override fun resolveCleaningTasks(resultRequest: CleaningResultRequest) {
+        if (resultRequest.results.size > apiConfigProperties.upsertLimit)
+            throw BpdmUpsertLimitException(resultRequest.results.size, apiConfigProperties.upsertLimit)
+
+        resultRequest.results.forEach { resultEntry ->
+            if (resultEntry.result == null && resultEntry.errors.isEmpty())
+                throw BpdmEmptyResultException(resultEntry.taskId)
         }
     }
 

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/exception/BpdmEmptyResultException.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/exception/BpdmEmptyResultException.kt
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class BpdmEmptyResultException(
+    taskId: String
+) : RuntimeException("Result for cleaning task with ID '$taskId' is invalid as it does not contain resulting business partner data but also no errors.")

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/BusinessPartnerTestValues.kt
@@ -202,4 +202,257 @@ object BusinessPartnerTestValues {
         bpnS = "BPNSTEST-2",
         bpnA = "BPNATEST-2"
     )
+
+    val logisticAddress1 = LogisticAddress(
+        name = "Address Name 1",
+        states = listOf(
+            AddressState(
+                description = "Address State 1",
+                validFrom = LocalDateTime.of(1970, 4, 4, 4, 4),
+                validTo = LocalDateTime.of(1975, 5, 5, 5, 5),
+                type = BusinessStateType.ACTIVE
+            ),
+            AddressState(
+                description = "Address State 2",
+                validFrom = LocalDateTime.of(1975, 5, 5, 5, 5),
+                validTo = null,
+                type = BusinessStateType.INACTIVE
+            ),
+        ),
+        identifiers = listOf(
+            AddressIdentifier(
+                value = "Address Identifier Value 1",
+                type = "Address Identifier Type 1"
+            ),
+            AddressIdentifier(
+                value = "Address Identifier Value 2",
+                type = "Address Identifier Type 2"
+            )
+        ),
+        physicalPostalAddress = PhysicalPostalAddressDto(
+            geographicCoordinates = GeoCoordinateDto(0.12f, 0.12f, 0.12f),
+            country = CountryCode.AD,
+            administrativeAreaLevel1 = "AD-07",
+            administrativeAreaLevel2 = "Admin-Level 2-1",
+            administrativeAreaLevel3 = "Admin-Level 3-1",
+            postalCode = "Postal Code 1",
+            city = "City 1",
+            district = "District 1",
+            street = StreetDto(
+                name = "Street Name 1",
+                houseNumber = "House Number 1",
+                milestone = "Milestone 1",
+                direction = "Direction 1",
+                namePrefix = "Name Prefix 1",
+                additionalNameSuffix = "Additional Name Suffix 1",
+                additionalNamePrefix = "Additional Name Prefix 1",
+                nameSuffix = "Name Suffix 1"
+            ),
+            companyPostalCode = "Company Postal Code 1",
+            industrialZone = "Industrial Zone 1",
+            building = "Building 1",
+            floor = "Floor 1",
+            door = "Door 1"
+        ),
+        alternativePostalAddress = AlternativePostalAddressDto(
+            geographicCoordinates = GeoCoordinateDto(0.23f, 0.23f, 0.23f),
+            country = CountryCode.AD,
+            administrativeAreaLevel1 = "AD-08",
+            postalCode = "Postal Code Alt 1",
+            city = "City Alt 1",
+            deliveryServiceType = DeliveryServiceType.PRIVATE_BAG,
+            deliveryServiceQualifier = "Delivery Service Qualifier 1",
+            deliveryServiceNumber = "Delivery Service Number 1"
+        ),
+        bpnAReference = BpnReference(
+            referenceType = BpnReferenceType.Bpn,
+            referenceValue = "BPNATEST-1"
+        ),
+        hasChanged = true
+    )
+
+    val logisticAddress2 = LogisticAddress(
+        name = "Address Name 2",
+        states = listOf(
+            AddressState(
+                description = "Address State 2",
+                validFrom = LocalDateTime.of(1971, 4, 4, 4, 4),
+                validTo = null,
+                type = BusinessStateType.ACTIVE
+            )
+        ),
+        identifiers = listOf(
+            AddressIdentifier(
+                value = "Address Identifier Value 2-1",
+                type = "Address Identifier Type 2-1"
+            )
+        ),
+        physicalPostalAddress = PhysicalPostalAddressDto(
+            geographicCoordinates = GeoCoordinateDto(0.45f, 0.46f, 0.47f),
+            country = CountryCode.AD,
+            administrativeAreaLevel1 = "AD-07",
+            administrativeAreaLevel2 = "Admin-Level 2-2",
+            administrativeAreaLevel3 = "Admin-Level 3-2",
+            postalCode = "Postal Code 2",
+            city = "City 2",
+            district = "District 2",
+            street = StreetDto(
+                name = "Street Name 2",
+                houseNumber = "House Number 2",
+                milestone = "Milestone 2",
+                direction = "Direction 2",
+                namePrefix = "Name Prefix 2",
+                additionalNameSuffix = "Additional Name Suffix 2",
+                additionalNamePrefix = "Additional Name Prefix 2",
+                nameSuffix = "Name Suffix 2"
+            ),
+            companyPostalCode = "Company Postal Code 2",
+            industrialZone = "Industrial Zone 2",
+            building = "Building 2",
+            floor = "Floor 2",
+            door = "Door 2"
+        ),
+        alternativePostalAddress = AlternativePostalAddressDto(
+            geographicCoordinates = GeoCoordinateDto(0.01f, 0.02f, 0.03f),
+            country = CountryCode.AD,
+            administrativeAreaLevel1 = "AD-08",
+            postalCode = "Postal Code Alt 2",
+            city = "City Alt 2",
+            deliveryServiceType = DeliveryServiceType.PO_BOX,
+            deliveryServiceQualifier = "Delivery Service Qualifier 2",
+            deliveryServiceNumber = "Delivery Service Number 2"
+        ),
+        bpnAReference = BpnReference(
+            referenceType = BpnReferenceType.BpnRequestIdentifier,
+            referenceValue = "BPN_REQUEST_ID_TEST"
+        ),
+        hasChanged = true
+    )
+
+    val legalEntity1 = LegalEntity(
+        legalName = "Legal Entity Name 1",
+        legalShortName = "Legal Short Name 1",
+        identifiers = listOf(
+            LegalEntityIdentifier(
+                value = "Legal Identifier Value 1",
+                type = "Legal Identifier Type 1",
+                issuingBody = "Legal Issuing Body 1"
+            ),
+            LegalEntityIdentifier(
+                value = "Legal Identifier Value 2",
+                type = "Legal Identifier Type 2",
+                issuingBody = "Legal Issuing Body 2"
+            ),
+        ),
+        legalForm = "Legal Form 1",
+        states = listOf(
+            LegalEntityState(
+                description = "Legal State Description 1",
+                validFrom = LocalDateTime.of(1995, 2, 2, 3, 3),
+                validTo = LocalDateTime.of(2000, 3, 3, 4, 4),
+                type = BusinessStateType.ACTIVE
+            ),
+            LegalEntityState(
+                description = "Legal State Description 2",
+                validFrom = LocalDateTime.of(2000, 3, 3, 4, 4),
+                validTo = null,
+                type = BusinessStateType.INACTIVE
+            ),
+        ),
+        classifications = listOf(
+            BusinessPartnerClassification(
+                type = ClassificationType.SIC,
+                code = "Classification Code 1",
+                value = "Classification Value 1"
+            ),
+            BusinessPartnerClassification(
+                type = ClassificationType.NACE,
+                code = "Classification Code 2",
+                value = "Classification Value 2"
+            )
+        ),
+        legalAddress = logisticAddress1,
+        bpnLReference = BpnReference(
+            referenceValue = "BPNL1-TEST",
+            referenceType = BpnReferenceType.Bpn
+        ),
+        hasChanged = false
+    )
+
+    val legalEntity2 = LegalEntity(
+        legalName = "Legal Entity Name 2",
+        legalShortName = "Legal Short Name 2",
+        identifiers = listOf(
+            LegalEntityIdentifier(
+                value = "Legal Identifier Value 2",
+                type = "Legal Identifier Type 2",
+                issuingBody = "Legal Issuing Body 2"
+            )
+        ),
+        legalForm = "Legal Form 2",
+        states = listOf(
+            LegalEntityState(
+                description = "Legal State Description 2",
+                validFrom = LocalDateTime.of(1900, 5, 5, 5, 5),
+                validTo = null,
+                type = BusinessStateType.ACTIVE
+            )
+        ),
+        classifications = listOf(
+            BusinessPartnerClassification(
+                type = ClassificationType.SIC,
+                code = "Classification Code 2",
+                value = "Classification Value 2"
+            )
+        ),
+        legalAddress = logisticAddress2,
+        bpnLReference = BpnReference(
+            referenceValue = "BPNL-REQUEST_ID_TEST",
+            referenceType = BpnReferenceType.BpnRequestIdentifier
+        ),
+        hasChanged = false
+    )
+
+    val site1 = Site(
+        name = "Site Name 1",
+        states = listOf(
+            SiteState(
+                description = "Site State Description 1",
+                validFrom = LocalDateTime.of(1991, 10, 10, 10, 10),
+                validTo = LocalDateTime.of(2001, 11, 11, 11, 11),
+                type = BusinessStateType.ACTIVE
+            ),
+            SiteState(
+                description = "Site State Description 2",
+                validFrom = LocalDateTime.of(2001, 11, 11, 11, 11),
+                validTo = null,
+                type = BusinessStateType.INACTIVE
+            )
+        ),
+        mainAddress = logisticAddress1,
+        bpnSReference = BpnReference(
+            referenceValue = "BPNS_TEST",
+            referenceType = BpnReferenceType.Bpn
+        ),
+        hasChanged = false
+    )
+
+    val site2 = Site(
+        name = "Site Name 2",
+        states = listOf(
+            SiteState(
+                description = "Site State Description 2",
+                validFrom = LocalDateTime.of(1997, 12, 12, 12, 12),
+                validTo = null,
+                type = BusinessStateType.ACTIVE
+            )
+        ),
+        mainAddress = logisticAddress2,
+        bpnSReference = BpnReference(
+            referenceValue = "BPNS_REQUEST_ID_TEST",
+            referenceType = BpnReferenceType.BpnRequestIdentifier
+        ),
+        hasChanged = true
+    )
+
 }


### PR DESCRIPTION
## Description

This pull request introduces an endpoint to post cleaning results for previously reserved cleaning tasks to the orchestrator. The API endpoint is implemented in the orchestrator controller and returns dummy data on invocation.

I also added tests checking the upsert limit and whether the endpoint can be invoked.

For the necessary test I created template objects for L/S/A business partners that can be used by the tests.

Solves issue #458

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
