### PR TITLE
Fix: Add Health check on docker images

### DIFF
--- a/bpdm-bridge-dummy/Dockerfile
+++ b/bpdm-bridge-dummy/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /home/app
 RUN mvn -B -U clean package -pl bpdm-bridge-dummy -am -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
+# Adding wget for the health check
+RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-bridge-dummy/target/bpdm-bridge-dummy.jar /usr/local/lib/bpdm/app.jar
 RUN apk update && apk upgrade libssl3 libcrypto3
 ARG USERNAME=bpdm
@@ -14,4 +16,7 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
+# Health check instruction
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8083/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/bpdm-cleaning-service-dummy/Dockerfile
+++ b/bpdm-cleaning-service-dummy/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /home/app
 RUN mvn -B -U clean package -pl bpdm-cleaning-service-dummy -am -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
+# Adding wget for the health check
+RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-cleaning-service-dummy/target/bpdm-cleaning-service-dummy.jar /usr/local/lib/bpdm/app.jar
 RUN apk update && apk upgrade libssl3 libcrypto3
 ARG USERNAME=bpdm
@@ -14,4 +16,7 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
+# Health check instruction
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8084/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/bpdm-gate/Dockerfile
+++ b/bpdm-gate/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR  $HOME
 RUN --mount=type=cache,target=/root/.m2 mvn -B -U clean package -pl bpdm-gate -am -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
+# Adding wget for the health check
+RUN apk --no-cache add wget
 ENV HOME=/home/app
 COPY --from=build $HOME/bpdm-gate/target/bpdm-gate.jar /usr/local/lib/bpdm/app.jar
 RUN apk update && apk upgrade libssl3 libcrypto3
@@ -16,4 +18,7 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-ENTRYPOINT java $JAVA_OPTIONS -jar app.jar
+# Health check instruction
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8081/actuator/health || exit 1
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/bpdm-orchestrator/Dockerfile
+++ b/bpdm-orchestrator/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /home/app
 RUN mvn -B -U clean package -pl bpdm-orchestrator -am -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
+# Adding wget for the health check
+RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-orchestrator/target/bpdm-orchestrator.jar /usr/local/lib/bpdm/app.jar
 RUN apk update && apk upgrade libssl3 libcrypto3
 ARG USERNAME=bpdm
@@ -14,4 +16,7 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
+# Health check instruction
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8085/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/bpdm-pool/Dockerfile
+++ b/bpdm-pool/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR $HOME
 RUN --mount=type=cache,target=/root/.m2 mvn -B -U clean package -pl bpdm-pool -am -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
+# Adding wget for the health check
+RUN apk --no-cache add wget
 ENV HOME=/home/app
 COPY --from=build $HOME/bpdm-pool/target/bpdm-pool.jar /usr/local/lib/bpdm/app.jar
 RUN apk update && apk upgrade libssl3 libcrypto3
@@ -16,4 +18,7 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-ENTRYPOINT java $JAVA_OPTIONS -jar app.jar
+# Health check instruction
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
## Description
Add health check on docker image for fixing trivy findings

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
