### PR TITLE
Feat: Add configmap Hash reload

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the gate and pool applications
-version: 3.1.0-alpha.5
+version: 3.1.0-alpha.6
 appVersion: "4.1.0-alpha.3"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 4.1.0-alpha.2
+    version: 4.1.0-alpha.3
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 5.1.0-alpha.2
+    version: 5.1.0-alpha.3
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 1.1.0-alpha.2
+    version: 1.1.0-alpha.3
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 1.0.0-alpha.3
+    version: 1.0.0-alpha.4
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 1.0.0-alpha.1
+    version: 1.0.0-alpha.2
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: opensearch

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
 appVersion: "4.1.0-alpha.3"
-version: 1.1.0-alpha.2
+version: 1.1.0-alpha.3
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/deployment.yaml
@@ -32,12 +32,13 @@ spec:
       {{- include "bpdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations}}
+      {{- toYaml . | nindent 8}}
+      {{- end}}
       labels:
-        {{- include "bpdm.selectorLabels" . | nindent 8 }}
+        {{- include "bpdm.selectorLabels" . | nindent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
 appVersion: "4.1.0-alpha.3"
-version: 1.0.0-alpha.3
+version: 1.0.0-alpha.4
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
@@ -32,9 +32,10 @@ spec:
       {{- include "bpdm.selectorLabels" . | nindent 6}}
   template:
     metadata:
-      {{- with .Values.podAnnotations}}
       annotations:
-        {{- toYaml . | nindent 8}}
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations}}
+      {{- toYaml . | nindent 8}}
       {{- end}}
       labels:
         {{- include "bpdm.selectorLabels" . | nindent 8}}

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "4.1.0-alpha.3"
-version: 4.1.0-alpha.2
+version: 4.1.0-alpha.3
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/deployment.yaml
@@ -32,12 +32,13 @@ spec:
       {{- include "bpdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations}}
+      {{- toYaml . | nindent 8}}
+      {{- end}}
       labels:
-        {{- include "bpdm.selectorLabels" . | nindent 8 }}
+        {{- include "bpdm.selectorLabels" . | nindent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-orchestrator
 appVersion: "4.1.0-alpha.3"
-version: 1.0.0-alpha.1
+version: 1.0.0-alpha.2
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
@@ -32,8 +32,9 @@ spec:
       {{- include "bpdm.selectorLabels" . | nindent 6}}
   template:
     metadata:
-      {{- with .Values.podAnnotations}}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations}}
         {{- toYaml . | nindent 8}}
       {{- end}}
       labels:

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "4.1.0-alpha.3"
-version: 5.1.0-alpha.2
+version: 5.1.0-alpha.3
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/deployment.yaml
@@ -32,12 +32,13 @@ spec:
       {{- include "bpdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations}}
+      {{- toYaml . | nindent 8}}
+      {{- end}}
       labels:
-        {{- include "bpdm.selectorLabels" . | nindent 8 }}
+        {{- include "bpdm.selectorLabels" . | nindent 8}}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Description
Add configmap hash to deployment yamls so it can be reloaded when the configmap changes

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
