### PR TITLE
Feat: Administrative Level 1 endpoint - don't call it "region" in descriptions and properties

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/CountrySubdivisionDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/CountrySubdivisionDto.kt
@@ -22,15 +22,15 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 import com.neovisionaries.i18n.CountryCode
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Region within a country")
-data class RegionDto(
+@Schema(description = "Country subdivision")
+data class CountrySubdivisionDto(
 
     @get:Schema(description = "Country code")
     val countryCode: CountryCode,
 
-    @get:Schema(description = "Abbreviation or shorthand of the area")
-    val regionCode: String,
+    @get:Schema(description = "The country subdivision code according to ISO 3166-2")
+    val code: String,
 
-    @get:Schema(description = "Describes the full name of the region within a country according to ISO 3166-214")
-    val regionName: String
+    @get:Schema(description = "The name of the country subdivision according to ISO 3166-2")
+    val name: String
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdm.common.dto.FieldQualityRuleDto
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.dto.response.CountrySubdivisionDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.RegionDto
@@ -168,17 +169,17 @@ interface PoolMetadataApi {
     fun getRegions(@ParameterObject paginationRequest: PaginationRequest): PageDto<RegionDto>
 
     @Operation(
-        summary = "Get page of regions suitable for the administrativeAreaLevel1 address property",
-        description = "Lists all currently known regions in a paginated result"
+        summary = "Get page of country subdivisions suitable for the administrativeAreaLevel1 address property",
+        description = "Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result"
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "Page of existing regions, may be empty"),
+            ApiResponse(responseCode = "200", description = "Page of existing country subdivisions, may be empty"),
             ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
         ]
     )
     @GetMapping("/administrative-areas-level1")
     @GetExchange("/administrative-areas-level1")
-    fun getAdminAreasLevel1(@ParameterObject paginationRequest: PaginationRequest): PageDto<RegionDto>
+    fun getAdminAreasLevel1(@ParameterObject paginationRequest: PaginationRequest): PageDto<CountrySubdivisionDto>
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.FieldQualityRuleDto
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.dto.response.CountrySubdivisionDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.RegionDto
@@ -71,8 +72,8 @@ class MetadataController(
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")
-    override fun getAdminAreasLevel1(paginationRequest: PaginationRequest): PageDto<RegionDto> {
-        return metadataService.getRegions(paginationRequest)
+    override fun getAdminAreasLevel1(paginationRequest: PaginationRequest): PageDto<CountrySubdivisionDto> {
+        return metadataService.getCountrySubdivisions(paginationRequest)
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadMetaDataAsRole())")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
@@ -23,6 +23,7 @@ import com.neovisionaries.i18n.CountryCode
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.dto.response.CountrySubdivisionDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.RegionDto
@@ -178,7 +179,6 @@ class MetadataService(
 
     @Transactional
     fun createRegion(request: RegionDto): RegionDto {
-
         logger.info { "Create new Region with key ${request.regionCode} and name ${request.regionName}" }
 
         val region = Region(
@@ -187,13 +187,18 @@ class MetadataService(
             regionName = request.regionName
         )
 
-        return regionRepository.save(region).toDto()
+        return regionRepository.save(region).toRegionDto()
     }
 
     fun getRegions(paginationRequest: PaginationRequest): PageDto<RegionDto> {
         val pageRequest = paginationRequest.toPageRequest(RegionRepository.DEFAULT_SORTING)
         val page = regionRepository.findAll(pageRequest)
-        return page.toDto(page.content.map { it.toDto() })
+        return page.toDto(page.content.map { it.toRegionDto() })
     }
 
+    fun getCountrySubdivisions(paginationRequest: PaginationRequest): PageDto<CountrySubdivisionDto> {
+        val pageRequest = paginationRequest.toPageRequest(RegionRepository.DEFAULT_SORTING)
+        val page = regionRepository.findAll(pageRequest)
+        return page.toDto(page.content.map { it.toCountrySubdivisionDto() })
+    }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -277,6 +277,10 @@ fun PartnerChangelogEntry.toDto(): ChangelogEntryVerboseDto {
     return ChangelogEntryVerboseDto(bpn, businessPartnerType, createdAt, changelogType)
 }
 
-fun Region.toDto(): RegionDto {
-    return RegionDto(countryCode, regionCode, regionName)
+fun Region.toRegionDto(): RegionDto {
+    return RegionDto(countryCode = countryCode, regionCode = regionCode, regionName = regionName)
+}
+
+fun Region.toCountrySubdivisionDto(): CountrySubdivisionDto {
+    return CountrySubdivisionDto(countryCode = countryCode, code = regionCode, name = regionName)
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
@@ -437,11 +437,10 @@ class MetadataControllerIT @Autowired constructor(
         assertThat(firstPage.totalPages).isEqualTo(348)
         assertThat(firstPage.content.size).isEqualTo(10)
 
-        // INSERT INTO bpdm.regions (country_code, region_code, region_name) VALUES ('AD', 'AD-02', 'Canillo');
         with(firstPage.content.first()) {
             assertThat(countryCode).isEqualTo(AD)
-            assertThat(regionCode).isEqualTo("AD-02")
-            assertThat(regionName).isEqualTo("Canillo")
+            assertThat(code).isEqualTo("AD-02")
+            assertThat(name).isEqualTo("Canillo")
         }
 
         val lastPage = poolClient.metadata.getAdminAreasLevel1(PaginationRequest(347))
@@ -449,11 +448,10 @@ class MetadataControllerIT @Autowired constructor(
         assertThat(lastPage.totalPages).isEqualTo(348)
         assertThat(lastPage.content.size).isEqualTo(8)
 
-        // INSERT INTO bpdm.regions (country_code, region_code, region_name) VALUES ('ZW', 'ZW-MW', 'Mashonaland West');
         with(lastPage.content.last()) {
             assertThat(countryCode).isEqualTo(ZW)
-            assertThat(regionCode).isEqualTo("ZW-MW")
-            assertThat(regionName).isEqualTo("Mashonaland West")
+            assertThat(code).isEqualTo("ZW-MW")
+            assertThat(name).isEqualTo("Mashonaland West")
         }
     }
 }


### PR DESCRIPTION
For endpoint and DTOs rephrase *region* to *administrativeAreaLevel1* and *country subdivision* because region is not an official term according to ISO 3166-2.

Solves #499 
