### PR TITLE
fix: Adapt Spring Security configuration to new Spring version

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/config/BpdmSecurityConfigurerAdapterImpl.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/config/BpdmSecurityConfigurerAdapterImpl.kt
@@ -26,26 +26,30 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher
 
 @Configuration
 class BpdmSecurityConfigurerAdapterImpl(
     val securityConfigProperties: SecurityConfigProperties
 ) : BpdmSecurityConfigurerAdapter {
+
     override fun configure(http: HttpSecurity) {
-        http.csrf().disable()
-        http.cors()
-        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        http.authorizeHttpRequests()
-            .requestMatchers(AntPathRequestMatcher("/api/**", HttpMethod.OPTIONS.name())).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/")).permitAll() // forwards to swagger
-            .requestMatchers(AntPathRequestMatcher("/docs/api-docs/**")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/ui/swagger-ui/**")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/actuator/health/**")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/error")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/api/**")).authenticated()
-        http.oauth2ResourceServer()
-            .jwt()
-            .jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
+        http.csrf { it.disable() }
+        http.cors {}
+        http.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+        http.authorizeHttpRequests {
+            it.requestMatchers(antMatcher(HttpMethod.OPTIONS, "/api/**")).permitAll()
+            it.requestMatchers(antMatcher("/")).permitAll() // forwards to swagger
+            it.requestMatchers(antMatcher("/docs/api-docs/**")).permitAll()
+            it.requestMatchers(antMatcher("/ui/swagger-ui/**")).permitAll()
+            it.requestMatchers(antMatcher("/actuator/health/**")).permitAll()
+            it.requestMatchers(antMatcher("/error")).permitAll()
+            it.requestMatchers(antMatcher("/api/**")).authenticated()
+        }
+        http.oauth2ResourceServer {
+            it.jwt {
+                it.jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
+            }
+        }
     }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/BpdmSecurityConfigurerAdapterImpl.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/BpdmSecurityConfigurerAdapterImpl.kt
@@ -26,26 +26,30 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher
 
 @Configuration
 class BpdmSecurityConfigurerAdapterImpl(
     val securityConfigProperties: SecurityConfigProperties
 ) : BpdmSecurityConfigurerAdapter {
+
     override fun configure(http: HttpSecurity) {
-        http.csrf().disable()
-            .cors()
-            .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            .and().authorizeHttpRequests()
-            .requestMatchers(AntPathRequestMatcher("/api/**", HttpMethod.OPTIONS.name())).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/")).permitAll() // forwards to swagger
-            .requestMatchers(AntPathRequestMatcher("/docs/api-docs/**")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/ui/swagger-ui/**")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/actuator/health/**")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/error")).permitAll()
-            .requestMatchers(AntPathRequestMatcher("/api/**")).authenticated()
-            .and().oauth2ResourceServer()
-            .jwt()
-            .jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
+        http.csrf { it.disable() }
+        http.cors {}
+        http.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+        http.authorizeHttpRequests {
+            it.requestMatchers(antMatcher(HttpMethod.OPTIONS, "/api/**")).permitAll()
+            it.requestMatchers(antMatcher("/")).permitAll() // forwards to swagger
+            it.requestMatchers(antMatcher("/docs/api-docs/**")).permitAll()
+            it.requestMatchers(antMatcher("/ui/swagger-ui/**")).permitAll()
+            it.requestMatchers(antMatcher("/actuator/health/**")).permitAll()
+            it.requestMatchers(antMatcher("/error")).permitAll()
+            it.requestMatchers(antMatcher("/api/**")).authenticated()
+        }
+        http.oauth2ResourceServer {
+            it.jwt { jwt ->
+                jwt.jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
+            }
+        }
     }
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/BpdmSecurityConfigurerAdapterImpl.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/BpdmSecurityConfigurerAdapterImpl.kt
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher
 
 @Configuration
 class BpdmSecurityConfigurerAdapterImpl(
@@ -38,17 +38,17 @@ class BpdmSecurityConfigurerAdapterImpl(
         http.cors {}
         http.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
         http.authorizeHttpRequests {
-            it.requestMatchers(AntPathRequestMatcher("/api/**", HttpMethod.OPTIONS.name())).permitAll()
-            it.requestMatchers(AntPathRequestMatcher("/")).permitAll() // forwards to swagger
-            it.requestMatchers(AntPathRequestMatcher("/docs/api-docs/**")).permitAll()
-            it.requestMatchers(AntPathRequestMatcher("/ui/swagger-ui/**")).permitAll()
-            it.requestMatchers(AntPathRequestMatcher("/actuator/health/**")).permitAll()
-            it.requestMatchers(AntPathRequestMatcher("/error")).permitAll()
-            it.requestMatchers(AntPathRequestMatcher("/api/**")).authenticated()
+            it.requestMatchers(antMatcher(HttpMethod.OPTIONS, "/api/**")).permitAll()
+            it.requestMatchers(antMatcher("/")).permitAll() // forwards to swagger
+            it.requestMatchers(antMatcher("/docs/api-docs/**")).permitAll()
+            it.requestMatchers(antMatcher("/ui/swagger-ui/**")).permitAll()
+            it.requestMatchers(antMatcher("/actuator/health/**")).permitAll()
+            it.requestMatchers(antMatcher("/error")).permitAll()
+            it.requestMatchers(antMatcher("/api/**")).authenticated()
         }
         http.oauth2ResourceServer {
-            it.jwt {
-                it.jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
+            it.jwt { jwt ->
+                jwt.jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
             }
         }
     }


### PR DESCRIPTION
Adapt `BpdmSecurityConfigurerAdapter` configuration for each module to the new Spring version, there some of the old methods where deprecated.

Solves #600 
