### PR TITLE
Feat: Create administrative areas level 1 endpoint

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/CommonMappings.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/CommonMappings.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdm.common.model.NamedType
 import org.eclipse.tractusx.bpdm.common.model.NamedUrlType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 
 fun <T : NamedUrlType> T.toDto(): TypeKeyNameUrlDto<T> {
     return TypeKeyNameUrlDto(this, getTypeName(), getUrl())
@@ -46,8 +47,8 @@ fun CountryCode.toDto(): TypeKeyNameVerboseDto<CountryCode> {
     return TypeKeyNameVerboseDto(this, getName())
 }
 
-fun PaginationRequest.toPageRequest() =
-    PageRequest.of(page, size)
+fun PaginationRequest.toPageRequest(sort: Sort = Sort.unsorted()) =
+    PageRequest.of(page, size, sort)
 
 fun <T, R> Page<T>.toPageDto(contentMapper: (T) -> R): PageDto<R> =
     PageDto(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -138,7 +138,8 @@ interface PoolMetadataApi {
 
     @Operation(
         summary = "Create new Region",
-        description = "Create a new region which can be referenced by business partner records. "
+        description = "Create a new region which can be referenced by business partner records.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -153,7 +154,8 @@ interface PoolMetadataApi {
 
     @Operation(
         summary = "Get page of regions",
-        description = "Lists all currently known regions in a paginated result"
+        description = "Lists all currently known regions in a paginated result",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -165,5 +167,18 @@ interface PoolMetadataApi {
     @GetExchange("/regions")
     fun getRegions(@ParameterObject paginationRequest: PaginationRequest): PageDto<RegionDto>
 
+    @Operation(
+        summary = "Get page of regions suitable for the administrativeAreaLevel1 address property",
+        description = "Lists all currently known regions in a paginated result"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of existing regions, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+        ]
+    )
+    @GetMapping("/administrative-areas-level1")
+    @GetExchange("/administrative-areas-level1")
+    fun getAdminAreasLevel1(@ParameterObject paginationRequest: PaginationRequest): PageDto<RegionDto>
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -71,8 +71,13 @@ class MetadataController(
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
+    override fun getAdminAreasLevel1(paginationRequest: PaginationRequest): PageDto<RegionDto> {
+        return metadataService.getRegions(paginationRequest)
+    }
+
+    @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
     override fun getRegions(paginationRequest: PaginationRequest): PageDto<RegionDto> {
-        return metadataService.getRegions(PageRequest.of(paginationRequest.page, paginationRequest.size))
+        return metadataService.getRegions(paginationRequest)
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getChangeMetaDataAsRole())")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/RegionRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/RegionRepository.kt
@@ -20,10 +20,15 @@
 package org.eclipse.tractusx.bpdm.pool.repository
 
 import org.eclipse.tractusx.bpdm.pool.entity.Region
+import org.springframework.data.domain.Sort
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.PagingAndSortingRepository
 
 interface RegionRepository : PagingAndSortingRepository<Region, Long>, CrudRepository<Region, Long> {
+
+    companion object {
+        val DEFAULT_SORTING = Sort.by(Region::countryCode.name, Region::regionCode.name)
+    }
 
     fun findByRegionCodeIn(regionCodes: Set<String>): Set<Region>
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
@@ -22,9 +22,11 @@ package org.eclipse.tractusx.bpdm.pool.service
 import com.neovisionaries.i18n.CountryCode
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.RegionDto
+import org.eclipse.tractusx.bpdm.common.service.toPageRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.dto.AddressMetadataDto
 import org.eclipse.tractusx.bpdm.pool.dto.LegalEntityMetadataDto
@@ -188,7 +190,8 @@ class MetadataService(
         return regionRepository.save(region).toDto()
     }
 
-    fun getRegions(pageRequest: Pageable): PageDto<RegionDto> {
+    fun getRegions(paginationRequest: PaginationRequest): PageDto<RegionDto> {
+        val pageRequest = paginationRequest.toPageRequest(RegionRepository.DEFAULT_SORTING)
         val page = regionRepository.findAll(pageRequest)
         return page.toDto(page.content.map { it.toDto() })
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
@@ -68,7 +68,7 @@ class TestHelpers(
                 FOR table_names IN SELECT table_name
                     FROM information_schema.tables
                     WHERE table_schema='$BPDM_DB_SCHEMA_NAME'
-                    AND table_name NOT IN ('flyway_schema_history') 
+                    AND table_name NOT IN ('flyway_schema_history','regions') 
                 LOOP 
                     EXECUTE format('TRUNCATE TABLE $BPDM_DB_SCHEMA_NAME.%I CONTINUE IDENTITY CASCADE;', table_names.table_name);
                 END LOOP;


### PR DESCRIPTION
Create api/catena/administrative-areas-level1 (GET) endpoint as replacement for the confusingly named api/catena/regions (GET and POST) endpoints. The later two endpoints are marked as deprectated in OpenAPI.
The endpoint sorts the returned regions by `countryCode` and `regionCode`.

Solves #499 