### PR TITLE
fix(Charts): Fix trivy scan on chart orchestrator

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 3.1.0
+version: 3.1.1
 appVersion: "4.1.0"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -45,11 +45,11 @@ dependencies:
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 1.0.0
+    version: 1.0.1
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 1.0.0
+    version: 1.0.1
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: opensearch

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
 appVersion: "4.1.0"
-version: 1.0.0
-description: A Helm chart for deploying the BPDM bridge dummy service
+version: 1.0.1
+description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
@@ -10,7 +10,7 @@ This Helm Chart deploys the BPDM service to a Kubernetes environment.
 In an existing Kubernetes cluster the application can be deployed with the following command:
 
 ```bash
-helm install release_name ./charts/bpdm-bridge-dummy --namespace your_namespace -f /path/to/my_release-values.yaml
+helm install release_name ./charts/bpdm-cleanning-service-dummy --namespace your_namespace -f /path/to/my_release-values.yaml
 ```
 
 This will install a new release of the BPDM Cleaning Service in the given namespace.
@@ -57,7 +57,7 @@ ingress:
   hosts:
     - host: business-partners.your-domain.net
       paths:
-        - path: /bridge
+        - path: /cleaning-service
           pathType: Prefix
 ```
 
@@ -73,9 +73,7 @@ effect.
 ```yaml
 applicationConfig:
   bpdm:
-    pool:
-      base-url: http://remote.domain.net/api/catena
-    gate:
+    orchestrator:
       base-url: http://remote.domain.net/api/catena
 ```
 -->

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/_helpers.tpl
@@ -61,41 +61,23 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{- define "bpdm-cleaning-service-dummy.poolServiceName" -}}
-{{- $config := .Values.applicationConfig -}}
-{{- if and $config (not (empty $config.bpdm)) -}}
-    {{- $bpdm := $config.bpdm -}}
-    {{- if and $bpdm (not (empty $bpdm.pool)) -}}
-        {{- $pool := $bpdm.pool -}}
-        {{- if and $pool (not (empty (index $pool "base-url"))) -}}
-            {{- index $pool "base-url" -}}
-        {{- else -}}
-            {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-        {{- end -}}
-    {{- else -}}
-        {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-    {{- end -}}
-{{- else -}}
-    {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-{{- end -}}
-{{- end }}
 
-{{- define "bpdm-cleaning-service-dummy.gateServiceName" -}}
+{{- define "bpdm-cleaning-service-dummy.orchestratorServiceName" -}}
 {{- $config := .Values.applicationConfig -}}
 {{- if and $config (not (empty $config.bpdm)) -}}
     {{- $bpdm := $config.bpdm -}}
-    {{- if and $bpdm (not (empty $bpdm.gate)) -}}
-        {{- $gate := $bpdm.gate -}}
-        {{- if and $gate (not (empty (index $gate "base-url"))) -}}
-            {{- index $gate "base-url" -}}
+    {{- if and $bpdm (not (empty $bpdm.orchestrator)) -}}
+        {{- $orchestrator := $bpdm.orchestrator -}}
+        {{- if and $orchestrator (not (empty (index $orchestrator "base-url"))) -}}
+            {{- index $orchestrator "base-url" -}}
         {{- else -}}
-            {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
+            {{- print "http://" (printf "%s-bpdm-orchestrator" .Release.Name) ":8080" -}}
         {{- end -}}
     {{- else -}}
-        {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
+        {{- print "http://" (printf "%s-bpdm-orchestrator" .Release.Name) ":8080" -}}
     {{- end -}}
 {{- else -}}
-    {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
+    {{- print "http://" (printf "%s-bpdm-orchestrator" .Release.Name) ":8080" -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/configMap.yaml
@@ -23,11 +23,14 @@ kind: ConfigMap
 metadata:
   name: {{include "bpdm.fullname" .}}
   labels:
-    {{- include "bpdm.labels" . | nindent 4}}
+    {{- include "bpdm.labels" . | nindent 4 }}
 data:
   deployment.yml: |-
     # Place for putting standard deployment configuration
     # which can be overwritten by external.yml
+    bpdm:
+      orchestrator:
+        base-url: {{include "bpdm-cleaning-service-dummy.orchestratorServiceName" .}}
   external.yml: |-
     # External properties for overwriting application config
     {{- if .Values.applicationConfig }}

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
@@ -20,16 +20,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{include "bpdm.fullname" .}}
+  name: {{ include "bpdm.fullname" . }}
   labels:
-    {{- include "bpdm.labels" . | nindent 4}}
+    {{- include "bpdm.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled}}
-  replicas: {{.Values.replicaCount}}
-  {{- end}}
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
-      {{- include "bpdm.selectorLabels" . | nindent 6}}
+      {{- include "bpdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -40,23 +40,23 @@ spec:
       labels:
         {{- include "bpdm.selectorLabels" . | nindent 8}}
     spec:
-      {{- with .Values.imagePullSecrets}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # @url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8}}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{.Chart.Name}}
+        - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12}}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{.Values.image.pullPolicy}}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: SPRING_PROFILES_ACTIVE
-              value: {{.Values.springProfiles | join ","  }}
+              value: {{ .Values.springProfiles | join ","  }}
             - name: SPRING_CONFIG_IMPORT
               value: "/etc/conf/deployment.yml,/etc/conf/external.yml,/etc/conf/secrets.yml"
           ports:
@@ -65,34 +65,34 @@ spec:
               protocol: TCP
           # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12}}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12}}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12}}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12}}
+            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/conf
               name: config
               readOnly: true
-      {{- with .Values.nodeSelector}}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
-      {{- with .Values.affinity}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
-      {{- with .Values.tolerations}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config
           projected:
             sources:
               - configMap:
-                  name: {{include "bpdm.fullname" .}}
+                  name: {{ include "bpdm.fullname" . }}
               - secret:
-                  name: {{include "bpdm.fullname" .}}
+                  name: {{ include "bpdm.fullname" . }}

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/secret.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{include "bpdm.fullname" .}}
+  name: {{ include "bpdm.fullname" . }}
 type: Opaque
 stringData:
   secrets.yml: |-

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/service.yaml
@@ -20,13 +20,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{include "bpdm.fullname" .}}
+  name: {{ include "bpdm.fullname" . }}
   labels:
-    {{- include "bpdm.labels" . | nindent 4}}
+    {{- include "bpdm.labels" . | nindent 4 }}
 spec:
-  type: {{.Values.service.type}}
+  type: {{ .Values.service.type }}
   ports:
-    - port: {{.Values.service.port}}
-      targetPort: {{.Values.service.targetPort}}
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
   selector:
-    {{- include "bpdm.selectorLabels" . | nindent 4}}
+    {{- include "bpdm.selectorLabels" . | nindent 4 }}

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
@@ -38,6 +38,8 @@ podAnnotations: {}
 springProfiles: []
 
 securityContext:
+  seccompProfile:
+    type: RuntimeDefault
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 10001
@@ -110,7 +112,7 @@ startupProbe:
 # Used to overwrite the default property values of the application configuration
 applicationConfig:
 #  bpdm:
-#    pool:
+#    orchestrator:
 #      base-url: ...
 
 # Used to overwrite the secret property values of the application configuration

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-orchestrator
 appVersion: "4.1.0"
-version: 1.0.0
+version: 1.0.1
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/_helpers.tpl
@@ -61,43 +61,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{- define "bpdm-orchestrator.poolServiceName" -}}
-{{- $config := .Values.applicationConfig -}}
-{{- if and $config (not (empty $config.bpdm)) -}}
-    {{- $bpdm := $config.bpdm -}}
-    {{- if and $bpdm (not (empty $bpdm.pool)) -}}
-        {{- $pool := $bpdm.pool -}}
-        {{- if and $pool (not (empty (index $pool "base-url"))) -}}
-            {{- index $pool "base-url" -}}
-        {{- else -}}
-            {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-        {{- end -}}
-    {{- else -}}
-        {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-    {{- end -}}
-{{- else -}}
-    {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-{{- end -}}
-{{- end }}
 
-{{- define "bpdm-orchestrator.gateServiceName" -}}
-{{- $config := .Values.applicationConfig -}}
-{{- if and $config (not (empty $config.bpdm)) -}}
-    {{- $bpdm := $config.bpdm -}}
-    {{- if and $bpdm (not (empty $bpdm.gate)) -}}
-        {{- $gate := $bpdm.gate -}}
-        {{- if and $gate (not (empty (index $gate "base-url"))) -}}
-            {{- index $gate "base-url" -}}
-        {{- else -}}
-            {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
-        {{- end -}}
-    {{- else -}}
-        {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
-    {{- end -}}
-{{- else -}}
-    {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
-{{- end -}}
-{{- end }}
 
 
 

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/configMap.yaml
@@ -23,7 +23,7 @@ kind: ConfigMap
 metadata:
   name: {{include "bpdm.fullname" .}}
   labels:
-    {{- include "bpdm.labels" . | nindent 4}}
+    {{- include "bpdm.labels" . | nindent 4 }}
 data:
   deployment.yml: |-
     # Place for putting standard deployment configuration

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
@@ -20,40 +20,40 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{include "bpdm.fullname" .}}
+  name: {{ include "bpdm.fullname" . }}
   labels:
-    {{- include "bpdm.labels" . | nindent 4}}
+    {{- include "bpdm.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled}}
-  replicas: {{.Values.replicaCount}}
-  {{- end}}
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
-      {{- include "bpdm.selectorLabels" . | nindent 6}}
+      {{- include "bpdm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations}}
-        {{- toYaml . | nindent 8}}
+      {{- toYaml . | nindent 8}}
       {{- end}}
       labels:
         {{- include "bpdm.selectorLabels" . | nindent 8}}
     spec:
-      {{- with .Values.imagePullSecrets}}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # @url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
       automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8}}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{.Chart.Name}}
+        - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12}}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{.Values.image.pullPolicy}}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: {{.Values.springProfiles | join ","  }}
@@ -61,38 +61,38 @@ spec:
               value: "/etc/conf/deployment.yml,/etc/conf/external.yml,/etc/conf/secrets.yml"
           ports:
             - name: http
-              containerPort: 8085
+              containerPort: 8080
               protocol: TCP
           # @url: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12}}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12}}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12}}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12}}
+            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/conf
               name: config
               readOnly: true
-      {{- with .Values.nodeSelector}}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
-      {{- with .Values.affinity}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
-      {{- with .Values.tolerations}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8}}
-      {{- end}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config
           projected:
             sources:
               - configMap:
-                  name: {{include "bpdm.fullname" .}}
+                  name: {{ include "bpdm.fullname" . }}
               - secret:
-                  name: {{include "bpdm.fullname" .}}
+                  name: {{ include "bpdm.fullname" . }}

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/secret.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{include "bpdm.fullname" .}}
+  name: {{ include "bpdm.fullname" . }}
 type: Opaque
 stringData:
   secrets.yml: |-

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/service.yaml
@@ -20,13 +20,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{include "bpdm.fullname" .}}
+  name: {{ include "bpdm.fullname" . }}
   labels:
-    {{- include "bpdm.labels" . | nindent 4}}
+    {{- include "bpdm.labels" . | nindent 4 }}
 spec:
-  type: {{.Values.service.type}}
+  type: {{ .Values.service.type }}
   ports:
-    - port: {{.Values.service.port}}
-      targetPort: {{.Values.service.targetPort}}
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
   selector:
-    {{- include "bpdm.selectorLabels" . | nindent 4}}
+    {{- include "bpdm.selectorLabels" . | nindent 4 }}

--- a/charts/bpdm/charts/bpdm-orchestrator/values.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/values.yaml
@@ -38,6 +38,8 @@ podAnnotations: {}
 springProfiles: []
 
 securityContext:
+  seccompProfile:
+    type: RuntimeDefault
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 10001
@@ -62,11 +64,11 @@ ingress:
 
 resources:
   limits:
-    cpu: 1000m
-    memory: 1Gi
+    cpu: 500m
+    memory: 512Mi
   requests:
-    cpu: 200m
-    memory: 1Gi
+    cpu: 100m
+    memory: 256Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Description
Fixed trivy finding for https://avd.aquasec.com/misconfig/kubernetes/general/avd-ksv-0104/

Artifact: charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
Type: helm
Vulnerability KSV104
Severity: MEDIUM
Message: container bpdm-orchestrator of deployment bpdm-orchestrator in default namespace should specify a seccomp profile
Link: [KSV104](https://avd.aquasec.com/misconfig/ksv104)

This was happening on both cleaning and orchestrator deployment

https://github.com/eclipse-tractusx/bpdm/issues/599

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files


