### PR TITLE
Refactor: Consistently name endpoints, DTOs, properties in Orchestrator-API

### DIFF
--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
@@ -32,81 +32,80 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-const val TagRequester = "Requester"
-const val TagCleaningService = "Cleaning Service"
+const val TagClient = "Task Client"
+const val TagWorker = "Task Worker"
 
-@RequestMapping("/api/cleaning-tasks", produces = [MediaType.APPLICATION_JSON_VALUE])
-@HttpExchange("/api/cleaning-tasks")
-interface CleaningTaskApi {
+@RequestMapping("/api/golden-record-tasks", produces = [MediaType.APPLICATION_JSON_VALUE])
+@HttpExchange("/api/golden-record-tasks")
+interface GoldenRecordTaskApi {
 
     @Operation(
-        summary = "Create new cleaning tasks for given business partner data",
-        description = "Create cleaning tasks for given business partner data in given cleaning mode. " +
-                "The mode decides through which cleaning steps the given business partner data will go through. " +
-                "The response contains the states of the created cleaning tasks in the order of given business partner data." +
-                "If there is an error in the request no cleaning tasks are created (all or nothing). " +
+        summary = "Create new golden record tasks for given business partner data",
+        description = "Create golden record tasks for given business partner data in given mode. " +
+                "The mode decides through which processing steps the given business partner data will go through. " +
+                "The response contains the states of the created tasks in the order of given business partner data." +
+                "If there is an error in the request no tasks are created (all or nothing). " +
                 "For a single request, the maximum number of business partners in the request is limited to \${bpdm.api.upsert-limit} entries."
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "The states of successfully created cleaning tasks including the task identifier for tracking purposes."
+                description = "The states of successfully created tasks including the task identifier for tracking purposes."
             ),
             ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
         ]
     )
-    @Tag(name = TagRequester)
+    @Tag(name = TagClient)
     @PostMapping
     @PostExchange
-    fun createCleaningTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
-
+    fun createTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
 
     @Operation(
-        summary = "Search for the state of cleaning tasks by task identifiers",
-        description = "Returns the state of finished cleaning tasks based on the provided task identifiers."
+        summary = "Search for the state of golden record tasks by task identifiers",
+        description = "Returns the state of golden record tasks based on the provided task identifiers."
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "The state of the finished cleaning tasks for the provided task identifiers."
+                description = "The state of the tasks for the provided task identifiers."
             ),
             ApiResponse(responseCode = "400", description = "On malformed task search requests", content = [Content()]),
         ]
     )
-    @Tag(name = TagRequester)
+    @Tag(name = TagClient)
     @PostMapping("/state/search")
     @PostExchange("/state/search")
-    fun searchCleaningTaskState(@RequestBody searchTaskIdRequest: TaskStateRequest): TaskStateResponse
+    fun searchTaskStates(@RequestBody stateRequest: TaskStateRequest): TaskStateResponse
 
     @Operation(
-        summary = "Reserve the next cleaning tasks waiting in the given cleaning step",
-        description = "Reserve up to a given number of cleaning tasks enqueued in the given cleaning step. " +
-                "The cleaning tasks contain the business partner to clean which consists of the generic and L/S/A data. " +
-                "For cleaning the business partners have a time limit which is returned with the reserved tasks." +
+        summary = "Reserve the next golden record tasks waiting in the given step queue",
+        description = "Reserve up to a given number of golden record tasks in the given step queue. " +
+                "The response entries contain the business partner data to process which consists of the generic and L/S/A data. " +
+                "The reservation has a time limit which is returned. " +
                 "For a single request, the maximum number of reservable tasks is limited to \${bpdm.api.upsert-limit}."
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "The reserved cleaning tasks with their business partner data to clean."
+                description = "The reserved tasks with their business partner data to process."
             ),
             ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
         ]
     )
-    @Tag(name = TagCleaningService)
-    @PostMapping("/reservations")
-    @PostExchange("/reservations")
-    fun reserveCleaningTasks(@RequestBody reservationRequest: CleaningReservationRequest): CleaningReservationResponse
+    @Tag(name = TagWorker)
+    @PostMapping("/step-reservations")
+    @PostExchange("/step-reservations")
+    fun reserveTasksForStep(@RequestBody reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse
 
     @Operation(
-        summary = "Post cleaning results for reserved cleaning tasks in given cleaning step",
-        description = "Post business partner cleaning results for the given cleaning tasks. " +
-                "In order to post a result for a cleaning task it needs to be reserved first, has to currently be in the given cleaning step and the time limit is not exceeded." +
-                "The number of results you can post at a time does not need to match the original number of reserved tasks." +
-                "Results are accepted via strategy 'all or nothing'." +
+        summary = "Post step results for reserved golden record tasks in the given step queue",
+        description = "Post business partner step results for the given tasks. " +
+                "In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. " +
+                "The number of results you can post at a time does not need to match the original number of reserved tasks. " +
+                "Results are accepted via strategy 'all or nothing'. " +
                 "For a single request, the maximum number of postable results is limited to \${bpdm.api.upsert-limit}."
     )
     @ApiResponses(
@@ -118,8 +117,8 @@ interface CleaningTaskApi {
             ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
         ]
     )
-    @Tag(name = "Cleaning Service")
-    @PostMapping("/results")
-    @PostExchange("/results")
-    fun resolveCleaningTasks(@RequestBody resultRequest: CleaningResultRequest)
+    @Tag(name = TagWorker)
+    @PostMapping("/step-results")
+    @PostExchange("/step-results")
+    fun resolveStepResults(@RequestBody resultRequest: TaskStepResultRequest)
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/OrchestrationApiClient.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/OrchestrationApiClient.kt
@@ -19,10 +19,9 @@
 
 package org.eclipse.tractusx.orchestrator.api.client
 
-import org.eclipse.tractusx.orchestrator.api.CleaningTaskApi
+import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
 
 interface OrchestrationApiClient {
 
-    val cleaningTasks: CleaningTaskApi
-
+    val goldenRecordTasks: GoldenRecordTaskApi
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/OrchestrationApiClientImpl.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/OrchestrationApiClientImpl.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.orchestrator.api.client
 
 import org.eclipse.tractusx.bpdm.common.service.ParameterObjectArgumentResolver
-import org.eclipse.tractusx.orchestrator.api.CleaningTaskApi
+import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
@@ -44,7 +44,8 @@ class OrchestrationApiClientImpl(
             .build()
     }
 
-    override val cleaningTasks by lazy { createClient<CleaningTaskApi>() }
+    override val goldenRecordTasks by lazy { createClient<GoldenRecordTaskApi>() }
+
     private inline fun <reified T> createClient() =
         httpServiceProxyFactory.createClient(T::class.java)
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressIdentifierDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressIdentifierDto.kt
@@ -19,14 +19,10 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseAddressStateDto
-import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
-import java.time.LocalDateTime
+import org.eclipse.tractusx.bpdm.common.dto.IBaseAddressIdentifierDto
 
-data class AddressState(
-    override val description: String?,
-    override val validFrom: LocalDateTime?,
-    override val validTo: LocalDateTime?,
-    override val type: BusinessStateType
+data class AddressIdentifierDto(
+    override val value: String,
+    override val type: String
 
-) : IBaseAddressStateDto
+) : IBaseAddressIdentifierDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressStateDto.kt
@@ -19,14 +19,14 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteStateDto
+import org.eclipse.tractusx.bpdm.common.dto.IBaseAddressStateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-data class SiteState(
+data class AddressStateDto(
     override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType
 
-) : IBaseSiteStateDto
+) : IBaseAddressStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BpnReference.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BpnReference.kt
@@ -22,9 +22,11 @@ package org.eclipse.tractusx.orchestrator.api.model
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "A reference to the BPN of a business partner. Either by the BPN value itself or a BPN request identifier")
-data class BpnReference(
+data class BpnReferenceDto(
+
     @get:Schema(description = "The value by which the BPN is referenced")
     val referenceValue: String,
+
     @get:Schema(description = "The type by which to reference the BPN with")
     val referenceType: BpnReferenceType
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassificationDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassificationDto.kt
@@ -19,10 +19,12 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.common.dto.IBaseClassificationDto
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-data class LegalEntityIdentifier(
-    override val value: String,
-    override val type: String,
-    override val issuingBody: String?
-) : IBaseLegalEntityIdentifierDto
+data class BusinessPartnerClassificationDto(
+    override val type: ClassificationType,
+    override val code: String?,
+    override val value: String?
+
+) : IBaseClassificationDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerFullDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerFullDto.kt
@@ -19,11 +19,20 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseClassificationDto
-import org.eclipse.tractusx.bpdm.common.model.ClassificationType
+import io.swagger.v3.oas.annotations.media.Schema
 
-data class BusinessPartnerClassification(
-    override val type: ClassificationType,
-    override val code: String?,
-    override val value: String?
-) : IBaseClassificationDto
+@Schema(description = "Business partner data in full representation, consisting of generic data as well as its L/S/A representation.")
+data class BusinessPartnerFullDto(
+
+    @get:Schema(description = "The business partner data in generic representation", required = true)
+    val generic: BusinessPartnerGenericDto,
+
+    @get:Schema(description = "The legal entity part of this business partner data")
+    val legalEntity: LegalEntityDto? = null,
+
+    @get:Schema(description = "The site part of this business partner data")
+    val site: SiteDto? = null,
+
+    @get:Schema(description = "The address part of this business partner data")
+    val address: LogisticAddressDto? = null
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
@@ -20,28 +20,23 @@
 package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.*
 
-data class LegalEntity(
-    @get:Schema(description = "A reference to the BPNL of this legal entity. Either by the BPN value itself or a BPN request identifier.")
-    val bpnLReference: BpnReference? = null,
 
-    @get:Schema(description = "Whether this legal entity data is different from its golden record counterpart in the Pool")
-    val hasChanged: Boolean? = null,
-
-    @get:Schema(description = LegalEntityDescription.legalName)
-    val legalName: String? = null,
-
-    override val legalShortName: String? = null,
-
-    override val identifiers: Collection<LegalEntityIdentifier> = emptyList(),
-
+data class BusinessPartnerGenericDto(
+    override val nameParts: List<String> = emptyList(),
+    override val shortName: String? = null,
+    override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
     override val legalForm: String? = null,
+    override val states: Collection<BusinessPartnerStateDto> = emptyList(),
+    override val classifications: Collection<ClassificationDto> = emptyList(),
+    override val roles: Collection<BusinessPartnerRole> = emptyList(),
+    override val postalAddress: PostalAddressDto = PostalAddressDto(),
+    override val bpnL: String? = null,
+    override val bpnS: String? = null,
+    override val bpnA: String? = null,
 
-    override val states: Collection<LegalEntityState> = emptyList(),
+    @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
+    val ownerBpnL: String? = null,
 
-    override val classifications: Collection<BusinessPartnerClassification> = emptyList(),
-
-    override val legalAddress: LogisticAddress? = null,
-) : IBaseLegalEntityDto
+    ) : IBaseBusinessPartnerDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
@@ -20,20 +20,30 @@
 package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 
-data class Site(
-    @get:Schema(description = "A reference to the BPNS of this site. Either by the BPN value itself or a BPN request identifier.")
-    val bpnSReference: BpnReference? = null,
+data class LegalEntityDto(
 
-    @get:Schema(description = "Whether this site data is different from its golden record counterpart in the Pool")
+    @get:Schema(description = "A reference to the BPNL of this legal entity. Either by the BPN value itself or a BPN request identifier.")
+    val bpnLReference: BpnReferenceDto? = null,
+
+    @get:Schema(description = "Whether this legal entity data is different from its golden record counterpart in the Pool")
     val hasChanged: Boolean? = null,
 
-    @get:Schema(description = SiteDescription.name)
-    val name: String? = null,
+    @get:Schema(description = LegalEntityDescription.legalName)
+    val legalName: String? = null,
 
-    override val states: Collection<SiteState> = emptyList(),
+    override val legalShortName: String? = null,
 
-    override val mainAddress: LogisticAddress? = null,
-) : IBaseSiteDto
+    override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
+
+    override val legalForm: String? = null,
+
+    override val states: Collection<LegalEntityState> = emptyList(),
+
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
+
+    override val legalAddress: LogisticAddressDto? = null
+
+) : IBaseLegalEntityDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityIdentifierDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityIdentifierDto.kt
@@ -19,11 +19,11 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityIdentifierDto
 
-@Schema(description = "Request object for posting cleaning results")
-data class CleaningResultRequest(
-    @get:ArraySchema(arraySchema = Schema(description = "The cleaning results for previously reserved cleaning tasks"))
-    val results: List<CleaningResultEntry>
-)
+data class LegalEntityIdentifierDto(
+    override val value: String,
+    override val type: String,
+    override val issuingBody: String?
+
+) : IBaseLegalEntityIdentifierDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddressDto.kt
@@ -19,14 +19,27 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.Instant
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 
-@Schema(description = "Response object for giving a list of reserved cleaning tasks")
-data class CleaningReservationResponse(
-    @get:ArraySchema(arraySchema = Schema(description = "The reserved cleaning tasks with their business partner data to clean"))
-    val reservedTasks: List<CleaningReservation>,
-    @get:Schema(description = "The timestamp until the reservation is valid and accepts cleaning results")
-    val timeout: Instant
-)
+data class LogisticAddressDto(
+
+    @get:Schema(description = "A reference to the BPNA of this address. Either by the BPN value itself or a BPN request identifier.")
+    val bpnAReference: BpnReferenceDto? = null,
+
+    @get:Schema(description = "Whether this address data is different from its golden record counterpart in the Pool")
+    val hasChanged: Boolean? = null,
+
+    @get:Schema(description = LogisticAddressDescription.name)
+    val name: String? = null,
+
+    override val states: Collection<AddressStateDto> = emptyList(),
+
+    override val identifiers: Collection<AddressIdentifierDto> = emptyList(),
+
+    override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
+
+    override val alternativePostalAddress: AlternativePostalAddressDto? = null
+
+) : IBaseLogisticAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
@@ -20,24 +20,22 @@
 package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseLogisticAddressDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
+import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 
-data class LogisticAddress(
-    @get:Schema(description = "A reference to the BPNA of this address. Either by the BPN value itself or a BPN request identifier.")
-    val bpnAReference: BpnReference? = null,
+data class SiteDto(
 
-    @get:Schema(description = "Whether this address data is different from its golden record counterpart in the Pool")
+    @get:Schema(description = "A reference to the BPNS of this site. Either by the BPN value itself or a BPN request identifier.")
+    val bpnSReference: BpnReferenceDto? = null,
+
+    @get:Schema(description = "Whether this site data is different from its golden record counterpart in the Pool")
     val hasChanged: Boolean? = null,
 
-    @get:Schema(description = LogisticAddressDescription.name)
+    @get:Schema(description = SiteDescription.name)
     val name: String? = null,
 
-    override val states: Collection<AddressState> = emptyList(),
+    override val states: Collection<SiteStateDto> = emptyList(),
 
-    override val identifiers: Collection<AddressIdentifier> = emptyList(),
+    override val mainAddress: LogisticAddressDto? = null
 
-    override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
-
-    override val alternativePostalAddress: AlternativePostalAddressDto? = null
-) : IBaseLogisticAddressDto
+) : IBaseSiteDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteStateDto.kt
@@ -19,7 +19,14 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-enum class ReservationState {
-    Queued,
-    Reserved
-}
+import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteStateDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
+
+data class SiteStateDto(
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
+    override val type: BusinessStateType
+
+) : IBaseSiteStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/StepState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/StepState.kt
@@ -19,14 +19,7 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-
-
-@Schema(description = "The cleaning task's processing state together with optional business partner data in case processing is done")
-data class TaskRequesterState(
-    @get:Schema(required = true)
-    val taskId: String,
-    val businessPartnerResult: BusinessPartnerGeneric?,
-    @get:Schema(required = true)
-    val processingState: TaskProcessingStateDto
-)
+enum class StepState {
+    Queued,
+    Reserved
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskClientStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskClientStateDto.kt
@@ -21,10 +21,15 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object for reserving a number of cleaning tasks waiting in a cleaning step.")
-data class CleaningReservationRequest(
-    @get:Schema(description = "The maximum number of cleaning tasks to reserve. Can be fewer if queue is not full enough.", required = true)
-    val amount: Int = 10,
-    @get:Schema(description = "The cleaning step queue to reserve from", required = true)
-    val step: CleaningStep
+
+@Schema(description = "The golden record task's processing state together with optional business partner data in case processing is done")
+data class TaskClientStateDto(
+
+    @get:Schema(required = true)
+    val taskId: String,
+
+    val businessPartnerResult: BusinessPartnerGenericDto?,
+
+    @get:Schema(required = true)
+    val processingState: TaskProcessingStateDto
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateRequest.kt
@@ -22,10 +22,12 @@ package org.eclipse.tractusx.orchestrator.api.model
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object to specify for which business partner data cleaning tasks should be created and in which mode")
+@Schema(description = "Request object to specify for which business partner data tasks should be created and in which mode")
 data class TaskCreateRequest(
-    @get:Schema(required = true, description = "The cleaning mode affecting which cleaning steps the business partner goes through")
+
+    @get:Schema(required = true, description = "The mode affecting which processing steps the business partner goes through")
     val mode: TaskMode,
-    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be cleaned"))
-    val businessPartners: List<BusinessPartnerGeneric>
+
+    @get:ArraySchema(arraySchema = Schema(description = "The list of business partner data to be processed"))
+    val businessPartners: List<BusinessPartnerGenericDto>
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateResponse.kt
@@ -21,11 +21,8 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Response object for giving a list of created cleaning tasks")
+@Schema(description = "Response object for giving a list of created tasks")
 data class TaskCreateResponse(
-    val createdTasks: List<TaskRequesterState>
-) {
 
-}
-
-
+    val createdTasks: List<TaskClientStateDto>
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorDto.kt
@@ -19,16 +19,14 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(description = "Describes an error that happened during processing of a task")
+data class TaskErrorDto(
 
-@Schema(description = "A cleaning result for a cleaning task")
-data class CleaningResultEntry(
-    @get:Schema(description = "The identifier of the cleaning task for which this is a result", required = true)
-    val taskId: String,
-    @get:Schema(description = "The actual result in form of business partner data. Maybe null if an error occurred during cleaning of this task.")
-    val result: BusinessPartnerFull? = null,
-    @get:ArraySchema(arraySchema = Schema(description = "Errors that occurred during cleaning of this task"))
-    val errors: List<TaskError> = emptyList()
+    @get:Schema(description = "The type of error that occurred", required = true)
+    val type: TaskErrorType,
+
+    @get:Schema(description = "The free text, detailed description of the error", required = true)
+    val description: String
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskProcessingStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskProcessingStateDto.kt
@@ -22,21 +22,28 @@ package org.eclipse.tractusx.orchestrator.api.model
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-@Schema(description = "Contains detail information about the current processing state of a cleaning task")
+@Schema(description = "Contains detailed information about the current processing state of a golden record task")
 data class TaskProcessingStateDto(
-    @get:Schema(description = "The last cleaning step this cleaning task has entered", required = true)
-    val cleaningStep: CleaningStep,
-    @get:Schema(description = "Whether the cleaning task is queued or already reserved in the latest cleaning step", required = true)
-    val reservationState: ReservationState,
-    @get:Schema(description = "The processing result of the cleaning task, can also still be pending", required = true)
+
+    @get:Schema(description = "The processing result of the task, can also still be pending", required = true)
     val resultState: ResultState,
+
+    @get:Schema(description = "The last step this task has entered", required = true)
+    val step: TaskStep,
+
+    @get:Schema(description = "Whether the task is queued or already reserved for the latest step", required = true)
+    val stepState: StepState,
+
     @get:Schema(
-        description = "The actual errors that happened during processing if the cleaning task has an error result state. " +
-                "The errors refer to the latest cleaning step.", required = true
+        description = "The actual errors that happened during processing if the task has an error result state. " +
+                "The errors refer to the latest step.",
+        required = true
     )
-    val errors: List<TaskError> = emptyList(),
-    @get:Schema(description = "When the cleaning task has been created", required = true)
+    val errors: List<TaskErrorDto> = emptyList(),
+
+    @get:Schema(description = "When the task has been created", required = true)
     val createdAt: Instant,
-    @get:Schema(description = "When the cleaning task has last been modified", required = true)
+
+    @get:Schema(description = "When the task has last been modified", required = true)
     val modifiedAt: Instant
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateRequest.kt
@@ -21,7 +21,8 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object for giving a list of task identifiers to search for the state of cleaning tasks")
+@Schema(description = "Request object for giving a list of task identifiers to search for the state of tasks")
 data class TaskStateRequest(
+
     val taskIds: List<String>
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStateResponse.kt
@@ -23,5 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Response object for giving a list of task states")
 data class TaskStateResponse(
-    val createdTasks: List<TaskRequesterState>
+
+    val tasks: List<TaskClientStateDto>
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStep.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStep.kt
@@ -19,22 +19,8 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.*
-
-
-data class BusinessPartnerGeneric(
-    override val nameParts: List<String> = emptyList(),
-    override val shortName: String? = null,
-    override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
-    override val legalForm: String? = null,
-    override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<ClassificationDto> = emptyList(),
-    override val roles: Collection<BusinessPartnerRole> = emptyList(),
-    override val postalAddress: PostalAddressDto = PostalAddressDto(),
-    override val bpnL: String? = null,
-    override val bpnS: String? = null,
-    override val bpnA: String? = null,
-    @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
-    val ownerBpnL: String? = null,
-) : IBaseBusinessPartnerDto
+enum class TaskStep {
+    CleanAndSync,
+    PoolSync,
+    Clean
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationEntryDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationEntryDto.kt
@@ -21,10 +21,12 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Describes an error that happened during processing of a cleaning task")
-data class TaskError(
-    @get:Schema(description = "The type of error that occurred", required = true)
-    val type: TaskErrorType,
-    @get:Schema(description = "The free text, detailed description of the error", required = true)
-    val description: String
+@Schema(description = "Task reservation entry")
+data class TaskStepReservationEntryDto(
+
+    @get:Schema(description = "The identifier of the reserved task")
+    val taskId: String,
+
+    @get:Schema(description = "The business partner data to process")
+    val businessPartner: BusinessPartnerFullDto
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationRequest.kt
@@ -21,10 +21,12 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Cleaning reservation entry")
-data class CleaningReservation(
-    @get:Schema(description = "The identifier of the reserved cleaning task")
-    val taskId: String,
-    @get:Schema(description = "The business partner data to clean")
-    val businessPartner: BusinessPartnerFull
+@Schema(description = "Request object for reserving a number of tasks waiting in a step queue.")
+data class TaskStepReservationRequest(
+
+    @get:Schema(description = "The maximum number of tasks to reserve. Can be fewer if queue is not full enough.", required = true)
+    val amount: Int = 10,
+
+    @get:Schema(description = "The step queue to reserve from", required = true)
+    val step: TaskStep
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationResponse.kt
@@ -19,8 +19,16 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-enum class CleaningStep {
-    CleanAndSync,
-    PoolSync,
-    Clean
-}
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "Response object for giving a list of reserved tasks")
+data class TaskStepReservationResponse(
+
+    @get:ArraySchema(arraySchema = Schema(description = "The reserved tasks with their business partner data to process"))
+    val reservedTasks: List<TaskStepReservationEntryDto>,
+
+    @get:Schema(description = "The timestamp until the reservation is valid and results are accepted")
+    val timeout: Instant
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepResultEntryDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepResultEntryDto.kt
@@ -19,10 +19,19 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseAddressIdentifierDto
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 
-data class AddressIdentifier(
-    override val value: String,
-    override val type: String
 
-) : IBaseAddressIdentifierDto
+@Schema(description = "A step result for a golden record task")
+data class TaskStepResultEntryDto(
+
+    @get:Schema(description = "The identifier of the task for which this is a result", required = true)
+    val taskId: String,
+
+    @get:Schema(description = "The actual result in form of business partner data. Maybe null if an error occurred during processing of this task.")
+    val businessPartner: BusinessPartnerFullDto? = null,
+
+    @get:ArraySchema(arraySchema = Schema(description = "Errors that occurred during processing of this task"))
+    val errors: List<TaskErrorDto> = emptyList()
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepResultRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepResultRequest.kt
@@ -21,14 +21,8 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Business partner data in full representation, consisting of generic data as well as its L/S/A representation.")
-data class BusinessPartnerFull(
-    @get:Schema(description = "The business partner data in generic representation", required = true)
-    val generic: BusinessPartnerGeneric,
-    @get:Schema(description = "The legal entity part of this business partner data")
-    val legalEntity: LegalEntity? = null,
-    @get:Schema(description = "The site part of this business partner data")
-    val site: Site? = null,
-    @get:Schema(description = "The address part of this business partner data")
-    val address: LogisticAddress? = null
+@Schema(description = "Request object for posting step results of previously reserved tasks")
+data class TaskStepResultRequest(
+
+    val results: List<TaskStepResultEntryDto>
 )

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
@@ -23,16 +23,16 @@ import org.eclipse.tractusx.bpdm.common.exception.BpdmUpsertLimitException
 import org.eclipse.tractusx.bpdm.orchestrator.config.ApiConfigProperties
 import org.eclipse.tractusx.bpdm.orchestrator.exception.BpdmEmptyResultException
 import org.eclipse.tractusx.bpdm.orchestrator.util.DummyValues
-import org.eclipse.tractusx.orchestrator.api.CleaningTaskApi
+import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class CleaningTaskController(
+class GoldenRecordTaskController(
     val apiConfigProperties: ApiConfigProperties
-) : CleaningTaskApi {
+) : GoldenRecordTaskApi {
 
-    override fun createCleaningTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
+    override fun createTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
         if (createRequest.businessPartners.size > apiConfigProperties.upsertLimit)
             throw BpdmUpsertLimitException(createRequest.businessPartners.size, apiConfigProperties.upsertLimit)
 
@@ -40,31 +40,31 @@ class CleaningTaskController(
         return DummyValues.dummyResponseCreateTask
     }
 
-    override fun reserveCleaningTasks(reservationRequest: CleaningReservationRequest): CleaningReservationResponse {
+    override fun reserveTasksForStep(reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse {
         if (reservationRequest.amount > apiConfigProperties.upsertLimit) {
             throw BpdmUpsertLimitException(reservationRequest.amount, apiConfigProperties.upsertLimit)
         }
 
         //ToDo: Replace with service logic
         return when (reservationRequest.step) {
-            CleaningStep.CleanAndSync -> DummyValues.dummyCleaningReservationResponse
-            CleaningStep.PoolSync -> DummyValues.dummyPoolSyncResponse
-            CleaningStep.Clean -> DummyValues.dummyCleaningReservationResponse
+            TaskStep.CleanAndSync -> DummyValues.dummyStepReservationResponse
+            TaskStep.PoolSync -> DummyValues.dummyPoolSyncResponse
+            TaskStep.Clean -> DummyValues.dummyStepReservationResponse
         }
     }
 
-    override fun resolveCleaningTasks(resultRequest: CleaningResultRequest) {
+    override fun resolveStepResults(resultRequest: TaskStepResultRequest) {
         if (resultRequest.results.size > apiConfigProperties.upsertLimit)
             throw BpdmUpsertLimitException(resultRequest.results.size, apiConfigProperties.upsertLimit)
 
         resultRequest.results.forEach { resultEntry ->
-            if (resultEntry.result == null && resultEntry.errors.isEmpty())
+            if (resultEntry.businessPartner == null && resultEntry.errors.isEmpty())
                 throw BpdmEmptyResultException(resultEntry.taskId)
         }
     }
 
 
-    override fun searchCleaningTaskState(searchTaskIdRequest: TaskStateRequest): TaskStateResponse {
+    override fun searchTaskStates(stateRequest: TaskStateRequest): TaskStateResponse {
         // ToDo: Replace with service logic
         return DummyValues.dummyResponseTaskState
     }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/DummyValues.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/DummyValues.kt
@@ -30,25 +30,25 @@ object DummyValues {
     val dummyResponseCreateTask =
         TaskCreateResponse(
             listOf(
-                TaskRequesterState(
+                TaskClientStateDto(
                     taskId = "0",
                     businessPartnerResult = null,
                     processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.CleanAndSync,
-                        reservationState = ReservationState.Queued,
                         resultState = ResultState.Pending,
+                        step = TaskStep.CleanAndSync,
+                        stepState = StepState.Queued,
                         errors = emptyList(),
                         createdAt = Instant.now(),
                         modifiedAt = Instant.now()
                     )
                 ),
-                TaskRequesterState(
+                TaskClientStateDto(
                     taskId = "1",
                     businessPartnerResult = null,
                     processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.CleanAndSync,
-                        reservationState = ReservationState.Queued,
                         resultState = ResultState.Pending,
+                        step = TaskStep.CleanAndSync,
+                        stepState = StepState.Queued,
                         errors = emptyList(),
                         createdAt = Instant.now(),
                         modifiedAt = Instant.now()
@@ -57,13 +57,13 @@ object DummyValues {
             )
         )
 
-    val dummyCleaningReservationResponse = CleaningReservationResponse(
+    val dummyStepReservationResponse = TaskStepReservationResponse(
         timeout = Instant.now().plusSeconds(300),
         reservedTasks = listOf(
-            CleaningReservation(
+            TaskStepReservationEntryDto(
                 taskId = "0",
-                businessPartner = BusinessPartnerFull(
-                    generic = BusinessPartnerGeneric(
+                businessPartner = BusinessPartnerFullDto(
+                    generic = BusinessPartnerGenericDto(
                         nameParts = listOf("Dummy", "Name"),
                         postalAddress = PostalAddressDto(
                             physicalPostalAddress = PhysicalPostalAddressDto(
@@ -74,10 +74,10 @@ object DummyValues {
                     )
                 )
             ),
-            CleaningReservation(
+            TaskStepReservationEntryDto(
                 taskId = "1",
-                businessPartner = BusinessPartnerFull(
-                    generic = BusinessPartnerGeneric(
+                businessPartner = BusinessPartnerFullDto(
+                    generic = BusinessPartnerGenericDto(
                         nameParts = listOf("Other", "Name"),
                         postalAddress = PostalAddressDto(
                             physicalPostalAddress = PhysicalPostalAddressDto(
@@ -92,8 +92,8 @@ object DummyValues {
     )
 
 
-    private val businessPartnerFull1 = BusinessPartnerFull(
-        generic = BusinessPartnerGeneric(
+    private val businessPartnerFull1 = BusinessPartnerFullDto(
+        generic = BusinessPartnerGenericDto(
             nameParts = listOf("Dummy", "Name"),
             postalAddress = PostalAddressDto(
                 addressType = AddressType.LegalAddress,
@@ -103,14 +103,14 @@ object DummyValues {
                 )
             )
         ),
-        legalEntity = LegalEntity(
+        legalEntity = LegalEntityDto(
             legalName = "Dummy Name",
-            bpnLReference = BpnReference(
+            bpnLReference = BpnReferenceDto(
                 referenceValue = "request-id-l-1",
                 referenceType = BpnReferenceType.BpnRequestIdentifier
             ),
-            legalAddress = LogisticAddress(
-                bpnAReference = BpnReference(
+            legalAddress = LogisticAddressDto(
+                bpnAReference = BpnReferenceDto(
                     referenceValue = "request-id-a-1",
                     referenceType = BpnReferenceType.BpnRequestIdentifier
                 ),
@@ -120,8 +120,8 @@ object DummyValues {
                 )
             ),
         ),
-        address = LogisticAddress(
-            bpnAReference = BpnReference(
+        address = LogisticAddressDto(
+            bpnAReference = BpnReferenceDto(
                 referenceValue = "request-id-a-1",
                 referenceType = BpnReferenceType.BpnRequestIdentifier
             ),
@@ -132,8 +132,8 @@ object DummyValues {
         )
     )
 
-    private val businessPartnerFull2 = BusinessPartnerFull(
-        generic = BusinessPartnerGeneric(
+    private val businessPartnerFull2 = BusinessPartnerFullDto(
+        generic = BusinessPartnerGenericDto(
             nameParts = listOf("Other", "Name"),
             postalAddress = PostalAddressDto(
                 addressType = AddressType.AdditionalAddress,
@@ -143,14 +143,14 @@ object DummyValues {
                 )
             )
         ),
-        legalEntity = LegalEntity(
+        legalEntity = LegalEntityDto(
             legalName = "Other Name",
-            bpnLReference = BpnReference(
+            bpnLReference = BpnReferenceDto(
                 referenceValue = "BPNL1",
                 referenceType = BpnReferenceType.Bpn
             ),
-            legalAddress = LogisticAddress(
-                bpnAReference = BpnReference(
+            legalAddress = LogisticAddressDto(
+                bpnAReference = BpnReferenceDto(
                     referenceValue = "BPNA1",
                     referenceType = BpnReferenceType.Bpn
                 ),
@@ -160,14 +160,14 @@ object DummyValues {
                 )
             )
         ),
-        site = Site(
+        site = SiteDto(
             name = "Other Site Name",
-            bpnSReference = BpnReference(
+            bpnSReference = BpnReferenceDto(
                 referenceValue = "BPNS1",
                 referenceType = BpnReferenceType.Bpn
             ),
-            mainAddress = LogisticAddress(
-                bpnAReference = BpnReference(
+            mainAddress = LogisticAddressDto(
+                bpnAReference = BpnReferenceDto(
                     referenceValue = "BPNA2",
                     referenceType = BpnReferenceType.Bpn
                 ),
@@ -177,8 +177,8 @@ object DummyValues {
                 )
             )
         ),
-        address = LogisticAddress(
-            bpnAReference = BpnReference(
+        address = LogisticAddressDto(
+            bpnAReference = BpnReferenceDto(
                 referenceValue = "BPNA3",
                 referenceType = BpnReferenceType.Bpn
             ),
@@ -189,14 +189,14 @@ object DummyValues {
         )
     )
 
-    val dummyPoolSyncResponse = CleaningReservationResponse(
+    val dummyPoolSyncResponse = TaskStepReservationResponse(
         timeout = Instant.now().plusSeconds(300),
         reservedTasks = listOf(
-            CleaningReservation(
+            TaskStepReservationEntryDto(
                 taskId = "0",
                 businessPartner = businessPartnerFull1
             ),
-            CleaningReservation(
+            TaskStepReservationEntryDto(
                 taskId = "1",
                 businessPartner = businessPartnerFull2
             )
@@ -206,25 +206,25 @@ object DummyValues {
     val dummyResponseTaskState =
         TaskStateResponse(
             listOf(
-                TaskRequesterState(
+                TaskClientStateDto(
                     taskId = "0",
                     businessPartnerResult = null,
                     processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.CleanAndSync,
-                        reservationState = ReservationState.Queued,
                         resultState = ResultState.Pending,
+                        step = TaskStep.CleanAndSync,
+                        stepState = StepState.Queued,
                         errors = emptyList(),
                         createdAt = Instant.now(),
                         modifiedAt = Instant.now()
                     )
                 ),
-                TaskRequesterState(
+                TaskClientStateDto(
                     taskId = "1",
                     businessPartnerResult = null,
                     processingState = TaskProcessingStateDto(
-                        cleaningStep = CleaningStep.Clean,
-                        reservationState = ReservationState.Queued,
                         resultState = ResultState.Pending,
+                        step = TaskStep.Clean,
+                        stepState = StepState.Queued,
                         errors = emptyList(),
                         createdAt = Instant.now(),
                         modifiedAt = Instant.now()

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskControllerIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/CleaningTaskControllerIT.kt
@@ -47,7 +47,7 @@ class CleaningTaskControllerIT @Autowired constructor(
 
         val expected = DummyValues.dummyResponseCreateTask
 
-        val response = orchestratorClient.cleaningTasks.createCleaningTasks(request)
+        val response = orchestratorClient.goldenRecordTasks.createTasks(request)
 
         Assertions.assertThat(response).isEqualTo(expected)
     }
@@ -57,14 +57,14 @@ class CleaningTaskControllerIT @Autowired constructor(
      */
     @Test
     fun `request reservation for clean and sync and expect dummy response`() {
-        val request = CleaningReservationRequest(
+        val request = TaskStepReservationRequest(
             amount = 2,
-            step = CleaningStep.CleanAndSync
+            step = TaskStep.CleanAndSync
         )
 
-        val expected = DummyValues.dummyCleaningReservationResponse
+        val expected = DummyValues.dummyStepReservationResponse
 
-        val response = orchestratorClient.cleaningTasks.reserveCleaningTasks(request)
+        val response = orchestratorClient.goldenRecordTasks.reserveTasksForStep(request)
 
         Assertions.assertThat(response).isEqualTo(expected)
     }
@@ -74,14 +74,14 @@ class CleaningTaskControllerIT @Autowired constructor(
      */
     @Test
     fun `request reservation for pool sync and expect dummy response`() {
-        val request = CleaningReservationRequest(
+        val request = TaskStepReservationRequest(
             amount = 2,
-            step = CleaningStep.PoolSync
+            step = TaskStep.PoolSync
         )
 
         val expected = DummyValues.dummyPoolSyncResponse
 
-        val response = orchestratorClient.cleaningTasks.reserveCleaningTasks(request)
+        val response = orchestratorClient.goldenRecordTasks.reserveTasksForStep(request)
 
         Assertions.assertThat(response).isEqualTo(expected)
     }
@@ -91,14 +91,14 @@ class CleaningTaskControllerIT @Autowired constructor(
      */
     @Test
     fun `request reservation for clean and expect dummy response`() {
-        val request = CleaningReservationRequest(
+        val request = TaskStepReservationRequest(
             amount = 2,
-            step = CleaningStep.Clean
+            step = TaskStep.Clean
         )
 
-        val expected = DummyValues.dummyCleaningReservationResponse
+        val expected = DummyValues.dummyStepReservationResponse
 
-        val response = orchestratorClient.cleaningTasks.reserveCleaningTasks(request)
+        val response = orchestratorClient.goldenRecordTasks.reserveTasksForStep(request)
 
         Assertions.assertThat(response).isEqualTo(expected)
     }
@@ -108,11 +108,11 @@ class CleaningTaskControllerIT @Autowired constructor(
      */
     @Test
     fun `post cleaning result is invokable`() {
-        val request = CleaningResultRequest(
+        val request = TaskStepResultRequest(
             results = listOf(
-                CleaningResultEntry(
+                TaskStepResultEntryDto(
                     taskId = "0",
-                    result = BusinessPartnerFull(
+                    businessPartner = BusinessPartnerFullDto(
                         generic = BusinessPartnerTestValues.businessPartner1,
                         legalEntity = BusinessPartnerTestValues.legalEntity1,
                         site = BusinessPartnerTestValues.site1,
@@ -120,9 +120,9 @@ class CleaningTaskControllerIT @Autowired constructor(
                     ),
                     errors = emptyList()
                 ),
-                CleaningResultEntry(
+                TaskStepResultEntryDto(
                     taskId = "1",
-                    result = BusinessPartnerFull(
+                    businessPartner = BusinessPartnerFullDto(
                         generic = BusinessPartnerTestValues.businessPartner2,
                         legalEntity = BusinessPartnerTestValues.legalEntity2,
                         site = BusinessPartnerTestValues.site2,
@@ -130,17 +130,17 @@ class CleaningTaskControllerIT @Autowired constructor(
                     ),
                     errors = emptyList()
                 ),
-                CleaningResultEntry(
+                TaskStepResultEntryDto(
                     taskId = "2",
-                    result = null,
+                    businessPartner = null,
                     errors = listOf(
-                        TaskError(type = TaskErrorType.Unspecified, "Error Description")
+                        TaskErrorDto(type = TaskErrorType.Unspecified, "Error Description")
                     )
                 ),
             )
         )
 
-        orchestratorClient.cleaningTasks.resolveCleaningTasks(request)
+        orchestratorClient.goldenRecordTasks.resolveStepResults(request)
     }
 
     /**
@@ -162,7 +162,7 @@ class CleaningTaskControllerIT @Autowired constructor(
         )
 
         Assertions.assertThatThrownBy {
-            orchestratorClient.cleaningTasks.createCleaningTasks(request)
+            orchestratorClient.goldenRecordTasks.createTasks(request)
         }.isInstanceOf(WebClientResponseException::class.java)
     }
 
@@ -174,13 +174,13 @@ class CleaningTaskControllerIT @Autowired constructor(
     fun `expect exception on requesting too many reservations`() {
 
         //Create entries above the upsert limit of 3
-        val request = CleaningReservationRequest(
+        val request = TaskStepReservationRequest(
             amount = 200,
-            step = CleaningStep.CleanAndSync
+            step = TaskStep.CleanAndSync
         )
 
         Assertions.assertThatThrownBy {
-            orchestratorClient.cleaningTasks.reserveCleaningTasks(request)
+            orchestratorClient.goldenRecordTasks.reserveTasksForStep(request)
         }.isInstanceOf(WebClientResponseException::class.java)
     }
 
@@ -191,14 +191,14 @@ class CleaningTaskControllerIT @Autowired constructor(
     @Test
     fun `expect exception on posting too many cleaning results`() {
 
-        val validCleaningResultEntry = CleaningResultEntry(
+        val validCleaningResultEntry = TaskStepResultEntryDto(
             taskId = "0",
-            result = null,
-            errors = listOf(TaskError(type = TaskErrorType.Unspecified, description = "Description"))
+            businessPartner = null,
+            errors = listOf(TaskErrorDto(type = TaskErrorType.Unspecified, description = "Description"))
         )
 
         //Create entries above the upsert limit of 3
-        val request = CleaningResultRequest(
+        val request = TaskStepResultRequest(
             results = listOf(
                 validCleaningResultEntry.copy(taskId = "0"),
                 validCleaningResultEntry.copy(taskId = "1"),
@@ -208,7 +208,7 @@ class CleaningTaskControllerIT @Autowired constructor(
         )
 
         Assertions.assertThatThrownBy {
-            orchestratorClient.cleaningTasks.resolveCleaningTasks(request)
+            orchestratorClient.goldenRecordTasks.resolveStepResults(request)
         }.isInstanceOf(WebClientResponseException::class.java)
     }
 
@@ -225,7 +225,7 @@ class CleaningTaskControllerIT @Autowired constructor(
         val expected = DummyValues.dummyResponseTaskState
 
 
-        val response = orchestratorClient.cleaningTasks.searchCleaningTaskState(request)
+        val response = orchestratorClient.goldenRecordTasks.searchTaskStates(request)
 
         // Assert that the response matches the expected value
         Assertions.assertThat(response).isEqualTo(expected)
@@ -237,18 +237,18 @@ class CleaningTaskControllerIT @Autowired constructor(
      */
     @Test
     fun `expect exception on posting empty cleaning result`() {
-        val request = CleaningResultRequest(
+        val request = TaskStepResultRequest(
             results = listOf(
-                CleaningResultEntry(
+                TaskStepResultEntryDto(
                     taskId = "0",
-                    result = null,
+                    businessPartner = null,
                     errors = emptyList()
                 )
             )
         )
 
         Assertions.assertThatThrownBy {
-            orchestratorClient.cleaningTasks.resolveCleaningTasks(request)
+            orchestratorClient.goldenRecordTasks.resolveStepResults(request)
         }.isInstanceOf(WebClientResponseException::class.java)
     }
 

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskControllerIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskControllerIT.kt
@@ -31,7 +31,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["bpdm.api.upsert-limit=3"])
-class CleaningTaskControllerIT @Autowired constructor(
+class GoldenRecordTaskControllerIT @Autowired constructor(
     val orchestratorClient: OrchestrationApiClient
 ) {
 

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/util/BusinessPartnerTestValues.kt
@@ -25,8 +25,15 @@ import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.orchestrator.api.model.*
+import org.eclipse.tractusx.orchestrator.api.model.AddressIdentifierDto
+import org.eclipse.tractusx.orchestrator.api.model.AddressStateDto
 import org.eclipse.tractusx.orchestrator.api.model.AlternativePostalAddressDto
+import org.eclipse.tractusx.orchestrator.api.model.LegalEntityDto
+import org.eclipse.tractusx.orchestrator.api.model.LegalEntityIdentifierDto
+import org.eclipse.tractusx.orchestrator.api.model.LogisticAddressDto
 import org.eclipse.tractusx.orchestrator.api.model.PhysicalPostalAddressDto
+import org.eclipse.tractusx.orchestrator.api.model.SiteDto
+import org.eclipse.tractusx.orchestrator.api.model.SiteStateDto
 import org.eclipse.tractusx.orchestrator.api.model.StreetDto
 import java.time.LocalDateTime
 
@@ -37,7 +44,7 @@ import java.time.LocalDateTime
 object BusinessPartnerTestValues {
 
     //Business Partner with two entries in every collection
-    val businessPartner1 = BusinessPartnerGeneric(
+    val businessPartner1 = BusinessPartnerGenericDto(
         nameParts = listOf("NamePart1", "NamePart2"),
         shortName = "shortname",
         identifiers = listOf(
@@ -129,7 +136,7 @@ object BusinessPartnerTestValues {
     )
 
     //Business Partner with single entry in every collection
-    val businessPartner2 = BusinessPartnerGeneric(
+    val businessPartner2 = BusinessPartnerGenericDto(
         nameParts = listOf("name-part-2"),
         shortName = "shortname-2",
         identifiers = listOf(
@@ -203,16 +210,16 @@ object BusinessPartnerTestValues {
         bpnA = "BPNATEST-2"
     )
 
-    val logisticAddress1 = LogisticAddress(
+    val logisticAddress1 = LogisticAddressDto(
         name = "Address Name 1",
         states = listOf(
-            AddressState(
+            AddressStateDto(
                 description = "Address State 1",
                 validFrom = LocalDateTime.of(1970, 4, 4, 4, 4),
                 validTo = LocalDateTime.of(1975, 5, 5, 5, 5),
                 type = BusinessStateType.ACTIVE
             ),
-            AddressState(
+            AddressStateDto(
                 description = "Address State 2",
                 validFrom = LocalDateTime.of(1975, 5, 5, 5, 5),
                 validTo = null,
@@ -220,11 +227,11 @@ object BusinessPartnerTestValues {
             ),
         ),
         identifiers = listOf(
-            AddressIdentifier(
+            AddressIdentifierDto(
                 value = "Address Identifier Value 1",
                 type = "Address Identifier Type 1"
             ),
-            AddressIdentifier(
+            AddressIdentifierDto(
                 value = "Address Identifier Value 2",
                 type = "Address Identifier Type 2"
             )
@@ -264,17 +271,17 @@ object BusinessPartnerTestValues {
             deliveryServiceQualifier = "Delivery Service Qualifier 1",
             deliveryServiceNumber = "Delivery Service Number 1"
         ),
-        bpnAReference = BpnReference(
+        bpnAReference = BpnReferenceDto(
             referenceType = BpnReferenceType.Bpn,
             referenceValue = "BPNATEST-1"
         ),
         hasChanged = true
     )
 
-    val logisticAddress2 = LogisticAddress(
+    val logisticAddress2 = LogisticAddressDto(
         name = "Address Name 2",
         states = listOf(
-            AddressState(
+            AddressStateDto(
                 description = "Address State 2",
                 validFrom = LocalDateTime.of(1971, 4, 4, 4, 4),
                 validTo = null,
@@ -282,7 +289,7 @@ object BusinessPartnerTestValues {
             )
         ),
         identifiers = listOf(
-            AddressIdentifier(
+            AddressIdentifierDto(
                 value = "Address Identifier Value 2-1",
                 type = "Address Identifier Type 2-1"
             )
@@ -322,23 +329,23 @@ object BusinessPartnerTestValues {
             deliveryServiceQualifier = "Delivery Service Qualifier 2",
             deliveryServiceNumber = "Delivery Service Number 2"
         ),
-        bpnAReference = BpnReference(
+        bpnAReference = BpnReferenceDto(
             referenceType = BpnReferenceType.BpnRequestIdentifier,
             referenceValue = "BPN_REQUEST_ID_TEST"
         ),
         hasChanged = true
     )
 
-    val legalEntity1 = LegalEntity(
+    val legalEntity1 = LegalEntityDto(
         legalName = "Legal Entity Name 1",
         legalShortName = "Legal Short Name 1",
         identifiers = listOf(
-            LegalEntityIdentifier(
+            LegalEntityIdentifierDto(
                 value = "Legal Identifier Value 1",
                 type = "Legal Identifier Type 1",
                 issuingBody = "Legal Issuing Body 1"
             ),
-            LegalEntityIdentifier(
+            LegalEntityIdentifierDto(
                 value = "Legal Identifier Value 2",
                 type = "Legal Identifier Type 2",
                 issuingBody = "Legal Issuing Body 2"
@@ -360,30 +367,30 @@ object BusinessPartnerTestValues {
             ),
         ),
         classifications = listOf(
-            BusinessPartnerClassification(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.SIC,
                 code = "Classification Code 1",
                 value = "Classification Value 1"
             ),
-            BusinessPartnerClassification(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.NACE,
                 code = "Classification Code 2",
                 value = "Classification Value 2"
             )
         ),
         legalAddress = logisticAddress1,
-        bpnLReference = BpnReference(
+        bpnLReference = BpnReferenceDto(
             referenceValue = "BPNL1-TEST",
             referenceType = BpnReferenceType.Bpn
         ),
         hasChanged = false
     )
 
-    val legalEntity2 = LegalEntity(
+    val legalEntity2 = LegalEntityDto(
         legalName = "Legal Entity Name 2",
         legalShortName = "Legal Short Name 2",
         identifiers = listOf(
-            LegalEntityIdentifier(
+            LegalEntityIdentifierDto(
                 value = "Legal Identifier Value 2",
                 type = "Legal Identifier Type 2",
                 issuingBody = "Legal Issuing Body 2"
@@ -399,30 +406,30 @@ object BusinessPartnerTestValues {
             )
         ),
         classifications = listOf(
-            BusinessPartnerClassification(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.SIC,
                 code = "Classification Code 2",
                 value = "Classification Value 2"
             )
         ),
         legalAddress = logisticAddress2,
-        bpnLReference = BpnReference(
+        bpnLReference = BpnReferenceDto(
             referenceValue = "BPNL-REQUEST_ID_TEST",
             referenceType = BpnReferenceType.BpnRequestIdentifier
         ),
         hasChanged = false
     )
 
-    val site1 = Site(
+    val site1 = SiteDto(
         name = "Site Name 1",
         states = listOf(
-            SiteState(
+            SiteStateDto(
                 description = "Site State Description 1",
                 validFrom = LocalDateTime.of(1991, 10, 10, 10, 10),
                 validTo = LocalDateTime.of(2001, 11, 11, 11, 11),
                 type = BusinessStateType.ACTIVE
             ),
-            SiteState(
+            SiteStateDto(
                 description = "Site State Description 2",
                 validFrom = LocalDateTime.of(2001, 11, 11, 11, 11),
                 validTo = null,
@@ -430,17 +437,17 @@ object BusinessPartnerTestValues {
             )
         ),
         mainAddress = logisticAddress1,
-        bpnSReference = BpnReference(
+        bpnSReference = BpnReferenceDto(
             referenceValue = "BPNS_TEST",
             referenceType = BpnReferenceType.Bpn
         ),
         hasChanged = false
     )
 
-    val site2 = Site(
+    val site2 = SiteDto(
         name = "Site Name 2",
         states = listOf(
-            SiteState(
+            SiteStateDto(
                 description = "Site State Description 2",
                 validFrom = LocalDateTime.of(1997, 12, 12, 12, 12),
                 validTo = null,
@@ -448,7 +455,7 @@ object BusinessPartnerTestValues {
             )
         ),
         mainAddress = logisticAddress2,
-        bpnSReference = BpnReference(
+        bpnSReference = BpnReferenceDto(
             referenceValue = "BPNS_REQUEST_ID_TEST",
             referenceType = BpnReferenceType.BpnRequestIdentifier
         ),


### PR DESCRIPTION
Fix some naming inconsistencies and inaccuracies regarding the previously known *CleaningTaskApi*:
- Name the endpoint */api/golden-record-tasks* and the API interface *GoldenRecordTaskApi*
- Use "golden record task" or short "task" in the documentation
- Use API tags *Task Client* and *Task Worker*
- Rename endpoint */reservations* to */step-reservations*
- Rename endpoint */results* to */step-results*
- Rename classes and properties eliminating the name part *cleaning*
- Consistently name all data classes which are transitively used in the API either *Request*, *Response* or *Dto* to clarify the distinction to internal data.

Solves #508 
