### PR TITLE
Refactor(Pool): Fix controller naming

### DIFF
--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -133,7 +133,7 @@ interface PoolLegalEntityApi {
     )
     @PostMapping("/search")
     @PostExchange("/search")
-    fun searchSites(
+    fun searchLegalEntitys(
         @RequestBody bpnLs: Collection<String>
     ): ResponseEntity<Collection<PoolLegalEntityVerboseDto>>
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -79,7 +79,7 @@ class LegalEntityController(
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
-    override fun searchSites(
+    override fun searchLegalEntitys(
         bpnLs: Collection<String>
     ): ResponseEntity<Collection<PoolLegalEntityVerboseDto>> {
         if (bpnLs.size > controllerConfigProperties.searchRequestLimit) {

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -502,7 +502,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .take(2) // only search for a subset of the existing legal entities
 
         val bpnsToSearch = expected.map { it.bpnl }
-        val response = poolClient.legalEntities.searchSites(bpnsToSearch).body?.map { it.legalEntity }
+        val response = poolClient.legalEntities.searchLegalEntitys(bpnsToSearch).body?.map { it.legalEntity }
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -646,7 +646,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .take(2) // only search for a subset of the existing legal entities
 
         val bpnsToSearch = expected.map { it.bpnl }.plus("NONEXISTENT") // also search for nonexistent BPN
-        val response = poolClient.legalEntities.searchSites(bpnsToSearch).body?.map { it.legalEntity }
+        val response = poolClient.legalEntities.searchLegalEntitys(bpnsToSearch).body?.map { it.legalEntity }
 
         assertThat(response)
             .usingRecursiveComparison()


### PR DESCRIPTION
## Description
Change of name in the endpoint method /api/catena/legal-entities/search method was named searchSites when it is intended to find legal entities.
Refactor usage on UnitTest and Controller calls 



## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
