### PR TITLE
Refactoring: Generic Business Partner DTO Locations

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -20,8 +20,6 @@
 package org.eclipse.tractusx.bpdm.cleaning.service
 
 
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
 import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.orchestrator.api.model.*
 
@@ -36,13 +34,13 @@ fun BusinessPartnerGenericDto.toLegalEntityDto(bpnReferenceDto: BpnReferenceDto,
         identifiers = identifiers.mapNotNull { it.toLegalEntityIdentifierDto() },
         legalForm = legalForm,
         states = states.mapNotNull { it.toLegalEntityState() },
-        classifications = classifications.map { it.toBusinessPartnerClassificationDto() },
+        classifications = classifications.map { it.toLegalEntityClassificationDto() },
         legalAddress = legalAddress
 
     )
 }
 
-fun ClassificationDto.toBusinessPartnerClassificationDto(): ClassificationDto {
+fun BusinessPartnerClassificationDto.toLegalEntityClassificationDto(): ClassificationDto {
 
     return ClassificationDto(code = code, type = type, value = value)
 }

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -20,19 +20,16 @@
 package org.eclipse.tractusx.bpdm.cleaning.testdata
 
 import com.neovisionaries.i18n.CountryCode
-import org.eclipse.tractusx.bpdm.cleaning.service.toBusinessPartnerClassificationDto
+import org.eclipse.tractusx.bpdm.cleaning.service.toLegalEntityClassificationDto
 import org.eclipse.tractusx.bpdm.cleaning.service.toLegalEntityIdentifierDto
 import org.eclipse.tractusx.bpdm.cleaning.service.toLegalEntityState
 import org.eclipse.tractusx.bpdm.cleaning.service.toSiteState
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.orchestrator.api.model.*
-import org.eclipse.tractusx.orchestrator.api.model.LegalEntityDto
-import org.eclipse.tractusx.orchestrator.api.model.LogisticAddressDto
-import org.eclipse.tractusx.orchestrator.api.model.PhysicalPostalAddressDto
-import org.eclipse.tractusx.orchestrator.api.model.SiteDto
-import org.eclipse.tractusx.orchestrator.api.model.StreetDto
 import java.time.LocalDateTime
 
 /**
@@ -61,7 +58,7 @@ object CommonValues {
         )
     )
     private val classifications = listOf(
-        ClassificationDto(
+        BusinessPartnerClassificationDto(
             type = ClassificationType.NACE,
             code = "Code1",
             value = "Value1"
@@ -147,7 +144,7 @@ object CommonValues {
         identifiers = identifiers.mapNotNull { it.toLegalEntityIdentifierDto() },
         legalForm = legalForm,
         states = states.mapNotNull { it.toLegalEntityState() },
-        classifications = classifications.map { it.toBusinessPartnerClassificationDto() }
+        classifications = classifications.map { it.toLegalEntityClassificationDto() }
     )
 
     val expectedSiteDto = SiteDto(

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAddressStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAddressStateDto.kt
@@ -25,7 +25,8 @@ import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
 @Schema(description = AddressStateDescription.header)
-interface IBaseAddressStateDto : IBusinessPartnerStateDto {
+interface IBaseAddressStateDto : IBaseStateDto {
+
     @get:Schema(description = AddressStateDescription.description)
     override val description: String?
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -31,16 +31,16 @@ interface IBaseBusinessPartnerDto {
     val shortName: String?
 
     @get:ArraySchema(arraySchema = Schema(description = "The list of identifiers of the business partner. Sorted and duplicates removed by the service."))
-    val identifiers: Collection<BusinessPartnerIdentifierDto>
+    val identifiers: Collection<IBusinessPartnerIdentifierDto>
 
-    @get:Schema(description = "") //TODO Add Description
+    @get:Schema(description = "The name according to official registers.")
     val legalName: String?
 
     @get:Schema(description = "Technical key of the legal form.")
     val legalForm: String?
 
     @get:ArraySchema(arraySchema = Schema(description = "The list of (temporary) states of the business partner. Sorted and duplicates removed by the service."))
-    val states: Collection<BusinessPartnerStateDto>
+    val states: Collection<IBaseStateDto>
 
     @get:ArraySchema(arraySchema = Schema(description = "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service."))
     val classifications: Collection<IBaseClassificationDto>
@@ -51,6 +51,7 @@ interface IBaseBusinessPartnerDto {
     @get:Schema(description = "Address of the official seat of this business partner.")
     val postalAddress: IBaseBusinessPartnerPostalAddressDto
 
+    // TODO: rename to bpnL, bpnS, bpnA (breaking change!)
     @get:Schema(description = "BPNL of the golden record legal entity this business partner refers to")
     val legalEntityBpn: String?
 
@@ -59,5 +60,4 @@ interface IBaseBusinessPartnerDto {
 
     @get:Schema(description = "BPNA of the golden record address this business partner refers to")
     val addressBpn: String?
-
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseClassificationDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseClassificationDto.kt
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = ClassificationDescription.header)
 interface IBaseClassificationDto {
+
     @get:Schema(description = ClassificationDescription.type)
     val type: ClassificationType?
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseIdentifierDto.kt
@@ -19,8 +19,13 @@
 
 package org.eclipse.tractusx.bpdm.common.dto
 
-interface IBaseIdentifierDto {
-    val value: String
+import io.swagger.v3.oas.annotations.media.Schema
 
-    val type: String
+interface IBaseIdentifierDto {
+
+    @get:Schema(description = "Technical key of the type to which this identifier belongs to")
+    val type: String?
+
+    @get:Schema(description = "Value of the identifier")
+    val value: String?
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityStateDto.kt
@@ -25,7 +25,8 @@ import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
 @Schema(description = LegalEntityStateDescription.header)
-interface IBaseLegalEntityStateDto : IBusinessPartnerStateDto {
+interface IBaseLegalEntityStateDto : IBaseStateDto {
+
     @get:Schema(description = LegalEntityStateDescription.description)
     override val description: String?
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseStateDto.kt
@@ -20,19 +20,20 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@Schema(
-    description = "Identifier record for a business partner",
-    requiredProperties = ["type", "value"]
-)
-data class BusinessPartnerIdentifierDto(
+interface IBaseStateDto {
 
-    @get:Schema(description = "Technical key of the type to which this identifier belongs to")
-    val type: String? = null,
+    @get:Schema(description = "Date since when the status is/was valid.")
+    val validFrom: LocalDateTime?
 
-    @get:Schema(description = "Value of the identifier")
-    val value: String? = null,
+    @get:Schema(description = "Date until the status was valid, if applicable.")
+    val validTo: LocalDateTime?
 
-    @get:Schema(description = "Body which issued the identifier")
-    val issuingBody: String?
-)
+    @get:Schema(description = "The type of this specified status.")
+    val type: BusinessStateType?
+
+    @get:Schema(description = "Denotation of the status.")
+    val description: String?
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerIdentifierDto.kt
@@ -20,22 +20,9 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
-import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
-import java.time.LocalDateTime
 
-@Schema(description = LegalEntityStateDescription.header, requiredProperties = ["type"])
-data class BusinessPartnerStateDto(
+interface IBusinessPartnerIdentifierDto : IBaseIdentifierDto {
 
-    @get:Schema(description = "Date since when the status is/was valid.")
-    val validFrom: LocalDateTime?,
-
-    @get:Schema(description = "Date until the status was valid, if applicable.")
-    val validTo: LocalDateTime?,
-
-    @get:Schema(description = "The type of this specified status.")
-    val type: BusinessStateType?,
-
-    @get:Schema(description = "Denotation of the status.")
-    val description: String?
-)
+    @get:Schema(description = "Body which issued the identifier")
+    val issuingBody: String?
+}

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerClassificationDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerClassificationDto.kt
@@ -17,21 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.bpdm.gate.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.dto.IBaseClassificationDto
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = ClassificationDescription.header)
-data class ClassificationBusinessPartnerDto(
+data class BusinessPartnerClassificationDto(
 
-    @get:Schema(description = ClassificationDescription.type)
     override val type: ClassificationType?,
-
-    @get:Schema(description = ClassificationDescription.code)
     override val code: String?,
-
-    @get:Schema(description = ClassificationDescription.value)
     override val value: String?
+
 ) : IBaseClassificationDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerIdentifierDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerIdentifierDto.kt
@@ -19,16 +19,12 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.AddressType
-import org.eclipse.tractusx.bpdm.common.dto.AlternativePostalAddressDto
-import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerPostalAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.IBusinessPartnerIdentifierDto
 
-@Schema(description = "Postal address of a input business partner", requiredProperties = ["physicalPostalAddress"])
-data class BusinessPartnerPostalAddressInputDto(
+data class BusinessPartnerIdentifierDto(
 
-    override val addressType: AddressType?,
-    override val physicalPostalAddress: PhysicalPostalAddressGateDto,
-    override val alternativePostalAddress: AlternativePostalAddressDto? = null
+    override val type: String?,
+    override val value: String?,
+    override val issuingBody: String?
 
-) : IBaseBusinessPartnerPostalAddressDto
+) : IBusinessPartnerIdentifierDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerPostalAddressDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerPostalAddressDto.kt
@@ -19,11 +19,9 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerPostalAddressDto
 
-@Schema(description = "Postal address of a business partner")
 data class BusinessPartnerPostalAddressDto(
 
     override val addressType: AddressType? = null,

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerStateDto.kt
@@ -17,26 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.bpdm.gate.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteStateDescription
+import org.eclipse.tractusx.bpdm.common.dto.IBaseStateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(description = SiteDescription.header)
-interface IBaseSiteStateDto : IBaseStateDto {
+data class BusinessPartnerStateDto(
 
-    @get:Schema(description = SiteStateDescription.description)
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
+    override val type: BusinessStateType?,
     override val description: String?
 
-    @get:Schema(description = SiteStateDescription.validFrom)
-    override val validFrom: LocalDateTime?
-
-    @get:Schema(description = SiteStateDescription.validTo)
-    override val validTo: LocalDateTime?
-
-    @get:Schema(description = SiteStateDescription.type)
-    override val type: BusinessStateType
-}
+) : IBaseStateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerInputRequest.kt
@@ -20,18 +20,15 @@
 package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationBusinessPartnerDto
-import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
-import org.eclipse.tractusx.bpdm.gate.api.model.IBaseBusinessPartnerGateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 
 @Schema(
     description = "Generic business partner with external id",
     requiredProperties = ["externalId"]
 )
 data class BusinessPartnerInputRequest(
+
     override val externalId: String,
     override val nameParts: List<String> = emptyList(),
     override val shortName: String? = null,
@@ -39,12 +36,12 @@ data class BusinessPartnerInputRequest(
     override val legalName: String? = null,
     override val legalForm: String? = null,
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<ClassificationBusinessPartnerDto> = emptyList(),
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto = BusinessPartnerPostalAddressDto(),
     override val isOwnCompanyData: Boolean = false,
     override val legalEntityBpn: String? = null,
     override val siteBpn: String? = null,
-    override val addressBpn: String? = null,
+    override val addressBpn: String? = null
 
-    ) : IBaseBusinessPartnerGateDto
+) : IBaseBusinessPartnerGateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/BusinessPartnerOutputRequest.kt
@@ -20,17 +20,13 @@
 package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
-import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
-import org.eclipse.tractusx.bpdm.gate.api.model.IBaseBusinessPartnerGateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 
 
 @Schema(
     description = "Generic business partner with external id",
-    requiredProperties = ["externalId", "postalAddress"]
+    requiredProperties = ["externalId"]
 )
 data class BusinessPartnerOutputRequest(
 
@@ -41,12 +37,12 @@ data class BusinessPartnerOutputRequest(
     override val legalName: String? = null,
     override val legalForm: String? = null,
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<ClassificationDto> = emptyList(),
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto = BusinessPartnerPostalAddressDto(),
     override val isOwnCompanyData: Boolean = false,
     override val legalEntityBpn: String? = null,
     override val siteBpn: String? = null,
-    override val addressBpn: String? = null,
+    override val addressBpn: String? = null
 
-    ) : IBaseBusinessPartnerGateDto
+) : IBaseBusinessPartnerGateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerInputDto.kt
@@ -20,13 +20,9 @@
 package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationBusinessPartnerDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
-import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
-import org.eclipse.tractusx.bpdm.gate.api.model.IBaseBusinessPartnerGateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 import java.time.Instant
 
 
@@ -35,6 +31,7 @@ import java.time.Instant
     requiredProperties = ["externalId", "postalAddress"]
 )
 data class BusinessPartnerInputDto(
+
     override val externalId: String,
     override val nameParts: List<String> = emptyList(),
     override val shortName: String?,
@@ -42,7 +39,7 @@ data class BusinessPartnerInputDto(
     override val legalName: String? = null,
     override val legalForm: String? = null,
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<ClassificationBusinessPartnerDto> = emptyList(),
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto,
     override val isOwnCompanyData: Boolean,

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
@@ -20,13 +20,9 @@
 package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
-import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
-import org.eclipse.tractusx.bpdm.gate.api.model.IBaseBusinessPartnerGateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 import java.time.Instant
 
 @Schema(
@@ -34,6 +30,7 @@ import java.time.Instant
     requiredProperties = ["externalId", "postalAddress", "bpnL", "bpnA"]
 )
 data class BusinessPartnerOutputDto(
+
     override val externalId: String,
     override val nameParts: List<String> = emptyList(),
     override val shortName: String?,
@@ -41,7 +38,7 @@ data class BusinessPartnerOutputDto(
     override val legalName: String? = null,
     override val legalForm: String? = null,
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<ClassificationDto> = emptyList(),
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: BusinessPartnerPostalAddressDto,
     override val isOwnCompanyData: Boolean,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -19,13 +19,10 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNullMappingException
 import org.eclipse.tractusx.bpdm.common.model.StageType
-import org.eclipse.tractusx.bpdm.gate.api.model.AlternativePostalAddressGateDto
-import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerPostalAddressDto
-import org.eclipse.tractusx.bpdm.gate.api.model.PhysicalPostalAddressGateDto
-import org.eclipse.tractusx.bpdm.gate.api.model.StreetGateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
@@ -49,7 +46,7 @@ class BusinessPartnerMappings {
             legalName = entity.legalName,
             legalForm = entity.legalForm,
             states = entity.states.map(::toStateDto),
-            classifications = entity.classifications.map(::toClassificationNullableDto),
+            classifications = entity.classifications.map(::toClassificationDto),
             roles = entity.roles,
             postalAddress = toPostalAddressDto(entity.postalAddress),
             isOwnCompanyData = entity.isOwnCompanyData,
@@ -115,7 +112,7 @@ class BusinessPartnerMappings {
             roles = dto.roles.toSortedSet(),
             identifiers = dto.identifiers.mapNotNull(::toIdentifier).toSortedSet(),
             states = dto.states.mapNotNull(::toState).toSortedSet(),
-            classifications = dto.classifications.map(::toClassificationOutput).toSortedSet(),
+            classifications = dto.classifications.mapNotNull(::toClassification).toSortedSet(),
             shortName = dto.shortName,
             legalName = dto.legalName,
             legalForm = dto.legalForm,
@@ -255,25 +252,15 @@ class BusinessPartnerMappings {
     private fun toState(dto: BusinessPartnerStateDto) =
         dto.type?.let { State(type = it, validFrom = dto.validFrom, validTo = dto.validTo, description = dto.description) }
 
-    private fun toClassificationNullableDto(entity: Classification) =
-        ClassificationBusinessPartnerDto(type = entity.type, code = entity.code, value = entity.value)
-
     private fun toClassificationDto(entity: Classification) =
-        ClassificationDto(type = entity.type, code = entity.code, value = entity.value)
+        BusinessPartnerClassificationDto(type = entity.type, code = entity.code, value = entity.value)
 
-
-    private fun toClassification(dto: ClassificationBusinessPartnerDto) =
+    private fun toClassification(dto: BusinessPartnerClassificationDto) =
         dto.type?.let { Classification(type = it, code = dto.code, value = dto.value) }
-
-    private fun toClassificationOutput(dto: ClassificationDto) =
-        Classification(type = dto.type, code = dto.code, value = dto.value)
 
     private fun toGeoCoordinateDto(entity: GeographicCoordinate) =
         GeoCoordinateDto(latitude = entity.latitude, longitude = entity.longitude, altitude = entity.altitude)
 
-
     private fun toGeographicCoordinate(dto: GeoCoordinateDto) =
         GeographicCoordinate(latitude = dto.latitude, longitude = dto.longitude, altitude = dto.altitude)
-
-
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -20,9 +20,6 @@
 package org.eclipse.tractusx.bpdm.gate.service
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerIdentifierDto
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerStateDto
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
@@ -40,6 +37,7 @@ class OrchestratorMappings(
     private val bpnConfigProperties: BpnConfigProperties
 ) {
     private val logger = KotlinLogging.logger { }
+
     fun toBusinessPartnerGenericDto(entity: BusinessPartner) = BusinessPartnerGenericDto(
         nameParts = entity.nameParts,
         shortName = entity.shortName,
@@ -57,7 +55,7 @@ class OrchestratorMappings(
     )
 
     private fun toClassificationDto(entity: Classification) =
-        ClassificationDto(type = entity.type, code = entity.code, value = entity.value)
+        BusinessPartnerClassificationDto(type = entity.type, code = entity.code, value = entity.value)
 
     private fun toPostalAddressDto(entity: PostalAddress) =
         PostalAddressDto(
@@ -131,20 +129,20 @@ class OrchestratorMappings(
     }
 
     //Mapping BusinessPartnerGenericDto from to BusinessPartner
-    fun toBusinessPartner(entity: BusinessPartnerGenericDto, externalId: String) = BusinessPartner(
+    fun toBusinessPartner(dto: BusinessPartnerGenericDto, externalId: String) = BusinessPartner(
         externalId = externalId,
-        nameParts = entity.nameParts.toMutableList(),
-        shortName = entity.shortName,
-        identifiers = entity.identifiers.mapNotNull { toIdentifier(it) }.toSortedSet(),
-        legalName = entity.legalName,
-        legalForm = entity.legalForm,
-        states = entity.states.mapNotNull { toState(it) }.toSortedSet(),
-        classifications = entity.classifications.map { toClassification(it) }.toSortedSet(),
-        roles = entity.roles.toSortedSet(),
-        postalAddress = toPostalAddress(entity.postalAddress),
-        bpnL = entity.legalEntityBpn,
-        bpnS = entity.siteBpn,
-        bpnA = entity.addressBpn,
+        nameParts = dto.nameParts.toMutableList(),
+        shortName = dto.shortName,
+        identifiers = dto.identifiers.mapNotNull { toIdentifier(it) }.toSortedSet(),
+        legalName = dto.legalName,
+        legalForm = dto.legalForm,
+        states = dto.states.mapNotNull { toState(it) }.toSortedSet(),
+        classifications = dto.classifications.map { toClassification(it) }.toSortedSet(),
+        roles = dto.roles.toSortedSet(),
+        postalAddress = toPostalAddress(dto.postalAddress),
+        bpnL = dto.legalEntityBpn,
+        bpnS = dto.siteBpn,
+        bpnA = dto.addressBpn,
         stage = StageType.Output
     )
 
@@ -158,14 +156,14 @@ class OrchestratorMappings(
     private fun toState(dto: BusinessPartnerStateDto) =
         dto.type?.let { State(type = it, validFrom = dto.validFrom, validTo = dto.validTo, description = dto.description) }
 
-    private fun toClassification(dto: ClassificationDto) =
+    private fun toClassification(dto: BusinessPartnerClassificationDto) =
         Classification(type = dto.type, code = dto.code, value = dto.value)
 
-    private fun toPostalAddress(entity: PostalAddressDto) =
+    private fun toPostalAddress(dto: PostalAddressDto) =
         PostalAddress(
-            addressType = entity.addressType,
-            physicalPostalAddress = entity.physicalPostalAddress?.let(::toPhysicalPostalAddress),
-            alternativePostalAddress = entity.alternativePostalAddress?.let(this::toAlternativePostalAddress)
+            addressType = dto.addressType,
+            physicalPostalAddress = dto.physicalPostalAddress?.let(::toPhysicalPostalAddress),
+            alternativePostalAddress = dto.alternativePostalAddress?.let(this::toAlternativePostalAddress)
         )
 
     private fun toPhysicalPostalAddress(dto: PhysicalPostalAddressDto) =

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -29,6 +29,9 @@ import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNullMappingException
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.api.exception.BusinessPartnerSharingError
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerClassificationDto
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerIdentifierDto
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerStateDto
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerOutputRequest
@@ -328,7 +331,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
             legalName = request.legalName,
             legalForm = request.legalForm,
             states = request.states.toSortedSet(stateDtoComparator),
-            classifications = request.classifications.toSortedSet(classificationDtoOutputComparator),
+            classifications = request.classifications.toSortedSet(classificationDtoComparator),
             roles = request.roles.toSortedSet(),
             postalAddress = request.postalAddress,
             isOwnCompanyData = request.isOwnCompanyData,
@@ -355,21 +358,16 @@ class BusinessPartnerControllerIT @Autowired constructor(
         BusinessPartnerIdentifierDto::value,
         BusinessPartnerIdentifierDto::issuingBody
     )
+
     val stateDtoComparator = compareBy(nullsFirst(), BusinessPartnerStateDto::validFrom)       // here null means MIN
         .thenBy(nullsLast(), BusinessPartnerStateDto::validTo)        // here null means MAX
         .thenBy(BusinessPartnerStateDto::type)
         .thenBy(BusinessPartnerStateDto::description)
 
     val classificationDtoComparator = compareBy(
-        ClassificationBusinessPartnerDto::type,
-        ClassificationBusinessPartnerDto::code,
-        ClassificationBusinessPartnerDto::value
-    )
-
-    val classificationDtoOutputComparator = compareBy(
-        ClassificationDto::type,
-        ClassificationDto::code,
-        ClassificationDto::value
+        BusinessPartnerClassificationDto::type,
+        BusinessPartnerClassificationDto::code,
+        BusinessPartnerClassificationDto::value
     )
 
     private fun mockOrchestratorApi() {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -20,14 +20,13 @@
 package org.eclipse.tractusx.bpdm.gate.util
 
 import com.neovisionaries.i18n.CountryCode
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.orchestrator.api.model.*
-import org.eclipse.tractusx.orchestrator.api.model.AlternativePostalAddressDto
-import org.eclipse.tractusx.orchestrator.api.model.PhysicalPostalAddressDto
-import org.eclipse.tractusx.orchestrator.api.model.StreetDto
 import java.time.LocalDateTime
 
 object BusinessPartnerGenericMockValues {
@@ -65,12 +64,12 @@ object BusinessPartnerGenericMockValues {
             )
         ),
         classifications = listOf(
-            ClassificationDto(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.NACE,
                 code = "code-1-cleaned",
                 value = "value-1-cleaned"
             ),
-            ClassificationDto(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.NAF,
                 code = "code-2-cleaned",
                 value = "value-2-cleaned"

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -156,31 +156,31 @@ object BusinessPartnerVerboseValues {
         name = CountryCode.US.getName()
     )
 
-    val bpClassification1 = ClassificationBusinessPartnerDto(
+    val bpClassification1 = BusinessPartnerClassificationDto(
         type = ClassificationType.NACE,
         code = "code1",
         value = "Sale of motor vehicles"
     )
 
-    val bpClassification2 = ClassificationBusinessPartnerDto(
+    val bpClassification2 = BusinessPartnerClassificationDto(
         type = ClassificationType.NACE,
         code = "code2",
         value = "Data processing, hosting and related activities"
     )
 
-    val bpClassification3 = ClassificationBusinessPartnerDto(
+    val bpClassification3 = BusinessPartnerClassificationDto(
         type = ClassificationType.NACE,
         code = "code3",
         value = "Other information service activities"
     )
 
-    val bpClassification4 = ClassificationBusinessPartnerDto(
+    val bpClassification4 = BusinessPartnerClassificationDto(
         type = ClassificationType.NACE,
         code = "code4",
         value = "Financial and insurance activities"
     )
 
-    val bpClassificationChina = ClassificationBusinessPartnerDto(
+    val bpClassificationChina = BusinessPartnerClassificationDto(
         type = ClassificationType.NACE,
         code = "code3",
         value = "北京市"
@@ -835,12 +835,12 @@ object BusinessPartnerVerboseValues {
             ),
         ),
         classifications = listOf(
-            ClassificationDto(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.NACE,
                 code = "code-1-cleaned",
                 value = "value-1-cleaned"
             ),
-            ClassificationDto(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.NAF,
                 code = "code-2-cleaned",
                 value = "value-2-cleaned"

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassificationDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassificationDto.kt
@@ -19,10 +19,13 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.IBaseClassificationDto
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
+@Schema(requiredProperties = ["type"])
 data class BusinessPartnerClassificationDto(
+
     override val type: ClassificationType,
     override val code: String?,
     override val value: String?

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
@@ -20,17 +20,22 @@
 package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerDto
 
 
+@Schema(
+    description = "Generic business partner with external id"
+)
 data class BusinessPartnerGenericDto(
+
     override val nameParts: List<String> = emptyList(),
     override val shortName: String? = null,
     override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
     override val legalName: String? = null,
     override val legalForm: String? = null,
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<ClassificationDto> = emptyList(),
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val postalAddress: PostalAddressDto = PostalAddressDto(),
     override val legalEntityBpn: String? = null,
@@ -38,6 +43,6 @@ data class BusinessPartnerGenericDto(
     override val addressBpn: String? = null,
 
     @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
-    val ownerBpnL: String? = null,
+    val ownerBpnL: String? = null
 
-    ) : IBaseBusinessPartnerDto
+) : IBaseBusinessPartnerDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerIdentifierDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerIdentifierDto.kt
@@ -17,14 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
-import java.time.LocalDateTime
+import org.eclipse.tractusx.bpdm.common.dto.IBusinessPartnerIdentifierDto
 
-interface IBusinessPartnerStateDto {
-    val description: String?
-    val validFrom: LocalDateTime?
-    val validTo: LocalDateTime?
-    val type: BusinessStateType
-}
+data class BusinessPartnerIdentifierDto(
+
+    override val type: String?,
+    override val value: String?,
+    override val issuingBody: String?
+
+) : IBusinessPartnerIdentifierDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerStateDto.kt
@@ -17,26 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteStateDescription
+import org.eclipse.tractusx.bpdm.common.dto.IBaseStateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(description = SiteDescription.header)
-interface IBaseSiteStateDto : IBaseStateDto {
+data class BusinessPartnerStateDto(
 
-    @get:Schema(description = SiteStateDescription.description)
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
+    override val type: BusinessStateType?,
     override val description: String?
 
-    @get:Schema(description = SiteStateDescription.validFrom)
-    override val validFrom: LocalDateTime?
-
-    @get:Schema(description = SiteStateDescription.validTo)
-    override val validTo: LocalDateTime?
-
-    @get:Schema(description = SiteStateDescription.type)
-    override val type: BusinessStateType
-}
+) : IBaseStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PostalAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PostalAddressDto.kt
@@ -23,6 +23,7 @@ import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerPostalAddressDto
 
 data class PostalAddressDto(
+
     override val addressType: AddressType? = null,
     override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
     override val alternativePostalAddress: AlternativePostalAddressDto? = null

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -20,21 +20,14 @@
 package org.eclipse.tractusx.bpdm.orchestrator.testdata
 
 import com.neovisionaries.i18n.CountryCode
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.orchestrator.api.model.*
-import org.eclipse.tractusx.orchestrator.api.model.AddressIdentifierDto
-import org.eclipse.tractusx.orchestrator.api.model.AddressStateDto
-import org.eclipse.tractusx.orchestrator.api.model.AlternativePostalAddressDto
-import org.eclipse.tractusx.orchestrator.api.model.LegalEntityDto
-import org.eclipse.tractusx.orchestrator.api.model.LegalEntityIdentifierDto
-import org.eclipse.tractusx.orchestrator.api.model.LogisticAddressDto
-import org.eclipse.tractusx.orchestrator.api.model.PhysicalPostalAddressDto
-import org.eclipse.tractusx.orchestrator.api.model.SiteDto
-import org.eclipse.tractusx.orchestrator.api.model.SiteStateDto
-import org.eclipse.tractusx.orchestrator.api.model.StreetDto
 import java.time.LocalDateTime
 
 /**
@@ -76,12 +69,12 @@ object BusinessPartnerTestValues {
             )
         ),
         classifications = listOf(
-            ClassificationDto(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.NACE,
                 code = "code-1",
                 value = "value-1"
             ),
-            ClassificationDto(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.NAF,
                 code = "code-2",
                 value = "value-2"
@@ -158,7 +151,7 @@ object BusinessPartnerTestValues {
             )
         ),
         classifications = listOf(
-            ClassificationDto(
+            BusinessPartnerClassificationDto(
                 type = ClassificationType.SIC,
                 code = "code-2",
                 value = "value-2"


### PR DESCRIPTION
The DTOs related to the Generic Business Partner were refactored, making sure all its data classes are located in the appropriate API modules (gate-api and orchestrator-api). Common interfaces are used whenever possible.
This meant splitting up some DTOs for the different modules which were formerly in the common module.

This is the first step towards #570
