### PR TITLE
Feat: Add Authentication connection to Orchestrator

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/ClientsConfig.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/ClientsConfig.kt
@@ -47,8 +47,8 @@ class ClientsConfig {
         havingValue = "false",
         matchIfMissing = true
     )
-    fun orchestratorClientNoAuth(poolConfigProperties: OrchestratorConfigProperties): OrchestrationApiClient {
-        val url = poolConfigProperties.baseUrl
+    fun orchestratorClientNoAuth(orchestratorConfigProperties: OrchestratorConfigProperties): OrchestrationApiClient {
+        val url = orchestratorConfigProperties.baseUrl
         return OrchestrationApiClientImpl { webClientBuilder(url).build() }
     }
 
@@ -59,12 +59,12 @@ class ClientsConfig {
         havingValue = "true"
     )
     fun orchestratorClientWithAuth(
-        poolConfigProperties: OrchestratorConfigProperties,
+        orchestratorConfigProperties: OrchestratorConfigProperties,
         clientRegistrationRepository: ClientRegistrationRepository,
         authorizedClientService: OAuth2AuthorizedClientService
     ): OrchestrationApiClient {
-        val url = poolConfigProperties.baseUrl
-        val clientRegistrationId = poolConfigProperties.oauth2ClientRegistration
+        val url = orchestratorConfigProperties.baseUrl
+        val clientRegistrationId = orchestratorConfigProperties.oauth2ClientRegistration
             ?: throw IllegalArgumentException("bpdm.orchestrator.oauth2-client-registration is required if bpdm.orchestrator.security-enabled is set")
         return OrchestrationApiClientImpl {
             webClientBuilder(url)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/OrchestratorClientConfig.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/OrchestratorClientConfig.kt
@@ -26,7 +26,14 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
+import java.util.function.Consumer
 
 
 @Configuration
@@ -44,9 +51,52 @@ class OrchestratorClientConfig {
         return OrchestrationApiClientImpl { webClientBuilder(url).build() }
     }
 
+
+    @Bean
+    @ConditionalOnProperty(
+        value = ["bpdm.orchestrator.security-enabled"],
+        havingValue = "true"
+    )
+    fun orchestratorClientWithAuth(
+        orchestratorConfigProperties: OrchestratorConfigProperties,
+        clientRegistrationRepository: ClientRegistrationRepository,
+        authorizedClientService: OAuth2AuthorizedClientService
+    ): OrchestrationApiClient {
+        val url = orchestratorConfigProperties.baseUrl
+        val clientRegistrationId = orchestratorConfigProperties.oauth2ClientRegistration
+            ?: throw IllegalArgumentException("bpdm.orchestrator.oauth2-client-registration is required if bpdm.orchestrator.security-enabled is set")
+        return OrchestrationApiClientImpl {
+            webClientBuilder(url)
+                .apply(oauth2Configuration(clientRegistrationRepository, authorizedClientService, clientRegistrationId))
+                .build()
+        }
+    }
+
+
     private fun webClientBuilder(url: String) =
         WebClient.builder()
             .baseUrl(url)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+
+    private fun oauth2Configuration(
+        clientRegistrationRepository: ClientRegistrationRepository,
+        authorizedClientService: OAuth2AuthorizedClientService,
+        clientRegistrationId: String
+    ): Consumer<WebClient.Builder> {
+        val authorizedClientManager = authorizedClientManager(clientRegistrationRepository, authorizedClientService)
+        val oauth = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+        oauth.setDefaultClientRegistrationId(clientRegistrationId)
+        return oauth.oauth2Configuration()
+    }
+
+    private fun authorizedClientManager(
+        clientRegistrationRepository: ClientRegistrationRepository,
+        authorizedClientService: OAuth2AuthorizedClientService
+    ): OAuth2AuthorizedClientManager {
+        val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
+        val authorizedClientManager = AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService)
+        authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+        return authorizedClientManager
+    }
 
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/OrchestratorConfigProperties.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/OrchestratorConfigProperties.kt
@@ -25,4 +25,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "bpdm.orchestrator")
 data class OrchestratorConfigProperties(
     val baseUrl: String = "http://localhost:8085",
+    val securityEnabled: Boolean = false,
+    val oauth2ClientRegistration: String?
 )


### PR DESCRIPTION
## Description
- Added client configuration to have authentication when connecting to orchestrator Apis.
- This should handle for both auth and no auth options
- Fixed some wrong naming on props for cleaning module regarding auth


[<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->](https://github.com/eclipse-tractusx/bpdm/issues/582)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
