### PR TITLE
Fix trivy findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - BPDM Gate: New business partner type 'GENERIC' for changelog
 - BPDM Gate: New business partner type 'GENERIC' for sharing state
 - Workflows: Trivy now targets the latest alpha Docker image instead of the latest release version
+- Apps: Increase projectreactor.netty version to fix Trivy vulnerability 
 
 
 ## [4.0.1] - 2023-08-28

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -40,7 +40,7 @@ maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.100.Final, Apache-2
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.12, Apache-2.0, approved, #5946
-maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.12, Apache-2.0, approved, #6999
+maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.13, Apache-2.0, approved, #6999
 maven/mavencentral/io.projectreactor/reactor-core/3.5.11, Apache-2.0, approved, #5934
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
@@ -63,11 +63,11 @@ maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.15, Apache-2.0
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.15, Apache-2.0, approved, #6997
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.15, Apache-2.0, approved, #7920
 maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, EPL-1.0, approved, tools.aspectj
-maven/mavencentral/org.eclipse.tractusx/bpdm-common/4.1.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/4.1.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/4.1.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/4.1.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/4.1.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-common/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/9.16.3, Apache-2.0, approved, #7935
 maven/mavencentral/org.hibernate.orm/hibernate-core/6.2.13.Final, LGPL-2.1-only AND Apache-2.0 AND MIT AND CC-PDDC AND (EPL-2.0 OR BSD-3-Clause), approved, #9121
 maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0, approved, clearlydefined

--- a/bpdm-bridge-dummy/Dockerfile
+++ b/bpdm-bridge-dummy/Dockerfile
@@ -7,7 +7,7 @@ FROM eclipse-temurin:17-jre-alpine
 # Adding wget for the health check
 RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-bridge-dummy/target/bpdm-bridge-dummy.jar /usr/local/lib/bpdm/app.jar
-RUN apk update && apk upgrade libssl3 libcrypto3
+RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
 ARG GID=3000

--- a/bpdm-cleaning-service-dummy/Dockerfile
+++ b/bpdm-cleaning-service-dummy/Dockerfile
@@ -7,7 +7,7 @@ FROM eclipse-temurin:17-jre-alpine
 # Adding wget for the health check
 RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-cleaning-service-dummy/target/bpdm-cleaning-service-dummy.jar /usr/local/lib/bpdm/app.jar
-RUN apk update && apk upgrade libssl3 libcrypto3
+RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
 ARG GID=3000

--- a/bpdm-gate/Dockerfile
+++ b/bpdm-gate/Dockerfile
@@ -9,7 +9,7 @@ FROM eclipse-temurin:17-jre-alpine
 RUN apk --no-cache add wget
 ENV HOME=/home/app
 COPY --from=build $HOME/bpdm-gate/target/bpdm-gate.jar /usr/local/lib/bpdm/app.jar
-RUN apk update && apk upgrade libssl3 libcrypto3
+RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
 ARG GID=3000

--- a/bpdm-orchestrator/Dockerfile
+++ b/bpdm-orchestrator/Dockerfile
@@ -7,7 +7,7 @@ FROM eclipse-temurin:17-jre-alpine
 # Adding wget for the health check
 RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-orchestrator/target/bpdm-orchestrator.jar /usr/local/lib/bpdm/app.jar
-RUN apk update && apk upgrade libssl3 libcrypto3
+RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
 ARG GID=3000

--- a/bpdm-pool/Dockerfile
+++ b/bpdm-pool/Dockerfile
@@ -9,7 +9,7 @@ FROM eclipse-temurin:17-jre-alpine
 RUN apk --no-cache add wget
 ENV HOME=/home/app
 COPY --from=build $HOME/bpdm-pool/target/bpdm-pool.jar /usr/local/lib/bpdm/app.jar
-RUN apk update && apk upgrade libssl3 libcrypto3
+RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
 ARG GID=3000

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <sonar.version>3.9.1.2184</sonar.version>
         <jacoco.version>0.8.7</jacoco.version>
         <testcontainers.version>1.18.3</testcontainers.version>
+        <io.projectreactor.netty>1.1.13</io.projectreactor.netty>
     </properties>
 
     <pluginRepositories>
@@ -176,6 +177,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>${io.projectreactor.netty}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Description
Dependency update in pom.xml to fix vulnerabilities detected in the Trivy scan.
https://github.com/catenax-ng/tx-bpdm/security/code-scanning/4377

Update of DockerFile to fix vulnerabilities detected in the Trivy scan.
https://avd.aquasec.com/nvd/2023/cve-2023-5678/

https://github.com/eclipse-tractusx/bpdm/issues/624

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
