### PR TITLE
CICD: Add Orchestrator service to trivy.yml

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -140,3 +140,36 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "trivy-results4.sarif"
+
+  analyze-product-bpdm-orchestrator:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner
+        if: always()
+        uses: aquasecurity/trivy-action@master
+        with:
+          # Path to Docker image
+          image-ref: "docker.io/tractusx/bpdm-orchestrator:latest"
+          format: "sarif"
+          output: "trivy-results4.sarif"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH"
+          timeout: 15m
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results4.sarif"


### PR DESCRIPTION
<!-- 
feat: Add Orchestrator service to trivy.yml'
-->

## Description
Add Model Orchestrator Service to trivy scan

https://github.com/eclipse-tractusx/bpdm/issues/422

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
