### PR TITLE
feat: Extend TaskStepResultRequest in orchestrator-api with step

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -41,26 +41,27 @@ class CleaningServiceDummy(
     fun pollForCleaningTasks() {
         try {
             logger.info { "Starting polling for cleaning tasks from Orchestrator..." }
+            val step = TaskStep.CleanAndSync
 
             // Step 1: Fetch and reserve the next cleaning request
             val cleaningRequest = orchestrationApiClient.goldenRecordTasks
-                .reserveTasksForStep(TaskStepReservationRequest(amount = 10, TaskStep.CleanAndSync))
+                .reserveTasksForStep(TaskStepReservationRequest(amount = 10, step))
 
             val cleaningTasks = cleaningRequest.reservedTasks
 
             logger.info { "${cleaningTasks.size} tasks found for cleaning. Proceeding with cleaning..." }
 
             if (cleaningTasks.isNotEmpty()) {
-
                 val cleaningResults = cleaningTasks.map { reservedTask ->
                     // Step 2: Generate dummy cleaning results
                     processCleaningTask(reservedTask)
                 }
 
                 // Step 3: Send the cleaning result back to the Orchestrator
-                orchestrationApiClient.goldenRecordTasks.resolveStepResults(TaskStepResultRequest(cleaningResults))
+                orchestrationApiClient.goldenRecordTasks.resolveStepResults(TaskStepResultRequest(step, cleaningResults))
                 logger.info { "Cleaning tasks processing completed for this iteration." }
             }
+
         } catch (e: Exception) {
             logger.error(e) { "Error while processing cleaning task" }
         }

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
@@ -78,7 +78,6 @@ class CleaningServiceApiCallsTest @Autowired constructor(
 
     @Test
     fun `pollForCleaningTasks should reserve and resolve tasks from orchestrator`() {
-
         // Call the method under test
         cleaningServiceDummy.pollForCleaningTasks()
 
@@ -91,10 +90,7 @@ class CleaningServiceApiCallsTest @Autowired constructor(
 
     @Test
     fun `reserveTasksForStep should return expected response`() {
-
-
         val expectedResponse = jacksonObjectMapper.writeValueAsString(createSampleTaskStepReservationResponse(businessPartnerWithBpnA))
-
 
         val result = orchestrationApiClient.goldenRecordTasks.reserveTasksForStep(
             TaskStepReservationRequest(amount = 10, TaskStep.Clean)
@@ -105,14 +101,12 @@ class CleaningServiceApiCallsTest @Autowired constructor(
         assertEquals(expectedResult, result)
 
         orchestrationApiClient.goldenRecordTasks.resolveStepResults(
-            TaskStepResultRequest(emptyList())
+            TaskStepResultRequest(TaskStep.Clean, emptyList())
         )
-
     }
 
 
     fun mockOrchestratorReserveApi() {
-
         // Orchestrator reserve
         orchestratorMockApi.stubFor(
             post(urlPathEqualTo(ORCHESTRATOR_RESERVE_TASKS_URL))

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
@@ -102,7 +102,7 @@ interface GoldenRecordTaskApi {
 
     @Operation(
         summary = "Post step results for reserved golden record tasks in the given step queue",
-        description = "Post business partner step results for the given tasks. " +
+        description = "Post business partner step results for the given tasks in the given step queue. " +
                 "In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. " +
                 "The number of results you can post at a time does not need to match the original number of reserved tasks. " +
                 "Results are accepted via strategy 'all or nothing'. " +
@@ -114,7 +114,11 @@ interface GoldenRecordTaskApi {
                 responseCode = "204",
                 description = "If the results could be processed"
             ),
-            ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
+            ApiResponse(
+                responseCode = "400",
+                description = "On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue",
+                content = [Content()]
+            ),
         ]
     )
     @Tag(name = TagWorker)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepResultRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepResultRequest.kt
@@ -24,5 +24,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "Request object for posting step results of previously reserved tasks")
 data class TaskStepResultRequest(
 
+    @get:Schema(description = "The step queue containing the tasks for which results are posted", required = true)
+    val step: TaskStep,
+
     val results: List<TaskStepResultEntryDto>
 )

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskService.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskService.kt
@@ -81,13 +81,14 @@ class GoldenRecordTaskService(
             .forEach { resultEntry ->
                 val task = taskStorage.getTask(resultEntry.taskId)
                     ?: throw BpdmTaskNotFoundException(resultEntry.taskId)
-
+                val step = resultRequest.step
                 val errors = resultEntry.errors
                 val resultBusinessPartner = resultEntry.businessPartner
+
                 if (errors.isNotEmpty()) {
-                    goldenRecordTaskStateMachine.doResolveFailed(task, errors)
+                    goldenRecordTaskStateMachine.doResolveFailed(task, step, errors)
                 } else if (resultBusinessPartner != null) {
-                    goldenRecordTaskStateMachine.doResolveSuccessful(task, resultBusinessPartner)
+                    goldenRecordTaskStateMachine.doResolveSuccessful(task, step, resultBusinessPartner)
                 } else {
                     throw BpdmEmptyResultException(resultEntry.taskId)
                 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachine.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachine.kt
@@ -65,11 +65,11 @@ class GoldenRecordTaskStateMachine(
         state.taskModifiedAt = now
     }
 
-    fun doResolveSuccessful(task: GoldenRecordTask, resultBusinessPartner: BusinessPartnerFullDto) {
+    fun doResolveSuccessful(task: GoldenRecordTask, step: TaskStep, resultBusinessPartner: BusinessPartnerFullDto) {
         val state = task.processingState
         val now = Instant.now()
 
-        if (state.resultState != ResultState.Pending || state.stepState != StepState.Reserved) {
+        if (state.resultState != ResultState.Pending || state.stepState != StepState.Reserved || state.step != step) {
             throw BpdmIllegalStateException(task.taskId, state)
         }
 
@@ -92,11 +92,11 @@ class GoldenRecordTaskStateMachine(
         task.businessPartner = resultBusinessPartner
     }
 
-    fun doResolveFailed(task: GoldenRecordTask, errors: List<TaskErrorDto>) {
+    fun doResolveFailed(task: GoldenRecordTask, step: TaskStep, errors: List<TaskErrorDto>) {
         val state = task.processingState
         val now = Instant.now()
 
-        if (state.resultState != ResultState.Pending || state.stepState != StepState.Reserved) {
+        if (state.resultState != ResultState.Pending || state.stepState != StepState.Reserved || state.step != step) {
             throw BpdmIllegalStateException(task.taskId, state)
         }
 


### PR DESCRIPTION
When posting task results (`POST /api/golden-record-tasks/step-results`) the request DTO now requires a `step` enum.
This is a precondition for authorization because permission should be checked based on step-based roles.

Relates to #534