### PR TITLE
feat: Add authentication and authorization to Orchestrator

### DIFF
--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/BpdmSecurityConfigurerAdapterImpl.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/BpdmSecurityConfigurerAdapterImpl.kt
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.config
+
+import org.eclipse.tractusx.bpdm.common.config.BpdmSecurityConfigurerAdapter
+import org.eclipse.tractusx.bpdm.common.config.CustomJwtAuthenticationConverter
+import org.eclipse.tractusx.bpdm.common.config.SecurityConfigProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+
+@Configuration
+class BpdmSecurityConfigurerAdapterImpl(
+    val securityConfigProperties: SecurityConfigProperties
+) : BpdmSecurityConfigurerAdapter {
+
+    override fun configure(http: HttpSecurity) {
+        http.csrf { it.disable() }
+        http.cors {}
+        http.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+        http.authorizeHttpRequests {
+            it.requestMatchers(AntPathRequestMatcher("/api/**", HttpMethod.OPTIONS.name())).permitAll()
+            it.requestMatchers(AntPathRequestMatcher("/")).permitAll() // forwards to swagger
+            it.requestMatchers(AntPathRequestMatcher("/docs/api-docs/**")).permitAll()
+            it.requestMatchers(AntPathRequestMatcher("/ui/swagger-ui/**")).permitAll()
+            it.requestMatchers(AntPathRequestMatcher("/actuator/health/**")).permitAll()
+            it.requestMatchers(AntPathRequestMatcher("/error")).permitAll()
+            it.requestMatchers(AntPathRequestMatcher("/api/**")).authenticated()
+        }
+        http.oauth2ResourceServer {
+            it.jwt {
+                it.jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
+            }
+        }
+    }
+}

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/OrchestratorConfigProperties.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/OrchestratorConfigProperties.kt
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.config
+
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "bpdm.orchestrator-security")
+data class OrchestratorConfigProperties(
+    private val createTask: String = "create_task",
+    private val viewTask: String = "view_task",
+    private val processTaskPrefix: String = "process_task_step"
+) {
+    fun roleCreateTask() =
+        "ROLE_$createTask"
+
+    fun roleViewTask() =
+        "ROLE_$viewTask"
+
+    fun roleProcessTask(step: TaskStep) =
+        "ROLE_${processTaskPrefix}_${step.name}"
+}

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.bpdm.orchestrator.service.GoldenRecordTaskService
 import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -34,6 +35,7 @@ class GoldenRecordTaskController(
     val goldenRecordTaskService: GoldenRecordTaskService
 ) : GoldenRecordTaskApi {
 
+    @PreAuthorize("hasAuthority(@orchestratorConfigProperties.roleCreateTask())")
     override fun createTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
         if (createRequest.businessPartners.size > apiConfigProperties.upsertLimit)
             throw BpdmUpsertLimitException(createRequest.businessPartners.size, apiConfigProperties.upsertLimit)
@@ -41,6 +43,7 @@ class GoldenRecordTaskController(
         return goldenRecordTaskService.createTasks(createRequest)
     }
 
+    @PreAuthorize("hasAuthority(@orchestratorConfigProperties.roleProcessTask(#reservationRequest.step))")
     override fun reserveTasksForStep(reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse {
         if (reservationRequest.amount > apiConfigProperties.upsertLimit)
             throw BpdmUpsertLimitException(reservationRequest.amount, apiConfigProperties.upsertLimit)
@@ -48,6 +51,7 @@ class GoldenRecordTaskController(
         return goldenRecordTaskService.reserveTasksForStep(reservationRequest)
     }
 
+    @PreAuthorize("hasAuthority(@orchestratorConfigProperties.roleProcessTask(#resultRequest.step))")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     override fun resolveStepResults(resultRequest: TaskStepResultRequest) {
         if (resultRequest.results.size > apiConfigProperties.upsertLimit)
@@ -56,6 +60,7 @@ class GoldenRecordTaskController(
         goldenRecordTaskService.resolveStepResults(resultRequest)
     }
 
+    @PreAuthorize("hasAuthority(@orchestratorConfigProperties.roleViewTask())")
     override fun searchTaskStates(stateRequest: TaskStateRequest): TaskStateResponse {
         return goldenRecordTaskService.searchTaskStates(stateRequest)
     }

--- a/bpdm-orchestrator/src/main/resources/application-auth.properties
+++ b/bpdm-orchestrator/src/main/resources/application-auth.properties
@@ -1,0 +1,34 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+bpdm.security.enabled=true
+bpdm.security.cors-origins=*
+# OAuth configuration
+bpdm.security.client-id=BPDM_ORCHESTRATOR
+bpdm.security.realm=master
+bpdm.security.auth-server-url=http://localhost:8180
+bpdm.security.auth-url=${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}/protocol/openid-connect/auth
+bpdm.security.token-url=${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}/protocol/openid-connect/token
+bpdm.security.refresh-url=${bpdm.security.token-url}
+# Orchestrator roles
+bpdm.orchestrator-security.createTask=create_task
+bpdm.orchestrator-security.viewTask=view_task
+bpdm.orchestrator-security.processTaskPrefix=process_task_step
+# Spring security
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}/protocol/openid-connect/certs


### PR DESCRIPTION
Spring profile `auth` enables authentication/authorization.
The endpoints in `GoldenRecordTaskController` then require the following permissions:
- `createTasks()` requires role "create_task"
- `searchTaskStates()` requires role "view_task"
- `reserveTasksForStep()` and `resolveStepResults()` require a step-specific role, e.g. for `CleanAndSync` the role "process_task_step_CleanAndSync" is required