### PR TITLE
Feat: Move Sharing State Transition Logic to the Sharing State Service

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerController.kt
@@ -45,7 +45,7 @@ class BusinessPartnerController(
         if (businessPartners.size > apiConfigProperties.upsertLimit || businessPartners.map { it.externalId }.containsDuplicates()) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)
         }
-        val result = businessPartnerService.upsertBusinessPartnersInput(businessPartners)
+        val result = businessPartnerService.upsertBusinessPartnersInput(businessPartners.toList())
         return ResponseEntity.ok(result)
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/exception/BpdmInvalidStateRequestException.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/exception/BpdmInvalidStateRequestException.kt
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class BpdmInvalidStateRequestException(
+    msg: String
+) : RuntimeException(msg)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
@@ -51,8 +51,9 @@ interface SharingStateRepository : PagingAndSortingRepository<SharingState, Long
             }
     }
 
-    fun findByExternalIdAndBusinessPartnerType(externalId: String, businessPartnerType: BusinessPartnerType): SharingState?
+    fun findByExternalIdInAndBusinessPartnerType(externalId: Collection<String>, businessPartnerType: BusinessPartnerType): Collection<SharingState>
 
     fun findBySharingStateType(sharingStateType: SharingStateType): Set<SharingState>
 
+    fun findBySharingStateTypeAndTaskIdNotNull(sharingStateType: SharingStateType): Set<SharingState>
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SitePersistenceService.kt
@@ -24,7 +24,6 @@ import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.common.util.replace
 import org.eclipse.tractusx.bpdm.gate.api.model.ChangelogType
-import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateOutputRequest
 import org.eclipse.tractusx.bpdm.gate.entity.*
@@ -73,6 +72,9 @@ class SitePersistenceService(
                     sharingStateService.upsertSharingState(site.toSharingStateDTO())
                 }
         }
+
+        val initRequests = sites.map { SharingStateService.SharingStateIdentifierDto(it.externalId, BusinessPartnerType.SITE ) }
+        sharingStateService.setInitial(initRequests)
     }
 
     //Creates Changelog For both Site and Logistic Address when they are created or updated
@@ -149,8 +151,15 @@ class SitePersistenceService(
                         saveChangelog(site.externalId, ChangelogType.CREATE, datatype)
                     }
                 }
-            sharingStateService.upsertSharingState(site.toSharingStateDTO(SharingStateType.Success))
         }
+
+        val successRequests = sites.map {
+            SharingStateService.SuccessRequest(
+                SharingStateService.SharingStateIdentifierDto(it.externalId, BusinessPartnerType.SITE),
+                it.bpn
+            )
+        }
+        sharingStateService.setSuccess(successRequests)
     }
 
     private fun updateSiteOutput(site: Site, updatedSite: SiteGateOutputRequest, legalEntityRecord: LegalEntity) {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -138,7 +138,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val upsertSharingStatesRequests = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.ADDRESS,
+                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId1,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
@@ -148,7 +148,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.ADDRESS,
+                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId2,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
@@ -158,7 +158,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
                 taskId = "1"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.ADDRESS,
+                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
@@ -169,7 +169,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
             )
         )
 
-        val upsertSharingStateResponses = readSharingStates(BusinessPartnerType.ADDRESS, externalIds)
+        val upsertSharingStateResponses = readSharingStates(BusinessPartnerType.GENERIC, externalIds)
 
 
         testHelpers.assertRecursively(upsertSharingStateResponses).isEqualTo(upsertSharingStatesRequests)
@@ -501,7 +501,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val createdSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.ADDRESS,
+                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
@@ -511,7 +511,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.ADDRESS,
+                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
@@ -524,25 +524,28 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         //Firstly verifies if the Sharing States was created for new Business Partners
         val externalIds = listOf(externalId4, externalId5)
-        val upsertSharingStateResponses = readSharingStates(BusinessPartnerType.ADDRESS, externalIds)
-        testHelpers.assertRecursively(upsertSharingStateResponses).isEqualTo(createdSharingState)
+        val upsertSharingStateResponses = readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        testHelpers
+            .assertRecursively(upsertSharingStateResponses)
+            .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
+            .isEqualTo(createdSharingState)
 
         // Call Finish Cleaning Method
         businessPartnerService.finishCleaningTask()
 
         val cleanedSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.ADDRESS,
+                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Success,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
+                bpn = BusinessPartnerGenericMockValues.businessPartner1.bpnA,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.ADDRESS,
+                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Error,
                 sharingErrorCode = BusinessPartnerSharingError.SharingProcessError,
@@ -554,8 +557,10 @@ class BusinessPartnerControllerIT @Autowired constructor(
         )
 
         //Check for both Sharing State changes (Error and Success)
-        val readCleanedSharingState = readSharingStates(BusinessPartnerType.ADDRESS, externalIds)
-        testHelpers.assertRecursively(readCleanedSharingState).isEqualTo(cleanedSharingState)
+        val readCleanedSharingState = readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        testHelpers.assertRecursively(readCleanedSharingState)
+            .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
+            .isEqualTo(cleanedSharingState)
 
         //Assert that Cleaned Golden Record is persisted in the Output correctly
         val searchResponsePage = gateClient.businessParters.getBusinessPartnersOutput(listOf(externalId4))


### PR DESCRIPTION
## Description

Currently, the sharing state service is somewhat of a glorified repository. It just takes a DTO, maps it to the entity and saves whatever is inside. This means the logic of managing sharing state transitions is left to the invoking services.

The goal of this pull request is to move such sharing state transition logic to the sharing state, by this capsulating responsibitilies between the services better.

In addition I added some validation logic for transitioning to shring states making sure essential information for that state is given. At the same time, information that is irrelevant for the transitioned sharing state is being ignored (such as error information for any other state than Error).

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
