### PR TITLE
Feat (Gate) - Resolve Finished Cleaning Task

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/Application.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/Application.kt
@@ -22,7 +22,9 @@ package org.eclipse.tractusx.bpdm.gate
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
 class Application

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.repository
 
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.entity.SharingState
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
@@ -51,5 +52,7 @@ interface SharingStateRepository : PagingAndSortingRepository<SharingState, Long
     }
 
     fun findByExternalIdAndBusinessPartnerType(externalId: String, businessPartnerType: BusinessPartnerType): SharingState?
+
+    fun findBySharingStateType(sharingStateType: SharingStateType): Set<SharingState>
 
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
 import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.config.BpnConfigProperties
 import org.eclipse.tractusx.bpdm.gate.entity.AlternativePostalAddress
@@ -127,4 +128,82 @@ class OrchestratorMappings(
         ResultState.Success -> SharingStateType.Success
         ResultState.Error -> SharingStateType.Error
     }
+
+    //Mapping BusinessPartnerGenericDto from to BusinessPartner
+    fun toBusinessPartner(entity: BusinessPartnerGenericDto, externalId: String) = BusinessPartner(
+        externalId = externalId,
+        nameParts = entity.nameParts.toMutableList(),
+        shortName = entity.shortName,
+        identifiers = entity.identifiers.map { toIdentifier(it) }.toSortedSet(),
+        legalForm = entity.legalForm,
+        states = entity.states.map { toState(it) }.toSortedSet(),
+        classifications = entity.classifications.map { toClassification(it) }.toSortedSet(),
+        roles = entity.roles.toSortedSet(),
+        postalAddress = toPostalAddress(entity.postalAddress),
+        bpnL = entity.bpnL,
+        bpnS = entity.bpnS,
+        bpnA = entity.bpnA,
+        stage = StageType.Output
+    )
+
+    private fun toIdentifier(dto: BusinessPartnerIdentifierDto) =
+        Identifier(type = dto.type, value = dto.value, issuingBody = dto.issuingBody)
+
+    private fun toState(dto: BusinessPartnerStateDto) =
+        State(type = dto.type, validFrom = dto.validFrom, validTo = dto.validTo, description = dto.description)
+
+    private fun toClassification(dto: ClassificationDto) =
+        Classification(type = dto.type, code = dto.code, value = dto.value)
+
+    private fun toPostalAddress(entity: PostalAddressDto) =
+        PostalAddress(
+            addressType = entity.addressType,
+            physicalPostalAddress = entity.physicalPostalAddress?.let(::toPhysicalPostalAddress),
+            alternativePostalAddress = entity.alternativePostalAddress?.let(this::toAlternativePostalAddress)
+        )
+
+    private fun toPhysicalPostalAddress(dto: PhysicalPostalAddressDto) =
+        PhysicalPostalAddress(
+            geographicCoordinates = dto.geographicCoordinates?.let(::toGeographicCoordinate),
+            country = dto.country,
+            administrativeAreaLevel1 = dto.administrativeAreaLevel1,
+            administrativeAreaLevel2 = dto.administrativeAreaLevel2,
+            administrativeAreaLevel3 = dto.administrativeAreaLevel3,
+            postalCode = dto.postalCode,
+            city = dto.city,
+            district = dto.district,
+            street = dto.street?.let(::toStreet),
+            companyPostalCode = dto.companyPostalCode,
+            industrialZone = dto.industrialZone,
+            building = dto.building,
+            floor = dto.floor,
+            door = dto.door
+        )
+
+    private fun toAlternativePostalAddress(dto: AlternativePostalAddressDto) =
+        AlternativePostalAddress(
+            geographicCoordinates = dto.geographicCoordinates?.let(::toGeographicCoordinate),
+            country = dto.country,
+            administrativeAreaLevel1 = dto.administrativeAreaLevel1,
+            postalCode = dto.postalCode,
+            city = dto.city,
+            deliveryServiceType = dto.deliveryServiceType,
+            deliveryServiceQualifier = dto.deliveryServiceQualifier,
+            deliveryServiceNumber = dto.deliveryServiceNumber
+        )
+
+    private fun toStreet(dto: StreetDto) =
+        Street(
+            name = dto.name,
+            houseNumber = dto.houseNumber,
+            milestone = dto.milestone,
+            direction = dto.direction,
+            namePrefix = dto.namePrefix,
+            additionalNamePrefix = dto.additionalNamePrefix,
+            nameSuffix = dto.nameSuffix,
+            additionalNameSuffix = dto.additionalNameSuffix
+        )
+
+    private fun toGeographicCoordinate(dto: GeoCoordinateDto) =
+        GeographicCoordinate(latitude = dto.latitude, longitude = dto.longitude, altitude = dto.altitude)
 }

--- a/bpdm-gate/src/main/resources/application.properties
+++ b/bpdm-gate/src/main/resources/application.properties
@@ -62,6 +62,8 @@ spring.jpa.properties.hibernate.order_inserts=true
 #Flyway configuration
 spring.flyway.enabled=true
 spring.flyway.schemas=bpdmgate
+#Cleaning Task Job Configurations
+goldenRecordTask.pollingCron=-
 
 
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.util
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
+import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.eclipse.tractusx.orchestrator.api.model.AlternativePostalAddressDto
+import org.eclipse.tractusx.orchestrator.api.model.PhysicalPostalAddressDto
+import org.eclipse.tractusx.orchestrator.api.model.StreetDto
+import java.time.LocalDateTime
+
+object BusinessPartnerGenericMockValues {
+
+    //Business Partner with two entries in every collection
+    val businessPartner1 = BusinessPartnerGenericDto(
+        nameParts = listOf("part-cleaned-1", "name-cleaned-2"),
+        shortName = "shot-name-cleaned",
+        identifiers = listOf(
+            BusinessPartnerIdentifierDto(
+                type = "identifier-type-1-cleaned",
+                value = "identifier-value-1-cleaned",
+                issuingBody = "issuingBody-1-cleaned"
+            ),
+            BusinessPartnerIdentifierDto(
+                type = "identifier-type-2-cleaned",
+                value = "identifier-value-2-cleaned",
+                issuingBody = "issuingBody-2-cleaned"
+            ),
+        ),
+        legalForm = "legal-form-cleaned",
+        states = listOf(
+            BusinessPartnerStateDto(
+                validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
+                validTo = LocalDateTime.of(2023, 10, 23, 16, 40),
+                type = BusinessStateType.INACTIVE,
+                description = "business-state-description-1"
+            ),
+            BusinessPartnerStateDto(
+                validFrom = LocalDateTime.of(2000, 8, 21, 14, 30),
+                validTo = LocalDateTime.of(2020, 9, 22, 15, 50),
+                type = BusinessStateType.ACTIVE,
+                description = "business-state-description-2"
+            )
+        ),
+        classifications = listOf(
+            ClassificationDto(
+                type = ClassificationType.NACE,
+                code = "code-1-cleaned",
+                value = "value-1-cleaned"
+            ),
+            ClassificationDto(
+                type = ClassificationType.NAF,
+                code = "code-2-cleaned",
+                value = "value-2-cleaned"
+            ),
+        ),
+        roles = listOf(
+            BusinessPartnerRole.CUSTOMER,
+            BusinessPartnerRole.SUPPLIER
+        ),
+        postalAddress = PostalAddressDto(
+            addressType = AddressType.AdditionalAddress,
+            physicalPostalAddress = PhysicalPostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),
+                country = CountryCode.PT,
+                administrativeAreaLevel1 = "PT-PT",
+                administrativeAreaLevel2 = "pt-admin-level-2-cleaned",
+                administrativeAreaLevel3 = "pt-admin-level-3-cleaned",
+                postalCode = "phys-postal-code-cleaned",
+                city = "city",
+                district = "district",
+                street = StreetDto(
+                    name = "name",
+                    houseNumber = "house-number",
+                    milestone = "milestone",
+                    direction = "direction",
+                    namePrefix = "name-prefix",
+                    additionalNamePrefix = "add-name-prefix",
+                    nameSuffix = "name-suffix",
+                    additionalNameSuffix = "add-name-suffix"
+
+                ),
+                companyPostalCode = "comp-postal-code",
+                industrialZone = "industrial-zone",
+                building = "building",
+                floor = "floor",
+                door = "door"
+            ),
+            alternativePostalAddress = AlternativePostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(0.6f, 0.6f, 0.6f),
+                country = CountryCode.PT,
+                administrativeAreaLevel1 = "PT-PT",
+                postalCode = "postal-code-cleaned",
+                city = "alt-city-cleaned",
+                deliveryServiceNumber = "delivery-service-number-cleaned",
+                deliveryServiceQualifier = "delivery-service-qualifier-cleaned",
+                deliveryServiceType = DeliveryServiceType.PO_BOX
+            )
+        ),
+        ownerBpnL = "BPNL_CLEANED_VALUES",
+        bpnL = "000000123AAA123",
+        bpnS = "000000123BBB222",
+        bpnA = "000000123CCC333"
+    )
+
+}

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerNonVerboseValues.kt
@@ -19,7 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.util
 
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.AddressIdentifierDto
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputChildRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
 import org.eclipse.tractusx.bpdm.gate.api.model.request.*
@@ -42,6 +42,13 @@ object BusinessPartnerNonVerboseValues {
     val bpInputRequestFull = BusinessPartnerVerboseValues.bpInputRequestFull
 
     val bpInputRequestChina = BusinessPartnerVerboseValues.bpInputRequestChina
+
+    val bpInputRequestCleaned = BusinessPartnerVerboseValues.bpInputRequestCleaned
+
+    val bpInputRequestError = BusinessPartnerVerboseValues.bpInputRequestError
+
+    //Output Business Partner Test Values
+    val bpOutputRequestCleaned = BusinessPartnerVerboseValues.bpOutputRequestCleaned
 
     val legalEntityGateInputRequest1 = LegalEntityGateInputRequest(
         legalEntity = BusinessPartnerVerboseValues.legalEntity1,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.bpdm.common.service.toDto
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.*
 import java.time.Instant
 import java.time.LocalDateTime
@@ -745,6 +746,137 @@ object BusinessPartnerVerboseValues {
         bpnL = "BPNL0000000002XY",
         bpnS = "BPNS0000000003X9",
         bpnA = "BPNA0000000001XY"
+    )
+
+    val bpInputRequestCleaned = BusinessPartnerInputRequest(
+        externalId = externalId4,
+        nameParts = listOf("Name Part Value"),
+        shortName = "Random Short Name",
+        legalForm = "Random Form Value",
+        isOwnCompanyData = true,
+        identifiers = listOf(
+            bpIdentifier1, bpIdentifier2, bpIdentifier1
+        ),
+        classifications = listOf(
+            bpClassification1, bpClassification3
+        ),
+        states = listOf(bpState2, bpState1),
+        roles = listOf(BusinessPartnerRole.CUSTOMER, BusinessPartnerRole.SUPPLIER),
+        postalAddress = bpPostalAddressInputDtoFull,
+        bpnL = "BPNL0000000002XY",
+        bpnS = "BPNS0000000003X9",
+        bpnA = "BPNA0000000001XY"
+    )
+
+    val bpInputRequestError = BusinessPartnerInputRequest(
+        externalId = externalId5,
+        nameParts = listOf("Name Part Value"),
+        shortName = "Random Short Name",
+        legalForm = "Random Form Value",
+        isOwnCompanyData = true,
+        identifiers = listOf(
+            bpIdentifier1, bpIdentifier2, bpIdentifier1
+        ),
+        classifications = listOf(
+            bpClassification1, bpClassification3
+        ),
+        states = listOf(bpState2, bpState1),
+        roles = listOf(BusinessPartnerRole.CUSTOMER, BusinessPartnerRole.SUPPLIER),
+        postalAddress = bpPostalAddressInputDtoFull,
+        bpnL = "BPNL0000000002XY",
+        bpnS = "BPNS0000000003X9",
+        bpnA = "BPNA0000000001XY"
+    )
+
+    val bpOutputRequestCleaned = BusinessPartnerOutputRequest(
+        externalId = externalId4,
+        nameParts = listOf("part-cleaned-1", "name-cleaned-2"),
+        shortName = "shot-name-cleaned",
+        legalForm = "legal-form-cleaned",
+        identifiers = listOf(
+            BusinessPartnerIdentifierDto(
+                type = "identifier-type-1-cleaned",
+                value = "identifier-value-1-cleaned",
+                issuingBody = "issuingBody-1-cleaned"
+            ),
+            BusinessPartnerIdentifierDto(
+                type = "identifier-type-2-cleaned",
+                value = "identifier-value-2-cleaned",
+                issuingBody = "issuingBody-2-cleaned"
+            ),
+        ),
+        classifications = listOf(
+            ClassificationDto(
+                type = ClassificationType.NACE,
+                code = "code-1-cleaned",
+                value = "value-1-cleaned"
+            ),
+            ClassificationDto(
+                type = ClassificationType.NAF,
+                code = "code-2-cleaned",
+                value = "value-2-cleaned"
+            ),
+        ),
+        states = listOf(
+            BusinessPartnerStateDto(
+                validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
+                validTo = LocalDateTime.of(2023, 10, 23, 16, 40),
+                type = BusinessStateType.INACTIVE,
+                description = "business-state-description-1"
+            ),
+            BusinessPartnerStateDto(
+                validFrom = LocalDateTime.of(2000, 8, 21, 14, 30),
+                validTo = LocalDateTime.of(2020, 9, 22, 15, 50),
+                type = BusinessStateType.ACTIVE,
+                description = "business-state-description-2"
+            )
+        ),
+        roles = listOf(
+            BusinessPartnerRole.CUSTOMER,
+            BusinessPartnerRole.SUPPLIER
+        ),
+        postalAddress = BusinessPartnerPostalAddressDto(
+            addressType = AddressType.AdditionalAddress,
+            physicalPostalAddress = PhysicalPostalAddressGateDto(
+                geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),
+                country = CountryCode.PT,
+                administrativeAreaLevel1 = "PT-PT",
+                administrativeAreaLevel2 = "pt-admin-level-2-cleaned",
+                administrativeAreaLevel3 = "pt-admin-level-3-cleaned",
+                postalCode = "phys-postal-code-cleaned",
+                city = "city",
+                district = "district",
+                street = StreetGateDto(
+                    name = "name",
+                    houseNumber = "house-number",
+                    milestone = "milestone",
+                    direction = "direction",
+                    namePrefix = "name-prefix",
+                    additionalNamePrefix = "add-name-prefix",
+                    nameSuffix = "name-suffix",
+                    additionalNameSuffix = "add-name-suffix"
+
+                ),
+                companyPostalCode = "comp-postal-code",
+                industrialZone = "industrial-zone",
+                building = "building",
+                floor = "floor",
+                door = "door"
+            ),
+            alternativePostalAddress = AlternativePostalAddressGateDto(
+                geographicCoordinates = GeoCoordinateDto(0.6f, 0.6f, 0.6f),
+                country = CountryCode.PT,
+                administrativeAreaLevel1 = "PT-PT",
+                postalCode = "postal-code-cleaned",
+                city = "alt-city-cleaned",
+                deliveryServiceNumber = "delivery-service-number-cleaned",
+                deliveryServiceQualifier = "delivery-service-qualifier-cleaned",
+                deliveryServiceType = DeliveryServiceType.PO_BOX
+            )
+        ),
+        bpnL = "000000123AAA123",
+        bpnS = "000000123BBB222",
+        bpnA = "000000123CCC333"
     )
 
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.orchestrator.controller
 
+import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.bpdm.common.exception.BpdmUpsertLimitException
 import org.eclipse.tractusx.bpdm.orchestrator.config.ApiConfigProperties
 import org.eclipse.tractusx.bpdm.orchestrator.service.GoldenRecordTaskService
@@ -28,6 +29,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.util.*
 
 @RestController
 class GoldenRecordTaskController(


### PR DESCRIPTION
## Description
In this PR, the BPDM Gate can poll the BPDM Orchestrator whether there is already a final cleaning result for the respective cleaning task. When a new cleaning result for a finished cleaning task has been returned by the Orchestrator the Gate then saves the cleaning result as a generic business partner output, resolves the task identifier and updates the sharing state of the respective business partner. Also, some Unit tests have been added.

Related to #430 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
