### PR TITLE
Fix: Add latest-alpha tag and use it for trivy.yml

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -65,7 +65,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=ref,event=branch,branch=main,value=latest-alpha
+            type=raw,value=latest-alpha,enable={{is_default_branch}}
 
       - name: DockerHub login
         if:  inputs.push


### PR DESCRIPTION
## Description
A new Latest-Alpha tag will be released when a push to main is done
It can be checked in this registry https://hub.docker.com/u/tractusx
It will be used for trivy scan 

Issue fix for:  https://github.com/eclipse-tractusx/bpdm/issues/560

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
