### PR TITLE
Feat (Gate) - Added new error for missing task in orchestrator

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/exception/GateErrorCodes.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/exception/GateErrorCodes.kt
@@ -29,6 +29,7 @@ enum class BusinessPartnerSharingError : ErrorCode {
     SharingProcessError,
     SharingTimeout,
     BpnNotInPool,
+    MissingTaskID,
 }
 
 enum class ChangeLogOutputError : ErrorCode {

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -255,19 +255,29 @@ class BusinessPartnerService(
             .map { Pair(it, sharingStateMap[it.taskId]!!) }
             .groupBy { (task, _) -> task.processingState.resultState }
 
+        val sharingStatesWithoutTasks = sharingStates.filter { it.taskId !in tasks.map { task -> task.taskId } }
+
         val businessPartnersToUpsert = taskStatesByResult[ResultState.Success]?.map { (task, sharingState) ->
             orchestratorMappings.toBusinessPartner(task.businessPartnerResult!!, sharingState.externalId)
         } ?: emptyList()
         upsertBusinessPartnersOutputFromCandidates(businessPartnersToUpsert)
 
-
-        val errorRequests = taskStatesByResult[ResultState.Error]?.map { (task, sharingState) ->
+        val errorRequests = (taskStatesByResult[ResultState.Error]?.map { (task, sharingState) ->
             SharingStateService.ErrorRequest(
                 SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
                 BusinessPartnerSharingError.SharingProcessError,
                 if (task.processingState.errors.isNotEmpty()) task.processingState.errors.joinToString(" // ") { it.description } else null
             )
-        } ?: emptyList()
+        } ?: emptyList()).toMutableList()
+
+        errorRequests.addAll(sharingStatesWithoutTasks.map { sharingState ->
+            SharingStateService.ErrorRequest(
+                SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
+                BusinessPartnerSharingError.SharingProcessError,
+                errorMessage = "Missing Task in Orchestrator"
+            )
+        })
+
         sharingStateService.setError(errorRequests)
 
     }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -273,7 +273,7 @@ class BusinessPartnerService(
         errorRequests.addAll(sharingStatesWithoutTasks.map { sharingState ->
             SharingStateService.ErrorRequest(
                 SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
-                BusinessPartnerSharingError.SharingProcessError,
+                BusinessPartnerSharingError.MissingTaskID,
                 errorMessage = "Missing Task in Orchestrator"
             )
         })

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -615,7 +615,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
                 businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Error,
-                sharingErrorCode = BusinessPartnerSharingError.SharingProcessError,
+                sharingErrorCode = BusinessPartnerSharingError.MissingTaskID,
                 sharingErrorMessage = "Missing Task in Orchestrator",
                 bpn = null,
                 sharingProcessStarted = null,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -574,5 +574,61 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
     }
 
+    @Test
+    fun `insert one business partners but task is missing in orchestrator`() {
+
+        val upsertRequests = listOf(
+            BusinessPartnerNonVerboseValues.bpInputRequestCleaned,
+            BusinessPartnerNonVerboseValues.bpInputRequestError,
+            BusinessPartnerNonVerboseValues.bpInputRequestChina,
+        )
+        gateClient.businessParters.upsertBusinessPartnersInput(upsertRequests).body!!
+
+        val externalId3 = BusinessPartnerNonVerboseValues.bpInputRequestChina.externalId
+
+        val createdSharingState = listOf(
+            SharingStateDto(
+                businessPartnerType = BusinessPartnerType.GENERIC,
+                externalId = externalId3,
+                sharingStateType = SharingStateType.Pending,
+                sharingErrorCode = null,
+                sharingErrorMessage = null,
+                bpn = null,
+                sharingProcessStarted = null,
+                taskId = "2"
+            )
+        )
+
+        //Firstly verifies if the Sharing States was created for new Business Partner
+        val externalIds = listOf(externalId3)
+        val upsertSharingStateResponses = readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        testHelpers
+            .assertRecursively(upsertSharingStateResponses)
+            .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
+            .isEqualTo(createdSharingState)
+
+        // Call Finish Cleaning Method
+        businessPartnerService.finishCleaningTask()
+
+        val cleanedSharingState = listOf(
+            SharingStateDto(
+                businessPartnerType = BusinessPartnerType.GENERIC,
+                externalId = externalId3,
+                sharingStateType = SharingStateType.Error,
+                sharingErrorCode = BusinessPartnerSharingError.SharingProcessError,
+                sharingErrorMessage = "Missing Task in Orchestrator",
+                bpn = null,
+                sharingProcessStarted = null,
+                taskId = "2"
+            )
+        )
+
+        //Check for Sharing State
+        val readCleanedSharingState = readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        testHelpers.assertRecursively(readCleanedSharingState)
+            .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
+            .isEqualTo(cleanedSharingState)
+
+    }
 
 }


### PR DESCRIPTION
## Description

This PR adds a new error message to a sharing state, when a request is done to the orchestrator with the task-id, but no related task is found.

Related issues: #589

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
