### PR TITLE
Docs(Api): add OpenAPI descriptions for BPDM applications in JSON format

### DIFF
--- a/docs/api/bridge-dummy.json
+++ b/docs/api/bridge-dummy.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Business Partner Data Management Bridge Dummy",
+    "description": "Bridge between Gate and Pool as a simple replacement for a dedicated sharing service",
+    "version": "4.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8083",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/bridge/sync": {
+      "post": {
+        "tags": [
+          "bridge-controller"
+        ],
+        "summary": "Start sync between Gate and Pool",
+        "operationId": "triggerSync",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/docs/api/gate.json
+++ b/docs/api/gate.json
@@ -1,0 +1,3745 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Business Partner Data Management Gate",
+    "description": "A gate for a member to share business partner data with CatenaX",
+    "version": "4.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8081",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/catena/sharing-state": {
+      "get": {
+        "tags": [
+          "sharing-state-controller"
+        ],
+        "summary": "Returns sharing states of business partners, optionally filtered by a business partner type and an array of external IDs",
+        "operationId": "getSharingStates",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          },
+          {
+            "name": "businessPartnerType",
+            "in": "query",
+            "description": "Business partner type",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "LEGAL_ENTITY",
+                "SITE",
+                "ADDRESS",
+                "GENERIC"
+              ]
+            }
+          },
+          {
+            "name": "externalIds",
+            "in": "query",
+            "description": "External IDs",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of sharing states",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSharingStateDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "sharing-state-controller"
+        ],
+        "summary": "Creates or updates a sharing state of a business partner",
+        "operationId": "upsertSharingState",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SharingStateDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Operation completed successfully"
+          },
+          "400": {
+            "description": "Invalid data (e.g. external ID)"
+          }
+        }
+      }
+    },
+    "/api/catena/output/sites": {
+      "put": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Creates or updates an existing site in the output stage",
+        "description": "Create or update sites (Output). Updates instead of creating a new site if an already existing external ID is used. The same external ID may not occur more than once in a single request. For a single request, the maximum number of sites in the request is limited to 100 entries.",
+        "operationId": "upsertSitesOutput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SiteGateOutputRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Sites were successfully updated or created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed site request"
+          }
+        }
+      }
+    },
+    "/api/catena/output/legal-entities": {
+      "put": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Creates or updates an existing legal entity in the output stage",
+        "description": "Create or update legal entities (Output). Updates instead of creating a new legal entity if an already existing external ID is used. The same external ID may not occur more than once in a single request. For a single request, the maximum number of legal entities in the request is limited to 100 entries.",
+        "operationId": "upsertLegalEntitiesOutput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LegalEntityGateOutputRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Legal entities were successfully updated or created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed legal entity request"
+          }
+        }
+      }
+    },
+    "/api/catena/output/addresses": {
+      "put": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Creates or updates an existing address in the output stage",
+        "description": "Create or update addresses (Output). Updates instead of creating a new address if an already existing external ID is used. The same external ID may not occur more than once in a single request. For a single request, the maximum number of addresses in the request is limited to 100 entries.",
+        "operationId": "upsertAddressesOutput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AddressGateOutputRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Addresses were successfully updated or created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed address request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/sites": {
+      "get": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Returns sites from the input stage",
+        "description": "Returns page of sites from the input stage.",
+        "operationId": "getSites",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested page of sites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSiteGateInputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Creates or updates an existing site in the input stage",
+        "description": "Create or update sites. Updates instead of creating a new site if an already existing external ID is used. The same external ID may not occur more than once in a single request. For a single request, the maximum number of sites in the request is limited to 100 entries.",
+        "operationId": "upsertSites",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SiteGateInputRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Sites were successfully updated or created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed site request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/legal-entities": {
+      "get": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns legal entities from the input stage",
+        "description": "Returns page of legal entities from the input stage.",
+        "operationId": "getLegalEntities",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested page of legal entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLegalEntityGateInputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Creates or updates an existing legal entity in the input stage",
+        "description": "Create or update legal entities. Updates instead of creating a new legal entity if an already existing external ID is used. The same external ID may not occur more than once in a single request. For a single request, the maximum number of legal entities in the request is limited to 100 entries.",
+        "operationId": "upsertLegalEntities",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LegalEntityGateInputRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Legal entities were successfully updated or created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed legal entity request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/business-partners": {
+      "put": {
+        "tags": [
+          "business-partner-controller"
+        ],
+        "summary": "Create or update business partner with given external ID",
+        "description": "Create or update generic business partner. Updates instead of creating a new business partner if an already existing external ID is used. The same external ID may not occur more than once in a single request. For a single request, the maximum number of business partners in the request is limited to 100 entries.",
+        "operationId": "upsertBusinessPartnersInput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BusinessPartnerInputRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Business partner were successfully updated or created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BusinessPartnerInputDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed legal entity request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/addresses": {
+      "get": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Returns addresses from the input stage",
+        "description": "Returns page of addresses from the input stage.",
+        "operationId": "getAddresses",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested page of addresses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoAddressGateInputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Creates or updates an existing address in the input stage",
+        "description": "Create or update addresses. Updates instead of creating a new address if an already existing external ID is used. The same external ID may not occur more than once in a single request. For a single request, the maximum number of addresses in the request is limited to 100 entries.",
+        "operationId": "upsertAddresses",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AddressGateInputRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Addresses were successfully updated or created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed address request"
+          }
+        }
+      }
+    },
+    "/api/catena/output/sites/search": {
+      "post": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Returns sites by an array of external IDs from the output stage",
+        "description": "Get page of sites from the output stage. Can optionally be filtered by external IDs.",
+        "operationId": "getSitesOutput",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of sites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSiteGateOutputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/output/legal-entities/search": {
+      "post": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns legal entities by an array of external IDs from the output stage",
+        "description": "Get page of legal entities from the output stage. Can optionally be filtered by external IDs.",
+        "operationId": "getLegalEntitiesOutput",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of legal entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLegalEntityGateOutputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/output/changelog/search": {
+      "post": {
+        "tags": [
+          "changelog-controller"
+        ],
+        "summary": "Returns changelog entries for changes to the business partner output stage",
+        "description": "Returns changelog entries as of a specified timestamp from the output stage, optionally filtered by timestamp, an array of external IDs and a business partner type.",
+        "operationId": "getOutputChangelog",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangelogSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The changelog entries for the specified parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageChangeLogDtoChangelogGateDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/output/business-partners/search": {
+      "post": {
+        "tags": [
+          "business-partner-controller"
+        ],
+        "summary": "Search business partners by an array of external IDs from the output stage",
+        "description": "Get page of business partners output data filtered by a collection of external IDs. An empty external ID list will return a paginated list of all business partners.",
+        "operationId": "getBusinessPartnersOutput",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of business partners",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoBusinessPartnerOutputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/output/addresses/search": {
+      "post": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Returns addresses by an array of external IDs from the output stage",
+        "description": "Get page of addresses from the output stage. Can optionally be filtered by external IDs.",
+        "operationId": "getAddressesOutput",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of addresses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoAddressGateOutputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/sites/search": {
+      "post": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Returns sites by an array of external IDs from the input stage",
+        "description": "Returns page of sites from the input stage. Can optionally be filtered by external IDs.",
+        "operationId": "getSitesByExternalIds",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of sites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSiteGateInputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/legal-entities/search": {
+      "post": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns legal entities by an array of external IDs from the input stage",
+        "description": "Returns page of legal entities from the input stage. Can optionally be filtered by external IDs.",
+        "operationId": "getLegalEntitiesByExternalIds",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of legal-entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLegalEntityGateInputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/changelog/search": {
+      "post": {
+        "tags": [
+          "changelog-controller"
+        ],
+        "summary": "Returns changelog entries for changes to the business partner input stage",
+        "description": "Returns changelog entries as of a specified timestamp from the input stage, optionally filtered by timestamp, an array of external IDs and a business partner type.",
+        "operationId": "getInputChangelog",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangelogSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The changelog entries for the specified parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageChangeLogDtoChangelogGateDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/business-partners/search": {
+      "post": {
+        "tags": [
+          "business-partner-controller"
+        ],
+        "summary": "Search business partner by external ID. An empty external ID list returns a paginated list of all business partners.",
+        "description": "Get page of business partners filtered by a collection of external IDs.",
+        "operationId": "getBusinessPartnersInput",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of busines partners",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoBusinessPartnerInputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/input/addresses/search": {
+      "post": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Returns addresses by an array of external IDs from the input stage",
+        "description": "Returns page of addresses from the input stage. Can optionally be filtered by external IDs.",
+        "operationId": "getAddressesByExternalIds",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The requested page of addresses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoAddressGateInputDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/mermaid/": {
+      "get": {
+        "tags": [
+          "gate-documentation-controller"
+        ],
+        "summary": "Get mermaid class diagramm for the gate JPA model",
+        "operationId": "getMermaidGatePersistence",
+        "responses": {
+          "200": {
+            "description": "Entity model as mermaid diagramm",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catena/input/sites/{externalId}": {
+      "get": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Returns site by external ID from the input stage",
+        "description": "Returns site by external ID from the input stage.",
+        "operationId": "getSiteByExternalId",
+        "parameters": [
+          {
+            "name": "externalId",
+            "in": "path",
+            "description": "External ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found site with external ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteGateInputDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No site found under specified external ID"
+          }
+        }
+      }
+    },
+    "/api/catena/input/legal-entities/{externalId}": {
+      "get": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns legal entity by external ID from the input stage",
+        "description": "Returns legal entity by external ID from the input stage.",
+        "operationId": "getLegalEntityByExternalId",
+        "parameters": [
+          {
+            "name": "externalId",
+            "in": "path",
+            "description": "External ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found legal entity with external ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LegalEntityGateInputDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No legal entity found under specified external ID"
+          }
+        }
+      }
+    },
+    "/api/catena/input/addresses/{externalId}": {
+      "get": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Returns address by external ID from the input stage",
+        "description": "Returns address by external ID from the input stage.",
+        "operationId": "getAddressByExternalId",
+        "parameters": [
+          {
+            "name": "externalId",
+            "in": "path",
+            "description": "External ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found address with external ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressGateInputDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No address found under specified external ID"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddressGateInputDto": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the address to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the sharing member chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressGateDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressGateDto"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the legal entity, that owns the address."
+          },
+          "siteExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the site, that the address belongs to."
+          }
+        },
+        "description": "In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressGateInputRequest": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the address to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the sharing member chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressGateDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressGateDto"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the legal entity, that owns the address."
+          },
+          "siteExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the site, that the address belongs to."
+          }
+        },
+        "description": "Request for creating/updating a business partner record of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressGateOutputChildRequest": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the address to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the sharing member chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressGateDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressGateDto"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "bpn": {
+            "type": "string",
+            "description": "A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity."
+          }
+        },
+        "description": "In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressGateOutputDto": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the address to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the sharing member chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressGateDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressGateDto"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the legal entity, that owns the address."
+          },
+          "siteExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the site, that the address belongs to."
+          },
+          "bpna": {
+            "type": "string",
+            "description": "A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity."
+          }
+        },
+        "description": "In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressGateOutputRequest": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the address to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the sharing member chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressGateDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressGateDto"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the legal entity, that owns the address."
+          },
+          "siteExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner, representing the site, that the address belongs to."
+          },
+          "bpn": {
+            "type": "string",
+            "description": "A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity."
+          }
+        },
+        "description": "Request for creating/updating a business partner record of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressIdentifierDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"0847976000005\"."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the identifier."
+          }
+        },
+        "description": "An address identifier (uniquely) identifies the address, such as the Global Location Number (GLN)."
+      },
+      "AddressStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the address."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        },
+        "description": "An address state indicates if the address is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the business partner is still operating at that address."
+      },
+      "AlternativePostalAddressGateDto": {
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "type": "string",
+            "description": "The 2-digit country code of the physical postal address according to ISO 3166-1.",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "administrativeAreaLevel1": {
+            "type": "string",
+            "description": "The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "deliveryServiceType": {
+            "type": "string",
+            "description": "One of the alternative postal address types: P.O. box, private bag, boite postale.",
+            "enum": [
+              "PO_BOX",
+              "PRIVATE_BAG",
+              "BOITE_POSTALE"
+            ]
+          },
+          "deliveryServiceQualifier": {
+            "type": "string",
+            "description": "The qualifier uniquely identifying the delivery service endpoint of the alternative postal address in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number is assigned multiple times in some cities."
+          },
+          "deliveryServiceNumber": {
+            "type": "string",
+            "description": "The number indicating the delivery service endpoint of the alternative postal address to which the delivery is to be delivered, such as a P.O. box number or a private bag number."
+          }
+        },
+        "description": "An alternative postal address describes an alternative way of delivery for example if the goods are to be picked up somewhere else."
+      },
+      "BusinessPartnerIdentifierDto": {
+        "required": [
+          "type",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Technical key of the type to which this identifier belongs to"
+          },
+          "value": {
+            "type": "string",
+            "description": "Value of the identifier"
+          },
+          "issuingBody": {
+            "type": "string",
+            "description": "Body which issued the identifier"
+          }
+        },
+        "description": "Identifier record for a business partner"
+      },
+      "BusinessPartnerInputDto": {
+        "required": [
+          "externalId",
+          "postalAddress"
+        ],
+        "type": "object",
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Abbreviated name or shorthand."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerIdentifierDto"
+            }
+          },
+          "legalName": {
+            "type": "string"
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "Technical key of the legal form."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationBusinessPartnerDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member. Sorted and duplicates removed by the service.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "postalAddress": {
+            "$ref": "#/components/schemas/BusinessPartnerPostalAddressDto"
+          },
+          "legalEntityBpn": {
+            "type": "string",
+            "description": "BPNL of the golden record legal entity this business partner refers to"
+          },
+          "siteBpn": {
+            "type": "string",
+            "description": "BPNS of the golden record site this business partner refers to"
+          },
+          "addressBpn": {
+            "type": "string",
+            "description": "BPNA of the golden record address this business partner refers to"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "ownCompanyData": {
+            "type": "boolean",
+            "description": "True if the sharing member declares itself as the owner of the business partner."
+          }
+        },
+        "description": "Generic business partner with external id"
+      },
+      "BusinessPartnerInputRequest": {
+        "required": [
+          "externalId"
+        ],
+        "type": "object",
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Abbreviated name or shorthand."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerIdentifierDto"
+            }
+          },
+          "legalName": {
+            "type": "string"
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "Technical key of the legal form."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationBusinessPartnerDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member. Sorted and duplicates removed by the service.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "postalAddress": {
+            "$ref": "#/components/schemas/BusinessPartnerPostalAddressDto"
+          },
+          "legalEntityBpn": {
+            "type": "string",
+            "description": "BPNL of the golden record legal entity this business partner refers to"
+          },
+          "siteBpn": {
+            "type": "string",
+            "description": "BPNS of the golden record site this business partner refers to"
+          },
+          "addressBpn": {
+            "type": "string",
+            "description": "BPNA of the golden record address this business partner refers to"
+          },
+          "ownCompanyData": {
+            "type": "boolean",
+            "description": "True if the sharing member declares itself as the owner of the business partner."
+          }
+        },
+        "description": "Generic business partner with external id"
+      },
+      "BusinessPartnerOutputDto": {
+        "required": [
+          "bpnA",
+          "bpnL",
+          "externalId",
+          "postalAddress"
+        ],
+        "type": "object",
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Abbreviated name or shorthand."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerIdentifierDto"
+            }
+          },
+          "legalName": {
+            "type": "string"
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "Technical key of the legal form."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member. Sorted and duplicates removed by the service.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "postalAddress": {
+            "$ref": "#/components/schemas/BusinessPartnerPostalAddressDto"
+          },
+          "legalEntityBpn": {
+            "type": "string",
+            "description": "BPNL of the golden record legal entity this business partner refers to"
+          },
+          "siteBpn": {
+            "type": "string",
+            "description": "BPNS of the golden record site this business partner refers to"
+          },
+          "addressBpn": {
+            "type": "string",
+            "description": "BPNA of the golden record address this business partner refers to"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "ownCompanyData": {
+            "type": "boolean",
+            "description": "True if the sharing member declares itself as the owner of the business partner."
+          }
+        },
+        "description": "Generic business partner output with external id"
+      },
+      "BusinessPartnerPostalAddressDto": {
+        "type": "object",
+        "properties": {
+          "addressType": {
+            "type": "string",
+            "description": "Type of the address",
+            "enum": [
+              "LegalAndSiteMainAddress",
+              "LegalAddress",
+              "SiteMainAddress",
+              "AdditionalAddress"
+            ]
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressGateDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressGateDto"
+          }
+        },
+        "description": "Postal address of a business partner"
+      },
+      "BusinessPartnerStateDto": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "validFrom": {
+            "type": "string",
+            "description": "Date since when the status is/was valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "Date until the status was valid, if applicable.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this specified status.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Denotation of the status."
+          }
+        },
+        "description": "A legal entity state indicates if the legal entity is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the legal entity is still operating."
+      },
+      "ChangelogGateDto": {
+        "type": "object",
+        "properties": {
+          "externalId": {
+            "type": "string",
+            "description": "The external identifier of the business partner for which the changelog entry was created."
+          },
+          "businessPartnerType": {
+            "type": "string",
+            "description": "One of the types of business partners for which the changelog entry was created: legal entity, site, address.",
+            "enum": [
+              "LEGAL_ENTITY",
+              "SITE",
+              "ADDRESS",
+              "GENERIC"
+            ]
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "The date and time when the changelog entry was created.",
+            "format": "date-time"
+          },
+          "changelogType": {
+            "type": "string",
+            "description": "One of the actions for which the changelog entry was created: create, update.",
+            "enum": [
+              "CREATE",
+              "UPDATE"
+            ]
+          }
+        },
+        "description": "An entry of the changelog, which is created each time a business partner is modified and contains data about the change. The actual new state of the business partner is not included."
+      },
+      "ChangelogSearchRequest": {
+        "type": "object",
+        "properties": {
+          "timestampAfter": {
+            "type": "string",
+            "description": "Only changelog entries created after this time. Ignored if empty.",
+            "format": "date-time",
+            "example": "2023-03-20T10:23:28.194Z"
+          },
+          "externalIds": {
+            "uniqueItems": true,
+            "type": "array",
+            "description": "Only for business partners with the given array of external IDs. Ignored if empty.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "businessPartnerTypes": {
+            "uniqueItems": true,
+            "type": "array",
+            "description": "Only for business partners with the given array of business partner types. Ignored if empty.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "LEGAL_ENTITY",
+                "SITE",
+                "ADDRESS",
+                "GENERIC"
+              ]
+            }
+          }
+        }
+      },
+      "ClassificationBusinessPartnerDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of classification.",
+            "enum": [
+              "NACE",
+              "NAF",
+              "NAICS",
+              "SIC"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "description": "The identifier of the class belonging to the classification."
+          },
+          "value": {
+            "type": "string",
+            "description": "The name of the class belonging to the classification."
+          }
+        },
+        "description": "A legal entity classification is an assignment of the legal entity to an industry. It does not necessarily have to be the only industry the company is active in (see large companies operating in different industries). Multiple assignments to several industries are possible per classification type."
+      },
+      "ClassificationDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of classification.",
+            "enum": [
+              "NACE",
+              "NAF",
+              "NAICS",
+              "SIC"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "description": "The identifier of the class belonging to the classification."
+          },
+          "value": {
+            "type": "string",
+            "description": "The name of the class belonging to the classification."
+          }
+        },
+        "description": "A legal entity classification is an assignment of the legal entity to an industry. It does not necessarily have to be the only industry the company is active in (see large companies operating in different industries). Multiple assignments to several industries are possible per classification type."
+      },
+      "ErrorInfoChangeLogOutputError": {
+        "title": "ErrorInfo",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "Error code identifying the error",
+            "enum": [
+              "ExternalIdNotFound"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message that explains the error"
+          },
+          "entityKey": {
+            "type": "string",
+            "description": "Key (externalId) of the entity that failed"
+          }
+        },
+        "description": "Holds information about failures"
+      },
+      "GeoCoordinateDto": {
+        "type": "object",
+        "properties": {
+          "longitude": {
+            "type": "number",
+            "description": "Longitude coordinate",
+            "format": "float"
+          },
+          "latitude": {
+            "type": "number",
+            "description": "Latitude coordinate",
+            "format": "float"
+          },
+          "altitude": {
+            "type": "number",
+            "description": "Altitude, if applicable",
+            "format": "float"
+          }
+        },
+        "description": "The exact location of the physical postal address in latitude, longitude, and altitude."
+      },
+      "LegalEntityGateInputDto": {
+        "required": [
+          "externalId"
+        ],
+        "type": "object",
+        "properties": {
+          "legalNameParts": {
+            "type": "array",
+            "description": "The list of name parts of the legal entity to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "The legal form of the legal entity."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/AddressGateInputDto"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          }
+        },
+        "description": "In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityGateInputRequest": {
+        "required": [
+          "externalId"
+        ],
+        "type": "object",
+        "properties": {
+          "legalNameParts": {
+            "type": "array",
+            "description": "The list of name parts of the legal entity to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "The legal form of the legal entity."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/LogisticAddressGateDto"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          }
+        },
+        "description": "Request for creating/updating a business partner record of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityGateOutputRequest": {
+        "required": [
+          "externalId"
+        ],
+        "type": "object",
+        "properties": {
+          "legalNameParts": {
+            "type": "array",
+            "description": "The list of name parts of the legal entity to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "The legal form of the legal entity."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/AddressGateOutputChildRequest"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "bpn": {
+            "type": "string",
+            "description": "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number."
+          }
+        },
+        "description": "Request for creating/updating a business partner record of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityGateOutputResponse": {
+        "required": [
+          "externalId"
+        ],
+        "type": "object",
+        "properties": {
+          "legalNameParts": {
+            "type": "array",
+            "description": "The list of name parts of the legal entity to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "The legal form of the legal entity."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/AddressGateOutputDto"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "bpnl": {
+            "type": "string",
+            "description": "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number."
+          }
+        },
+        "description": "In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityIdentifierDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"DE123465789\"."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the identifier."
+          },
+          "issuingBody": {
+            "type": "string",
+            "description": "The name of the official register, where the identifier is registered. For example, a Handelsregisternummer in Germany is only valid with its corresponding Handelsregister."
+          }
+        }
+      },
+      "LegalEntityStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the legal entity, such as from the German Handelsregister."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        },
+        "description": "A legal entity state indicates if the legal entity is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the legal entity is still operating."
+      },
+      "LogisticAddressGateDto": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the address to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the sharing member chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressGateDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressGateDto"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          }
+        },
+        "description": "In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "PageChangeLogDtoChangelogGateDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/ChangelogGateDto"
+            }
+          },
+          "invalidEntries": {
+            "type": "integer",
+            "description": "Number of entries in the page that have been omitted due to being invalid (error)",
+            "format": "int32"
+          },
+          "errors": {
+            "type": "array",
+            "description": "Infos about the entries with errors",
+            "items": {
+              "$ref": "#/components/schemas/ErrorInfoChangeLogOutputError"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoAddressGateInputDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/AddressGateInputDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoAddressGateOutputDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/AddressGateOutputDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoBusinessPartnerInputDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerInputDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoBusinessPartnerOutputDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerOutputDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoLegalEntityGateInputDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityGateInputDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoLegalEntityGateOutputResponse": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityGateOutputResponse"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoSharingStateDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/SharingStateDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoSiteGateInputDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/SiteGateInputDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoSiteGateOutputResponse": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/SiteGateOutputResponse"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PhysicalPostalAddressGateDto": {
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "type": "string",
+            "description": "The 2-digit country code of the physical postal address according to ISO 3166-1.",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "administrativeAreaLevel1": {
+            "type": "string",
+            "description": "The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country."
+          },
+          "administrativeAreaLevel2": {
+            "type": "string",
+            "description": "The name of the locally regulated secondary country subdivision of the physical postal address, such as county within a country."
+          },
+          "administrativeAreaLevel3": {
+            "type": "string",
+            "description": "The name of the locally regulated tertiary country subdivision of the physical address, such as townships within a country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "district": {
+            "type": "string",
+            "description": "The name of the district of the physical postal address which divides the city in several smaller areas."
+          },
+          "street": {
+            "$ref": "#/components/schemas/StreetGateDto"
+          },
+          "companyPostalCode": {
+            "type": "string",
+            "description": "The company postal code of the physical postal address, which is sometimes required for large companies."
+          },
+          "industrialZone": {
+            "type": "string",
+            "description": "The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area."
+          },
+          "building": {
+            "type": "string",
+            "description": "The alphanumeric identifier of the building addressed by the physical postal address."
+          },
+          "floor": {
+            "type": "string",
+            "description": "The number of a floor in the building addressed by the physical postal address, synonym: level."
+          },
+          "door": {
+            "type": "string",
+            "description": "The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite."
+          }
+        },
+        "description": "A physical postal address describes the physical location of an office, warehouse, gate, etc."
+      },
+      "SharingStateDto": {
+        "type": "object",
+        "properties": {
+          "businessPartnerType": {
+            "type": "string",
+            "description": "One of the types of business partners for which the sharing state entry was created.",
+            "enum": [
+              "LEGAL_ENTITY",
+              "SITE",
+              "ADDRESS",
+              "GENERIC"
+            ]
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The external identifier of the business partner for which the sharing state entry was created."
+          },
+          "sharingStateType": {
+            "type": "string",
+            "description": "One of the sharing state types of the current sharing state.",
+            "enum": [
+              "Pending",
+              "Success",
+              "Error",
+              "Initial"
+            ]
+          },
+          "sharingErrorCode": {
+            "type": "string",
+            "description": "One of the sharing error codes in case the current sharing state type is \"error\".",
+            "enum": [
+              "SharingProcessError",
+              "SharingTimeout",
+              "BpnNotInPool"
+            ]
+          },
+          "sharingErrorMessage": {
+            "type": "string",
+            "description": "The error message in case the current sharing state type is \"error\"."
+          },
+          "bpn": {
+            "type": "string",
+            "description": "The business partner number associated to the combination of external identifier and business partner type in case the sharing state type is “success”. Can be either a BPNL, BPNS or BPNA."
+          },
+          "sharingProcessStarted": {
+            "type": "string",
+            "description": "The date and time when the sharing process was started.",
+            "format": "date-time"
+          },
+          "taskId": {
+            "type": "string",
+            "description": "The orchestrator task identifier that was created"
+          }
+        },
+        "description": "A sharing state entry shows the progress in the sharing process and is updated each time the progress for a business partner changes. The business partner is identified by a combination of external ID and business partner type."
+      },
+      "SiteGateInputDto": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the site to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the owner chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of the (temporary) states of the site.",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/AddressGateInputDto"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner owning the site."
+          }
+        },
+        "description": "In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SiteGateInputRequest": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the site to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the owner chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of the (temporary) states of the site.",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/LogisticAddressGateDto"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner owning the site."
+          }
+        },
+        "description": "Request for creating/updating a business partner record of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SiteGateOutputRequest": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the site to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the owner chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of the (temporary) states of the site.",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/AddressGateOutputChildRequest"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner owning the site."
+          },
+          "bpn": {
+            "type": "string",
+            "description": "A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located."
+          }
+        },
+        "description": "Request for creating/updating a business partner record of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SiteGateOutputResponse": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts of the site to accommodate the different number of name fields in different systems. This is not according to official registers but according to the name the owner chooses.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of the (temporary) states of the site.",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/AddressGateOutputDto"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner."
+          },
+          "legalEntityExternalId": {
+            "type": "string",
+            "description": "The identifier which uniquely identifies (in the internal system landscape of the sharing member) the business partner owning the site."
+          },
+          "bpns": {
+            "type": "string",
+            "description": "A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located."
+          }
+        },
+        "description": "In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SiteStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the site."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        },
+        "description": "A site state indicates if the site is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the site is still operating."
+      },
+      "StreetGateDto": {
+        "type": "object",
+        "properties": {
+          "namePrefix": {
+            "type": "string",
+            "description": "The street related information, which is usually printed before the official street name on an address label."
+          },
+          "additionalNamePrefix": {
+            "type": "string",
+            "description": "The additional street related information, which is usually printed before the official street name on an address label."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the street."
+          },
+          "nameSuffix": {
+            "type": "string",
+            "description": "The street related information, which is usually printed after the official street name on an address label."
+          },
+          "additionalNameSuffix": {
+            "type": "string",
+            "description": "The additional street related information, which is usually printed after the official street name on an address label."
+          },
+          "houseNumber": {
+            "type": "string",
+            "description": "The number representing the exact location of a building within the street."
+          },
+          "milestone": {
+            "type": "string",
+            "description": "The number representing the exact location of an addressed object within a street without house numbers, such as within long roads."
+          },
+          "direction": {
+            "type": "string",
+            "description": "The cardinal direction describing where the exit to the location of the addressed object on large highways / motorways is located, such as Highway 101 South."
+          }
+        },
+        "description": "The street of the physical postal address, synonyms: road, avenue, lane, boulevard, highway"
+      },
+      "Unit": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/docs/api/orchestrator.json
+++ b/docs/api/orchestrator.json
@@ -1,0 +1,1564 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Business Partner Data Management Orchestrator",
+    "description": "Orchestrator component acts as a passive component and offers for each processing steps individual endpoints",
+    "version": "4.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8085",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/golden-record-tasks": {
+      "post": {
+        "tags": [
+          "Task Client"
+        ],
+        "summary": "Create new golden record tasks for given business partner data",
+        "description": "Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.",
+        "operationId": "createTasks",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The states of successfully created tasks including the task identifier for tracking purposes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
+    "/api/golden-record-tasks/step-results": {
+      "post": {
+        "tags": [
+          "Task Worker"
+        ],
+        "summary": "Post step results for reserved golden record tasks in the given step queue",
+        "description": "Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.",
+        "operationId": "resolveStepResults",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskStepResultRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "If the results could be processed"
+          },
+          "400": {
+            "description": "On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue"
+          }
+        }
+      }
+    },
+    "/api/golden-record-tasks/step-reservations": {
+      "post": {
+        "tags": [
+          "Task Worker"
+        ],
+        "summary": "Reserve the next golden record tasks waiting in the given step queue",
+        "description": "Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.",
+        "operationId": "reserveTasksForStep",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskStepReservationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The reserved tasks with their business partner data to process.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStepReservationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
+    "/api/golden-record-tasks/state/search": {
+      "post": {
+        "tags": [
+          "Task Client"
+        ],
+        "summary": "Search for the state of golden record tasks by task identifiers",
+        "description": "Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.",
+        "operationId": "searchTaskStates",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskStateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The state of the tasks for the provided task identifiers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskStateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed task search requests"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddressIdentifierDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"0847976000005\"."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the identifier."
+          }
+        }
+      },
+      "AddressStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the address."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        }
+      },
+      "AlternativePostalAddressDto": {
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "type": "string",
+            "description": "The 2-digit country code of the physical postal address according to ISO 3166-1.",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "administrativeAreaLevel1": {
+            "type": "string",
+            "description": "The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "deliveryServiceType": {
+            "type": "string",
+            "description": "One of the alternative postal address types: P.O. box, private bag, boite postale.",
+            "enum": [
+              "PO_BOX",
+              "PRIVATE_BAG",
+              "BOITE_POSTALE"
+            ]
+          },
+          "deliveryServiceQualifier": {
+            "type": "string",
+            "description": "The qualifier uniquely identifying the delivery service endpoint of the alternative postal address in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number is assigned multiple times in some cities."
+          },
+          "deliveryServiceNumber": {
+            "type": "string",
+            "description": "The number indicating the delivery service endpoint of the alternative postal address to which the delivery is to be delivered, such as a P.O. box number or a private bag number."
+          }
+        },
+        "description": "The alternative postal address of the address, for example if the goods are to be picked up somewhere else."
+      },
+      "BpnReferenceDto": {
+        "type": "object",
+        "properties": {
+          "referenceValue": {
+            "type": "string",
+            "description": "The value by which the BPN is referenced"
+          },
+          "referenceType": {
+            "type": "string",
+            "description": "The type by which to reference the BPN with",
+            "enum": [
+              "Bpn",
+              "BpnRequestIdentifier"
+            ]
+          }
+        },
+        "description": "A reference to the BPN of a business partner. Either by the BPN value itself or a BPN request identifier"
+      },
+      "BusinessPartnerFullDto": {
+        "required": [
+          "generic"
+        ],
+        "type": "object",
+        "properties": {
+          "generic": {
+            "$ref": "#/components/schemas/BusinessPartnerGenericDto"
+          },
+          "legalEntity": {
+            "$ref": "#/components/schemas/LegalEntityDto"
+          },
+          "site": {
+            "$ref": "#/components/schemas/SiteDto"
+          },
+          "address": {
+            "$ref": "#/components/schemas/LogisticAddressDto"
+          }
+        },
+        "description": "Business partner data in full representation, consisting of generic data as well as its L/S/A representation."
+      },
+      "BusinessPartnerGenericDto": {
+        "type": "object",
+        "properties": {
+          "nameParts": {
+            "type": "array",
+            "description": "The list of name parts to accommodate the different number of name fields in different systems.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shortName": {
+            "type": "string",
+            "description": "Abbreviated name or shorthand."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerIdentifierDto"
+            }
+          },
+          "legalName": {
+            "type": "string"
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "Technical key of the legal form."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the business partner. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles this business partner takes in relation to the sharing member. Sorted and duplicates removed by the service.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SUPPLIER",
+                "CUSTOMER"
+              ]
+            }
+          },
+          "postalAddress": {
+            "$ref": "#/components/schemas/PostalAddressDto"
+          },
+          "legalEntityBpn": {
+            "type": "string",
+            "description": "BPNL of the golden record legal entity this business partner refers to"
+          },
+          "siteBpn": {
+            "type": "string",
+            "description": "BPNS of the golden record site this business partner refers to"
+          },
+          "addressBpn": {
+            "type": "string",
+            "description": "BPNA of the golden record address this business partner refers to"
+          },
+          "ownerBpnL": {
+            "type": "string",
+            "description": "The BPNL of the company sharing and claiming this business partner as its own"
+          }
+        }
+      },
+      "BusinessPartnerIdentifierDto": {
+        "required": [
+          "type",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Technical key of the type to which this identifier belongs to"
+          },
+          "value": {
+            "type": "string",
+            "description": "Value of the identifier"
+          },
+          "issuingBody": {
+            "type": "string",
+            "description": "Body which issued the identifier"
+          }
+        },
+        "description": "Identifier record for a business partner"
+      },
+      "BusinessPartnerStateDto": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "validFrom": {
+            "type": "string",
+            "description": "Date since when the status is/was valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "Date until the status was valid, if applicable.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of this specified status.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Denotation of the status."
+          }
+        },
+        "description": "A legal entity state indicates if the legal entity is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the legal entity is still operating."
+      },
+      "ClassificationDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of classification.",
+            "enum": [
+              "NACE",
+              "NAF",
+              "NAICS",
+              "SIC"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "description": "The identifier of the class belonging to the classification."
+          },
+          "value": {
+            "type": "string",
+            "description": "The name of the class belonging to the classification."
+          }
+        },
+        "description": "A legal entity classification is an assignment of the legal entity to an industry. It does not necessarily have to be the only industry the company is active in (see large companies operating in different industries). Multiple assignments to several industries are possible per classification type."
+      },
+      "GeoCoordinateDto": {
+        "type": "object",
+        "properties": {
+          "longitude": {
+            "type": "number",
+            "description": "Longitude coordinate",
+            "format": "float"
+          },
+          "latitude": {
+            "type": "number",
+            "description": "Latitude coordinate",
+            "format": "float"
+          },
+          "altitude": {
+            "type": "number",
+            "description": "Altitude, if applicable",
+            "format": "float"
+          }
+        },
+        "description": "The exact location of the physical postal address in latitude, longitude, and altitude."
+      },
+      "LegalEntityDto": {
+        "type": "object",
+        "properties": {
+          "bpnLReference": {
+            "$ref": "#/components/schemas/BpnReferenceDto"
+          },
+          "hasChanged": {
+            "type": "boolean",
+            "description": "Whether this legal entity data is different from its golden record counterpart in the Pool"
+          },
+          "legalName": {
+            "type": "string",
+            "description": "The name of the legal entity according to official registers."
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierDto"
+            }
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "The legal form of the legal entity."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityState"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/LogisticAddressDto"
+          }
+        },
+        "description": "The legal entity part of this business partner data"
+      },
+      "LegalEntityIdentifierDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"DE123465789\"."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the identifier."
+          },
+          "issuingBody": {
+            "type": "string",
+            "description": "The name of the official register, where the identifier is registered. For example, a Handelsregisternummer in Germany is only valid with its corresponding Handelsregister."
+          }
+        }
+      },
+      "LegalEntityState": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the legal entity, such as from the German Handelsregister."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        }
+      },
+      "LogisticAddressDto": {
+        "type": "object",
+        "properties": {
+          "bpnAReference": {
+            "$ref": "#/components/schemas/BpnReferenceDto"
+          },
+          "hasChanged": {
+            "type": "boolean",
+            "description": "Whether this address data is different from its golden record counterpart in the Pool"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressDto"
+          }
+        },
+        "description": "The address part of this business partner data"
+      },
+      "PhysicalPostalAddressDto": {
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "type": "string",
+            "description": "The 2-digit country code of the physical postal address according to ISO 3166-1.",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "administrativeAreaLevel1": {
+            "type": "string",
+            "description": "The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country."
+          },
+          "administrativeAreaLevel2": {
+            "type": "string",
+            "description": "The name of the locally regulated secondary country subdivision of the physical postal address, such as county within a country."
+          },
+          "administrativeAreaLevel3": {
+            "type": "string",
+            "description": "The name of the locally regulated tertiary country subdivision of the physical address, such as townships within a country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "district": {
+            "type": "string",
+            "description": "The name of the district of the physical postal address which divides the city in several smaller areas."
+          },
+          "street": {
+            "$ref": "#/components/schemas/StreetDto"
+          },
+          "companyPostalCode": {
+            "type": "string",
+            "description": "The company postal code of the physical postal address, which is sometimes required for large companies."
+          },
+          "industrialZone": {
+            "type": "string",
+            "description": "The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area."
+          },
+          "building": {
+            "type": "string",
+            "description": "The alphanumeric identifier of the building addressed by the physical postal address."
+          },
+          "floor": {
+            "type": "string",
+            "description": "The number of a floor in the building addressed by the physical postal address, synonym: level."
+          },
+          "door": {
+            "type": "string",
+            "description": "The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite."
+          }
+        },
+        "description": "The physical postal address of the address, such as an office, warehouse, gate, etc."
+      },
+      "PostalAddressDto": {
+        "type": "object",
+        "properties": {
+          "addressType": {
+            "type": "string",
+            "description": "Type of the address",
+            "enum": [
+              "LegalAndSiteMainAddress",
+              "LegalAddress",
+              "SiteMainAddress",
+              "AdditionalAddress"
+            ]
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressDto"
+          }
+        },
+        "description": "Address of the official seat of this business partner."
+      },
+      "SiteDto": {
+        "type": "object",
+        "properties": {
+          "bpnSReference": {
+            "$ref": "#/components/schemas/BpnReferenceDto"
+          },
+          "hasChanged": {
+            "type": "boolean",
+            "description": "Whether this site data is different from its golden record counterpart in the Pool"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the site. This is not according to official registers but according to the name the owner chooses."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of the (temporary) states of the site.",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateDto"
+            }
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/LogisticAddressDto"
+          }
+        },
+        "description": "The site part of this business partner data"
+      },
+      "SiteStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the site."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        }
+      },
+      "StreetDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the street."
+          },
+          "houseNumber": {
+            "type": "string",
+            "description": "The number representing the exact location of a building within the street."
+          },
+          "milestone": {
+            "type": "string",
+            "description": "The number representing the exact location of an addressed object within a street without house numbers, such as within long roads."
+          },
+          "direction": {
+            "type": "string",
+            "description": "The cardinal direction describing where the exit to the location of the addressed object on large highways / motorways is located, such as Highway 101 South."
+          },
+          "namePrefix": {
+            "type": "string",
+            "description": "The street related information, which is usually printed before the official street name on an address label."
+          },
+          "additionalNamePrefix": {
+            "type": "string",
+            "description": "The additional street related information, which is usually printed before the official street name on an address label."
+          },
+          "nameSuffix": {
+            "type": "string",
+            "description": "The street related information, which is usually printed after the official street name on an address label."
+          },
+          "additionalNameSuffix": {
+            "type": "string",
+            "description": "The additional street related information, which is usually printed after the official street name on an address label."
+          }
+        }
+      },
+      "TaskClientStateDto": {
+        "required": [
+          "processingState",
+          "taskId"
+        ],
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "businessPartnerResult": {
+            "$ref": "#/components/schemas/BusinessPartnerGenericDto"
+          },
+          "processingState": {
+            "$ref": "#/components/schemas/TaskProcessingStateDto"
+          }
+        },
+        "description": "The golden record task's processing state together with optional business partner data in case processing is done"
+      },
+      "TaskCreateRequest": {
+        "required": [
+          "mode"
+        ],
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "description": "The mode affecting which processing steps the business partner goes through",
+            "enum": [
+              "UpdateFromSharingMember",
+              "UpdateFromPool"
+            ]
+          },
+          "businessPartners": {
+            "type": "array",
+            "description": "The list of business partner data to be processed",
+            "items": {
+              "$ref": "#/components/schemas/BusinessPartnerGenericDto"
+            }
+          }
+        },
+        "description": "Request object to specify for which business partner data tasks should be created and in which mode"
+      },
+      "TaskCreateResponse": {
+        "type": "object",
+        "properties": {
+          "createdTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskClientStateDto"
+            }
+          }
+        },
+        "description": "Response object for giving a list of created tasks"
+      },
+      "TaskErrorDto": {
+        "required": [
+          "description",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The type of error that occurred",
+            "enum": [
+              "Timeout",
+              "Unspecified"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "The free text, detailed description of the error"
+          }
+        },
+        "description": "Describes an error that happened during processing of a task"
+      },
+      "TaskProcessingStateDto": {
+        "required": [
+          "createdAt",
+          "errors",
+          "modifiedAt",
+          "resultState",
+          "step",
+          "stepState"
+        ],
+        "type": "object",
+        "properties": {
+          "resultState": {
+            "type": "string",
+            "description": "The processing result of the task, can also still be pending",
+            "enum": [
+              "Pending",
+              "Success",
+              "Error"
+            ]
+          },
+          "step": {
+            "type": "string",
+            "description": "The last step this task has entered",
+            "enum": [
+              "CleanAndSync",
+              "PoolSync",
+              "Clean"
+            ]
+          },
+          "stepState": {
+            "type": "string",
+            "description": "Whether the task is queued or already reserved for the latest step",
+            "enum": [
+              "Queued",
+              "Reserved",
+              "Success",
+              "Error"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "description": "The actual errors that happened during processing if the task has an error result state. The errors refer to the latest step.",
+            "items": {
+              "$ref": "#/components/schemas/TaskErrorDto"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "When the task has been created",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": "string",
+            "description": "When the task has last been modified",
+            "format": "date-time"
+          },
+          "timeout": {
+            "type": "string",
+            "description": "The timestamp until the task is removed from the Orchestrator",
+            "format": "date-time"
+          }
+        },
+        "description": "Contains detailed information about the current processing state of a golden record task"
+      },
+      "TaskStateRequest": {
+        "type": "object",
+        "properties": {
+          "taskIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Request object for giving a list of task identifiers to search for the state of tasks"
+      },
+      "TaskStateResponse": {
+        "type": "object",
+        "properties": {
+          "tasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskClientStateDto"
+            }
+          }
+        },
+        "description": "Response object for giving a list of task states"
+      },
+      "TaskStepReservationEntryDto": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "The identifier of the reserved task"
+          },
+          "businessPartner": {
+            "$ref": "#/components/schemas/BusinessPartnerFullDto"
+          }
+        },
+        "description": "Task reservation entry"
+      },
+      "TaskStepReservationRequest": {
+        "required": [
+          "amount",
+          "step"
+        ],
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "integer",
+            "description": "The maximum number of tasks to reserve. Can be fewer if queue is not full enough.",
+            "format": "int32"
+          },
+          "step": {
+            "type": "string",
+            "description": "The step queue to reserve from",
+            "enum": [
+              "CleanAndSync",
+              "PoolSync",
+              "Clean"
+            ]
+          }
+        },
+        "description": "Request object for reserving a number of tasks waiting in a step queue."
+      },
+      "TaskStepReservationResponse": {
+        "type": "object",
+        "properties": {
+          "reservedTasks": {
+            "type": "array",
+            "description": "The reserved tasks with their business partner data to process",
+            "items": {
+              "$ref": "#/components/schemas/TaskStepReservationEntryDto"
+            }
+          },
+          "timeout": {
+            "type": "string",
+            "description": "The timestamp until the reservation is valid and results are accepted",
+            "format": "date-time"
+          }
+        },
+        "description": "Response object for giving a list of reserved tasks"
+      },
+      "TaskStepResultEntryDto": {
+        "required": [
+          "taskId"
+        ],
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "description": "The identifier of the task for which this is a result"
+          },
+          "businessPartner": {
+            "$ref": "#/components/schemas/BusinessPartnerFullDto"
+          },
+          "errors": {
+            "type": "array",
+            "description": "Errors that occurred during processing of this task",
+            "items": {
+              "$ref": "#/components/schemas/TaskErrorDto"
+            }
+          }
+        },
+        "description": "A step result for a golden record task"
+      },
+      "TaskStepResultRequest": {
+        "required": [
+          "step"
+        ],
+        "type": "object",
+        "properties": {
+          "step": {
+            "type": "string",
+            "description": "The step queue containing the tasks for which results are posted",
+            "enum": [
+              "CleanAndSync",
+              "PoolSync",
+              "Clean"
+            ]
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskStepResultEntryDto"
+            }
+          }
+        },
+        "description": "Request object for posting step results of previously reserved tasks"
+      }
+    }
+  }
+}

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -1,0 +1,6304 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Business Partner Data Management Pool",
+    "description": "Service that manages and shares business partner data with other CatenaX services",
+    "version": "4.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/catena/sites": {
+      "get": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Get page of sites matching the pagination search criteria",
+        "description": "This endpoint retrieves all existing business partners of type sites.Note that when using search parameters the max page is 20.",
+        "operationId": "getSitesPaginated",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of business partners matching the search criteria, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSiteMatchVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Updates an existing site",
+        "description": "Update existing business partner records of type site referenced via BPNS. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId": "updateSite",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SitePartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Update sites request was processed successfully, possible errors are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SitePartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed requests"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Creates a new site",
+        "description": "Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId": "createSite",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SitePartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "New sites request was processed successfully, possible errors are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SitePartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed requests"
+          }
+        }
+      }
+    },
+    "/api/catena/legal-entities": {
+      "get": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns legal entities by different search parameters",
+        "description": "This endpoint tries to find matches among all existing business partners of type legal entity, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. The match of a partner is better the higher its relevancy score. Note that when using search parameters the max page is 20.",
+        "operationId": "getLegalEntities",
+        "parameters": [
+          {
+            "name": "legalName",
+            "in": "query",
+            "description": "Filter legal entities by name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of business partners matching the search criteria, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLegalEntityMatchVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed search or pagination request"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Updates an existing legal entity",
+        "description": "Update existing business partner records of type legal entity referenced via BPNL. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId": "updateBusinessPartners",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LegalEntityPartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Update legal entities request was processed successfully, possible errors are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LegalEntityPartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed requests"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Creates a new legal entity",
+        "description": "Create new business partners of type legal entity. The given additional identifiers of a record need to be unique, otherwise they are ignored. For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId": "createBusinessPartners",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LegalEntityPartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "New legal entities request was processed successfully, possible errors are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LegalEntityPartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed requests"
+          }
+        }
+      }
+    },
+    "/api/catena/addresses": {
+      "get": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Returns addresses by different search parameters",
+        "description": "This endpoint tries to find matches among all existing business partners of type address, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. The match of a partner is better the higher its relevancy score. Note that when using search parameters the max page is 20.",
+        "operationId": "getAddresses_1",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Filter business partners by name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of addresses matching the search criteria, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoAddressMatchVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed search or pagination request"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Updates an existing address",
+        "description": "Update existing business partner records of type address referenced via BPNA. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId": "updateAddresses",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AddressPartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The successfully updated records, possible errors are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressPartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed requests"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Creates a new address",
+        "description": "Create new business partners of type address by specifying the BPN of the parent each address belongs to. A parent can be either a site or legal entity business partner. If the parent cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId": "createAddresses",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AddressPartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "New business partner record successfully created, possible errors are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressPartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed requests"
+          }
+        }
+      }
+    },
+    "/api/opensearch/business-partner": {
+      "get": {
+        "tags": [
+          "open-search-controller"
+        ],
+        "summary": "Fetch information about the latest OpenSearch export",
+        "description": "Fetch information about the latest export (either ongoing or already finished)",
+        "operationId": "getBusinessPartners",
+        "responses": {
+          "200": {
+            "description": "Export information found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Fetching failed (no connection to database)"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "open-search-controller"
+        ],
+        "summary": "Index new business partner records on OpenSearch",
+        "description": "Triggers an asynchronous export of business partner records from BPDM to OpenSearch. Only exports records which have been updated since the last export. ",
+        "operationId": "export",
+        "responses": {
+          "200": {
+            "description": "Export of records successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Export failed (no connection to OpenSearch or database)"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "open-search-controller"
+        ],
+        "summary": "Clear business partner index on OpenSearch",
+        "description": "Deletes all business partner records in the OpenSearch index. Also resets the timestamp from the last export.",
+        "operationId": "clear",
+        "responses": {
+          "200": {
+            "description": "Index successfully cleared"
+          },
+          "500": {
+            "description": "Clearing failed (no connection to OpenSearch or database)"
+          }
+        }
+      }
+    },
+    "/api/catena/sites/search": {
+      "post": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
+        "description": "Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities",
+        "operationId": "searchSites",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteBpnSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Found sites that belong to specified legal entites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSitePoolVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        }
+      }
+    },
+    "/api/catena/sites/main-addresses/search": {
+      "post": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Search for sites' main addresses",
+        "description": "Search main addresses of site business partners by BPNS",
+        "operationId": "searchMainAddresses",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The found main addresses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MainAddressResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        }
+      }
+    },
+    "/api/catena/regions": {
+      "get": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Get page of regions",
+        "description": "Lists all currently known regions in a paginated result",
+        "operationId": "getRegions",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of existing regions, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoRegionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Create new Region",
+        "description": "Create a new region which can be referenced by business partner records.",
+        "operationId": "createRegion",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "New region successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/catena/legal-forms": {
+      "get": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Returns all legal forms",
+        "description": "Lists all currently known legal forms in a paginated result",
+        "operationId": "getLegalForms",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of existing legal forms, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLegalFormDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Creates a new legal form",
+        "description": "Create a new legal form which can be referenced by business partner records. The actual name of the legal form is free to choose and doesn't need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.",
+        "operationId": "createLegalForm",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LegalFormRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "New legal form successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LegalFormDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          },
+          "409": {
+            "description": "Legal form with specified technical key already exists"
+          }
+        }
+      }
+    },
+    "/api/catena/legal-entities/{bpnl}/confirm-up-to-date": {
+      "post": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Confirms that the data of a legal entity business partner is still up to date.",
+        "description": "Confirms that the data of a business partner is still up to date by saving the current timestamp at the time this POST-request is made as this business partner's \"currentness\". Ignores case of bpnl.",
+        "operationId": "setLegalEntityCurrentness",
+        "parameters": [
+          {
+            "name": "bpnl",
+            "in": "path",
+            "description": "BPNL value",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business partner's \"currentness\" successfully updated"
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          },
+          "404": {
+            "description": "No business partner found for specified bpnl"
+          }
+        }
+      }
+    },
+    "/api/catena/legal-entities/search": {
+      "post": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns legal entities by an array of BPNL",
+        "description": "Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
+        "operationId": "searchSites_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Found legal entites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PoolLegalEntityVerboseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters or if number of requested bpns exceeds limit"
+          }
+        }
+      }
+    },
+    "/api/catena/legal-entities/legal-addresses/search": {
+      "post": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Search Legal Addresses",
+        "description": "Search legal addresses of legal entities by BPNL",
+        "operationId": "searchLegalAddresses",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The found legal addresses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LegalAddressVerboseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        }
+      }
+    },
+    "/api/catena/identifier-types": {
+      "get": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Returns all identifier types filtered by business partner type and country.",
+        "description": "Lists all matching identifier types including validity details in a paginated result",
+        "operationId": "getIdentifierTypes",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          },
+          {
+            "name": "businessPartnerType",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Specifies if an identifier type is valid for legal entities (L) or addresses (A). Sites (S) are not supported.",
+              "enum": [
+                "LEGAL_ENTITY",
+                "ADDRESS"
+              ]
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "UNDEFINED",
+                "AC",
+                "AD",
+                "AE",
+                "AF",
+                "AG",
+                "AI",
+                "AL",
+                "AM",
+                "AN",
+                "AO",
+                "AQ",
+                "AR",
+                "AS",
+                "AT",
+                "AU",
+                "AW",
+                "AX",
+                "AZ",
+                "BA",
+                "BB",
+                "BD",
+                "BE",
+                "BF",
+                "BG",
+                "BH",
+                "BI",
+                "BJ",
+                "BL",
+                "BM",
+                "BN",
+                "BO",
+                "BQ",
+                "BR",
+                "BS",
+                "BT",
+                "BU",
+                "BV",
+                "BW",
+                "BY",
+                "BZ",
+                "CA",
+                "CC",
+                "CD",
+                "CF",
+                "CG",
+                "CH",
+                "CI",
+                "CK",
+                "CL",
+                "CM",
+                "CN",
+                "CO",
+                "CP",
+                "CR",
+                "CS",
+                "CU",
+                "CV",
+                "CW",
+                "CX",
+                "CY",
+                "CZ",
+                "DE",
+                "DG",
+                "DJ",
+                "DK",
+                "DM",
+                "DO",
+                "DZ",
+                "EA",
+                "EC",
+                "EE",
+                "EG",
+                "EH",
+                "ER",
+                "ES",
+                "ET",
+                "EU",
+                "EZ",
+                "FI",
+                "FJ",
+                "FK",
+                "FM",
+                "FO",
+                "FR",
+                "FX",
+                "GA",
+                "GB",
+                "GD",
+                "GE",
+                "GF",
+                "GG",
+                "GH",
+                "GI",
+                "GL",
+                "GM",
+                "GN",
+                "GP",
+                "GQ",
+                "GR",
+                "GS",
+                "GT",
+                "GU",
+                "GW",
+                "GY",
+                "HK",
+                "HM",
+                "HN",
+                "HR",
+                "HT",
+                "HU",
+                "IC",
+                "ID",
+                "IE",
+                "IL",
+                "IM",
+                "IN",
+                "IO",
+                "IQ",
+                "IR",
+                "IS",
+                "IT",
+                "JE",
+                "JM",
+                "JO",
+                "JP",
+                "KE",
+                "KG",
+                "KH",
+                "KI",
+                "KM",
+                "KN",
+                "KP",
+                "KR",
+                "KW",
+                "KY",
+                "KZ",
+                "LA",
+                "LB",
+                "LC",
+                "LI",
+                "LK",
+                "LR",
+                "LS",
+                "LT",
+                "LU",
+                "LV",
+                "LY",
+                "MA",
+                "MC",
+                "MD",
+                "ME",
+                "MF",
+                "MG",
+                "MH",
+                "MK",
+                "ML",
+                "MM",
+                "MN",
+                "MO",
+                "MP",
+                "MQ",
+                "MR",
+                "MS",
+                "MT",
+                "MU",
+                "MV",
+                "MW",
+                "MX",
+                "MY",
+                "MZ",
+                "NA",
+                "NC",
+                "NE",
+                "NF",
+                "NG",
+                "NI",
+                "NL",
+                "NO",
+                "NP",
+                "NR",
+                "NT",
+                "NU",
+                "NZ",
+                "OM",
+                "PA",
+                "PE",
+                "PF",
+                "PG",
+                "PH",
+                "PK",
+                "PL",
+                "PM",
+                "PN",
+                "PR",
+                "PS",
+                "PT",
+                "PW",
+                "PY",
+                "QA",
+                "RE",
+                "RO",
+                "RS",
+                "RU",
+                "RW",
+                "SA",
+                "SB",
+                "SC",
+                "SD",
+                "SE",
+                "SF",
+                "SG",
+                "SH",
+                "SI",
+                "SJ",
+                "SK",
+                "SL",
+                "SM",
+                "SN",
+                "SO",
+                "SR",
+                "SS",
+                "ST",
+                "SU",
+                "SV",
+                "SX",
+                "SY",
+                "SZ",
+                "TA",
+                "TC",
+                "TD",
+                "TF",
+                "TG",
+                "TH",
+                "TJ",
+                "TK",
+                "TL",
+                "TM",
+                "TN",
+                "TO",
+                "TP",
+                "TR",
+                "TT",
+                "TV",
+                "TW",
+                "TZ",
+                "UA",
+                "UG",
+                "UK",
+                "UM",
+                "US",
+                "UY",
+                "UZ",
+                "VA",
+                "VC",
+                "VE",
+                "VG",
+                "VI",
+                "VN",
+                "VU",
+                "WF",
+                "WS",
+                "XI",
+                "XU",
+                "XK",
+                "YE",
+                "YT",
+                "YU",
+                "ZA",
+                "ZM",
+                "ZR",
+                "ZW"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of existing identifier types, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoIdentifierTypeDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Creates a new identifier type",
+        "description": "Create a new identifier type (including validity details) which can be referenced by business partner records. Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. The actual name of the identifier type is free to choose and doesn't need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.",
+        "operationId": "createIdentifierType",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IdentifierTypeDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "New identifier type successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IdentifierTypeDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          },
+          "409": {
+            "description": "Identifier type with specified technical key already exists"
+          }
+        }
+      }
+    },
+    "/api/catena/business-partners/changelog/search": {
+      "post": {
+        "tags": [
+          "changelog-controller"
+        ],
+        "summary": "Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types",
+        "operationId": "getChangelogEntries",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangelogSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The specified changelog entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoChangelogEntryVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          },
+          "404": {
+            "description": "No business partner found for specified bpn"
+          }
+        }
+      }
+    },
+    "/api/catena/bpn/search": {
+      "post": {
+        "tags": [
+          "bpn-controller"
+        ],
+        "summary": "Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values",
+        "description": "Find business partner numbers by identifiers. The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. For a single request, the maximum number of identifier values to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
+        "operationId": "findBpnsByIdentifiers",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IdentifiersSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Found bpn to identifier value mappings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BpnIdentifierMappingDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters or if number of requested bpns exceeds limit"
+          },
+          "404": {
+            "description": "Specified identifier type not found"
+          }
+        }
+      }
+    },
+    "/api/catena/addresses/search": {
+      "post": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
+        "description": "Search business partners of type address by their BPNA or their parents' BPNL or BPNS.",
+        "operationId": "searchAddresses",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddressPartnerBpnSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Found sites for the specified sites and legal entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/api/catena/sites/{bpns}": {
+      "get": {
+        "tags": [
+          "site-controller"
+        ],
+        "summary": "Returns a site by its BPNS",
+        "description": "Get business partners of type site by BPNS ignoring case.",
+        "operationId": "getSite",
+        "parameters": [
+          {
+            "name": "bpns",
+            "in": "path",
+            "description": "BPNS value",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found site with specified BPNS",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SitePoolVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          },
+          "404": {
+            "description": "No site found under specified BPNS"
+          }
+        }
+      }
+    },
+    "/api/catena/mermaid/": {
+      "get": {
+        "tags": [
+          "pool-documentation-controller"
+        ],
+        "summary": "Get mermaid class diagramm for the pool JPA model",
+        "operationId": "getMermaidPoolPersistence",
+        "responses": {
+          "200": {
+            "description": "Entity model as mermaid diagramm",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/catena/legal-entities/{idValue}": {
+      "get": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
+        "description": "This endpoint tries to find a business partner by the specified identifier. The identifier value is case insensitively compared but needs to be given exactly. By default the value given is interpreted as a BPN. By specifying the technical key of another identifier typethe value is matched against the identifiers of that given type.",
+        "operationId": "getLegalEntity",
+        "parameters": [
+          {
+            "name": "idValue",
+            "in": "path",
+            "description": "Identifier value",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "idType",
+            "in": "query",
+            "description": "Type of identifier to use, defaults to BPN when omitted",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "BPN"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found business partner with specified identifier",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PoolLegalEntityVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          },
+          "404": {
+            "description": "No business partner found under specified identifier or specified identifier type not found"
+          }
+        }
+      }
+    },
+    "/api/catena/legal-entities/{bpnl}/sites": {
+      "get": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns all sites of a legal entity with a specific BPNL",
+        "description": "Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case.",
+        "operationId": "getSites",
+        "parameters": [
+          {
+            "name": "bpnl",
+            "in": "path",
+            "description": "BPNL value",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The sites for the specified bpnl",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSiteVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          },
+          "404": {
+            "description": "No business partner found for specified bpnl"
+          }
+        }
+      }
+    },
+    "/api/catena/legal-entities/{bpnl}/addresses": {
+      "get": {
+        "tags": [
+          "legal-entity-controller"
+        ],
+        "summary": "Returns all addresses of a legal entity with a specific BPNL",
+        "description": "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.",
+        "operationId": "getAddresses",
+        "parameters": [
+          {
+            "name": "bpnl",
+            "in": "path",
+            "description": "BPNL value",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The addresses for the specified BPNL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed pagination request"
+          },
+          "404": {
+            "description": "No business partner found for specified BPNL"
+          }
+        }
+      }
+    },
+    "/api/catena/field-quality-rules/": {
+      "get": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Get all field quality rules filtered by country (specified by its ISO 3166-1 alpha-2 country code)",
+        "description": "List the country specific data rules for entity fields.All fields that are not in this list are considered to be forbidden.",
+        "operationId": "getFieldQualityRules",
+        "parameters": [
+          {
+            "name": "country",
+            "in": "query",
+            "description": "ISO 3166-1 alpha-2 country code",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "UNDEFINED",
+                "AC",
+                "AD",
+                "AE",
+                "AF",
+                "AG",
+                "AI",
+                "AL",
+                "AM",
+                "AN",
+                "AO",
+                "AQ",
+                "AR",
+                "AS",
+                "AT",
+                "AU",
+                "AW",
+                "AX",
+                "AZ",
+                "BA",
+                "BB",
+                "BD",
+                "BE",
+                "BF",
+                "BG",
+                "BH",
+                "BI",
+                "BJ",
+                "BL",
+                "BM",
+                "BN",
+                "BO",
+                "BQ",
+                "BR",
+                "BS",
+                "BT",
+                "BU",
+                "BV",
+                "BW",
+                "BY",
+                "BZ",
+                "CA",
+                "CC",
+                "CD",
+                "CF",
+                "CG",
+                "CH",
+                "CI",
+                "CK",
+                "CL",
+                "CM",
+                "CN",
+                "CO",
+                "CP",
+                "CR",
+                "CS",
+                "CU",
+                "CV",
+                "CW",
+                "CX",
+                "CY",
+                "CZ",
+                "DE",
+                "DG",
+                "DJ",
+                "DK",
+                "DM",
+                "DO",
+                "DZ",
+                "EA",
+                "EC",
+                "EE",
+                "EG",
+                "EH",
+                "ER",
+                "ES",
+                "ET",
+                "EU",
+                "EZ",
+                "FI",
+                "FJ",
+                "FK",
+                "FM",
+                "FO",
+                "FR",
+                "FX",
+                "GA",
+                "GB",
+                "GD",
+                "GE",
+                "GF",
+                "GG",
+                "GH",
+                "GI",
+                "GL",
+                "GM",
+                "GN",
+                "GP",
+                "GQ",
+                "GR",
+                "GS",
+                "GT",
+                "GU",
+                "GW",
+                "GY",
+                "HK",
+                "HM",
+                "HN",
+                "HR",
+                "HT",
+                "HU",
+                "IC",
+                "ID",
+                "IE",
+                "IL",
+                "IM",
+                "IN",
+                "IO",
+                "IQ",
+                "IR",
+                "IS",
+                "IT",
+                "JE",
+                "JM",
+                "JO",
+                "JP",
+                "KE",
+                "KG",
+                "KH",
+                "KI",
+                "KM",
+                "KN",
+                "KP",
+                "KR",
+                "KW",
+                "KY",
+                "KZ",
+                "LA",
+                "LB",
+                "LC",
+                "LI",
+                "LK",
+                "LR",
+                "LS",
+                "LT",
+                "LU",
+                "LV",
+                "LY",
+                "MA",
+                "MC",
+                "MD",
+                "ME",
+                "MF",
+                "MG",
+                "MH",
+                "MK",
+                "ML",
+                "MM",
+                "MN",
+                "MO",
+                "MP",
+                "MQ",
+                "MR",
+                "MS",
+                "MT",
+                "MU",
+                "MV",
+                "MW",
+                "MX",
+                "MY",
+                "MZ",
+                "NA",
+                "NC",
+                "NE",
+                "NF",
+                "NG",
+                "NI",
+                "NL",
+                "NO",
+                "NP",
+                "NR",
+                "NT",
+                "NU",
+                "NZ",
+                "OM",
+                "PA",
+                "PE",
+                "PF",
+                "PG",
+                "PH",
+                "PK",
+                "PL",
+                "PM",
+                "PN",
+                "PR",
+                "PS",
+                "PT",
+                "PW",
+                "PY",
+                "QA",
+                "RE",
+                "RO",
+                "RS",
+                "RU",
+                "RW",
+                "SA",
+                "SB",
+                "SC",
+                "SD",
+                "SE",
+                "SF",
+                "SG",
+                "SH",
+                "SI",
+                "SJ",
+                "SK",
+                "SL",
+                "SM",
+                "SN",
+                "SO",
+                "SR",
+                "SS",
+                "ST",
+                "SU",
+                "SV",
+                "SX",
+                "SY",
+                "SZ",
+                "TA",
+                "TC",
+                "TD",
+                "TF",
+                "TG",
+                "TH",
+                "TJ",
+                "TK",
+                "TL",
+                "TM",
+                "TN",
+                "TO",
+                "TP",
+                "TR",
+                "TT",
+                "TV",
+                "TW",
+                "TZ",
+                "UA",
+                "UG",
+                "UK",
+                "UM",
+                "US",
+                "UY",
+                "UZ",
+                "VA",
+                "VC",
+                "VE",
+                "VG",
+                "VI",
+                "VN",
+                "VU",
+                "WF",
+                "WS",
+                "XI",
+                "XU",
+                "XK",
+                "YE",
+                "YT",
+                "YU",
+                "ZA",
+                "ZM",
+                "ZR",
+                "ZW"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of the existing rules for the given country",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FieldQualityRuleDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        }
+      }
+    },
+    "/api/catena/administrative-areas-level1": {
+      "get": {
+        "tags": [
+          "metadata-controller"
+        ],
+        "summary": "Get page of country subdivisions suitable for the administrativeAreaLevel1 address property",
+        "description": "Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result",
+        "operationId": "getAdminAreasLevel1",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of existing country subdivisions, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoCountrySubdivisionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          }
+        }
+      }
+    },
+    "/api/catena/addresses/{bpna}": {
+      "get": {
+        "tags": [
+          "address-controller"
+        ],
+        "summary": "Returns an address by its BPNA",
+        "description": "Get business partners of type address by BPNA ignoring case.",
+        "operationId": "getAddress",
+        "parameters": [
+          {
+            "name": "bpna",
+            "in": "path",
+            "description": "BPNA value",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found address with specified BPNA",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed request parameters"
+          },
+          "404": {
+            "description": "No address found under specified BPNA"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddressIdentifierDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"0847976000005\"."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the identifier."
+          }
+        },
+        "description": "An address identifier (uniquely) identifies the address, such as the Global Location Number (GLN)."
+      },
+      "AddressIdentifierVerboseDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"0847976000005\"."
+          },
+          "type": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoString"
+          }
+        },
+        "description": "An address identifier (uniquely) identifies the address, such as the Global Location Number (GLN)."
+      },
+      "AddressMatchVerboseDto": {
+        "type": "object",
+        "properties": {
+          "score": {
+            "type": "number",
+            "description": "Relative quality score of the match. The higher the better.",
+            "format": "float"
+          },
+          "address": {
+            "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+          }
+        },
+        "description": "Match for a business partner record of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressPartnerBpnSearchRequest": {
+        "type": "object",
+        "properties": {
+          "legalEntities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sites": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Request for searching business partners of type address by parent BPNs"
+      },
+      "AddressPartnerCreateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressDto"
+          },
+          "bpnParent": {
+            "type": "string"
+          },
+          "index": {
+            "type": "string"
+          }
+        },
+        "description": "Request for creating new business partner record of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressPartnerCreateResponseWrapper": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressPartnerCreateVerboseDto"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorInfoAddressCreateError"
+            }
+          },
+          "errorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "entityCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "Holds information about successfully and failed entities after the creating/updating of several objects"
+      },
+      "AddressPartnerCreateVerboseDto": {
+        "type": "object",
+        "properties": {
+          "bpna": {
+            "type": "string",
+            "description": "A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateVerboseDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierVerboseDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressVerboseDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressVerboseDto"
+          },
+          "bpnLegalEntity": {
+            "type": "string",
+            "description": "The BPNL of the legal entity owning the address."
+          },
+          "bpnSite": {
+            "type": "string",
+            "description": "The BPNS of the site the address belongs to."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "isLegalAddress": {
+            "type": "boolean",
+            "description": "Indicates if the address is the legal address to a legal entity."
+          },
+          "isMainAddress": {
+            "type": "boolean",
+            "description": "Indicates if the address is the main address to a site. This is where typically the main entrance or the reception is located, or where the mail is delivered to."
+          },
+          "index": {
+            "type": "string"
+          }
+        },
+        "description": "Created business partner of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressPartnerUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "bpna": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressDto"
+          }
+        },
+        "description": "Request for updating a business partner record of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "AddressPartnerUpdateResponseWrapper": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorInfoAddressUpdateError"
+            }
+          },
+          "errorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "entityCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "Holds information about successfully and failed entities after the creating/updating of several objects"
+      },
+      "AddressStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the address."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        },
+        "description": "An address state indicates if the address is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the business partner is still operating at that address."
+      },
+      "AddressStateVerboseDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the address."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoBusinessStateType"
+          }
+        },
+        "description": "An address state indicates if the address is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the business partner is still operating at that address."
+      },
+      "AlternativePostalAddressDto": {
+        "required": [
+          "city",
+          "country",
+          "deliveryServiceNumber",
+          "deliveryServiceType"
+        ],
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "type": "string",
+            "description": "The 2-digit country code of the physical postal address according to ISO 3166-1.",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "administrativeAreaLevel1": {
+            "type": "string",
+            "description": "The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "deliveryServiceType": {
+            "type": "string",
+            "description": "One of the alternative postal address types: P.O. box, private bag, boite postale.",
+            "enum": [
+              "PO_BOX",
+              "PRIVATE_BAG",
+              "BOITE_POSTALE"
+            ]
+          },
+          "deliveryServiceQualifier": {
+            "type": "string",
+            "description": "The qualifier uniquely identifying the delivery service endpoint of the alternative postal address in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number is assigned multiple times in some cities."
+          },
+          "deliveryServiceNumber": {
+            "type": "string",
+            "description": "The number indicating the delivery service endpoint of the alternative postal address to which the delivery is to be delivered, such as a P.O. box number or a private bag number."
+          }
+        },
+        "description": "An alternative postal address describes an alternative way of delivery for example if the goods are to be picked up somewhere else."
+      },
+      "AlternativePostalAddressVerboseDto": {
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoCountryCode"
+          },
+          "administrativeAreaLevel1": {
+            "$ref": "#/components/schemas/RegionDto"
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "deliveryServiceType": {
+            "type": "string",
+            "description": "One of the alternative postal address types: P.O. box, private bag, boite postale.",
+            "enum": [
+              "PO_BOX",
+              "PRIVATE_BAG",
+              "BOITE_POSTALE"
+            ]
+          },
+          "deliveryServiceQualifier": {
+            "type": "string",
+            "description": "The qualifier uniquely identifying the delivery service endpoint of the alternative postal address in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number is assigned multiple times in some cities."
+          },
+          "deliveryServiceNumber": {
+            "type": "string",
+            "description": "The number indicating the delivery service endpoint of the alternative postal address to which the delivery is to be delivered, such as a P.O. box number or a private bag number."
+          }
+        },
+        "description": "An alternative postal address describes an alternative way of delivery for example if the goods are to be picked up somewhere else."
+      },
+      "BpnIdentifierMappingDto": {
+        "type": "object",
+        "properties": {
+          "idValue": {
+            "type": "string"
+          },
+          "bpn": {
+            "type": "string"
+          }
+        },
+        "description": "Mapping of Business Partner Number to identifier value"
+      },
+      "ChangelogEntryVerboseDto": {
+        "type": "object",
+        "properties": {
+          "bpn": {
+            "type": "string",
+            "description": "The business partner number for which the changelog entry was created. Can be either a BPNL, BPNS or BPNA."
+          },
+          "businessPartnerType": {
+            "type": "string",
+            "description": "One of the types of business partners for which the changelog entry was created: legal entity, site, address.",
+            "enum": [
+              "LEGAL_ENTITY",
+              "SITE",
+              "ADDRESS",
+              "GENERIC"
+            ]
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "The date and time when the changelog entry was created.",
+            "format": "date-time"
+          },
+          "changelogType": {
+            "type": "string",
+            "description": "One of the actions for which the changelog entry was created: create, update.",
+            "enum": [
+              "CREATE",
+              "UPDATE"
+            ]
+          }
+        },
+        "description": "An entry of the changelog, which is created each time a business partner is modified and contains data about the change. The actual new state of the business partner is not included."
+      },
+      "ChangelogSearchRequest": {
+        "type": "object",
+        "properties": {
+          "timestampAfter": {
+            "type": "string",
+            "description": "Only changelog entries created after this time. Ignored if empty.",
+            "format": "date-time",
+            "example": "2023-03-20T10:23:28.194Z"
+          },
+          "bpns": {
+            "uniqueItems": true,
+            "type": "array",
+            "description": "Only for business partners with the given array of BPNL/S/A. Ignored if empty.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "businessPartnerTypes": {
+            "uniqueItems": true,
+            "type": "array",
+            "description": "Only for business partners with the given array of business partner types. Ignored if empty.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "LEGAL_ENTITY",
+                "SITE",
+                "ADDRESS",
+                "GENERIC"
+              ]
+            }
+          }
+        },
+        "description": "Request for searching and filtering the business partner changelog"
+      },
+      "ClassificationDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of classification.",
+            "enum": [
+              "NACE",
+              "NAF",
+              "NAICS",
+              "SIC"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "description": "The identifier of the class belonging to the classification."
+          },
+          "value": {
+            "type": "string",
+            "description": "The name of the class belonging to the classification."
+          }
+        },
+        "description": "A legal entity classification is an assignment of the legal entity to an industry. It does not necessarily have to be the only industry the company is active in (see large companies operating in different industries). Multiple assignments to several industries are possible per classification type."
+      },
+      "ClassificationVerboseDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The name of the class belonging to the classification."
+          },
+          "code": {
+            "type": "string",
+            "description": "The identifier of the class belonging to the classification."
+          },
+          "type": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoClassificationType"
+          }
+        },
+        "description": "A legal entity classification is an assignment of the legal entity to an industry. It does not necessarily have to be the only industry the company is active in (see large companies operating in different industries). Multiple assignments to several industries are possible per classification type."
+      },
+      "CountrySubdivisionDto": {
+        "type": "object",
+        "properties": {
+          "countryCode": {
+            "type": "string",
+            "description": "Country code",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "description": "The country subdivision code according to ISO 3166-2"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the country subdivision according to ISO 3166-2"
+          }
+        },
+        "description": "Country subdivision"
+      },
+      "ErrorInfoAddressCreateError": {
+        "title": "ErrorInfo",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "AddressCreateError",
+            "enum": [
+              "BpnNotValid",
+              "SiteNotFound",
+              "LegalEntityNotFound",
+              "RegionNotFound",
+              "IdentifierNotFound",
+              "AddressDuplicateIdentifier"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "entityKey": {
+            "type": "string"
+          }
+        },
+        "description": "Holds information about failures when creating or updating an entity"
+      },
+      "ErrorInfoAddressUpdateError": {
+        "title": "ErrorInfo",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "AddressUpdateError",
+            "enum": [
+              "AddressNotFound",
+              "RegionNotFound",
+              "IdentifierNotFound",
+              "AddressDuplicateIdentifier"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "entityKey": {
+            "type": "string"
+          }
+        },
+        "description": "Holds information about failures when creating or updating an entity"
+      },
+      "ErrorInfoLegalEntityCreateError": {
+        "title": "ErrorInfo",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "LegalEntityCreateError",
+            "enum": [
+              "LegalEntityDuplicateIdentifier",
+              "LegalFormNotFound",
+              "LegalEntityIdentifierNotFound",
+              "LegalAddressRegionNotFound",
+              "LegalAddressIdentifierNotFound",
+              "LegalAddressDuplicateIdentifier"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "entityKey": {
+            "type": "string"
+          }
+        },
+        "description": "Holds information about failures when creating or updating an entity"
+      },
+      "ErrorInfoLegalEntityUpdateError": {
+        "title": "ErrorInfo",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "LegalEntityUpdateError",
+            "enum": [
+              "LegalEntityNotFound",
+              "LegalEntityDuplicateIdentifier",
+              "LegalFormNotFound",
+              "LegalEntityIdentifierNotFound",
+              "LegalAddressRegionNotFound",
+              "LegalAddressIdentifierNotFound",
+              "LegalAddressDuplicateIdentifier"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "entityKey": {
+            "type": "string"
+          }
+        },
+        "description": "Holds information about failures when creating or updating an entity"
+      },
+      "ErrorInfoSiteCreateError": {
+        "title": "ErrorInfo",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "SiteCreateError",
+            "enum": [
+              "LegalEntityNotFound",
+              "MainAddressIdentifierNotFound",
+              "MainAddressRegionNotFound",
+              "MainAddressDuplicateIdentifier"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "entityKey": {
+            "type": "string"
+          }
+        },
+        "description": "Holds information about failures when creating or updating an entity"
+      },
+      "ErrorInfoSiteUpdateError": {
+        "title": "ErrorInfo",
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "SiteUpdateError",
+            "enum": [
+              "SiteNotFound",
+              "MainAddressIdentifierNotFound",
+              "MainAddressRegionNotFound",
+              "MainAddressDuplicateIdentifier"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "entityKey": {
+            "type": "string"
+          }
+        },
+        "description": "Holds information about failures when creating or updating an entity"
+      },
+      "FieldQualityRuleDto": {
+        "type": "object",
+        "properties": {
+          "fieldPath": {
+            "type": "string",
+            "description": "Path to the field"
+          },
+          "schemaName": {
+            "type": "string",
+            "description": "Schema name of the entity the field belongs to"
+          },
+          "country": {
+            "type": "string",
+            "description": "Country for wich the rule is valid",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "qualityLevel": {
+            "type": "string",
+            "description": "Defines the quality of an entity field.",
+            "enum": [
+              "MANDATORY",
+              "OPTIONAL",
+              "FORBIDDEN"
+            ]
+          }
+        },
+        "description": "Rule for the quality level of an entity field "
+      },
+      "GeoCoordinateDto": {
+        "type": "object",
+        "properties": {
+          "longitude": {
+            "type": "number",
+            "description": "Longitude coordinate",
+            "format": "float"
+          },
+          "latitude": {
+            "type": "number",
+            "description": "Latitude coordinate",
+            "format": "float"
+          },
+          "altitude": {
+            "type": "number",
+            "description": "Altitude, if applicable",
+            "format": "float"
+          }
+        },
+        "description": "The exact location of the physical postal address in latitude, longitude, and altitude."
+      },
+      "IdentifierTypeDetailDto": {
+        "type": "object",
+        "properties": {
+          "country": {
+            "type": "string",
+            "description": "2-digit country code for which this identifier is valid; null for universal identifiers.",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "mandatory": {
+            "type": "boolean",
+            "description": "True if identifier is mandatory in this country."
+          }
+        },
+        "description": "Information for which countries an identifier type is valid and mandatory."
+      },
+      "IdentifierTypeDto": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string",
+            "description": "The technical identifier (unique in combination with businessPartnerType)."
+          },
+          "businessPartnerType": {
+            "type": "string",
+            "description": "Specifies if an identifier type is valid for legal entities (L) or addresses (A). Sites (S) are not supported.",
+            "enum": [
+              "LEGAL_ENTITY",
+              "ADDRESS"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the identifier type."
+          },
+          "details": {
+            "type": "array",
+            "description": "Validity details.",
+            "items": {
+              "$ref": "#/components/schemas/IdentifierTypeDetailDto"
+            }
+          }
+        },
+        "description": "An identifier type defines the name or category of an identifier, such as the German Handelsregisternummer, VAT number, Global Location Number (GLN), etc. The identifier type is valid for a business partner type."
+      },
+      "IdentifiersSearchRequest": {
+        "type": "object",
+        "properties": {
+          "businessPartnerType": {
+            "type": "string",
+            "description": "Specifies if an identifier type is valid for legal entities (L) or addresses (A). Sites (S) are not supported.",
+            "enum": [
+              "LEGAL_ENTITY",
+              "ADDRESS"
+            ]
+          },
+          "idType": {
+            "type": "string"
+          },
+          "idValues": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Contains identifiers to search legal entities by"
+      },
+      "LegalAddressVerboseDto": {
+        "type": "object",
+        "properties": {
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressVerboseDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressVerboseDto"
+          },
+          "bpnLegalEntity": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "description": "Legal address for legal entity"
+      },
+      "LegalEntityIdentifierDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"DE123465789\"."
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the identifier."
+          },
+          "issuingBody": {
+            "type": "string",
+            "description": "The name of the official register, where the identifier is registered. For example, a Handelsregisternummer in Germany is only valid with its corresponding Handelsregister."
+          }
+        }
+      },
+      "LegalEntityIdentifierVerboseDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The value of the identifier like \"DE123465789\"."
+          },
+          "type": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoString"
+          },
+          "issuingBody": {
+            "type": "string",
+            "description": "The name of the official register, where the identifier is registered. For example, a Handelsregisternummer in Germany is only valid with its corresponding Handelsregister."
+          }
+        },
+        "description": "A legal entity identifier (uniquely) identifies the legal entity, such as the German Handelsregisternummer, a VAT number, etc."
+      },
+      "LegalEntityMatchVerboseDto": {
+        "type": "object",
+        "properties": {
+          "score": {
+            "type": "number",
+            "description": "Relative quality score of the match. The higher the better.",
+            "format": "float"
+          },
+          "legalName": {
+            "type": "string",
+            "description": "The name of the legal entity according to official registers."
+          },
+          "bpnl": {
+            "type": "string",
+            "description": "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierVerboseDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "$ref": "#/components/schemas/LegalFormDto"
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateVerboseDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationVerboseDto"
+            }
+          },
+          "relations": {
+            "type": "array",
+            "description": "Relations to other business partners.",
+            "items": {
+              "$ref": "#/components/schemas/RelationVerboseDto"
+            }
+          },
+          "currentness": {
+            "type": "string",
+            "description": "The date the business partner data was last indicated to be still current.",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+          }
+        },
+        "description": "Match with score for a business partner record of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityPartnerCreateRequest": {
+        "type": "object",
+        "properties": {
+          "legalName": {
+            "type": "string",
+            "description": "The name of the legal entity according to official registers."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "The legal form of the legal entity."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/LogisticAddressDto"
+          },
+          "index": {
+            "type": "string",
+            "description": "User defined index to conveniently match this entry to the corresponding entry in the response."
+          }
+        },
+        "description": "Request for creating new business partner record of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityPartnerCreateResponseWrapper": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityPartnerCreateVerboseDto"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorInfoLegalEntityCreateError"
+            }
+          },
+          "errorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "entityCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "Holds information about successfully and failed entities after the creating/updating of several objects"
+      },
+      "LegalEntityPartnerCreateVerboseDto": {
+        "type": "object",
+        "properties": {
+          "legalName": {
+            "type": "string",
+            "description": "The name of the legal entity according to official registers."
+          },
+          "bpnl": {
+            "type": "string",
+            "description": "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierVerboseDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "$ref": "#/components/schemas/LegalFormDto"
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateVerboseDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationVerboseDto"
+            }
+          },
+          "relations": {
+            "type": "array",
+            "description": "Relations to other business partners.",
+            "items": {
+              "$ref": "#/components/schemas/RelationVerboseDto"
+            }
+          },
+          "currentness": {
+            "type": "string",
+            "description": "The date the business partner data was last indicated to be still current.",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+          },
+          "index": {
+            "type": "string",
+            "description": "User defined index to conveniently match this entry to the corresponding entry in the response."
+          }
+        },
+        "description": "Created/updated business partner of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityPartnerUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "bpnl": {
+            "type": "string",
+            "description": "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number."
+          },
+          "legalName": {
+            "type": "string",
+            "description": "The name of the legal entity according to official registers."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "type": "string",
+            "description": "The legal form of the legal entity."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationDto"
+            }
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/LogisticAddressDto"
+          }
+        },
+        "description": "Request for updating a business partner record of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "LegalEntityPartnerUpdateResponseWrapper": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityPartnerCreateVerboseDto"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorInfoLegalEntityUpdateError"
+            }
+          },
+          "errorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "entityCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "Holds information about successfully and failed entities after the creating/updating of several objects"
+      },
+      "LegalEntityStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the legal entity, such as from the German Handelsregister."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        },
+        "description": "A legal entity state indicates if the legal entity is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the legal entity is still operating."
+      },
+      "LegalEntityStateVerboseDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the legal entity, such as from the German Handelsregister."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoBusinessStateType"
+          }
+        },
+        "description": "A legal entity state indicates if the legal entity is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the legal entity is still operating."
+      },
+      "LegalFormDto": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string",
+            "description": "The technical identifier of the legal form according to ISO 20275."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of legal form according to ISO 20275."
+          },
+          "abbreviation": {
+            "type": "string",
+            "description": "The abbreviated name of the legal form, such as AG for German Aktiengesellschaft."
+          }
+        },
+        "description": "A legal form is a mandatory corporate legal framework by which companies can conduct business, charitable or other permissible activities."
+      },
+      "LegalFormRequest": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "abbreviation": {
+            "type": "string"
+          }
+        },
+        "description": "New legal form record to be referenced by business partners"
+      },
+      "LogisticAddressDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the address.",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressDto"
+          }
+        },
+        "description": "In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "LogisticAddressVerboseDto": {
+        "type": "object",
+        "properties": {
+          "bpna": {
+            "type": "string",
+            "description": "A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the address. This is not according to official registers but according to the name the sharing member chooses."
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressStateVerboseDto"
+            }
+          },
+          "identifiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressIdentifierVerboseDto"
+            }
+          },
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressVerboseDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressVerboseDto"
+          },
+          "bpnLegalEntity": {
+            "type": "string",
+            "description": "The BPNL of the legal entity owning the address."
+          },
+          "bpnSite": {
+            "type": "string",
+            "description": "The BPNS of the site the address belongs to."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "isLegalAddress": {
+            "type": "boolean",
+            "description": "Indicates if the address is the legal address to a legal entity."
+          },
+          "isMainAddress": {
+            "type": "boolean",
+            "description": "Indicates if the address is the main address to a site. This is where typically the main entrance or the reception is located, or where the mail is delivered to."
+          }
+        },
+        "description": "In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA."
+      },
+      "MainAddressResponse": {
+        "type": "object",
+        "properties": {
+          "physicalPostalAddress": {
+            "$ref": "#/components/schemas/PhysicalPostalAddressVerboseDto"
+          },
+          "alternativePostalAddress": {
+            "$ref": "#/components/schemas/AlternativePostalAddressVerboseDto"
+          },
+          "bpnSite": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "description": "Main address for site"
+      },
+      "PageDtoAddressMatchVerboseDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/AddressMatchVerboseDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoChangelogEntryVerboseDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/ChangelogEntryVerboseDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoCountrySubdivisionDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/CountrySubdivisionDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoIdentifierTypeDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/IdentifierTypeDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoLegalEntityMatchVerboseDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityMatchVerboseDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoLegalFormDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/LegalFormDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoLogisticAddressVerboseDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoRegionDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/RegionDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoSiteMatchVerboseDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/SiteMatchVerboseDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoSitePoolVerboseDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/SitePoolVerboseDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PageDtoSiteVerboseDto": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "description": "Total number of all results in all pages",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "Total number pages",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number",
+            "format": "int32"
+          },
+          "contentSize": {
+            "type": "integer",
+            "description": "Number of results in the page",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "description": "Collection of results in the page",
+            "items": {
+              "$ref": "#/components/schemas/SiteVerboseDto"
+            }
+          }
+        },
+        "description": "Paginated collection of results"
+      },
+      "PhysicalPostalAddressDto": {
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "type": "string",
+            "description": "The 2-digit country code of the physical postal address according to ISO 3166-1.",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "administrativeAreaLevel1": {
+            "type": "string",
+            "description": "The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country."
+          },
+          "administrativeAreaLevel2": {
+            "type": "string",
+            "description": "The name of the locally regulated secondary country subdivision of the physical postal address, such as county within a country."
+          },
+          "administrativeAreaLevel3": {
+            "type": "string",
+            "description": "The name of the locally regulated tertiary country subdivision of the physical address, such as townships within a country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "district": {
+            "type": "string",
+            "description": "The name of the district of the physical postal address which divides the city in several smaller areas."
+          },
+          "street": {
+            "$ref": "#/components/schemas/StreetDto"
+          },
+          "companyPostalCode": {
+            "type": "string",
+            "description": "The company postal code of the physical postal address, which is sometimes required for large companies."
+          },
+          "industrialZone": {
+            "type": "string",
+            "description": "The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area."
+          },
+          "building": {
+            "type": "string",
+            "description": "The alphanumeric identifier of the building addressed by the physical postal address."
+          },
+          "floor": {
+            "type": "string",
+            "description": "The number of a floor in the building addressed by the physical postal address, synonym: level."
+          },
+          "door": {
+            "type": "string",
+            "description": "The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite."
+          }
+        },
+        "description": "A physical postal address describes the physical location of an office, warehouse, gate, etc."
+      },
+      "PhysicalPostalAddressVerboseDto": {
+        "type": "object",
+        "properties": {
+          "geographicCoordinates": {
+            "$ref": "#/components/schemas/GeoCoordinateDto"
+          },
+          "country": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoCountryCode"
+          },
+          "administrativeAreaLevel1": {
+            "$ref": "#/components/schemas/RegionDto"
+          },
+          "administrativeAreaLevel2": {
+            "type": "string",
+            "description": "The name of the locally regulated secondary country subdivision of the physical postal address, such as county within a country."
+          },
+          "administrativeAreaLevel3": {
+            "type": "string",
+            "description": "The name of the locally regulated tertiary country subdivision of the physical address, such as townships within a country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code."
+          },
+          "city": {
+            "type": "string",
+            "description": "The name of the city of the physical postal address, synonyms: town, village, municipality."
+          },
+          "district": {
+            "type": "string",
+            "description": "The name of the district of the physical postal address which divides the city in several smaller areas."
+          },
+          "street": {
+            "$ref": "#/components/schemas/StreetDto"
+          },
+          "companyPostalCode": {
+            "type": "string",
+            "description": "The company postal code of the physical postal address, which is sometimes required for large companies."
+          },
+          "industrialZone": {
+            "type": "string",
+            "description": "The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area."
+          },
+          "building": {
+            "type": "string",
+            "description": "The alphanumeric identifier of the building addressed by the physical postal address."
+          },
+          "floor": {
+            "type": "string",
+            "description": "The number of a floor in the building addressed by the physical postal address, synonym: level."
+          },
+          "door": {
+            "type": "string",
+            "description": "The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite."
+          }
+        },
+        "description": "A physical postal address describes the physical location of an office, warehouse, gate, etc."
+      },
+      "PoolLegalEntityVerboseDto": {
+        "type": "object",
+        "properties": {
+          "legalName": {
+            "type": "string",
+            "description": "The name of the legal entity according to official registers."
+          },
+          "bpnl": {
+            "type": "string",
+            "description": "A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number."
+          },
+          "identifiers": {
+            "type": "array",
+            "description": "The list of identifiers of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityIdentifierVerboseDto"
+            }
+          },
+          "legalShortName": {
+            "type": "string",
+            "description": "The abbreviated name of the legal entity."
+          },
+          "legalForm": {
+            "$ref": "#/components/schemas/LegalFormDto"
+          },
+          "states": {
+            "type": "array",
+            "description": "The list of (temporary) states of the legal entity.",
+            "items": {
+              "$ref": "#/components/schemas/LegalEntityStateVerboseDto"
+            }
+          },
+          "classifications": {
+            "type": "array",
+            "description": "The list of classifications of the legal entity, such as a specific industry.",
+            "items": {
+              "$ref": "#/components/schemas/ClassificationVerboseDto"
+            }
+          },
+          "relations": {
+            "type": "array",
+            "description": "Relations to other business partners.",
+            "items": {
+              "$ref": "#/components/schemas/RelationVerboseDto"
+            }
+          },
+          "currentness": {
+            "type": "string",
+            "description": "The date the business partner data was last indicated to be still current.",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "legalAddress": {
+            "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+          }
+        },
+        "description": "In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL."
+      },
+      "RegionDto": {
+        "type": "object",
+        "properties": {
+          "countryCode": {
+            "type": "string",
+            "description": "Country code",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "regionCode": {
+            "type": "string",
+            "description": "Abbreviation or shorthand of the area"
+          },
+          "regionName": {
+            "type": "string",
+            "description": "Describes the full name of the region within a country according to ISO 3166-214"
+          }
+        },
+        "description": "Region within a country"
+      },
+      "RelationVerboseDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoRelationType"
+          },
+          "startBpnl": {
+            "type": "string",
+            "description": "BPN of partner which is the source of the relation"
+          },
+          "endBpnl": {
+            "type": "string",
+            "description": "BPN of partner which is the target of the relation"
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "Time when the relation started",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "Time when the relation ended",
+            "format": "date-time"
+          }
+        },
+        "description": "Directed relation between two business partners"
+      },
+      "SiteBpnSearchRequest": {
+        "type": "object",
+        "properties": {
+          "legalEntities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sites": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "SiteMatchVerboseDto": {
+        "type": "object",
+        "properties": {
+          "mainAddress": {
+            "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+          },
+          "site": {
+            "$ref": "#/components/schemas/SiteVerboseDto"
+          }
+        },
+        "description": "Match for a business partner record of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SitePartnerCreateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the site. This is not according to official registers but according to the name the owner chooses."
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateDto"
+            }
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/LogisticAddressDto"
+          },
+          "bpnlParent": {
+            "type": "string"
+          },
+          "index": {
+            "type": "string"
+          }
+        },
+        "description": "Request for creating new business partner record of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SitePartnerCreateResponseWrapper": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SitePartnerCreateVerboseDto"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorInfoSiteCreateError"
+            }
+          },
+          "errorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "entityCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "Holds information about successfully and failed entities after the creating/updating of several objects"
+      },
+      "SitePartnerCreateVerboseDto": {
+        "type": "object",
+        "properties": {
+          "bpns": {
+            "type": "string",
+            "description": "A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the site. This is not according to official registers but according to the name the owner chooses."
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateVerboseDto"
+            }
+          },
+          "bpnLegalEntity": {
+            "type": "string",
+            "description": "The BPNL of the legal entity owning the site."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+          },
+          "index": {
+            "type": "string",
+            "description": "User defined index to conveniently match this entry to the corresponding entry in the response."
+          }
+        },
+        "description": "Created/updated business partner of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SitePartnerUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "bpns": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the site. This is not according to official registers but according to the name the owner chooses."
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateDto"
+            }
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/LogisticAddressDto"
+          }
+        },
+        "description": "Request for updating a business partner record of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SitePartnerUpdateResponseWrapper": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SitePartnerCreateVerboseDto"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorInfoSiteUpdateError"
+            }
+          },
+          "errorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "entityCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "Holds information about successfully and failed entities after the creating/updating of several objects"
+      },
+      "SitePoolVerboseDto": {
+        "type": "object",
+        "properties": {
+          "bpns": {
+            "type": "string",
+            "description": "A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the site. This is not according to official registers but according to the name the owner chooses."
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateVerboseDto"
+            }
+          },
+          "bpnLegalEntity": {
+            "type": "string",
+            "description": "The BPNL of the legal entity owning the site."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          },
+          "mainAddress": {
+            "$ref": "#/components/schemas/LogisticAddressVerboseDto"
+          }
+        },
+        "description": "In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "SiteStateDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the site."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string",
+            "description": "One of the state types: active, inactive.",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
+        },
+        "description": "A site state indicates if the site is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the site is still operating."
+      },
+      "SiteStateVerboseDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description from the original source indicating the state of the site."
+          },
+          "validFrom": {
+            "type": "string",
+            "description": "The date from which the state is valid.",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "description": "The date until the state is valid.",
+            "format": "date-time"
+          },
+          "type": {
+            "$ref": "#/components/schemas/TypeKeyNameVerboseDtoBusinessStateType"
+          }
+        },
+        "description": "A site state indicates if the site is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the site is still operating."
+      },
+      "SiteVerboseDto": {
+        "type": "object",
+        "properties": {
+          "bpns": {
+            "type": "string",
+            "description": "A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the site. This is not according to official registers but according to the name the owner chooses."
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiteStateVerboseDto"
+            }
+          },
+          "bpnLegalEntity": {
+            "type": "string",
+            "description": "The BPNL of the legal entity owning the site."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date when the data record has been created.",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date when the data record has been last updated.",
+            "format": "date-time"
+          }
+        },
+        "description": "In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS."
+      },
+      "StreetDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the street."
+          },
+          "houseNumber": {
+            "type": "string",
+            "description": "The number representing the exact location of a building within the street."
+          },
+          "milestone": {
+            "type": "string",
+            "description": "The number representing the exact location of an addressed object within a street without house numbers, such as within long roads."
+          },
+          "direction": {
+            "type": "string",
+            "description": "The cardinal direction describing where the exit to the location of the addressed object on large highways / motorways is located, such as Highway 101 South."
+          }
+        },
+        "description": "The street of the physical postal address, synonyms: road, avenue, lane, boulevard, highway"
+      },
+      "SyncDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "OPENSEARCH",
+              "SAAS_IMPORT"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "NOT_SYNCED",
+              "RUNNING",
+              "SUCCESS",
+              "ERROR"
+            ]
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "progress": {
+            "type": "number",
+            "format": "float"
+          },
+          "errorDetails": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "finishedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TypeKeyNameVerboseDtoBusinessStateType": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string",
+            "description": "Unique key of this type for reference",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name or denotation of this type"
+          }
+        },
+        "description": "Named type uniquely identified by its technical key"
+      },
+      "TypeKeyNameVerboseDtoClassificationType": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string",
+            "description": "Unique key of this type for reference",
+            "enum": [
+              "NACE",
+              "NAF",
+              "NAICS",
+              "SIC"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name or denotation of this type"
+          }
+        },
+        "description": "Named type uniquely identified by its technical key"
+      },
+      "TypeKeyNameVerboseDtoCountryCode": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string",
+            "description": "Unique key of this type for reference",
+            "enum": [
+              "UNDEFINED",
+              "AC",
+              "AD",
+              "AE",
+              "AF",
+              "AG",
+              "AI",
+              "AL",
+              "AM",
+              "AN",
+              "AO",
+              "AQ",
+              "AR",
+              "AS",
+              "AT",
+              "AU",
+              "AW",
+              "AX",
+              "AZ",
+              "BA",
+              "BB",
+              "BD",
+              "BE",
+              "BF",
+              "BG",
+              "BH",
+              "BI",
+              "BJ",
+              "BL",
+              "BM",
+              "BN",
+              "BO",
+              "BQ",
+              "BR",
+              "BS",
+              "BT",
+              "BU",
+              "BV",
+              "BW",
+              "BY",
+              "BZ",
+              "CA",
+              "CC",
+              "CD",
+              "CF",
+              "CG",
+              "CH",
+              "CI",
+              "CK",
+              "CL",
+              "CM",
+              "CN",
+              "CO",
+              "CP",
+              "CR",
+              "CS",
+              "CU",
+              "CV",
+              "CW",
+              "CX",
+              "CY",
+              "CZ",
+              "DE",
+              "DG",
+              "DJ",
+              "DK",
+              "DM",
+              "DO",
+              "DZ",
+              "EA",
+              "EC",
+              "EE",
+              "EG",
+              "EH",
+              "ER",
+              "ES",
+              "ET",
+              "EU",
+              "EZ",
+              "FI",
+              "FJ",
+              "FK",
+              "FM",
+              "FO",
+              "FR",
+              "FX",
+              "GA",
+              "GB",
+              "GD",
+              "GE",
+              "GF",
+              "GG",
+              "GH",
+              "GI",
+              "GL",
+              "GM",
+              "GN",
+              "GP",
+              "GQ",
+              "GR",
+              "GS",
+              "GT",
+              "GU",
+              "GW",
+              "GY",
+              "HK",
+              "HM",
+              "HN",
+              "HR",
+              "HT",
+              "HU",
+              "IC",
+              "ID",
+              "IE",
+              "IL",
+              "IM",
+              "IN",
+              "IO",
+              "IQ",
+              "IR",
+              "IS",
+              "IT",
+              "JE",
+              "JM",
+              "JO",
+              "JP",
+              "KE",
+              "KG",
+              "KH",
+              "KI",
+              "KM",
+              "KN",
+              "KP",
+              "KR",
+              "KW",
+              "KY",
+              "KZ",
+              "LA",
+              "LB",
+              "LC",
+              "LI",
+              "LK",
+              "LR",
+              "LS",
+              "LT",
+              "LU",
+              "LV",
+              "LY",
+              "MA",
+              "MC",
+              "MD",
+              "ME",
+              "MF",
+              "MG",
+              "MH",
+              "MK",
+              "ML",
+              "MM",
+              "MN",
+              "MO",
+              "MP",
+              "MQ",
+              "MR",
+              "MS",
+              "MT",
+              "MU",
+              "MV",
+              "MW",
+              "MX",
+              "MY",
+              "MZ",
+              "NA",
+              "NC",
+              "NE",
+              "NF",
+              "NG",
+              "NI",
+              "NL",
+              "NO",
+              "NP",
+              "NR",
+              "NT",
+              "NU",
+              "NZ",
+              "OM",
+              "PA",
+              "PE",
+              "PF",
+              "PG",
+              "PH",
+              "PK",
+              "PL",
+              "PM",
+              "PN",
+              "PR",
+              "PS",
+              "PT",
+              "PW",
+              "PY",
+              "QA",
+              "RE",
+              "RO",
+              "RS",
+              "RU",
+              "RW",
+              "SA",
+              "SB",
+              "SC",
+              "SD",
+              "SE",
+              "SF",
+              "SG",
+              "SH",
+              "SI",
+              "SJ",
+              "SK",
+              "SL",
+              "SM",
+              "SN",
+              "SO",
+              "SR",
+              "SS",
+              "ST",
+              "SU",
+              "SV",
+              "SX",
+              "SY",
+              "SZ",
+              "TA",
+              "TC",
+              "TD",
+              "TF",
+              "TG",
+              "TH",
+              "TJ",
+              "TK",
+              "TL",
+              "TM",
+              "TN",
+              "TO",
+              "TP",
+              "TR",
+              "TT",
+              "TV",
+              "TW",
+              "TZ",
+              "UA",
+              "UG",
+              "UK",
+              "UM",
+              "US",
+              "UY",
+              "UZ",
+              "VA",
+              "VC",
+              "VE",
+              "VG",
+              "VI",
+              "VN",
+              "VU",
+              "WF",
+              "WS",
+              "XI",
+              "XU",
+              "XK",
+              "YE",
+              "YT",
+              "YU",
+              "ZA",
+              "ZM",
+              "ZR",
+              "ZW"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name or denotation of this type"
+          }
+        },
+        "description": "Named type uniquely identified by its technical key"
+      },
+      "TypeKeyNameVerboseDtoRelationType": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string",
+            "description": "Unique key of this type for reference",
+            "enum": [
+              "CX_LEGAL_SUCCESSOR_OF",
+              "CX_LEGAL_PREDECESSOR_OF"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name or denotation of this type"
+          }
+        },
+        "description": "Named type uniquely identified by its technical key"
+      },
+      "TypeKeyNameVerboseDtoString": {
+        "type": "object",
+        "properties": {
+          "technicalKey": {
+            "type": "string",
+            "description": "Unique key of this type for reference"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name or denotation of this type"
+          }
+        },
+        "description": "Named type uniquely identified by its technical key"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Reintroduce OpenApi descriptions for the BPDM applications in JSON format as they are being referenced by the BPDM standard documents.

Just automatically converted the Yaml documents to Json, no new content.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
