### PR TITLE
Fix: Correct Chart Ingress Identation

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the gate and pool applications
-version: 3.1.0-alpha.5
+version: 3.1.0-alpha.6
 appVersion: "4.1.0-alpha.3"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -49,7 +49,7 @@ dependencies:
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 1.0.0-alpha.1
+    version: 1.0.0-alpha.2
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: opensearch

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-orchestrator
 appVersion: "4.1.0-alpha.3"
-version: 1.0.0-alpha.1
+version: 1.0.0-alpha.2
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/ingress.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/ingress.yaml
@@ -1,82 +1,82 @@
 ################################################################################
 # Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
-  #
-  # See the NOTICE file(s) distributed with this work for additional
-  # information regarding copyright ownership.
-  #
-  # This program and the accompanying materials are made available under the
-  # terms of the Apache License, Version 2.0 which is available at
-  # https://www.apache.org/licenses/LICENSE-2.0.
-  #
-  # Unless required by applicable law or agreed to in writing, software
-  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  # License for the specific language governing permissions and limitations
-  # under the License.
-  #
-  # SPDX-License-Identifier: Apache-2.0
-  ################################################################################
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
 
-  {{if .Values.ingress.enabled}}
+{{ if .Values.ingress.enabled }}
 
 
-  {{- $fullName := include "bpdm.fullname" . -}}
-  {{- $svcPort := .Values.service.port -}}
-  {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion))}}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")}}
+{{- $fullName := include "bpdm.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end}}
-  {{- end}}
-  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-  {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-  {{- else -}}
+{{- else -}}
 apiVersion: extensions/v1beta1
-  {{- end}}
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{$fullName}}
+  name: {{ $fullName }}
   labels:
-    {{- include "bpdm.labels" . | nindent 4}}
-  {{- with .Values.ingress.annotations}}
+    {{- include "bpdm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4}}
-  {{- end}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)}}
-  ingressClassName: {{.Values.ingress.className}}
-  {{- end}}
-  {{- if .Values.ingress.tls}}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls}}
+    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts}}
-        - {{. | quote}}
-        {{- end}}
-      secretName: {{.secretName}}
-    {{- end}}
-  {{- end}}
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-    {{- range .Values.ingress.hosts}}
-    - host: {{.host | quote}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths}}
-          - path: {{.path}}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)}}
-            pathType: {{.pathType}}
-            {{- end}}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion}}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{$fullName}}
+                name: {{ $fullName }}
                 port:
-                  number: {{$svcPort}}
-              {{- else}}
-              serviceName: {{$fullName}}
-              servicePort: {{$svcPort}}
-              {{- end}}
-          {{- end}}
-    {{- end}}
-  {{- end}}
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description
Orchestrator ingress yaml was with failed identation

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
