### PR TITLE
Docs (Gate-API): Deprecate Endpoints

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateAddressApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateAddressApi.kt
@@ -49,7 +49,8 @@ interface GateAddressApi {
         description = "Create or update addresses. " +
                 "Updates instead of creating a new address if an already existing external ID is used. " +
                 "The same external ID may not occur more than once in a single request. " +
-                "For a single request, the maximum number of addresses in the request is limited to \${bpdm.api.upsert-limit} entries."
+                "For a single request, the maximum number of addresses in the request is limited to \${bpdm.api.upsert-limit} entries.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -63,7 +64,8 @@ interface GateAddressApi {
 
     @Operation(
         summary = "Returns address by external ID from the input stage",
-        description = "Returns address by external ID from the input stage."
+        description = "Returns address by external ID from the input stage.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -77,7 +79,8 @@ interface GateAddressApi {
 
     @Operation(
         summary = "Returns addresses by an array of external IDs from the input stage",
-        description = "Returns page of addresses from the input stage. Can optionally be filtered by external IDs."
+        description = "Returns page of addresses from the input stage. Can optionally be filtered by external IDs.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -94,7 +97,8 @@ interface GateAddressApi {
 
     @Operation(
         summary = "Returns addresses from the input stage",
-        description = "Returns page of addresses from the input stage."
+        description = "Returns page of addresses from the input stage.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -108,7 +112,8 @@ interface GateAddressApi {
 
     @Operation(
         summary = "Returns addresses by an array of external IDs from the output stage",
-        description = "Get page of addresses from the output stage. Can optionally be filtered by external IDs."
+        description = "Get page of addresses from the output stage. Can optionally be filtered by external IDs.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -128,7 +133,8 @@ interface GateAddressApi {
         description = "Create or update addresses (Output). " +
                 "Updates instead of creating a new address if an already existing external ID is used. " +
                 "The same external ID may not occur more than once in a single request. " +
-                "For a single request, the maximum number of addresses in the request is limited to \${bpdm.api.upsert-limit} entries."
+                "For a single request, the maximum number of addresses in the request is limited to \${bpdm.api.upsert-limit} entries.",
+        deprecated = true
 
     )
     @ApiResponses(

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateLegalEntityApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateLegalEntityApi.kt
@@ -49,7 +49,8 @@ interface GateLegalEntityApi {
         description = "Create or update legal entities. " +
                 "Updates instead of creating a new legal entity if an already existing external ID is used. " +
                 "The same external ID may not occur more than once in a single request. " +
-                "For a single request, the maximum number of legal entities in the request is limited to \${bpdm.api.upsert-limit} entries."
+                "For a single request, the maximum number of legal entities in the request is limited to \${bpdm.api.upsert-limit} entries.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -63,7 +64,8 @@ interface GateLegalEntityApi {
 
     @Operation(
         summary = "Returns legal entity by external ID from the input stage",
-        description = "Returns legal entity by external ID from the input stage."
+        description = "Returns legal entity by external ID from the input stage.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -77,7 +79,8 @@ interface GateLegalEntityApi {
 
     @Operation(
         summary = "Returns legal entities by an array of external IDs from the input stage",
-        description = "Returns page of legal entities from the input stage. Can optionally be filtered by external IDs."
+        description = "Returns page of legal entities from the input stage. Can optionally be filtered by external IDs.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -94,7 +97,8 @@ interface GateLegalEntityApi {
 
     @Operation(
         summary = "Returns legal entities from the input stage",
-        description = "Returns page of legal entities from the input stage."
+        description = "Returns page of legal entities from the input stage.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -108,7 +112,8 @@ interface GateLegalEntityApi {
 
     @Operation(
         summary = "Returns legal entities by an array of external IDs from the output stage",
-        description = "Get page of legal entities from the output stage. Can optionally be filtered by external IDs."
+        description = "Get page of legal entities from the output stage. Can optionally be filtered by external IDs.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -128,7 +133,8 @@ interface GateLegalEntityApi {
         description = "Create or update legal entities (Output). " +
                 "Updates instead of creating a new legal entity if an already existing external ID is used. " +
                 "The same external ID may not occur more than once in a single request. " +
-                "For a single request, the maximum number of legal entities in the request is limited to \${bpdm.api.upsert-limit} entries."
+                "For a single request, the maximum number of legal entities in the request is limited to \${bpdm.api.upsert-limit} entries.",
+        deprecated = true
     )
     @ApiResponses(
         value = [

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
@@ -57,7 +57,8 @@ interface GateSharingStateApi {
     ): PageDto<SharingStateDto>
 
     @Operation(
-        summary = "Creates or updates a sharing state of a business partner"
+        summary = "Creates or updates a sharing state of a business partner",
+        deprecated = true
     )
     @ApiResponses(
         value = [

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSiteApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSiteApi.kt
@@ -49,7 +49,8 @@ interface GateSiteApi {
         description = "Create or update sites. " +
                 "Updates instead of creating a new site if an already existing external ID is used. " +
                 "The same external ID may not occur more than once in a single request. " +
-                "For a single request, the maximum number of sites in the request is limited to \${bpdm.api.upsert-limit} entries."
+                "For a single request, the maximum number of sites in the request is limited to \${bpdm.api.upsert-limit} entries.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -63,7 +64,8 @@ interface GateSiteApi {
 
     @Operation(
         summary = "Returns site by external ID from the input stage",
-        description = "Returns site by external ID from the input stage."
+        description = "Returns site by external ID from the input stage.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -77,7 +79,8 @@ interface GateSiteApi {
 
     @Operation(
         summary = "Returns sites by an array of external IDs from the input stage",
-        description = "Returns page of sites from the input stage. Can optionally be filtered by external IDs."
+        description = "Returns page of sites from the input stage. Can optionally be filtered by external IDs.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -94,7 +97,8 @@ interface GateSiteApi {
 
     @Operation(
         summary = "Returns sites from the input stage",
-        description = "Returns page of sites from the input stage."
+        description = "Returns page of sites from the input stage.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -108,7 +112,8 @@ interface GateSiteApi {
 
     @Operation(
         summary = "Returns sites by an array of external IDs from the output stage",
-        description = "Get page of sites from the output stage. Can optionally be filtered by external IDs."
+        description = "Get page of sites from the output stage. Can optionally be filtered by external IDs.",
+        deprecated = true
     )
     @ApiResponses(
         value = [
@@ -128,7 +133,8 @@ interface GateSiteApi {
         description = "Create or update sites (Output). " +
                 "Updates instead of creating a new site if an already existing external ID is used. " +
                 "The same external ID may not occur more than once in a single request. " +
-                "For a single request, the maximum number of sites in the request is limited to \${bpdm.api.upsert-limit} entries."
+                "For a single request, the maximum number of sites in the request is limited to \${bpdm.api.upsert-limit} entries.",
+        deprecated = true
     )
     @ApiResponses(
         value = [


### PR DESCRIPTION
This pull requests deprecates the Gate's L/S/A endpoints as well as the PUT sharing states endpoint. This is the first step towards building back the Bridge Dummy sharing process.

I have not deprecated the business partner filter properties in the changelog and sharing state endpoints as they could still be relevant later. A generic business partner can count as of type L/S/A if you so will and could be filterable like that.

Solves #548

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
