### PR TITLE
fix: Small improvements and fix of inconsistencies in CleaningTaskApi

### DIFF
--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/CleaningTaskApi.kt
@@ -32,6 +32,9 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
+const val TagRequester = "Requester"
+const val TagCleaningService = "Cleaning Service"
+
 @RequestMapping("/api/cleaning-tasks", produces = [MediaType.APPLICATION_JSON_VALUE])
 @HttpExchange("/api/cleaning-tasks")
 interface CleaningTaskApi {
@@ -53,7 +56,7 @@ interface CleaningTaskApi {
             ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
         ]
     )
-    @Tag(name = "Requester")
+    @Tag(name = TagRequester)
     @PostMapping
     @PostExchange
     fun createCleaningTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
@@ -72,9 +75,9 @@ interface CleaningTaskApi {
             ApiResponse(responseCode = "400", description = "On malformed task search requests", content = [Content()]),
         ]
     )
-    @Tag(name = "Requester")
-    @PostMapping("/cleaning-tasks/state/search")
-    @PostExchange("/cleaning-tasks/state/search")
+    @Tag(name = TagRequester)
+    @PostMapping("/state/search")
+    @PostExchange("/state/search")
     fun searchCleaningTaskState(@RequestBody searchTaskIdRequest: TaskStateRequest): TaskStateResponse
 
     @Operation(
@@ -93,7 +96,7 @@ interface CleaningTaskApi {
             ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
         ]
     )
-    @Tag(name = "Cleaning Service")
+    @Tag(name = TagCleaningService)
     @PostMapping("/reservations")
     @PostExchange("/reservations")
     fun reserveCleaningTasks(@RequestBody reservationRequest: CleaningReservationRequest): CleaningReservationResponse

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateRequest.kt
@@ -21,11 +21,7 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object for giving a list of tasks to search")
+@Schema(description = "Request object for giving a list of task identifiers to search for the state of cleaning tasks")
 data class TaskStateRequest(
-    val taskList: List<String>
-) {
-
-}
-
-
+    val taskIds: List<String>
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateResponse.kt
@@ -21,11 +21,7 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Response object for a given a list of tasks to search")
+@Schema(description = "Response object for giving a list of task states")
 data class TaskStateResponse(
     val createdTasks: List<TaskRequesterState>
-) {
-
-}
-
-
+)


### PR DESCRIPTION
- Use constant for Swagger-Tag
- Remove duplicate path segment in /api/cleaning-tasks/cleaning-tasks/state/search
- Improve field name in TaskStateRequest
- Improve schema description
