### PR TITLE
Docs(bpdm): updated Legal notice for documentation

### DIFF
--- a/docs/arc42/arc42-bpdm-rel_3_2.md
+++ b/docs/arc42/arc42-bpdm-rel_3_2.md
@@ -337,3 +337,15 @@ How to run the service
 The Glossary is currently under development and will be added below after internal approval ([DRAFT](https://confluence.catena-x.net/display/CORE/BPDM+Glossary+-+Internal+-+DRAFT)).
 
 The current version you can find in the Catena-X Standards.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/create_legal_entity_diagram.md
+++ b/docs/arc42/diagrams/create_legal_entity_diagram.md
@@ -65,3 +65,16 @@ After successfully saving the legal entities, the `BusinessPartnerBuildService` 
 ### 8. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful creation of the legal entities.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm
+

--- a/docs/arc42/diagrams/gate/address/get-addresses-by-external-id.md
+++ b/docs/arc42/diagrams/gate/address/get-addresses-by-external-id.md
@@ -47,3 +47,15 @@ An `AddressGateInputDto` is prepared to be returned
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of an address.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/address/get-addresses-by-many-external-id.md
+++ b/docs/arc42/diagrams/gate/address/get-addresses-by-many-external-id.md
@@ -55,3 +55,15 @@ the `list<AddressGateInputDto>`
 ### 8. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of addresses.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/address/get-addresses-input.md
+++ b/docs/arc42/diagrams/gate/address/get-addresses-input.md
@@ -53,3 +53,15 @@ the `list<AddressGateInputDto>`
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of the addresses.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/address/get-addresses-output.md
+++ b/docs/arc42/diagrams/gate/address/get-addresses-output.md
@@ -22,3 +22,14 @@ sequenceDiagram
     Controller-->>Client: Response: PageDto<AddressGateOutputDto>
 ````
 
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/address/upsert-addresses-input.md
+++ b/docs/arc42/diagrams/gate/address/upsert-addresses-input.md
@@ -112,3 +112,15 @@ and a ChangelogType which is CREATE.
 ### 18. Controller Response
 
 The controller sends a response back to the client, indicating the successful persist/update of the address/'s.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/address/upsert-addresses-output.md
+++ b/docs/arc42/diagrams/gate/address/upsert-addresses-output.md
@@ -119,3 +119,15 @@ and a ChangelogType which is CREATE.
 ### 18. Controller Response
 
 The controller sends a response back to the client, indicating the successful persist/update of the address/'s.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/changelog/changelog-input-search.md
+++ b/docs/arc42/diagrams/gate/changelog/changelog-input-search.md
@@ -48,3 +48,15 @@ An `Page<ChangelogGateDto!>` is prepared to be returned
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of changelogs.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/changelog/changelog-output-search.md
+++ b/docs/arc42/diagrams/gate/changelog/changelog-output-search.md
@@ -48,3 +48,15 @@ An `Page<ChangelogGateDto!>` is prepared to be returned
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of changelogs.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/legal-entity/get-legal-entities-search-input.md
+++ b/docs/arc42/diagrams/gate/legal-entity/get-legal-entities-search-input.md
@@ -50,3 +50,15 @@ the `list<LegalEntityGateInputDto>`
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of the legal entity's.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/legal-entity/get-legal-entities-search-output.md
+++ b/docs/arc42/diagrams/gate/legal-entity/get-legal-entities-search-output.md
@@ -54,3 +54,15 @@ the `list<LegalEntityGateOutputResponse>`
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of a legal entity.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/legal-entity/get-legal-entity-by-many-external-id.md
+++ b/docs/arc42/diagrams/gate/legal-entity/get-legal-entity-by-many-external-id.md
@@ -57,3 +57,15 @@ the `list<LegalEntityGateInputDto>`
 ### 8. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of a legal entity.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/legal-entity/get-legal-entity-external-id.md
+++ b/docs/arc42/diagrams/gate/legal-entity/get-legal-entity-external-id.md
@@ -48,3 +48,15 @@ An `LegalEntityGateInputDto` is prepared to be returned
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of a legal entity.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/legal-entity/upsert-legal-entity-input.md
+++ b/docs/arc42/diagrams/gate/legal-entity/upsert-legal-entity-input.md
@@ -108,3 +108,15 @@ here, and a ChangelogType which is CREATE.
 ### 17. Controller Response
 
 The controller sends a response back to the client, indicating the successful persist/update of the legal entity/'s.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/legal-entity/upsert-legal-entity-output.md
+++ b/docs/arc42/diagrams/gate/legal-entity/upsert-legal-entity-output.md
@@ -109,3 +109,15 @@ here, and a ChangelogType which is CREATE.
 ### 17. Controller Response
 
 The controller sends a response back to the client, indicating the successful persist/update of the legal entity/'s.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/site/get-sites-by-many-external-id.md
+++ b/docs/arc42/diagrams/gate/site/get-sites-by-many-external-id.md
@@ -56,3 +56,15 @@ the `list<SiteGateInputDto>`
 ### 8. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of a sites.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/site/get-sites-external-id.md
+++ b/docs/arc42/diagrams/gate/site/get-sites-external-id.md
@@ -48,3 +48,15 @@ An `SiteGateInputDto` is prepared to be returned
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of a site.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/site/get-sites-search-input.md
+++ b/docs/arc42/diagrams/gate/site/get-sites-search-input.md
@@ -50,3 +50,15 @@ the `list<SiteGateInputDto>`
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of the sites.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/site/get-sites-search-output.md
+++ b/docs/arc42/diagrams/gate/site/get-sites-search-output.md
@@ -50,3 +50,15 @@ the `list<SiteGateOutputResponse>`
 ### 7. Controller Response
 
 The controller sends the prepared response back to the client, indicating the successful retrieval of a site.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/site/upsert-site-input.md
+++ b/docs/arc42/diagrams/gate/site/upsert-site-input.md
@@ -114,3 +114,15 @@ a ChangelogType which is CREATE.
 ### 19. Controller Response
 
 The controller sends a response back to the client, indicating the successful persist/update of the site/'s.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/gate/site/upsert-site-output.md
+++ b/docs/arc42/diagrams/gate/site/upsert-site-output.md
@@ -118,3 +118,15 @@ a ChangelogType which is CREATE.
 ### 19. Controller Response
 
 The controller sends a response back to the client, indicating the successful persist/update of the site/'s.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/search_legal_entity_diagram.md
+++ b/docs/arc42/diagrams/search_legal_entity_diagram.md
@@ -55,3 +55,15 @@ After fetching and joining the necessary attributes, the `BusinessPartnerFetchSe
 ### 8. Controller Response
 
 The controller sends the prepared list of `PoolLegalEntityVerboseDto` back to the client, indicating a successful search operation.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/arc42/diagrams/update_legal_entity_diagram.md
+++ b/docs/arc42/diagrams/update_legal_entity_diagram.md
@@ -67,3 +67,16 @@ entities.
 ### 9. **Controller Response**
 
 Finally, the controller sends the prepared response back to the client, signaling the successful update of the legal entities.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm
+

--- a/docs/decision-records/001-multitenancy_approach.md
+++ b/docs/decision-records/001-multitenancy_approach.md
@@ -79,3 +79,16 @@ Chosen option: "Use multiple Gates so that every member will have its own Gate w
 
 <!-- This is an optional element. Feel free to remove. -->
 ## More Information
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm
+

--- a/docs/decision-records/002-edc_for_pool_api.md
+++ b/docs/decision-records/002-edc_for_pool_api.md
@@ -27,3 +27,15 @@ In case of BPDM Pool provides no confidential data about Business Partners. It's
 
 ### Implications
 It must be ensured that only Catena-X Member have access to the BPDM Pool API. In Fact an Identity and Access Management is required in the Pool Backend which checks the technical users based on its associated roles and rights.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/003-orchestrator_serviceApi_vs_messagebus_approach.md
+++ b/docs/decision-records/003-orchestrator_serviceApi_vs_messagebus_approach.md
@@ -122,3 +122,15 @@ Orchestration logic can basically be realized via an API and service based appro
 (Further/Next Steps to be discussed)
 
 Having in mind that a pushing mechanism might become required for a more efficient process orchestration or some other cases, it is not excluded to introduce an event queuing technology. We are open minded to this. But from current perspective we don't see hard requirements for this, so we want to focus on a minimal viable solution focusing on simplicity based on the KISS principle.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/004-openapi_descriptions.md
+++ b/docs/decision-records/004-openapi_descriptions.md
@@ -77,3 +77,15 @@ using `@get:Schema(ref = "legalAddressAliasForLogisticAddressDto")`.
 
 The potential workarounds are implemented as proof-of-concept
 in [Github pull request: Schema overriding hook for OpenApiConfig](https://github.com/eclipse-tractusx/bpdm/pull/405).
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/005-edc-usage-for-third-party-services.md
+++ b/docs/decision-records/005-edc-usage-for-third-party-services.md
@@ -86,3 +86,16 @@ In this scenario the operating environment itself operates a backend service or 
 
 
 ## More Information
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm
+

--- a/docs/edc/README.md
+++ b/docs/edc/README.md
@@ -240,3 +240,16 @@ asset and finally send that access token over your own EDC to the BPDM EDC in or
    invoke BPDM API endpoint directly. The gate EDC's URL can be invoked with the method's GET, POST and PUT. Use the method that matches original BPDM
    API endpoint the accessed asset covers. The response equals the original BPDM API endpoint response.
 
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm
+
+

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -27,3 +27,15 @@ The use case document should include the following information:
 2. What is the problem to solve or goal to achieve
 3. What are the steps necessary to reach that goal with the BPDM API
 4. Example requests for these steps
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/templates/decision-record.md
+++ b/docs/templates/decision-record.md
@@ -80,3 +80,15 @@ Chosen option: "{title of option 1}", because
  define when this decision when and how the decision should be realized and if/when it should be re-visited and/or
  how the decision is validated.
  Links to other decisions and resources might here appear as well.}
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/templates/use-case.md
+++ b/docs/templates/use-case.md
@@ -28,3 +28,15 @@ Example response:
   "exampleField": "example"
 }
 ```
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -3,3 +3,15 @@
 This folder contains use case descriptions for the BPDM API:
 
 * [Counting Business Partners](count-business-partners.md)
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/use-cases/count-business-partners.md
+++ b/docs/use-cases/count-business-partners.md
@@ -78,5 +78,17 @@ The total number of sites in the Pool is in the 'totalElements' field and is 120
 Usually, there is no endpoint to directly get the total number of all business partners irrespective of type.
 In order to get the total number of all business partners you need add up the total numbers of legal entities, sites and addresses.
 
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm
+
 
 


### PR DESCRIPTION
## Description
Updated legal notice for documents in BPDM project.

fixes #649 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
