### PR TITLE
Docs(bpdm): updated correct url for docker hub image

### DIFF
--- a/bpdm-bridge-dummy/DOCKER_NOTICE.md
+++ b/bpdm-bridge-dummy/DOCKER_NOTICE.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm-bridge-dummy](https://hub.docker.com/r/tractusx/bpdm-bridge-dummy)
 
 Eclipse Tractus-X product(s) installed within the image:
 

--- a/bpdm-cleaning-service-dummy/DOCKER_NOTICE.md
+++ b/bpdm-cleaning-service-dummy/DOCKER_NOTICE.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm-cleaning-service-dummy](https://hub.docker.com/r/tractusx/bpdm-cleaning-service-dummy)
 
 Eclipse Tractus-X product(s) installed within the image:
 

--- a/bpdm-gate/DOCKER_NOTICE.md
+++ b/bpdm-gate/DOCKER_NOTICE.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm-gate](https://hub.docker.com/r/tractusx/bpdm-gate)
 
 Eclipse Tractus-X product(s) installed within the image:
 

--- a/bpdm-orchestrator/DOCKER_NOTICE.md
+++ b/bpdm-orchestrator/DOCKER_NOTICE.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm-orchestrator](https://hub.docker.com/r/tractusx/bpdm-orchestrator)
 
 Eclipse Tractus-X product(s) installed within the image:
 

--- a/bpdm-pool/DOCKER_NOTICE.md
+++ b/bpdm-pool/DOCKER_NOTICE.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/r/tractusx/bpdm](https://hub.docker.com/r/tractusx/bpdm)
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm-pool](https://hub.docker.com/r/tractusx/bpdm-pool)
 
 Eclipse Tractus-X product(s) installed within the image:
 


### PR DESCRIPTION
## Description
Updated correct DockerHub image link for each service on BPDM under docker notice files

Fixes #642 #636 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
