### PR TITLE
fix(Generic): naming of BPN fields in generic business partner

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -121,20 +121,20 @@ class CleaningServiceDummy(
 
         val legalAddress = addressPartner.copy(bpnAReference = legalAddressBpnReference)
 
-        val bpnReferenceDto = createBpnReference(genericPartner.bpnL)
+        val bpnReferenceDto = createBpnReference(genericPartner.legalEntityBpn)
 
         return genericPartner.toLegalEntityDto(bpnReferenceDto, legalAddress)
 
     }
 
     fun createAddressRepresentation(genericPartner: BusinessPartnerGenericDto): LogisticAddressDto {
-        val bpnReferenceDto = createBpnReference(genericPartner.bpnA)
+        val bpnReferenceDto = createBpnReference(genericPartner.addressBpn)
         return genericPartner.toLogisticAddressDto(bpnReferenceDto)
     }
 
     fun createSiteRepresentation(genericPartner: BusinessPartnerGenericDto, siteAddressReference: LogisticAddressDto): SiteDto {
         val legalName = genericPartner.nameParts.joinToString(" ")
-        val bpnReferenceDto = createBpnReference(genericPartner.bpnS)
+        val bpnReferenceDto = createBpnReference(genericPartner.siteBpn)
         return genericPartner.toSiteDto(bpnReferenceDto, legalName, siteAddressReference)
     }
 
@@ -152,7 +152,7 @@ class CleaningServiceDummy(
     fun shouldCreateSite(genericPartner: BusinessPartnerGenericDto): Boolean {
         return genericPartner.postalAddress.addressType == AddressType.SiteMainAddress ||
                 genericPartner.postalAddress.addressType == AddressType.LegalAndSiteMainAddress ||
-                genericPartner.bpnS != null
+                genericPartner.siteBpn != null
     }
 
 

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummyTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummyTest.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.tractusx.bpdm.cleaning.service
 
-import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.RecursiveComparisonAssert
 import org.eclipse.tractusx.bpdm.cleaning.testdata.CommonValues.businessPartnerWithBpnA
@@ -30,7 +29,6 @@ import org.eclipse.tractusx.bpdm.cleaning.testdata.CommonValues.businessPartnerW
 import org.eclipse.tractusx.bpdm.cleaning.testdata.CommonValues.expectedLegalEntityDto
 import org.eclipse.tractusx.bpdm.cleaning.testdata.CommonValues.expectedLogisticAddressDto
 import org.eclipse.tractusx.bpdm.cleaning.testdata.CommonValues.expectedSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -53,7 +51,7 @@ class CleaningServiceDummyTest @Autowired constructor(
 
         val result = cleaningServiceDummy.processCleaningTask(taskStepReservationEntryDto)
 
-        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.bpnA
+        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.addressBpn
 
         val resultedAddress = result.businessPartner?.address
 
@@ -114,9 +112,9 @@ class CleaningServiceDummyTest @Autowired constructor(
 
         val result = cleaningServiceDummy.processCleaningTask(taskStepReservationEntryDto)
 
-        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.bpnA
+        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.addressBpn
 
-        val expectedBpnL = taskStepReservationEntryDto.businessPartner.generic.bpnL
+        val expectedBpnL = taskStepReservationEntryDto.businessPartner.generic.legalEntityBpn
 
         val resultedAddress = result.businessPartner?.address
 
@@ -154,9 +152,9 @@ class CleaningServiceDummyTest @Autowired constructor(
 
         val resultedSite = result.businessPartner?.site
 
-        val expectedBpnA = taskStepReservationResponse.businessPartner.generic.bpnA
+        val expectedBpnA = taskStepReservationResponse.businessPartner.generic.addressBpn
 
-        val expectedBpnS = taskStepReservationResponse.businessPartner.generic.bpnS
+        val expectedBpnS = taskStepReservationResponse.businessPartner.generic.siteBpn
 
 
         // legalEntity should Generate new bpnL and legalAddress should use passed bpnA since address type is LegalAndSiteMainAddress

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -116,14 +116,14 @@ object CommonValues {
 
     val businessPartnerWithBpnA = businessPartnerWithEmptyBpns.copy(
         postalAddress = postalAddressForAdditional,
-        bpnA = "FixedBPNA"
+        addressBpn = "FixedBPNA"
     )
 
 
     val businessPartnerWithBpnLAndBpnAAndLegalAddressType = businessPartnerWithEmptyBpns.copy(
         postalAddress = postalAddressForLegal,
-        bpnA = "FixedBPNA",
-        bpnL = "FixedBPNL"
+        addressBpn = "FixedBPNA",
+        legalEntityBpn = "FixedBPNL"
     )
 
     val businessPartnerWithEmptyBpnLAndAdditionalAddressType = businessPartnerWithEmptyBpns.copy(
@@ -132,8 +132,8 @@ object CommonValues {
 
     val businessPartnerWithBpnSAndBpnAAndLegalAndSiteMainAddressType = businessPartnerWithEmptyBpns.copy(
         postalAddress = postalAddressForLegalAndSite,
-        bpnA = "FixedBPNA",
-        bpnS = "FixedBPNS"
+        addressBpn = "FixedBPNA",
+        siteBpn = "FixedBPNS"
     )
 
     val businessPartnerWithEmptyBpnAndSiteMainAddressType = businessPartnerWithEmptyBpns.copy(

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -51,13 +51,13 @@ interface IBaseBusinessPartnerDto {
     @get:Schema(description = "Address of the official seat of this business partner.")
     val postalAddress: IBaseBusinessPartnerPostalAddressDto
 
-    @get:Schema(description = "BPNL")
-    val bpnL: String?
+    @get:Schema(description = "BPNL of the golden record legal entity this business partner refers to")
+    val legalEntityBpn: String?
 
-    @get:Schema(description = "BPNS")
-    val bpnS: String?
+    @get:Schema(description = "BPNS of the golden record site this business partner refers to")
+    val siteBpn: String?
 
-    @get:Schema(description = "BPNA")
-    val bpnA: String?
+    @get:Schema(description = "BPNA of the golden record address this business partner refers to")
+    val addressBpn: String?
 
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
@@ -43,8 +43,8 @@ data class BusinessPartnerInputRequest(
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto = BusinessPartnerPostalAddressDto(),
     override val isOwnCompanyData: Boolean = false,
-    override val bpnL: String? = null,
-    override val bpnS: String? = null,
-    override val bpnA: String? = null,
+    override val legalEntityBpn: String? = null,
+    override val siteBpn: String? = null,
+    override val addressBpn: String? = null,
 
     ) : IBaseBusinessPartnerGateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerOutputRequest.kt
@@ -45,8 +45,8 @@ data class BusinessPartnerOutputRequest(
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto = BusinessPartnerPostalAddressDto(),
     override val isOwnCompanyData: Boolean = false,
-    override val bpnL: String? = null,
-    override val bpnS: String? = null,
-    override val bpnA: String? = null,
+    override val legalEntityBpn: String? = null,
+    override val siteBpn: String? = null,
+    override val addressBpn: String? = null,
 
-) : IBaseBusinessPartnerGateDto
+    ) : IBaseBusinessPartnerGateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerInputDto.kt
@@ -46,9 +46,9 @@ data class BusinessPartnerInputDto(
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto,
     override val isOwnCompanyData: Boolean,
-    override val bpnL: String?,
-    override val bpnS: String?,
-    override val bpnA: String?,
+    override val legalEntityBpn: String?,
+    override val siteBpn: String?,
+    override val addressBpn: String?,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
@@ -45,9 +45,9 @@ data class BusinessPartnerOutputDto(
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto,
     override val isOwnCompanyData: Boolean,
-    override val bpnL: String,
-    override val bpnS: String?,
-    override val bpnA: String,
+    override val legalEntityBpn: String,
+    override val siteBpn: String?,
+    override val addressBpn: String,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -53,9 +53,9 @@ class BusinessPartnerMappings {
             roles = entity.roles,
             postalAddress = toPostalAddressDto(entity.postalAddress),
             isOwnCompanyData = entity.isOwnCompanyData,
-            bpnL = entity.bpnL,
-            bpnS = entity.bpnS,
-            bpnA = entity.bpnA,
+            legalEntityBpn = entity.bpnL,
+            siteBpn = entity.bpnS,
+            addressBpn = entity.bpnA,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt
         )
@@ -74,10 +74,10 @@ class BusinessPartnerMappings {
             roles = entity.roles,
             postalAddress = toPostalAddressDto(entity.postalAddress),
             isOwnCompanyData = entity.isOwnCompanyData,
-            bpnL = entity.bpnL
+            legalEntityBpn = entity.bpnL
                 ?: throw BpdmNullMappingException(BusinessPartner::class, BusinessPartnerOutputDto::class, BusinessPartner::bpnL, entity.externalId),
-            bpnS = entity.bpnS,
-            bpnA = entity.bpnA
+            siteBpn = entity.bpnS,
+            addressBpn = entity.bpnA
                 ?: throw BpdmNullMappingException(BusinessPartner::class, BusinessPartnerOutputDto::class, BusinessPartner::bpnA, entity.externalId),
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt
@@ -97,9 +97,9 @@ class BusinessPartnerMappings {
             legalName = dto.legalName,
             legalForm = dto.legalForm,
             isOwnCompanyData = dto.isOwnCompanyData,
-            bpnL = dto.bpnL,
-            bpnS = dto.bpnS,
-            bpnA = dto.bpnA,
+            bpnL = dto.legalEntityBpn,
+            bpnS = dto.siteBpn,
+            bpnA = dto.addressBpn,
             postalAddress = toPostalAddress(dto.postalAddress),
             parentId = null,
             parentType = null,
@@ -120,9 +120,9 @@ class BusinessPartnerMappings {
             legalName = dto.legalName,
             legalForm = dto.legalForm,
             isOwnCompanyData = dto.isOwnCompanyData,
-            bpnL = dto.bpnL,
-            bpnS = dto.bpnS,
-            bpnA = dto.bpnA,
+            bpnL = dto.legalEntityBpn,
+            bpnS = dto.siteBpn,
+            bpnA = dto.addressBpn,
             parentId = null,
             parentType = null,
             postalAddress = toPostalAddress(dto.postalAddress)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -50,9 +50,9 @@ class OrchestratorMappings(
         classifications = entity.classifications.map { toClassificationDto(it) },
         roles = entity.roles,
         postalAddress = toPostalAddressDto(entity.postalAddress),
-        bpnL = entity.bpnL,
-        bpnS = entity.bpnS,
-        bpnA = entity.bpnA,
+        legalEntityBpn = entity.bpnL,
+        siteBpn = entity.bpnS,
+        addressBpn = entity.bpnA,
         ownerBpnL = getOwnerBpnL(entity)
     )
 
@@ -142,9 +142,9 @@ class OrchestratorMappings(
         classifications = entity.classifications.map { toClassification(it) }.toSortedSet(),
         roles = entity.roles.toSortedSet(),
         postalAddress = toPostalAddress(entity.postalAddress),
-        bpnL = entity.bpnL,
-        bpnS = entity.bpnS,
-        bpnA = entity.bpnA,
+        bpnL = entity.legalEntityBpn,
+        bpnS = entity.siteBpn,
+        bpnA = entity.addressBpn,
         stage = StageType.Output
     )
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -310,9 +310,9 @@ class BusinessPartnerControllerIT @Autowired constructor(
             roles = request.roles.toSortedSet(),
             postalAddress = request.postalAddress,
             isOwnCompanyData = request.isOwnCompanyData,
-            bpnL = request.bpnL,
-            bpnS = request.bpnS,
-            bpnA = request.bpnA,
+            legalEntityBpn = request.legalEntityBpn,
+            siteBpn = request.siteBpn,
+            addressBpn = request.addressBpn,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -332,14 +332,14 @@ class BusinessPartnerControllerIT @Autowired constructor(
             roles = request.roles.toSortedSet(),
             postalAddress = request.postalAddress,
             isOwnCompanyData = request.isOwnCompanyData,
-            bpnL = request.bpnL ?: throw BpdmNullMappingException(
+            legalEntityBpn = request.legalEntityBpn ?: throw BpdmNullMappingException(
                 BusinessPartner::class,
                 BusinessPartnerOutputDto::class,
                 BusinessPartner::bpnL,
                 request.externalId
             ),
-            bpnS = request.bpnS,
-            bpnA = request.bpnA ?: throw BpdmNullMappingException(
+            siteBpn = request.siteBpn,
+            addressBpn = request.addressBpn ?: throw BpdmNullMappingException(
                 BusinessPartner::class,
                 BusinessPartnerOutputDto::class,
                 BusinessPartner::bpnA,
@@ -546,7 +546,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
                 sharingStateType = SharingStateType.Success,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = BusinessPartnerGenericMockValues.businessPartner1.bpnA,
+                bpn = BusinessPartnerGenericMockValues.businessPartner1.addressBpn,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -120,9 +120,9 @@ object BusinessPartnerGenericMockValues {
             )
         ),
         ownerBpnL = "BPNL_CLEANED_VALUES",
-        bpnL = "000000123AAA123",
-        bpnS = "000000123BBB222",
-        bpnA = "000000123CCC333"
+        legalEntityBpn = "000000123AAA123",
+        siteBpn = "000000123BBB222",
+        addressBpn = "000000123CCC333"
     )
 
 }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -371,8 +371,8 @@ object BusinessPartnerVerboseValues {
         states = listOf(bpState1, bpState2),
         roles = listOf(BusinessPartnerRole.SUPPLIER),
         postalAddress = bpPostalAddressInputDtoFull,
-        bpnL = "BPNL0000000000XY",
-        bpnA = "BPNA0000000001XY"
+        legalEntityBpn = "BPNL0000000000XY",
+        addressBpn = "BPNA0000000001XY"
     )
 
     val address1 = PhysicalPostalAddressVerboseDto(
@@ -769,9 +769,9 @@ object BusinessPartnerVerboseValues {
         states = listOf(bpState2, bpState1),
         roles = listOf(BusinessPartnerRole.CUSTOMER, BusinessPartnerRole.SUPPLIER),
         postalAddress = bpPostalAddressInputDtoChina,
-        bpnL = "BPNL0000000002XY",
-        bpnS = "BPNS0000000003X9",
-        bpnA = "BPNA0000000001XY"
+        legalEntityBpn = "BPNL0000000002XY",
+        siteBpn = "BPNS0000000003X9",
+        addressBpn = "BPNA0000000001XY"
     )
 
     val bpInputRequestCleaned = BusinessPartnerInputRequest(
@@ -790,9 +790,9 @@ object BusinessPartnerVerboseValues {
         states = listOf(bpState2, bpState1),
         roles = listOf(BusinessPartnerRole.CUSTOMER, BusinessPartnerRole.SUPPLIER),
         postalAddress = bpPostalAddressInputDtoFull,
-        bpnL = "BPNL0000000002XY",
-        bpnS = "BPNS0000000003X9",
-        bpnA = "BPNA0000000001XY"
+        legalEntityBpn = "BPNL0000000002XY",
+        siteBpn = "BPNS0000000003X9",
+        addressBpn = "BPNA0000000001XY"
     )
 
     val bpInputRequestError = BusinessPartnerInputRequest(
@@ -811,9 +811,9 @@ object BusinessPartnerVerboseValues {
         states = listOf(bpState2, bpState1),
         roles = listOf(BusinessPartnerRole.CUSTOMER, BusinessPartnerRole.SUPPLIER),
         postalAddress = bpPostalAddressInputDtoFull,
-        bpnL = "BPNL0000000002XY",
-        bpnS = "BPNS0000000003X9",
-        bpnA = "BPNA0000000001XY"
+        legalEntityBpn = "BPNL0000000002XY",
+        siteBpn = "BPNS0000000003X9",
+        addressBpn = "BPNA0000000001XY"
     )
 
     val bpOutputRequestCleaned = BusinessPartnerOutputRequest(
@@ -903,9 +903,9 @@ object BusinessPartnerVerboseValues {
                 deliveryServiceType = DeliveryServiceType.PO_BOX
             )
         ),
-        bpnL = "000000123AAA123",
-        bpnS = "000000123BBB222",
-        bpnA = "000000123CCC333"
+        legalEntityBpn = "000000123AAA123",
+        siteBpn = "000000123BBB222",
+        addressBpn = "000000123CCC333"
     )
 
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
@@ -33,9 +33,9 @@ data class BusinessPartnerGenericDto(
     override val classifications: Collection<ClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: PostalAddressDto = PostalAddressDto(),
-    override val bpnL: String? = null,
-    override val bpnS: String? = null,
-    override val bpnA: String? = null,
+    override val legalEntityBpn: String? = null,
+    override val siteBpn: String? = null,
+    override val addressBpn: String? = null,
 
     @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
     val ownerBpnL: String? = null,

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskControllerIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskControllerIT.kt
@@ -228,7 +228,7 @@ class GoldenRecordTaskControllerIT @Autowired constructor(
         // resolve task again
         val businessPartnerFull2 = businessPartnerFull1.copy(
             generic = businessPartnerFull1.generic.copy(
-                bpnL = "BPNL-test"
+                legalEntityBpn = "BPNL-test"
             )
         )
         val resultEntry2 = TaskStepResultEntryDto(

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -131,9 +131,9 @@ object BusinessPartnerTestValues {
             )
         ),
         ownerBpnL = "BPNL_OWNER_TEST_1",
-        bpnL = "BPNLTEST",
-        bpnS = "BPNSTEST",
-        bpnA = "BPNATEST"
+        legalEntityBpn = "BPNLTEST",
+        siteBpn = "BPNSTEST",
+        addressBpn = "BPNATEST"
     )
 
     //Business Partner with single entry in every collection
@@ -207,9 +207,9 @@ object BusinessPartnerTestValues {
             )
         ),
         ownerBpnL = "BPNL_OWNER_TEST_2",
-        bpnL = "BPNLTEST-2",
-        bpnS = "BPNSTEST-2",
-        bpnA = "BPNATEST-2"
+        legalEntityBpn = "BPNLTEST-2",
+        siteBpn = "BPNSTEST-2",
+        addressBpn = "BPNATEST-2"
     )
 
     val logisticAddress1 = LogisticAddressDto(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -95,9 +95,9 @@ class TaskStepBuildService(
             taskId = taskEntry.taskId,
             businessPartner = BusinessPartnerFullDto(
                 generic = businessPartnerDto.generic.copy(
-                    bpnL = legalEntity.bpn,
-                    bpnS = siteEntity?.bpn,
-                    bpnA = genericBpnA
+                    legalEntityBpn = legalEntity.bpn,
+                    siteBpn = siteEntity?.bpn,
+                    addressBpn = genericBpnA
                 ),
                 legalEntity = businessPartnerDto.legalEntity!!.copy(
                     bpnLReference = BpnReferenceDto(referenceValue = legalEntity.bpn, referenceType = BpnReferenceType.Bpn)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -79,7 +79,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val createdLegalEntity = poolClient.legalEntities.getLegalEntity(resultSteps[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
         assertThat(createdLegalEntity.legalAddress.bpnLegalEntity).isNotNull()
         assertThat(bpnMappings.size).isEqualTo(2)
-        assertThat(resultSteps[0].businessPartner?.generic?.bpnL).isEqualTo(createdLegalEntity.legalEntity.bpnl)
+        assertThat(resultSteps[0].businessPartner?.generic?.legalEntityBpn).isEqualTo(createdLegalEntity.legalEntity.bpnl)
     }
 
     @Test
@@ -127,7 +127,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         assertThat(resultSteps2[0].errors.size).isEqualTo(0)
         assertThat(createdLegalEntity1.legalEntity.bpnl).isNotEqualTo(resultSteps2[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
         val createdLegalEntity2 = poolClient.legalEntities.getLegalEntity(resultSteps2[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
-        assertThat(resultSteps2[0].businessPartner?.generic?.bpnL).isEqualTo(createdLegalEntity2.legalEntity.bpnl)
+        assertThat(resultSteps2[0].businessPartner?.generic?.legalEntityBpn).isEqualTo(createdLegalEntity2.legalEntity.bpnl)
 
     }
 


### PR DESCRIPTION
## Description

This pull request aligns with the specification of the Generic Business Partner model for BPN fields: #382.  I renamed the generic business partner's BPN fields in order to better represent their meaning, as explained in the linked issue. 

I changed the code of the API but left entities unchanged.

Fixes #594 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
