### PR TITLE
feat(orchestrator): Service logic for timeout

### DIFF
--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskProcessingStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskProcessingStateDto.kt
@@ -47,6 +47,6 @@ data class TaskProcessingStateDto(
     @get:Schema(description = "When the task has last been modified", required = true)
     val modifiedAt: Instant,
 
-    @get:Schema(description = "The timestamp until the task is removed from the Orchestrator")
+    @get:Schema(description = "The timestamp until the task is removed from the Orchestrator", deprecated = true)
     val timeout: Instant
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationResponse.kt
@@ -29,6 +29,6 @@ data class TaskStepReservationResponse(
     @get:ArraySchema(arraySchema = Schema(description = "The reserved tasks with their business partner data to process"))
     val reservedTasks: List<TaskStepReservationEntryDto>,
 
-    @get:Schema(description = "The timestamp until the reservation is valid and results are accepted")
+    @get:Schema(description = "The timestamp until the reservation is valid and results are accepted", deprecated = true)
     val timeout: Instant
 )

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/Application.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/Application.kt
@@ -23,10 +23,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 
 @SpringBootApplication(exclude = [DataSourceAutoConfiguration::class])
 @ConfigurationPropertiesScan
+@EnableScheduling
 class Application
 
 fun main(args: Array<String>) {

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/TaskConfigProperties.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/TaskConfigProperties.kt
@@ -24,8 +24,10 @@ import java.time.Duration
 
 @ConfigurationProperties(prefix = "bpdm.task")
 data class TaskConfigProperties(
-    // Duration after which a task is removed from the Orchestrator after creation
-    val taskTimeout: Duration = Duration.ofHours(3 * 24),
-    // Duration for which a reservation is valid and results are accepted
-    val taskReservationTimeout: Duration = Duration.ofHours(24)
+    // Cron expression for checking if any of the timeouts has been reached
+    val timeoutCheckCron: String = "-",
+    // Timeout after which a pending task should change into state "Error" with error type "Timeout" starting with its creation.
+    val taskPendingTimeout: Duration = Duration.ofDays(2),
+    // Timeout after which a task should be removed from the Orchestrator starting with its creation.
+    val taskRetentionTimeout: Duration = Duration.ofDays(14),
 )

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/model/TaskProcessingState.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/model/TaskProcessingState.kt
@@ -29,9 +29,12 @@ data class TaskProcessingState(
 
     var step: TaskStep,
     var stepState: StepState,
-    var reservationTimeout: Instant?,
 
     val taskCreatedAt: Instant,
     var taskModifiedAt: Instant,
-    val taskTimeout: Instant,
+
+    // only used while in resultState==pending
+    var taskPendingTimeout: Instant?,
+    // only used while in final resultState (!=pending)
+    var taskRetentionTimeout: Instant?
 )

--- a/bpdm-orchestrator/src/main/resources/application.yml
+++ b/bpdm-orchestrator/src/main/resources/application.yml
@@ -16,8 +16,9 @@ bpdm:
         unknown-user: Anonymous
 
     task:
-        task-reservation-timeout: 1d
-        task-timeout: 3d
+        timeoutCheckCron: 10 0/5 * * * ?
+        taskPendingTimeout: 3d
+        taskRetentionTimeout: 30d
 
 # Enable actuator endpoints
 management:


### PR DESCRIPTION
In the Orchestrator a cron-job checks if any of the two timeouts have been reached for any of the tasks:
- A task remaining in state "Pending" for a specified time (*taskPendingTimeout*) after its creation should go into state "Error" with error type "Timeout".
- A specified time (*taskRetentionTimeout*) after its creation a task should be completely removed from the Orchestrator.

**TaskStepReservationResponse.timeout** has been marked as deprecated as this field doesn't make much sense for a cleaning service.
We might add a task specific timeout in **TaskStepReservationEntryDto** but this is still up for debate.

Integration tests for the timeout cases have been added.

Solves #588 
