### PR TITLE
feat(Workflows): Add latest-alpha tag and use it for trivy.yml

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -65,6 +65,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch,branch=main,value=latest-alpha
 
       - name: DockerHub login
         if:  inputs.push

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -59,7 +59,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-pool:latest"
+          image-ref: "docker.io/tractusx/bpdm-pool:latest-alpha"
           format: "sarif"
           output: "trivy-results2.sarif"
           exit-code: "1"
@@ -92,7 +92,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-gate:latest"
+          image-ref: "docker.io/tractusx/bpdm-gate:latest-alpha"
           format: "sarif"
           output: "trivy-results3.sarif"
           exit-code: "1"
@@ -125,7 +125,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-bridge-dummy:latest"
+          image-ref: "docker.io/tractusx/bpdm-bridge-dummy:latest-alpha"
           format: "sarif"
           output: "trivy-results4.sarif"
           exit-code: "1"
@@ -158,7 +158,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-cleaning-service-dummy:latest"
+          image-ref: "docker.io/tractusx/bpdm-cleaning-service-dummy:latest-alpha"
           format: "sarif"
           output: "trivy-results4.sarif"
           exit-code: "1"
@@ -191,7 +191,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-orchestrator:latest"
+          image-ref: "docker.io/tractusx/bpdm-orchestrator:latest-alpha"
           format: "sarif"
           output: "trivy-results4.sarif"
           exit-code: "1"


### PR DESCRIPTION
## Description
A new Latest-Alpha tag will be released when a push to main is done
It can be checked in this registry https://hub.docker.com/u/tractusx
It will be used for trivy scan 

Issue fix for: https://github.com/eclipse-tractusx/bpdm/issues/561 https://github.com/eclipse-tractusx/bpdm/issues/560

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
