### PR TITLE
Feat (Gate) - Added Parent references for Generic related to LSA Type and Changelog Type rework

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
@@ -40,7 +40,7 @@ class GateQueryService(
 
     private val logger = KotlinLogging.logger { }
 
-    fun getChangedExternalIdsByBusinessPartnerType(modifiedAfter: Instant?): Map<BusinessPartnerType, Set<String>> {
+    fun getChangedExternalIdsByBusinessPartnerType(modifiedAfter: Instant?): Map<BusinessPartnerType?, Set<String>> {
         var page = 0
         var totalPages: Int
         val content = mutableListOf<ChangelogGateDto>()

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -56,4 +56,5 @@ interface IBaseBusinessPartnerDto {
 
     @get:Schema(description = "BPNA")
     val bpnA: String?
+
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
@@ -44,6 +44,6 @@ data class BusinessPartnerInputRequest(
     override val isOwner: Boolean = false,
     override val bpnL: String? = null,
     override val bpnS: String? = null,
-    override val bpnA: String? = null
+    override val bpnA: String? = null,
 
 ) : IBaseBusinessPartnerGateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerOutputRequest.kt
@@ -17,13 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
+import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
+import org.eclipse.tractusx.bpdm.gate.api.model.IBaseBusinessPartnerGateDto
 
 
-data class BusinessPartnerGeneric(
+@Schema(
+    description = "Generic business partner with external id",
+    requiredProperties = ["externalId", "postalAddress"]
+)
+data class BusinessPartnerOutputRequest(
+
+    override val externalId: String,
     override val nameParts: List<String> = emptyList(),
     override val shortName: String? = null,
     override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
@@ -31,10 +42,10 @@ data class BusinessPartnerGeneric(
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
     override val classifications: Collection<ClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
-    override val postalAddress: PostalAddressDto = PostalAddressDto(),
+    override val postalAddress: BusinessPartnerPostalAddressDto = BusinessPartnerPostalAddressDto(),
+    override val isOwner: Boolean = false,
     override val bpnL: String? = null,
     override val bpnS: String? = null,
     override val bpnA: String? = null,
-    @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
-    val ownerBpnL: String? = null,
-) : IBaseBusinessPartnerDto
+
+) : IBaseBusinessPartnerGateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ChangelogGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/ChangelogGateDto.kt
@@ -32,7 +32,7 @@ data class ChangelogGateDto(
     val externalId: String,
 
     @get:Schema(description = ChangelogDescription.businessPartnerType)
-    val businessPartnerType: BusinessPartnerType,
+    val businessPartnerType: BusinessPartnerType?,
 
     @get:Schema(description = ChangelogDescription.timestamp)
     val timestamp: Instant,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/ChangelogEntry.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/ChangelogEntry.kt
@@ -34,7 +34,7 @@ class ChangelogEntry(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "business_partner_type", nullable = false, updatable = false)
-    val businessPartnerType: BusinessPartnerType,
+    val businessPartnerType: BusinessPartnerType?,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "changelog_type", nullable = false, updatable = false)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.gate.entity.generic
 
 import jakarta.persistence.*
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import java.util.*
@@ -79,6 +80,13 @@ class BusinessPartner(
 
     @Column(name = "stage")
     @Enumerated(EnumType.STRING)
-    var stage: StageType
+    var stage: StageType,
+
+    @Column(name = "parent_id")
+    var parentId: String?,
+
+    @Column(name = "parent_type")
+    @Enumerated(EnumType.STRING)
+    var parentType: BusinessPartnerType?
 
 ) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -19,10 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
-import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNullMappingException
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.common.util.replace
@@ -31,6 +28,7 @@ import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
 import org.eclipse.tractusx.bpdm.gate.api.model.PhysicalPostalAddressGateDto
 import org.eclipse.tractusx.bpdm.gate.api.model.StreetGateDto
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
 import org.eclipse.tractusx.bpdm.gate.entity.AlternativePostalAddress
@@ -85,7 +83,7 @@ class BusinessPartnerMappings {
         )
     }
 
-    fun toBusinessPartner(dto: BusinessPartnerInputRequest, stage: StageType): BusinessPartner {
+    fun toBusinessPartner(dto: BusinessPartnerInputRequest, stage: StageType, parentId: String?, parentType: BusinessPartnerType?): BusinessPartner {
         return BusinessPartner(
             stage = stage,
             externalId = dto.externalId,
@@ -100,11 +98,13 @@ class BusinessPartnerMappings {
             bpnL = dto.bpnL,
             bpnS = dto.bpnS,
             bpnA = dto.bpnA,
-            postalAddress = toPostalAddress(dto.postalAddress)
+            postalAddress = toPostalAddress(dto.postalAddress),
+            parentId = parentId,
+            parentType = parentType,
         )
     }
 
-    fun updateBusinessPartner(entity: BusinessPartner, dto: BusinessPartnerInputRequest) {
+    fun updateBusinessPartner(entity: BusinessPartner, dto: BusinessPartnerInputRequest, parentId: String?, parentType: BusinessPartnerType?) {
         entity.nameParts.replace(dto.nameParts)
         entity.roles.replace(dto.roles)
         entity.identifiers.replace(dto.identifiers.map(::toIdentifier))
@@ -116,6 +116,47 @@ class BusinessPartnerMappings {
         entity.bpnL = dto.bpnL
         entity.bpnS = dto.bpnS
         entity.bpnA = dto.bpnA
+        entity.parentId = parentId
+        entity.parentType = parentType
+        updatePostalAddress(entity.postalAddress, dto.postalAddress)
+    }
+
+    //Output
+    fun toBusinessPartnerOutput(dto: BusinessPartnerOutputRequest, stage: StageType, parentId: String?, parentType: BusinessPartnerType?): BusinessPartner {
+        return BusinessPartner(
+            stage = stage,
+            externalId = dto.externalId,
+            nameParts = dto.nameParts.toMutableList(),
+            roles = dto.roles.toSortedSet(),
+            identifiers = dto.identifiers.map(::toIdentifier).toSortedSet(),
+            states = dto.states.map(::toState).toSortedSet(),
+            classifications = dto.classifications.map(::toClassification).toSortedSet(),
+            shortName = dto.shortName,
+            legalForm = dto.legalForm,
+            isOwner = dto.isOwner,
+            bpnL = dto.bpnL,
+            bpnS = dto.bpnS,
+            bpnA = dto.bpnA,
+            parentId = parentId,
+            parentType = parentType,
+            postalAddress = toPostalAddress(dto.postalAddress)
+        )
+    }
+
+    fun updateBusinessPartnerOutput(entity: BusinessPartner, dto: BusinessPartnerOutputRequest, parentId: String?, parentType: BusinessPartnerType?) {
+        entity.nameParts.replace(dto.nameParts)
+        entity.roles.replace(dto.roles)
+        entity.identifiers.replace(dto.identifiers.map(::toIdentifier))
+        entity.states.replace(dto.states.map(::toState))
+        entity.classifications.replace(dto.classifications.map(::toClassification))
+        entity.shortName = dto.shortName
+        entity.legalForm = dto.legalForm
+        entity.isOwner = dto.isOwner
+        entity.bpnL = dto.bpnL
+        entity.bpnS = dto.bpnS
+        entity.bpnA = dto.bpnA
+        entity.parentId = parentId
+        entity.parentType = parentType
         updatePostalAddress(entity.postalAddress, dto.postalAddress)
     }
 

--- a/bpdm-gate/src/main/resources/db/migration/V4_0_0_16__add_parent_type-generic.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V4_0_0_16__add_parent_type-generic.sql
@@ -1,0 +1,6 @@
+ALTER TABLE business_partners
+ADD COLUMN parent_id VARCHAR(255),
+ADD COLUMN parent_type VARCHAR(255);
+
+ALTER TABLE changelog_entries
+ALTER COLUMN business_partner_type DROP NOT NULL;

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -162,7 +162,9 @@ internal class BusinessPartnerIT @Autowired constructor(
             identifiers = sortedSetOf(createIdentifier()),
             states = sortedSetOf(createState()),
             classifications = sortedSetOf(createClassification()),
-            stage = StageType.Input
+            stage = StageType.Input,
+            parentId = null,
+            parentType = null
         )
     }
 


### PR DESCRIPTION
Added Parent references for Generic related to LSA Type and Changelog Type rework

## Description
New fields we're added in the Generic Business Partner (ParentID and ParentType) in order to be backwards compatible with the BPDM Gate's L/S/A endpoints. Logic for relationship verification in Sites and Addresses was added.
Changelogs creation was altered, and now businessPartnerType is optional. Mapping of Address Type to Business Partner Type was done as well.

New service for Generic Output persistence was created.

Related issues #490 and #489 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
