### PR TITLE
Refactoring: Reorganize Legal Entity DTOs between modules

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -24,6 +24,49 @@ import org.eclipse.tractusx.bpdm.common.dto.response.*
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNullMappingException
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 import kotlin.reflect.KProperty
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityClassificationDto as Gate_LegalEntityClassificationDto
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto as Gate_LegalEntityDto
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityIdentifierDto as Gate_LegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityStateDto as Gate_LegalEntityStateDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityClassificationDto as Pool_LegalEntityClassificationDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityDto as Pool_LegalEntityDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityIdentifierDto as Pool_LegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityStateDto as Pool_LegalEntityStateDto
+
+fun gateToPoolLegalEntity(gateDto: Gate_LegalEntityDto): Pool_LegalEntityDto {
+    return Pool_LegalEntityDto(
+        identifiers = gateDto.identifiers.map(::gateToPoolLegalEntityIdentifier),
+        legalShortName = gateDto.legalShortName,
+        legalForm = gateDto.legalForm,
+        states = gateDto.states.map(::gateToPoolLegalEntityState),
+        classifications = gateDto.classifications.map(::gateToPoolLegalEntityClassification)
+    )
+}
+
+fun gateToPoolLegalEntityIdentifier(gateDto: Gate_LegalEntityIdentifierDto): Pool_LegalEntityIdentifierDto {
+    return Pool_LegalEntityIdentifierDto(
+        type = gateDto.type,
+        value = gateDto.value,
+        issuingBody = gateDto.issuingBody
+    )
+}
+
+fun gateToPoolLegalEntityState(gateDto: Gate_LegalEntityStateDto): Pool_LegalEntityStateDto {
+    return Pool_LegalEntityStateDto(
+        validFrom = gateDto.validFrom,
+        validTo = gateDto.validTo,
+        type = gateDto.type,
+        description = gateDto.description
+    )
+}
+
+fun gateToPoolLegalEntityClassification(gateDto: Gate_LegalEntityClassificationDto): Pool_LegalEntityClassificationDto {
+    return Pool_LegalEntityClassificationDto(
+        type = gateDto.type,
+        code = gateDto.code,
+        value = gateDto.value
+    )
+}
 
 fun gateToPoolLogisticAddress(gateDto: LogisticAddressGateDto): LogisticAddressDto {
     return LogisticAddressDto(
@@ -85,16 +128,16 @@ fun gateToPoolPhysicalAddress(gateDto: PhysicalPostalAddressGateDto): PhysicalPo
 }
 
 
-fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): LegalEntityDto {
+fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): Gate_LegalEntityDto {
     val identifiers = legalEntity.identifiers.map {
-        LegalEntityIdentifierDto(
+        Gate_LegalEntityIdentifierDto(
             value = it.value,
             type = it.type.technicalKey,
             issuingBody = it.issuingBody
         )
     }
     val states = legalEntity.states.map {
-        LegalEntityStateDto(
+        Gate_LegalEntityStateDto(
             description = it.description,
             validFrom = it.validFrom,
             validTo = it.validTo,
@@ -102,13 +145,13 @@ fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): LegalEntityDto {
         )
     }
     val classifications = legalEntity.classifications.map {
-        ClassificationDto(
+        Gate_LegalEntityClassificationDto(
             type = it.type.technicalKey,
             code = it.code,
             value = it.value
         )
     }
-    return LegalEntityDto(
+    return Gate_LegalEntityDto(
         identifiers = identifiers,
         legalShortName = legalEntity.legalShortName,
         legalForm = legalEntity.legalForm?.technicalKey,

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -20,9 +20,13 @@
 package com.catenax.bpdm.bridge.dummy.dto
 
 import org.eclipse.tractusx.bpdm.common.dto.*
-import org.eclipse.tractusx.bpdm.common.dto.response.*
+import org.eclipse.tractusx.bpdm.common.dto.response.AlternativePostalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNullMappingException
 import org.eclipse.tractusx.bpdm.gate.api.model.*
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
 import kotlin.reflect.KProperty
 import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityClassificationDto as Gate_LegalEntityClassificationDto
 import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto as Gate_LegalEntityDto

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -26,7 +26,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerbos
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNullMappingException
 import org.eclipse.tractusx.bpdm.gate.api.model.*
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
 import kotlin.reflect.KProperty
 import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityClassificationDto as Gate_LegalEntityClassificationDto
 import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto as Gate_LegalEntityDto
@@ -40,6 +40,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityStateDto as Pool_Lega
 fun gateToPoolLegalEntity(gateDto: Gate_LegalEntityDto): Pool_LegalEntityDto {
     return Pool_LegalEntityDto(
         identifiers = gateDto.identifiers.map(::gateToPoolLegalEntityIdentifier),
+        legalName = gateDto.legalNameParts.firstOrNull() ?: "",
         legalShortName = gateDto.legalShortName,
         legalForm = gateDto.legalForm,
         states = gateDto.states.map(::gateToPoolLegalEntityState),
@@ -156,9 +157,10 @@ fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): Gate_LegalEntityD
         )
     }
     return Gate_LegalEntityDto(
-        identifiers = identifiers,
+        legalNameParts = listOfNotNull(legalEntity.legalName),
         legalShortName = legalEntity.legalShortName,
         legalForm = legalEntity.legalForm?.technicalKey,
+        identifiers = identifiers,
         states = states,
         classifications = classifications
     )

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/GateLegalEntityInfo.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/GateLegalEntityInfo.kt
@@ -23,7 +23,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
 
 data class GateLegalEntityInfo(
-    val legalNameParts: Collection<String>,
     val legalEntity: LegalEntityDto,
     val legalAddress: AddressGateInputDto,
     val externalId: String,

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateQueryService.kt
@@ -74,7 +74,6 @@ class GateQueryService(
 
         return entries.map {
             GateLegalEntityInfo(
-                legalNameParts = it.legalNameParts,
                 legalEntity = it.legalEntity,
                 legalAddress = it.legalAddress,
                 externalId = it.externalId,

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/GateUpdateService.kt
@@ -181,7 +181,6 @@ class GateUpdateService(
             return null
         }
         return LegalEntityGateOutputRequest(
-            legalNameParts = listOfNotNull(poolResponse.legalName),
             legalEntity = poolToGateLegalEntity(poolResponse.legalEntity),
             legalAddress = poolToGateAddressChild(poolResponse.legalAddress),
             externalId = requestEntry.externalId,

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -42,8 +42,7 @@ class PoolUpdateService(
             LegalEntityPartnerCreateRequest(
                 legalEntity = gateToPoolLegalEntity(it.legalEntity),
                 legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
-                index = it.externalId,
-                legalName = it.legalNameParts.firstOrNull() ?: ""
+                index = it.externalId
             )
         }
 
@@ -56,8 +55,7 @@ class PoolUpdateService(
             LegalEntityPartnerUpdateRequest(
                 legalEntity = gateToPoolLegalEntity(it.legalEntity),
                 legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
-                bpnl = it.bpn!!,
-                legalName = it.legalNameParts.firstOrNull() ?: ""
+                bpnl = it.bpn!!
             )
         }
 

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -40,7 +40,7 @@ class PoolUpdateService(
     fun createLegalEntitiesInPool(entriesToCreate: Collection<GateLegalEntityInfo>): LegalEntityPartnerCreateResponseWrapper {
         val createRequests = entriesToCreate.map {
             LegalEntityPartnerCreateRequest(
-                legalEntity = it.legalEntity,
+                legalEntity = gateToPoolLegalEntity(it.legalEntity),
                 legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
                 index = it.externalId,
                 legalName = it.legalNameParts.firstOrNull() ?: ""
@@ -54,7 +54,7 @@ class PoolUpdateService(
     fun updateLegalEntitiesInPool(entriesToUpdate: Collection<GateLegalEntityInfo>): LegalEntityPartnerUpdateResponseWrapper {
         val updateRequests = entriesToUpdate.map {
             LegalEntityPartnerUpdateRequest(
-                legalEntity = it.legalEntity,
+                legalEntity = gateToPoolLegalEntity(it.legalEntity),
                 legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
                 bpnl = it.bpn!!,
                 legalName = it.legalNameParts.firstOrNull() ?: ""

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/testdata/GateRequestValues.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/testdata/GateRequestValues.kt
@@ -224,6 +224,7 @@ object GateRequestValues {
 
     val legalEntity1 = LegalEntityDto(
         identifiers = listOf(identifier1, identifier2),
+        legalNameParts = listOf(CommonValues.name1),
         legalShortName = CommonValues.shortName1,
         legalForm = CommonValues.legalFormTechnicalKey1,
         states = listOf(leBusinessStatus1),
@@ -232,6 +233,7 @@ object GateRequestValues {
 
     val legalEntity2 = LegalEntityDto(
         identifiers = listOf(identifier3, identifier4),
+        legalNameParts = listOf(CommonValues.name3),
         legalShortName = CommonValues.shortName3,
         legalForm = CommonValues.legalFormTechnicalKey2,
         states = listOf(leBusinessStatus2),
@@ -240,6 +242,7 @@ object GateRequestValues {
 
     val legalEntity3 = LegalEntityDto(
         identifiers = listOf(identifier5),
+        legalNameParts = listOf(CommonValues.name1),
         legalShortName = CommonValues.shortName1,
         legalForm = CommonValues.legalFormTechnicalKey1,
         states = listOf(leBusinessStatus1),
@@ -249,21 +252,18 @@ object GateRequestValues {
     val legalEntityGateInputRequest1 = LegalEntityGateInputRequest(
         legalEntity = legalEntity1,
         legalAddress = address1,
-        legalNameParts = listOf(CommonValues.name1),
         externalId = CommonValues.externalId1,
     )
 
     val legalEntityGateInputRequest2 = LegalEntityGateInputRequest(
         legalEntity = legalEntity2,
         legalAddress = address2,
-        legalNameParts = listOf(CommonValues.name3),
         externalId = CommonValues.externalId2,
     )
 
     val legalEntityGateInputRequest3 = LegalEntityGateInputRequest(
         legalEntity = legalEntity3,
         legalAddress = address3,
-        legalNameParts = listOf(CommonValues.name1),
         externalId = CommonValues.externalId3,
     )
 

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/testdata/GateRequestValues.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/testdata/GateRequestValues.kt
@@ -19,11 +19,9 @@
 
 package com.catenax.bpdm.bridge.dummy.testdata
 
-import org.eclipse.tractusx.bpdm.common.dto.*
-import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
-import org.eclipse.tractusx.bpdm.gate.api.model.PhysicalPostalAddressGateDto
-import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateDto
-import org.eclipse.tractusx.bpdm.gate.api.model.StreetGateDto
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.dto.SiteStateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.api.model.request.AddressGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.LegalEntityGateInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.SiteGateInputRequest
@@ -90,25 +88,25 @@ object GateRequestValues {
         type = CommonValues.businessStateType2
     )
 
-    val classification1 = ClassificationDto(
+    val classification1 = LegalEntityClassificationDto(
         type = CommonValues.classificationType,
         code = CommonValues.classificationCode1,
         value = CommonValues.classificationValue1
     )
 
-    val classification2 = ClassificationDto(
+    val classification2 = LegalEntityClassificationDto(
         type = CommonValues.classificationType,
         code = CommonValues.classificationCode2,
         value = CommonValues.classificationValue2
     )
 
-    val classification3 = ClassificationDto(
+    val classification3 = LegalEntityClassificationDto(
         type = CommonValues.classificationType,
         code = CommonValues.classificationCode3,
         value = CommonValues.classificationValue3
     )
 
-    val classification4 = ClassificationDto(
+    val classification4 = LegalEntityClassificationDto(
         type = CommonValues.classificationType,
         code = CommonValues.classificationCode4,
         value = CommonValues.classificationValue4

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -20,7 +20,6 @@
 package org.eclipse.tractusx.bpdm.cleaning.service
 
 
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.orchestrator.api.model.*
 
 
@@ -40,9 +39,9 @@ fun BusinessPartnerGenericDto.toLegalEntityDto(bpnReferenceDto: BpnReferenceDto,
     )
 }
 
-fun BusinessPartnerClassificationDto.toLegalEntityClassificationDto(): ClassificationDto {
+fun BusinessPartnerClassificationDto.toLegalEntityClassificationDto(): LegalEntityClassificationDto {
 
-    return ClassificationDto(code = code, type = type, value = value)
+    return LegalEntityClassificationDto(code = code, type = type, value = value)
 }
 
 fun BusinessPartnerIdentifierDto.toLegalEntityIdentifierDto(): LegalEntityIdentifierDto? {
@@ -55,9 +54,9 @@ fun BusinessPartnerIdentifierDto.toLegalEntityIdentifierDto(): LegalEntityIdenti
 
 }
 
-fun BusinessPartnerStateDto.toLegalEntityState(): LegalEntityState? {
+fun BusinessPartnerStateDto.toLegalEntityState(): LegalEntityStateDto? {
 
-    return type?.let { LegalEntityState(description, validFrom, validTo, it) }
+    return type?.let { LegalEntityStateDto(description, validFrom, validTo, it) }
 }
 
 fun BusinessPartnerStateDto.toSiteState(): SiteStateDto? {

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -40,10 +40,10 @@ interface IBaseBusinessPartnerDto {
     val legalForm: String?
 
     @get:ArraySchema(arraySchema = Schema(description = "The list of (temporary) states of the business partner. Sorted and duplicates removed by the service."))
-    val states: Collection<IBaseStateDto>
+    val states: Collection<IBusinessPartnerStateDto>
 
     @get:ArraySchema(arraySchema = Schema(description = "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service."))
-    val classifications: Collection<IBaseClassificationDto>
+    val classifications: Collection<IBusinessPartnerClassificationDto>
 
     @get:ArraySchema(arraySchema = Schema(description = "Roles this business partner takes in relation to the sharing member. Sorted and duplicates removed by the service."))
     val roles: Collection<BusinessPartnerRole>

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
@@ -25,8 +25,9 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescri
 
 @Schema(description = LegalEntityDescription.header)
 interface IBaseLegalEntityDto {
+
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers, required = false))
-    val identifiers: Collection<IBaseLegalEntityIdentifierDto>
+    val identifiers: Collection<ILegalEntityIdentifierDto>
 
     @get:Schema(description = LegalEntityDescription.legalShortName)
     val legalShortName: String?
@@ -35,9 +36,8 @@ interface IBaseLegalEntityDto {
     val legalForm: String?
 
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.states))
-    val states: Collection<IBaseLegalEntityStateDto>
+    val states: Collection<ILegalEntityStateDto>
 
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications, required = false))
-    val classifications: Collection<IBaseClassificationDto>
-
+    val classifications: Collection<ILegalEntityClassificationDto>
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerClassificationDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerClassificationDto.kt
@@ -19,19 +19,4 @@
 
 package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
-import org.eclipse.tractusx.bpdm.common.model.ClassificationType
-
-@Schema(description = ClassificationDescription.header)
-data class ClassificationDto(
-
-    @get:Schema(description = ClassificationDescription.type)
-    override val type: ClassificationType,
-
-    @get:Schema(description = ClassificationDescription.code)
-    override val code: String?,
-
-    @get:Schema(description = ClassificationDescription.value)
-    override val value: String?
-) : IBaseClassificationDto
+interface IBusinessPartnerClassificationDto : IBaseClassificationDto

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBusinessPartnerStateDto.kt
@@ -17,15 +17,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package com.catenax.bpdm.bridge.dummy.dto
+package org.eclipse.tractusx.bpdm.common.dto
 
-import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
-import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
-
-data class GateLegalEntityInfo(
-    val legalNameParts: Collection<String>,
-    val legalEntity: LegalEntityDto,
-    val legalAddress: AddressGateInputDto,
-    val externalId: String,
-    val bpn: String?
-)
+interface IBusinessPartnerStateDto : IBaseStateDto

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityClassificationDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityClassificationDto.kt
@@ -20,12 +20,11 @@
 package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(name = "Name", description = "Name record for a business partner")
-data class NameDto(
-    @get:Schema(description = "Full name")
-    val value: String,
+interface ILegalEntityClassificationDto : IBaseClassificationDto {
 
-    @get:Schema(description = "Abbreviated name or shorthand")
-    val shortName: String?
-)
+    @get:Schema(description = ClassificationDescription.type, required = true)
+    override val type: ClassificationType
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityIdentifierDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityIdentifierDto.kt
@@ -23,7 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 
 @Schema(description = LegalEntityIdentifierDescription.header)
-interface IBaseLegalEntityIdentifierDto : IBaseIdentifierDto {
+interface ILegalEntityIdentifierDto : IBaseIdentifierDto {
+
     @get:Schema(description = LegalEntityIdentifierDescription.value)
     override val value: String
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityStateDto.kt
@@ -17,16 +17,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityStateDto
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-data class LegalEntityState(
-    override val description: String?,
-    override val validFrom: LocalDateTime?,
-    override val validTo: LocalDateTime?,
-    override val type: BusinessStateType
+@Schema(description = LegalEntityStateDescription.header)
+interface ILegalEntityStateDto : IBaseStateDto {
 
-) : IBaseLegalEntityStateDto
+    @get:Schema(description = LegalEntityStateDescription.description)
+    override val description: String?
+
+    @get:Schema(description = LegalEntityStateDescription.validFrom)
+    override val validFrom: LocalDateTime?
+
+    @get:Schema(description = LegalEntityStateDescription.validTo)
+    override val validTo: LocalDateTime?
+
+    @get:Schema(description = LegalEntityStateDescription.type)
+    override val type: BusinessStateType
+}

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerClassificationDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerClassificationDto.kt
@@ -19,7 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseClassificationDto
+import org.eclipse.tractusx.bpdm.common.dto.IBusinessPartnerClassificationDto
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
 data class BusinessPartnerClassificationDto(
@@ -28,4 +28,4 @@ data class BusinessPartnerClassificationDto(
     override val code: String?,
     override val value: String?
 
-) : IBaseClassificationDto
+) : IBusinessPartnerClassificationDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerStateDto.kt
@@ -19,7 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseStateDto
+import org.eclipse.tractusx.bpdm.common.dto.IBusinessPartnerStateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
@@ -30,4 +30,4 @@ data class BusinessPartnerStateDto(
     override val type: BusinessStateType?,
     override val description: String?
 
-) : IBaseStateDto
+) : IBusinessPartnerStateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityClassificationDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityClassificationDto.kt
@@ -17,15 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package com.catenax.bpdm.bridge.dummy.dto
+package org.eclipse.tractusx.bpdm.gate.api.model
 
-import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
-import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityClassificationDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-data class GateLegalEntityInfo(
-    val legalNameParts: Collection<String>,
-    val legalEntity: LegalEntityDto,
-    val legalAddress: AddressGateInputDto,
-    val externalId: String,
-    val bpn: String?
-)
+@Schema(description = ClassificationDescription.header)
+data class LegalEntityClassificationDto(
+
+    override val type: ClassificationType,
+    override val code: String?,
+    override val value: String?
+
+) : ILegalEntityClassificationDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
@@ -17,15 +17,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package com.catenax.bpdm.bridge.dummy.dto
+package org.eclipse.tractusx.bpdm.gate.api.model
 
-import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
-import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 
-data class GateLegalEntityInfo(
-    val legalNameParts: Collection<String>,
-    val legalEntity: LegalEntityDto,
-    val legalAddress: AddressGateInputDto,
-    val externalId: String,
-    val bpn: String?
-)
+@Schema(description = LegalEntityDescription.header)
+data class LegalEntityDto(
+
+    override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
+    override val legalShortName: String?,
+    override val legalForm: String? = null,
+    override val states: Collection<LegalEntityStateDto> = emptyList(),
+    override val classifications: Collection<LegalEntityClassificationDto> = emptyList()
+
+) : IBaseLegalEntityDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
@@ -19,17 +19,26 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model
 
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 
 @Schema(description = LegalEntityDescription.header)
 data class LegalEntityDto(
 
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
+    val legalNameParts: Collection<String> = emptyList(),
+
     override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
     override val legalShortName: String?,
     override val legalForm: String? = null,
     override val states: Collection<LegalEntityStateDto> = emptyList(),
-    override val classifications: Collection<LegalEntityClassificationDto> = emptyList()
+    override val classifications: Collection<LegalEntityClassificationDto> = emptyList(),
+
+    @get:ArraySchema(arraySchema = Schema(description = CommonDescription.roles))
+    val roles: Collection<BusinessPartnerRole> = emptyList()
 
 ) : IBaseLegalEntityDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityIdentifierDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityIdentifierDto.kt
@@ -17,15 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package com.catenax.bpdm.bridge.dummy.dto
+package org.eclipse.tractusx.bpdm.gate.api.model
 
-import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
-import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 
-data class GateLegalEntityInfo(
-    val legalNameParts: Collection<String>,
-    val legalEntity: LegalEntityDto,
-    val legalAddress: AddressGateInputDto,
-    val externalId: String,
-    val bpn: String?
-)
+@Schema(description = LegalEntityIdentifierDescription.header)
+data class LegalEntityIdentifierDto(
+
+    override val value: String,
+    override val type: String,
+    override val issuingBody: String?
+
+) : ILegalEntityIdentifierDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityStateDto.kt
@@ -17,25 +17,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.bpdm.gate.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
 @Schema(description = LegalEntityStateDescription.header)
-interface IBaseLegalEntityStateDto : IBaseStateDto {
+data class LegalEntityStateDto(
 
-    @get:Schema(description = LegalEntityStateDescription.description)
-    override val description: String?
-
-    @get:Schema(description = LegalEntityStateDescription.validFrom)
-    override val validFrom: LocalDateTime?
-
-    @get:Schema(description = LegalEntityStateDescription.validTo)
-    override val validTo: LocalDateTime?
-
-    @get:Schema(description = LegalEntityStateDescription.type)
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
     override val type: BusinessStateType
-}
+
+) : ILegalEntityStateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
@@ -21,9 +21,7 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
@@ -34,19 +32,13 @@ import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 @Schema(description = LegalEntityDescription.headerUpsertRequest)
 data class LegalEntityGateInputRequest(
 
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
-    val legalNameParts: Collection<String> = emptyList(),
-
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
-
-    @get:ArraySchema(arraySchema = Schema(description = CommonDescription.roles))
-    val roles: Collection<BusinessPartnerRole> = emptyList(),
 
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = LegalEntityDescription.legalAddress)
     val legalAddress: LogisticAddressGateDto,
 
     @get:Schema(description = CommonDescription.externalId, required = true)
-    val externalId: String,
+    val externalId: String
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateInputRequest.kt
@@ -24,10 +24,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 import org.eclipse.tractusx.bpdm.gate.api.model.LogisticAddressGateDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
@@ -24,11 +24,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputChildRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.headerUpsertRequest)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/LegalEntityGateOutputRequest.kt
@@ -21,9 +21,7 @@ package org.eclipse.tractusx.bpdm.gate.api.model.request
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
@@ -34,14 +32,8 @@ import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 @Schema(description = LegalEntityDescription.headerUpsertRequest)
 data class LegalEntityGateOutputRequest(
 
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
-    val legalNameParts: Collection<String> = emptyList(),
-
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
-
-    @get:ArraySchema(arraySchema = Schema(description = CommonDescription.roles))
-    val roles: Collection<BusinessPartnerRole> = emptyList(),
 
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = LegalEntityDescription.legalAddress)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
@@ -21,9 +21,7 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
@@ -34,14 +32,8 @@ import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 @Schema(description = LegalEntityDescription.header)
 data class LegalEntityGateInputDto(
 
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
-    val legalNameParts: Collection<String>,
-
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
-
-    @get:ArraySchema(arraySchema = Schema(description = CommonDescription.roles))
-    val roles: Collection<BusinessPartnerRole> = emptyList(),
 
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = LegalEntityDescription.legalAddress)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateInputDto.kt
@@ -24,10 +24,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 
 // TODO rename to LegalEntityGateInputResponse
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
@@ -24,10 +24,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.header)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/LegalEntityGateOutputResponse.kt
@@ -21,9 +21,7 @@ package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
@@ -33,14 +31,8 @@ import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
 @Schema(description = LegalEntityDescription.header)
 data class LegalEntityGateOutputResponse(
 
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.legalNameParts))
-    val legalNameParts: Collection<String>,
-
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
-
-    @get:ArraySchema(arraySchema = Schema(description = CommonDescription.roles))
-    val roles: Collection<BusinessPartnerRole> = emptyList(),
 
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = LegalEntityDescription.legalAddress)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityPersistenceService.kt
@@ -92,15 +92,17 @@ class LegalEntityPersistenceService(
         legalEntityRequest: LegalEntityGateInputRequest,
         logisticAddressRecord: LogisticAddress
     ): LegalEntity {
-        legalEntity.externalId = legalEntityRequest.externalId
-        legalEntity.legalForm = legalEntityRequest.legalEntity.legalForm
-        legalEntity.shortName = legalEntityRequest.legalEntity.legalShortName
+        val legalEntityDto = legalEntityRequest.legalEntity
 
-        legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
-        legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-        legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.identifiers.replace(legalEntityRequest.legalEntity.identifiers.map { toEntityIdentifiers(it, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toRoles(it, legalEntity, null, null) })
+        legalEntity.externalId = legalEntityRequest.externalId
+        legalEntity.legalForm = legalEntityDto.legalForm
+        legalEntity.shortName = legalEntityDto.legalShortName
+
+        legalEntity.states.replace(legalEntityDto.states.map { toEntityState(it, legalEntity) })
+        legalEntity.classifications.replace(legalEntityDto.classifications.map { toEntityClassification(it, legalEntity) })
+        legalEntity.nameParts.replace(legalEntityDto.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
+        legalEntity.identifiers.replace(legalEntityDto.identifiers.map { toEntityIdentifiers(it, legalEntity) })
+        legalEntity.roles.replace(legalEntityDto.roles.distinct().map { toRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity
@@ -172,16 +174,18 @@ class LegalEntityPersistenceService(
         legalEntityRequest: LegalEntityGateOutputRequest,
         logisticAddressRecord: LogisticAddress
     ): LegalEntity {
+        val legalEntityDto = legalEntityRequest.legalEntity
+
         legalEntity.bpn = legalEntityRequest.bpn
         legalEntity.externalId = legalEntityRequest.externalId
-        legalEntity.legalForm = legalEntityRequest.legalEntity.legalForm
-        legalEntity.shortName = legalEntityRequest.legalEntity.legalShortName
+        legalEntity.legalForm = legalEntityDto.legalForm
+        legalEntity.shortName = legalEntityDto.legalShortName
 
-        legalEntity.states.replace(legalEntityRequest.legalEntity.states.map { toEntityState(it, legalEntity) })
-        legalEntity.classifications.replace(legalEntityRequest.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-        legalEntity.nameParts.replace(legalEntityRequest.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-        legalEntity.identifiers.replace(legalEntityRequest.legalEntity.identifiers.map { toEntityIdentifiers(it, legalEntity) })
-        legalEntity.roles.replace(legalEntityRequest.roles.distinct().map { toRoles(it, legalEntity, null, null) })
+        legalEntity.states.replace(legalEntityDto.states.map { toEntityState(it, legalEntity) })
+        legalEntity.classifications.replace(legalEntityDto.classifications.map { toEntityClassification(it, legalEntity) })
+        legalEntity.nameParts.replace(legalEntityDto.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
+        legalEntity.identifiers.replace(legalEntityDto.identifiers.map { toEntityIdentifiers(it, legalEntity) })
+        legalEntity.roles.replace(legalEntityDto.roles.distinct().map { toRoles(it, legalEntity, null, null) })
 
         legalEntity.legalAddress = logisticAddressRecord
         legalEntity.legalAddress.legalEntity = legalEntity

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/LegalEntityService.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
-import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.model.StageType
@@ -38,8 +37,6 @@ class LegalEntityService(
     private val legalEntityPersistenceService: LegalEntityPersistenceService,
     private val legalEntityRepository: LegalEntityRepository
 ) {
-
-    private val logger = KotlinLogging.logger { }
 
     /**
      * Upsert legal entities input to the database
@@ -105,26 +102,21 @@ class LegalEntityService(
 
     private fun toValidOutputLegalEntities(legalEntityPage: Page<LegalEntity>): List<LegalEntityGateOutputResponse> {
         return legalEntityPage.content.map { legalEntity ->
-            legalEntity.toLegalEntityGateOutputResponse(legalEntity)
+            legalEntity.toLegalEntityGateOutputResponse()
         }
     }
 
     private fun toValidLegalEntities(legalEntityPage: Page<LegalEntity>): List<LegalEntityGateInputDto> {
         return legalEntityPage.content.map { legalEntity ->
-            legalEntity.toLegalEntityGateInputResponse(legalEntity)
+            legalEntity.toLegalEntityGateInputResponse()
         }
     }
 
-}
-
-private fun toValidSingleLegalEntity(legalEntity: LegalEntity): LegalEntityGateInputDto {
-
-    return LegalEntityGateInputDto(
-        legalEntity = legalEntity.toLegalEntityDto(),
-        legalNameParts = getNamePartValues(legalEntity.nameParts),
-        roles = legalEntity.roles.map { it.roleName },
-        legalAddress = legalEntity.legalAddress.toAddressGateInputResponse(legalEntity.legalAddress),
-        externalId = legalEntity.externalId
-    )
-
+    private fun toValidSingleLegalEntity(legalEntity: LegalEntity): LegalEntityGateInputDto {
+        return LegalEntityGateInputDto(
+            legalEntity = legalEntity.toLegalEntityDto(),
+            legalAddress = legalEntity.legalAddress.toAddressGateInputResponse(legalEntity.legalAddress),
+            externalId = legalEntity.externalId
+        )
+    }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -207,13 +207,12 @@ fun LegalEntityGateInputRequest.toLegalEntity(datatype: StageType): LegalEntity 
 
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-    legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-    legalEntity.roles.addAll(this.roles.distinct().map { toRoles(it, legalEntity, null, null) })
+    legalEntity.nameParts.addAll(this.legalEntity.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
+    legalEntity.roles.addAll(this.legalEntity.roles.distinct().map { toRoles(it, legalEntity, null, null) })
     legalEntity.identifiers.addAll(this.legalEntity.identifiers.map { toEntityIdentifiers(it, legalEntity) })
     legalEntity.legalAddress = addressInputRequest.toAddressGate(legalEntity, null, datatype)
 
     return legalEntity
-
 }
 
 fun LegalEntityGateOutputRequest.toLegalEntity(datatype: StageType): LegalEntity {
@@ -235,13 +234,12 @@ fun LegalEntityGateOutputRequest.toLegalEntity(datatype: StageType): LegalEntity
 
     legalEntity.states.addAll(this.legalEntity.states.map { toEntityState(it, legalEntity) })
     legalEntity.classifications.addAll(this.legalEntity.classifications.map { toEntityClassification(it, legalEntity) })
-    legalEntity.nameParts.addAll(this.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
-    legalEntity.roles.addAll(this.roles.distinct().map { toRoles(it, legalEntity, null, null) })
+    legalEntity.nameParts.addAll(this.legalEntity.legalNameParts.map { toNameParts(it, null, null, legalEntity) })
+    legalEntity.roles.addAll(this.legalEntity.roles.distinct().map { toRoles(it, legalEntity, null, null) })
     legalEntity.identifiers.addAll(this.legalEntity.identifiers.map { toEntityIdentifiers(it, legalEntity) })
     legalEntity.legalAddress = addressOutputRequest.toAddressGateOutput(legalEntity, null, datatype)
 
     return legalEntity
-
 }
 
 fun toRoles(role: BusinessPartnerRole, legalEntity: LegalEntity?, site: Site?, address: LogisticAddress?): Roles {
@@ -355,13 +353,14 @@ private fun Street.toStreetDto(): StreetGateDto {
 fun LegalEntity.toLegalEntityDto(): LegalEntityDto {
 
     return LegalEntityDto(
+        legalNameParts = getNamePartValues(nameParts),
         legalForm = legalForm,
         legalShortName = shortName,
         states = mapToLegalEntityStateDto(states),
         classifications = mapToLegalEntityClassificationsDto(classifications),
-        identifiers = mapToLegalEntityIdentifiersDto(identifiers)
+        identifiers = mapToLegalEntityIdentifiersDto(identifiers),
+        roles = roles.map { it.roleName },
     )
-
 }
 
 fun mapToLegalEntityStateDto(states: MutableSet<LegalEntityState>): Collection<LegalEntityStateDto> {
@@ -385,20 +384,16 @@ fun AddressIdentifier.mapToAddressIdentifiersDto(): AddressIdentifierDto {
 }
 
 //LegalEntity mapping to LegalEntityGateInputResponse
-fun LegalEntity.toLegalEntityGateInputResponse(legalEntity: LegalEntity): LegalEntityGateInputDto {
-
+fun LegalEntity.toLegalEntityGateInputResponse(): LegalEntityGateInputDto {
     return LegalEntityGateInputDto(
-        legalEntity = legalEntity.toLegalEntityDto(),
+        legalEntity = toLegalEntityDto(),
         legalAddress = legalAddress.toAddressGateInputResponse(legalAddress),
-        roles = roles.map { it.roleName },
-        externalId = legalEntity.externalId,
-        legalNameParts = getNamePartValues(nameParts)
+        externalId = externalId,
     )
 }
 
 //Site mapping to SiteDto
 fun Site.toSiteDto(): SiteGateDto {
-
     return SiteGateDto(
         roles = roles.map { it.roleName },
         nameParts = getNamePartValues(nameParts),
@@ -412,7 +407,6 @@ fun mapToDtoSitesStates(states: MutableSet<SiteState>): Collection<SiteStateDto>
 
 //Site mapping to SiteGateInputResponse
 fun Site.toSiteGateInputResponse(sitePage: Site): SiteGateInputDto {
-
     return SiteGateInputDto(
         site = sitePage.toSiteDto(),
         externalId = externalId,
@@ -424,7 +418,6 @@ fun Site.toSiteGateInputResponse(sitePage: Site): SiteGateInputDto {
 
 //Logistic Address mapping to AddressGateOutputResponse
 fun LogisticAddress.toAddressGateOutputResponse(logisticAddressPage: LogisticAddress): AddressGateOutputDto {
-
     return AddressGateOutputDto(
         address = logisticAddressPage.toLogisticAddressDto(),
         externalId = externalId,
@@ -436,7 +429,6 @@ fun LogisticAddress.toAddressGateOutputResponse(logisticAddressPage: LogisticAdd
 
 //Site mapping to SiteGateOutputResponse
 fun Site.toSiteGateOutputResponse(sitePage: Site): SiteGateOutputResponse {
-
     return SiteGateOutputResponse(
         site = sitePage.toSiteDto(),
         externalId = externalId,
@@ -447,14 +439,11 @@ fun Site.toSiteGateOutputResponse(sitePage: Site): SiteGateOutputResponse {
 }
 
 //LegalEntity mapping to LegalEntityGateOutputResponse
-fun LegalEntity.toLegalEntityGateOutputResponse(legalEntity: LegalEntity): LegalEntityGateOutputResponse {
-
+fun LegalEntity.toLegalEntityGateOutputResponse(): LegalEntityGateOutputResponse {
     return LegalEntityGateOutputResponse(
-        legalEntity = legalEntity.toLegalEntityDto(),
-        legalNameParts = getNamePartValues(legalEntity.nameParts),
-        externalId = legalEntity.externalId,
-        bpnl = legalEntity.bpn!!,
-        roles = roles.map { it.roleName },
+        legalEntity = toLegalEntityDto(),
+        externalId = externalId,
+        bpnl = bpn!!,
         legalAddress = legalAddress.toAddressGateOutputResponse(legalAddress)
     )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -256,7 +256,7 @@ fun toEntityState(dto: LegalEntityStateDto, legalEntity: LegalEntity): LegalEnti
     return LegalEntityState(dto.description, dto.validFrom, dto.validTo, dto.type, legalEntity)
 }
 
-fun toEntityClassification(dto: ClassificationDto, legalEntity: LegalEntity): LegalEntityClassification {
+fun toEntityClassification(dto: LegalEntityClassificationDto, legalEntity: LegalEntity): LegalEntityClassification {
     return LegalEntityClassification(dto.value, dto.code, dto.type, legalEntity)
 }
 
@@ -368,8 +368,8 @@ fun mapToLegalEntityStateDto(states: MutableSet<LegalEntityState>): Collection<L
     return states.map { LegalEntityStateDto(it.description, it.validFrom, it.validTo, it.type) }
 }
 
-fun mapToLegalEntityClassificationsDto(classification: MutableSet<LegalEntityClassification>): Collection<ClassificationDto> {
-    return classification.map { ClassificationDto(it.type, it.code, it.value) }
+fun mapToLegalEntityClassificationsDto(classification: MutableSet<LegalEntityClassification>): Collection<LegalEntityClassificationDto> {
+    return classification.map { LegalEntityClassificationDto(it.type, it.code, it.value) }
 }
 
 fun mapToLegalEntityIdentifiersDto(identifiers: MutableSet<LegalEntityIdentifier>): Collection<LegalEntityIdentifierDto> {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerNonVerboseValues.kt
@@ -53,21 +53,18 @@ object BusinessPartnerNonVerboseValues {
     val legalEntityGateInputRequest1 = LegalEntityGateInputRequest(
         legalEntity = BusinessPartnerVerboseValues.legalEntity1,
         legalAddress = BusinessPartnerVerboseValues.physicalAddress1,
-        legalNameParts = BusinessPartnerVerboseValues.legalEntityGateInputResponse1.legalNameParts,
         externalId = BusinessPartnerVerboseValues.externalId1,
     )
 
     val legalEntityGateInputRequest2 = LegalEntityGateInputRequest(
         legalEntity = BusinessPartnerVerboseValues.legalEntity2,
         legalAddress = BusinessPartnerVerboseValues.physicalAddress2,
-        legalNameParts = BusinessPartnerVerboseValues.legalEntityGateInputResponse2.legalNameParts,
         externalId = BusinessPartnerVerboseValues.externalId2,
     )
 
     val legalEntityGateInputRequest3 = LegalEntityGateInputRequest(
         legalEntity = BusinessPartnerVerboseValues.legalEntity3,
         legalAddress = BusinessPartnerVerboseValues.physicalAddress3,
-        legalNameParts = BusinessPartnerVerboseValues.logisticAddressGateInputResponse1.address.nameParts,
         externalId = BusinessPartnerVerboseValues.externalId3,
     )
 
@@ -154,7 +151,6 @@ object BusinessPartnerNonVerboseValues {
     val legalEntityGateOutputRequest1 = LegalEntityGateOutputRequest(
         legalEntity = BusinessPartnerVerboseValues.legalEntity1,
         legalAddress = AddressGateOutputChildRequest(BusinessPartnerVerboseValues.physicalAddress1, BusinessPartnerVerboseValues.legalEntityGateOutputResponse1.legalAddress.bpna),
-        legalNameParts = BusinessPartnerVerboseValues.legalEntityGateOutputResponse1.legalNameParts,
         externalId = BusinessPartnerVerboseValues.externalId1,
         bpn = BusinessPartnerVerboseValues.legalEntityGateOutputResponse1.bpnl
     )
@@ -162,7 +158,6 @@ object BusinessPartnerNonVerboseValues {
     val legalEntityGateOutputRequest2 = LegalEntityGateOutputRequest(
         legalEntity = BusinessPartnerVerboseValues.legalEntity2,
         legalAddress = AddressGateOutputChildRequest(BusinessPartnerVerboseValues.physicalAddress2, BusinessPartnerVerboseValues.legalEntityGateOutputResponse2.legalAddress.bpna),
-        legalNameParts = BusinessPartnerVerboseValues.legalEntityGateOutputResponse2.legalNameParts,
         externalId = BusinessPartnerVerboseValues.externalId2,
         bpn = BusinessPartnerVerboseValues.legalEntityGateOutputResponse2.bpnl
     )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -200,25 +200,25 @@ object BusinessPartnerVerboseValues {
         type = businessStateType2
     )
 
-    val bpClassification1Dto = ClassificationDto(
+    val bpClassification1Dto = LegalEntityClassificationDto(
         type = ClassificationType.NACE,
         code = "code1",
         value = "Sale of motor vehicles"
     )
 
-    val bpClassification2Dto = ClassificationDto(
+    val bpClassification2Dto = LegalEntityClassificationDto(
         type = ClassificationType.NACE,
         code = "code2",
         value = "Data processing, hosting and related activities"
     )
 
-    val bpClassification3Dto = ClassificationDto(
+    val bpClassification3Dto = LegalEntityClassificationDto(
         type = ClassificationType.NACE,
         code = "code3",
         value = "Other information service activities"
     )
 
-    val bpClassification4Dto = ClassificationDto(
+    val bpClassification4Dto = LegalEntityClassificationDto(
         type = ClassificationType.NACE,
         code = "code4",
         value = "Financial and insurance activities"

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -187,6 +187,7 @@ object BusinessPartnerVerboseValues {
     )
 
     val legalEntity1 = LegalEntityDto(
+        legalNameParts = listOf("Business Partner Name"),
         legalShortName = "short1",
         legalForm = "LF1",
         states = listOf(legalEntityBusinessStatus1),
@@ -194,6 +195,7 @@ object BusinessPartnerVerboseValues {
     )
 
     val legalEntity2 = LegalEntityDto(
+        legalNameParts = listOf("Company ABC AG"),
         legalShortName = "short3",
         legalForm = "LF2",
         states = listOf(legalEntityBusinessStatus2),
@@ -201,6 +203,7 @@ object BusinessPartnerVerboseValues {
     )
 
     val legalEntity3 = LegalEntityDto(
+        legalNameParts = listOf("Business Partner Name"),
         legalShortName = "short1",
         legalForm = "LF1",
         states = listOf(legalEntityBusinessStatus1),
@@ -457,7 +460,6 @@ object BusinessPartnerVerboseValues {
 
     val legalEntityGateInputResponse1 = LegalEntityGateInputDto(
         legalEntity = legalEntity1,
-        legalNameParts = listOf("Business Partner Name"),
         legalAddress = AddressGateInputDto(
             address = logisticAddress1,
             externalId = "${externalId1}_legalAddress",
@@ -469,7 +471,6 @@ object BusinessPartnerVerboseValues {
 
     val legalEntityGateInputResponse2 = LegalEntityGateInputDto(
         legalEntity = legalEntity2,
-        legalNameParts = listOf("Company ABC AG"),
         legalAddress = AddressGateInputDto(
             address = logisticAddress2,
             externalId = "${externalId2}_legalAddress",
@@ -492,7 +493,6 @@ object BusinessPartnerVerboseValues {
     //Gate Output Legal Entities Response
     val legalEntityGateOutputResponse1 = LegalEntityGateOutputResponse(
         legalEntity = legalEntity1,
-        legalNameParts = listOf("Business Partner Name"),
         externalId = externalId1,
         bpnl = "BPNL0000000000XY",
         legalAddress = AddressGateOutputDto(
@@ -508,7 +508,6 @@ object BusinessPartnerVerboseValues {
     val legalEntityGateOutputResponse2 = LegalEntityGateOutputResponse(
         legalEntity = legalEntity2,
         externalId = externalId2,
-        legalNameParts = listOf("Company ABC AG"),
         bpnl = "BPNL0000000001XZ",
         legalAddress = AddressGateOutputDto(
             address = physicalAddress2,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -21,17 +21,15 @@ package org.eclipse.tractusx.bpdm.gate.util
 
 import com.neovisionaries.i18n.CountryCode
 import org.eclipse.tractusx.bpdm.common.dto.*
-import org.eclipse.tractusx.bpdm.common.dto.response.*
+import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
-import org.eclipse.tractusx.bpdm.common.service.toDto
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerOutputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.*
-import java.time.Instant
 import java.time.LocalDateTime
 
 object BusinessPartnerVerboseValues {
@@ -78,18 +76,6 @@ object BusinessPartnerVerboseValues {
     val businessStateType1 = BusinessStateType.ACTIVE
     val businessStateType2 = BusinessStateType.INACTIVE
 
-    val legalForm1 = LegalFormDto(
-        technicalKey = "LF1",
-        name = "Limited Liability Company",
-        abbreviation = "LLC",
-    )
-
-    val legalForm2 = LegalFormDto(
-        technicalKey = "LF2",
-        name = "Gemeinschaft mit beschränkter Haftung",
-        abbreviation = "GmbH",
-    )
-
     val bpState1 = BusinessPartnerStateDto(
         validFrom = businessStatusValidFrom1,
         validTo = businessStatusValidUntil1,
@@ -120,30 +106,6 @@ object BusinessPartnerVerboseValues {
         type = identifierTypeTechnicalKey3,
         value = identifierValue3,
         issuingBody = null
-    )
-
-    val classification1 = ClassificationVerboseDto(
-        value = "Sale of motor vehicles",
-        code = "code1",
-        type = ClassificationType.NACE.toDto()
-    )
-
-    val classification2 = ClassificationVerboseDto(
-        value = "Data processing, hosting and related activities",
-        code = "code2",
-        type = ClassificationType.NACE.toDto()
-    )
-
-    val classification3 = ClassificationVerboseDto(
-        value = "Other information service activities",
-        code = "code3",
-        type = ClassificationType.NACE.toDto()
-    )
-
-    val classification4 = ClassificationVerboseDto(
-        value = "Financial and insurance activities",
-        code = "code4",
-        type = ClassificationType.NACE.toDto()
     )
 
 
@@ -243,26 +205,6 @@ object BusinessPartnerVerboseValues {
         legalForm = "LF1",
         states = listOf(legalEntityBusinessStatus1),
         classifications = listOf(bpClassification1Dto, bpClassification2Dto),
-    )
-
-    val leBusinessStatus1 = LegalEntityStateVerboseDto(
-        description = "Active",
-        validFrom = LocalDateTime.of(2020, 1, 1, 0, 0),
-        validTo = LocalDateTime.of(2021, 1, 1, 0, 0),
-        type = TypeKeyNameVerboseDto(
-            technicalKey = BusinessStateType.ACTIVE,
-            name = BusinessStateType.ACTIVE.getTypeName(),
-        )
-    )
-
-    val leBusinessStatus2 = LegalEntityStateVerboseDto(
-        description = "Insolvent",
-        validFrom = LocalDateTime.of(2019, 1, 1, 0, 0),
-        validTo = LocalDateTime.of(2022, 1, 1, 0, 0),
-        type = TypeKeyNameVerboseDto(
-            technicalKey = BusinessStateType.INACTIVE,
-            name = BusinessStateType.INACTIVE.getTypeName(),
-        )
     )
 
     val siteBusinessStatus1 = SiteStateDto(
@@ -407,70 +349,6 @@ object BusinessPartnerVerboseValues {
         floor = "Floor Two",
         door = "Door Two",
         street = StreetDto("TODO", ""),
-    )
-
-    val legalEntityResponsePool1 = PoolLegalEntityVerboseDto(
-        legalName = "Business Partner Name",
-        legalAddress = LogisticAddressVerboseDto(
-            bpna = "BPNA0000000001XY",
-            physicalPostalAddress = address1,
-            bpnLegalEntity = "BPNL0000000000XY",
-            bpnSite = "BPNS0000000001XY",
-            createdAt = Instant.now(),
-            updatedAt = Instant.now()
-        ), legalEntity = LegalEntityVerboseDto(
-            bpnl = "BPNL0000000000XY",
-            legalShortName = "short1",
-            legalForm = legalForm1,
-            states = listOf(leBusinessStatus1),
-            classifications = listOf(classification1, classification2),
-            currentness = Instant.now(),
-            createdAt = Instant.now(),
-            updatedAt = Instant.now(),
-        )
-
-    )
-
-    val legalEntityResponsePool2 = PoolLegalEntityVerboseDto(
-        legalName = "Another Organisation Corp", legalAddress = LogisticAddressVerboseDto(
-            bpna = "BPNA0000000002XY",
-            physicalPostalAddress = address2,
-            bpnLegalEntity = "BPNL0000000001XZ",
-            bpnSite = "BPNS0000000002XY",
-            createdAt = Instant.now(),
-            updatedAt = Instant.now()
-        ), legalEntity = LegalEntityVerboseDto(
-            bpnl = "BPNL0000000001XZ",
-            legalShortName = "short3",
-            legalForm = legalForm2,
-            states = listOf(leBusinessStatus2),
-            classifications = listOf(classification3, classification4),
-            currentness = Instant.now(),
-            createdAt = Instant.now(),
-            updatedAt = Instant.now(),
-        )
-    )
-
-    val legalEntityResponseGate1 = LegalEntityVerboseDto(
-        bpnl = "BPNL0000000000XY",
-        legalShortName = "short1",
-        legalForm = legalForm1,
-        states = listOf(leBusinessStatus1),
-        classifications = listOf(classification1, classification2),
-        currentness = Instant.now(),
-        createdAt = Instant.now(),
-        updatedAt = Instant.now(),
-    )
-
-    val legalEntityResponseGate2 = LegalEntityVerboseDto(
-        bpnl = "BPNL0000000001XZ",
-        legalShortName = "short3",
-        legalForm = legalForm2,
-        states = listOf(leBusinessStatus2),
-        classifications = listOf(classification3, classification4),
-        currentness = Instant.now(),
-        createdAt = Instant.now(),
-        updatedAt = Instant.now(),
     )
 
     //New Values for Logistic Addresses Tests

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassificationDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerClassificationDto.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseClassificationDto
+import org.eclipse.tractusx.bpdm.common.dto.IBusinessPartnerClassificationDto
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
 @Schema(requiredProperties = ["type"])
@@ -30,4 +30,4 @@ data class BusinessPartnerClassificationDto(
     override val code: String?,
     override val value: String?
 
-) : IBaseClassificationDto
+) : IBusinessPartnerClassificationDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerStateDto.kt
@@ -19,7 +19,7 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseStateDto
+import org.eclipse.tractusx.bpdm.common.dto.IBusinessPartnerStateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
@@ -30,4 +30,4 @@ data class BusinessPartnerStateDto(
     override val type: BusinessStateType?,
     override val description: String?
 
-) : IBaseStateDto
+) : IBusinessPartnerStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityClassificationDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityClassificationDto.kt
@@ -17,15 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package com.catenax.bpdm.bridge.dummy.dto
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
-import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityClassificationDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-data class GateLegalEntityInfo(
-    val legalNameParts: Collection<String>,
-    val legalEntity: LegalEntityDto,
-    val legalAddress: AddressGateInputDto,
-    val externalId: String,
-    val bpn: String?
-)
+@Schema(description = ClassificationDescription.header)
+data class LegalEntityClassificationDto(
+
+    override val type: ClassificationType,
+    override val code: String?,
+    override val value: String?
+
+) : ILegalEntityClassificationDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
@@ -20,7 +20,6 @@
 package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 
@@ -41,9 +40,9 @@ data class LegalEntityDto(
 
     override val legalForm: String? = null,
 
-    override val states: Collection<LegalEntityState> = emptyList(),
+    override val states: Collection<LegalEntityStateDto> = emptyList(),
 
-    override val classifications: Collection<ClassificationDto> = emptyList(),
+    override val classifications: Collection<LegalEntityClassificationDto> = emptyList(),
 
     val legalAddress: LogisticAddressDto? = null
 

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityIdentifierDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityIdentifierDto.kt
@@ -19,11 +19,12 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityIdentifierDto
 
 data class LegalEntityIdentifierDto(
+
     override val value: String,
     override val type: String,
     override val issuingBody: String?
 
-) : IBaseLegalEntityIdentifierDto
+) : ILegalEntityIdentifierDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityStateDto.kt
@@ -17,15 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package com.catenax.bpdm.bridge.dummy.dto
+package org.eclipse.tractusx.orchestrator.api.model
 
-import org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityDto
-import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressGateInputDto
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-data class GateLegalEntityInfo(
-    val legalNameParts: Collection<String>,
-    val legalEntity: LegalEntityDto,
-    val legalAddress: AddressGateInputDto,
-    val externalId: String,
-    val bpn: String?
-)
+data class LegalEntityStateDto(
+
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
+    override val type: BusinessStateType
+
+) : ILegalEntityStateDto

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.bpdm.orchestrator.testdata
 import com.neovisionaries.i18n.CountryCode
 import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
@@ -348,13 +347,13 @@ object BusinessPartnerTestValues {
         ),
         legalForm = "Legal Form 1",
         states = listOf(
-            LegalEntityState(
+            LegalEntityStateDto(
                 description = "Legal State Description 1",
                 validFrom = LocalDateTime.of(1995, 2, 2, 3, 3),
                 validTo = LocalDateTime.of(2000, 3, 3, 4, 4),
                 type = BusinessStateType.ACTIVE
             ),
-            LegalEntityState(
+            LegalEntityStateDto(
                 description = "Legal State Description 2",
                 validFrom = LocalDateTime.of(2000, 3, 3, 4, 4),
                 validTo = null,
@@ -362,12 +361,12 @@ object BusinessPartnerTestValues {
             ),
         ),
         classifications = listOf(
-            ClassificationDto(
+            LegalEntityClassificationDto(
                 type = ClassificationType.SIC,
                 code = "Classification Code 1",
                 value = "Classification Value 1"
             ),
-            ClassificationDto(
+            LegalEntityClassificationDto(
                 type = ClassificationType.NACE,
                 code = "Classification Code 2",
                 value = "Classification Value 2"
@@ -393,7 +392,7 @@ object BusinessPartnerTestValues {
         ),
         legalForm = "Legal Form 2",
         states = listOf(
-            LegalEntityState(
+            LegalEntityStateDto(
                 description = "Legal State Description 2",
                 validFrom = LocalDateTime.of(1900, 5, 5, 5, 5),
                 validTo = null,
@@ -401,7 +400,7 @@ object BusinessPartnerTestValues {
             )
         ),
         classifications = listOf(
-            ClassificationDto(
+            LegalEntityClassificationDto(
                 type = ClassificationType.SIC,
                 code = "Classification Code 2",
                 value = "Classification Value 2"

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -33,11 +33,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -95,7 +91,7 @@ interface PoolLegalEntityApi {
         @Parameter(description = "Identifier value") @PathVariable idValue: String,
         @Parameter(description = "Type of identifier to use, defaults to BPN when omitted", schema = Schema(defaultValue = "BPN"))
         @RequestParam idType: String? = "BPN"
-    ): PoolLegalEntityVerboseDto
+    ): LegalEntityWithLegalAddressVerboseDto
 
     @Operation(
         summary = "Confirms that the data of a legal entity business partner is still up to date.",
@@ -135,7 +131,7 @@ interface PoolLegalEntityApi {
     @PostExchange("/search")
     fun searchLegalEntitys(
         @RequestBody bpnLs: Collection<String>
-    ): ResponseEntity<Collection<PoolLegalEntityVerboseDto>>
+    ): ResponseEntity<Collection<LegalEntityWithLegalAddressVerboseDto>>
 
     @Operation(
         summary = "Returns all sites of a legal entity with a specific BPNL",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
@@ -38,6 +37,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -30,9 +30,9 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.CountrySubdivisionDto
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.RegionDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityClassificationDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityClassificationDto.kt
@@ -17,16 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityClassificationDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(name = "NameRegioncodeDto", description = "Region within a country")
-data class NameRegioncodeVerboseDto(
+@Schema(description = ClassificationDescription.header)
+data class LegalEntityClassificationDto(
 
-    @get:Schema(description = "Describes the full name of the region within a country according to ISO 3166-214")
-    val name: String,
+    override val type: ClassificationType,
+    override val code: String?,
+    override val value: String?
 
-    @get:Schema(description = "Abbreviation or shorthand of the area")
-    val regionCode: String,
-)
+) : ILegalEntityClassificationDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityClassificationVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityClassificationVerboseDto.kt
@@ -17,22 +17,23 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.verbose
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
+@Schema(description = ClassificationDescription.header)
+data class LegalEntityClassificationVerboseDto(
 
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
+    @get:Schema(description = ClassificationDescription.value)
+    val value: String? = null,
+
+    @get:Schema(description = ClassificationDescription.code)
+    val code: String? = null,
 
     // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
+    @get:Schema(description = ClassificationDescription.type)
+    val type: TypeKeyNameVerboseDto<ClassificationType>
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
@@ -26,9 +26,12 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescri
 @Schema(description = LegalEntityDescription.header)
 data class LegalEntityDto(
 
-    override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
+    @get:Schema(description = LegalEntityDescription.legalName)
+    val legalName: String,
+
     override val legalShortName: String?,
     override val legalForm: String? = null,
+    override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
     override val states: Collection<LegalEntityStateDto> = emptyList(),
     override val classifications: Collection<LegalEntityClassificationDto> = emptyList()
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
@@ -17,26 +17,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.bpdm.pool.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 
 @Schema(description = LegalEntityDescription.header)
 data class LegalEntityDto(
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers, required = false))
+
     override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
-
-    @get:Schema(description = LegalEntityDescription.legalShortName)
     override val legalShortName: String?,
-
-    @get:Schema(description = LegalEntityDescription.legalForm)
     override val legalForm: String? = null,
-
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.states))
     override val states: Collection<LegalEntityStateDto> = emptyList(),
+    override val classifications: Collection<LegalEntityClassificationDto> = emptyList()
 
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications, required = false))
-    override val classifications: Collection<ClassificationDto> = emptyList(),
-)  : IBaseLegalEntityDto
+) : IBaseLegalEntityDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityIdentifierDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityIdentifierDto.kt
@@ -17,12 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.bpdm.pool.api.model
 
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 
+@Schema(description = LegalEntityIdentifierDescription.header)
 data class LegalEntityIdentifierDto(
 
     override val value: String,
     override val type: String,
     override val issuingBody: String?
-) : IBaseLegalEntityIdentifierDto
+
+) : ILegalEntityIdentifierDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityIdentifierVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityIdentifierVerboseDto.kt
@@ -17,23 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.verbose
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
-import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = ClassificationDescription.header)
-data class LegalEntityClassificationVerboseDto(
+@Schema(description = LegalEntityIdentifierDescription.header)
+data class LegalEntityIdentifierVerboseDto(
 
-    @get:Schema(description = ClassificationDescription.value)
-    val value: String? = null,
-
-    @get:Schema(description = ClassificationDescription.code)
-    val code: String? = null,
+    @get:Schema(description = LegalEntityIdentifierDescription.value)
+    val value: String,
 
     // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = ClassificationDescription.type)
-    val type: TypeKeyNameVerboseDto<ClassificationType>
+    @get:Schema(description = LegalEntityIdentifierDescription.type)
+    val type: TypeKeyNameVerboseDto<String>,
+
+    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
+    val issuingBody: String? = null
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateDto.kt
@@ -17,9 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
@@ -27,15 +28,9 @@ import java.time.LocalDateTime
 @Schema(description = LegalEntityStateDescription.header)
 data class LegalEntityStateDto(
 
-    @get:Schema(description = LegalEntityStateDescription.description)
     override val description: String?,
-
-    @get:Schema(description = LegalEntityStateDescription.validFrom)
     override val validFrom: LocalDateTime?,
-
-    @get:Schema(description = LegalEntityStateDescription.validTo)
     override val validTo: LocalDateTime?,
-
-    @get:Schema(description = LegalEntityStateDescription.type)
     override val type: BusinessStateType
-) : IBaseLegalEntityStateDto
+
+) : ILegalEntityStateDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateVerboseDto.kt
@@ -17,26 +17,27 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.verbose
+package org.eclipse.tractusx.bpdm.pool.api.model
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
+import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import java.time.LocalDateTime
 
-@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
-@Schema(description = LegalEntityDescription.header)
-data class PoolLegalEntityVerboseDto(
+@Schema(description = LegalEntityStateDescription.header)
+data class LegalEntityStateVerboseDto(
 
-    @get:Schema(description = LegalEntityDescription.legalName)
-    val legalName: String,
+    @get:Schema(description = LegalEntityStateDescription.description)
+    val description: String?,
 
-    @field:JsonUnwrapped
-    val legalEntity: LegalEntityVerboseDto,
+    @get:Schema(description = LegalEntityStateDescription.validFrom)
+    val validFrom: LocalDateTime?,
+
+    @get:Schema(description = LegalEntityStateDescription.validTo)
+    val validTo: LocalDateTime?,
 
     // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityDescription.legalAddress)
-    val legalAddress: LogisticAddressVerboseDto,
+    @get:Schema(description = LegalEntityStateDescription.type)
+    val type: TypeKeyNameVerboseDto<BusinessStateType>
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
@@ -17,15 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.verbose
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
-import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import java.time.Instant
-
 
 @Schema(description = LegalEntityDescription.header)
 data class LegalEntityVerboseDto(
@@ -33,15 +31,18 @@ data class LegalEntityVerboseDto(
     @get:Schema(description = LegalEntityDescription.bpnl)
     val bpnl: String,
 
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers))
-    val identifiers: Collection<LegalEntityIdentifierVerboseDto> = emptyList(),
+    @get:Schema(description = LegalEntityDescription.legalName)
+    val legalName: String,
 
     @get:Schema(description = LegalEntityDescription.legalShortName)
     val legalShortName: String? = null,
 
-    // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = LegalEntityDescription.legalForm)
     val legalForm: LegalFormDto? = null,
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers))
+    val identifiers: Collection<LegalEntityIdentifierVerboseDto> = emptyList(),
 
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.states))
     val states: Collection<LegalEntityStateVerboseDto> = emptyList(),

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalFormDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalFormDto.kt
@@ -17,27 +17,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
-import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
-import java.time.LocalDateTime
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalFormDescription
 
-@Schema(description = LegalEntityStateDescription.header)
-data class LegalEntityStateVerboseDto(
+@Schema(description = LegalFormDescription.header)
+data class LegalFormDto(
 
-    @get:Schema(description = LegalEntityStateDescription.description)
-    val description: String?,
+    @get:Schema(description = LegalFormDescription.technicalKey)
+    val technicalKey: String,
 
-    @get:Schema(description = LegalEntityStateDescription.validFrom)
-    val validFrom: LocalDateTime?,
+    @get:Schema(description = LegalFormDescription.name)
+    val name: String,
 
-    @get:Schema(description = LegalEntityStateDescription.validTo)
-    val validTo: LocalDateTime?,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityStateDescription.type)
-    val type: TypeKeyNameVerboseDto<BusinessStateType>
+    @get:Schema(description = LegalFormDescription.abbreviation)
+    val abbreviation: String? = null,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/RelationVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/RelationVerboseDto.kt
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.verbose
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
@@ -33,9 +33,6 @@ import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityDto
 @Schema(description = LegalEntityDescription.headerCreateRequest)
 data class LegalEntityPartnerCreateRequest(
 
-    @get:Schema(description = LegalEntityDescription.legalName)
-    val legalName: String,
-
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 
@@ -45,6 +42,7 @@ data class LegalEntityPartnerCreateRequest(
 
     @get:Schema(description = CommonDescription.index)
     val index: String?
+
 ): RequestWithKey {
     override fun getRequestKey(): String? {
         return index

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerCreateRequest.kt
@@ -22,12 +22,12 @@ package org.eclipse.tractusx.bpdm.pool.api.model.request
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.RequestWithKey
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.headerCreateRequest)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
@@ -22,11 +22,11 @@ package org.eclipse.tractusx.bpdm.pool.api.model.request
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.LogisticAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.RequestWithKey
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.headerUpdateRequest)
@@ -43,9 +43,11 @@ data class LegalEntityPartnerUpdateRequest(
 
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = LegalEntityDescription.legalAddress)
-    val legalAddress: LogisticAddressDto,
+    val legalAddress: LogisticAddressDto
+
 ): RequestWithKey {
-    override fun getRequestKey(): String? {
+
+    override fun getRequestKey(): String {
         return bpnl
     }
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntityPartnerUpdateRequest.kt
@@ -35,9 +35,6 @@ data class LegalEntityPartnerUpdateRequest(
     @get:Schema(description = LegalEntityDescription.bpnl)
     val bpnl: String,
 
-    @get:Schema(description = LegalEntityDescription.legalName)
-    val legalName: String,
-
     @field:JsonUnwrapped
     val legalEntity: LegalEntityDto,
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
@@ -24,9 +24,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.headerMatchResponse)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityMatchVerboseDto.kt
@@ -26,7 +26,7 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.headerMatchResponse)
@@ -34,9 +34,6 @@ data class LegalEntityMatchVerboseDto(
 
     @get:Schema(description = CommonDescription.score)
     val score: Float,
-
-    @get:Schema(description = LegalEntityDescription.legalName)
-    val legalName: String,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
@@ -24,9 +24,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.headerUpsertResponse)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityPartnerCreateVerboseDto.kt
@@ -26,14 +26,11 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
 @Schema(description = LegalEntityDescription.headerUpsertResponse)
 data class LegalEntityPartnerCreateVerboseDto(
-
-    @get:Schema(description = LegalEntityDescription.legalName)
-    val legalName: String,
 
     @field:JsonUnwrapped
     val legalEntity: LegalEntityVerboseDto,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityWithLegalAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/LegalEntityWithLegalAddressVerboseDto.kt
@@ -17,27 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.verbose
+package org.eclipse.tractusx.bpdm.pool.api.model.response
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
-import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
-import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
-import java.time.LocalDateTime
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
 
-@Schema(description = LegalEntityStateDescription.header)
-data class LegalEntityStateVerboseDto(
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = LegalEntityDescription.header)
+data class LegalEntityWithLegalAddressVerboseDto(
 
-    @get:Schema(description = LegalEntityStateDescription.description)
-    val description: String?,
-
-    @get:Schema(description = LegalEntityStateDescription.validFrom)
-    val validFrom: LocalDateTime?,
-
-    @get:Schema(description = LegalEntityStateDescription.validTo)
-    val validTo: LocalDateTime?,
+    @field:JsonUnwrapped
+    val legalEntity: LegalEntityVerboseDto,
 
     // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityStateDescription.type)
-    val type: TypeKeyNameVerboseDto<BusinessStateType>
+    @get:Schema(description = LegalEntityDescription.legalAddress)
+    val legalAddress: LogisticAddressVerboseDto,
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityClassificationVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityClassificationVerboseDto.kt
@@ -17,22 +17,23 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.pool.api.model.verbose
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = LegalEntityIdentifierDescription.header)
-data class LegalEntityIdentifierVerboseDto(
+@Schema(description = ClassificationDescription.header)
+data class LegalEntityClassificationVerboseDto(
 
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
+    @get:Schema(description = ClassificationDescription.value)
+    val value: String? = null,
+
+    @get:Schema(description = ClassificationDescription.code)
+    val code: String? = null,
 
     // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
+    @get:Schema(description = ClassificationDescription.type)
+    val type: TypeKeyNameVerboseDto<ClassificationType>
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityIdentifierVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityIdentifierVerboseDto.kt
@@ -17,23 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.pool.api.model.verbose
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
-import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 
-@Schema(description = ClassificationDescription.header)
-data class ClassificationVerboseDto(
+@Schema(description = LegalEntityIdentifierDescription.header)
+data class LegalEntityIdentifierVerboseDto(
 
-    @get:Schema(description = ClassificationDescription.value)
-    val value: String? = null,
-
-    @get:Schema(description = ClassificationDescription.code)
-    val code: String? = null,
+    @get:Schema(description = LegalEntityIdentifierDescription.value)
+    val value: String,
 
     // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = ClassificationDescription.type)
-    val type: TypeKeyNameVerboseDto<ClassificationType>
+    @get:Schema(description = LegalEntityIdentifierDescription.type)
+    val type: TypeKeyNameVerboseDto<String>,
+
+    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
+    val issuingBody: String? = null
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityStateVerboseDto.kt
@@ -17,28 +17,27 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.pool.api.model.verbose
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
-import org.eclipse.tractusx.bpdm.common.model.RelationType
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
-@Schema(name = "RelationVerboseDto", description = "Directed relation between two business partners")
-data class RelationVerboseDto(
+@Schema(description = LegalEntityStateDescription.header)
+data class LegalEntityStateVerboseDto(
 
-    @get:Schema(description = "Type of relation like predecessor or ownership relation")
-    val type: TypeKeyNameVerboseDto<RelationType>,
+    @get:Schema(description = LegalEntityStateDescription.description)
+    val description: String?,
 
-    @get:Schema(description = "BPN of partner which is the source of the relation")
-    val startBpnl: String,
+    @get:Schema(description = LegalEntityStateDescription.validFrom)
+    val validFrom: LocalDateTime?,
 
-    @get:Schema(description = "BPN of partner which is the target of the relation")
-    val endBpnl: String,
+    @get:Schema(description = LegalEntityStateDescription.validTo)
+    val validTo: LocalDateTime?,
 
-    @get:Schema(description = "Time when the relation started")
-    val validFrom: LocalDateTime? = null,
-
-    @get:Schema(description = "Time when the relation ended")
-    val validTo: LocalDateTime? = null
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityStateDescription.type)
+    val type: TypeKeyNameVerboseDto<BusinessStateType>
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/LegalEntityVerboseDto.kt
@@ -17,12 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.pool.api.model.verbose
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import java.time.Instant
 
 
@@ -46,7 +47,7 @@ data class LegalEntityVerboseDto(
     val states: Collection<LegalEntityStateVerboseDto> = emptyList(),
 
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications))
-    val classifications: Collection<ClassificationVerboseDto> = emptyList(),
+    val classifications: Collection<LegalEntityClassificationVerboseDto> = emptyList(),
 
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.relations))
     val relations: Collection<RelationVerboseDto> = emptyList(),

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/PoolLegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/PoolLegalEntityVerboseDto.kt
@@ -17,12 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.pool.api.model.verbose
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
 
 @JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/RelationVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/verbose/RelationVerboseDto.kt
@@ -17,20 +17,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.dto.response
+package org.eclipse.tractusx.bpdm.pool.api.model.verbose
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalFormDescription
+import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
+import org.eclipse.tractusx.bpdm.common.model.RelationType
+import java.time.LocalDateTime
 
-@Schema(description = LegalFormDescription.header)
-data class LegalFormDto(
+@Schema(name = "RelationVerboseDto", description = "Directed relation between two business partners")
+data class RelationVerboseDto(
 
-    @get:Schema(description = LegalFormDescription.technicalKey)
-    val technicalKey: String,
+    @get:Schema(description = "Type of relation like predecessor or ownership relation")
+    val type: TypeKeyNameVerboseDto<RelationType>,
 
-    @get:Schema(description = LegalFormDescription.name)
-    val name: String,
+    @get:Schema(description = "BPN of partner which is the source of the relation")
+    val startBpnl: String,
 
-    @get:Schema(description = LegalFormDescription.abbreviation)
-    val abbreviation: String? = null,
+    @get:Schema(description = "BPN of partner which is the target of the relation")
+    val endBpnl: String,
+
+    @get:Schema(description = "Time when the relation started")
+    val validFrom: LocalDateTime? = null,
+
+    @get:Schema(description = "Time when the relation ended")
+    val validTo: LocalDateTime? = null
 )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.bpdm.pool.controller
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
@@ -33,7 +32,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.service.SearchService
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.config.BpnConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.PoolSecurityConfigProperties

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -28,11 +28,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchReq
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.eclipse.tractusx.bpdm.pool.config.BpnConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.PoolSecurityConfigProperties
@@ -66,7 +62,7 @@ class LegalEntityController(
     }
 
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
-    override fun getLegalEntity(idValue: String, idType: String?): PoolLegalEntityVerboseDto {
+    override fun getLegalEntity(idValue: String, idType: String?): LegalEntityWithLegalAddressVerboseDto {
         val actualType = idType ?: bpnConfigProperties.id
         return if (actualType == bpnConfigProperties.id) businessPartnerFetchService.findLegalEntityIgnoreCase(idValue.uppercase())
         else businessPartnerFetchService.findLegalEntityIgnoreCase(actualType, idValue)
@@ -80,7 +76,7 @@ class LegalEntityController(
     @PreAuthorize("hasAuthority(@poolSecurityConfigProperties.getReadPoolPartnerDataAsRole())")
     override fun searchLegalEntitys(
         bpnLs: Collection<String>
-    ): ResponseEntity<Collection<PoolLegalEntityVerboseDto>> {
+    ): ResponseEntity<Collection<LegalEntityWithLegalAddressVerboseDto>> {
         if (bpnLs.size > controllerConfigProperties.searchRequestLimit) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)
         }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -25,10 +25,10 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.CountrySubdivisionDto
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.RegionDto
 import org.eclipse.tractusx.bpdm.pool.api.PoolMetadataApi
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.service.MetadataService
 import org.springframework.data.domain.PageRequest

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -395,7 +395,7 @@ class BusinessPartnerBuildService(
             return Instant.now().truncatedTo(ChronoUnit.MICROS)
         }
 
-        fun toLegalEntityState(dto: IBaseLegalEntityStateDto, legalEntity: LegalEntity): LegalEntityState {
+        fun toLegalEntityState(dto: ILegalEntityStateDto, legalEntity: LegalEntity): LegalEntityState {
             return LegalEntityState(
                 description = dto.description,
                 validFrom = dto.validFrom,
@@ -438,7 +438,7 @@ class BusinessPartnerBuildService(
         }
 
         fun toLegalEntityIdentifier(
-            dto: IBaseLegalEntityIdentifierDto,
+            dto: ILegalEntityIdentifierDto,
             idTypes: Map<String, IdentifierType>,
             partner: LegalEntity
         ): LegalEntityIdentifier {
@@ -493,7 +493,7 @@ class BusinessPartnerBuildService(
             legalEntityDto: IBaseLegalEntityDto,
             bpnL: String,
             legalNameValue: String?,
-            metadataMap: BusinessPartnerBuildService.LegalEntityMetadataMapping
+            metadataMap: LegalEntityMetadataMapping
         ): LegalEntity {
 
             if (legalNameValue == null) {
@@ -509,7 +509,7 @@ class BusinessPartnerBuildService(
                 legalForm = legalForm,
                 currentness = Instant.now().truncatedTo(ChronoUnit.MICROS),
             )
-            BusinessPartnerBuildService.updateLegalEntity(newLegalEntity, legalEntityDto, legalNameValue, metadataMap)
+            updateLegalEntity(newLegalEntity, legalEntityDto, legalNameValue, metadataMap)
 
             return newLegalEntity
         }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -76,7 +76,7 @@ class BusinessPartnerBuildService(
 
         val requestsByLegalEntities = validRequests
             .mapIndexed { bpnIndex, request ->
-                val legalEntity = createLegalEntity(request.legalEntity, bpnLs[bpnIndex], request.legalName, legalEntityMetadataMap)
+                val legalEntity = createLegalEntity(request.legalEntity, bpnLs[bpnIndex], request.legalEntity.legalName, legalEntityMetadataMap)
                 val legalAddress = createLogisticAddress(request.legalAddress, bpnAs[bpnIndex], legalEntity, addressMetadataMap)
                 legalEntity.legalAddress = legalAddress
                 Pair(legalEntity, request)
@@ -198,7 +198,7 @@ class BusinessPartnerBuildService(
         val requestsByBpn = validRequests.associateBy { it.bpnl }
         val updatedLegalEntities = legalEntities.map { legalEntity ->
             val request = requestsByBpn[legalEntity.bpn]!!
-            updateLegalEntity(legalEntity, request.legalEntity, request.legalName, legalEntityMetadataMap)
+            updateLegalEntity(legalEntity, request.legalEntity, request.legalEntity.legalName, legalEntityMetadataMap)
             updateLogisticAddress(legalEntity.legalAddress, request.legalAddress, addressMetadataMap)
             legalEntityRepository.save(legalEntity)
         }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.service
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierType
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntity
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityIdentifier
@@ -46,19 +46,19 @@ class BusinessPartnerFetchService(
 ) {
 
     /**
-     * Fetch a business partner by [bpn] and return as [PoolLegalEntityVerboseDto]
+     * Fetch a business partner by [bpn] and return as [LegalEntityWithLegalAddressVerboseDto]
      */
-    fun findLegalEntityIgnoreCase(bpn: String): PoolLegalEntityVerboseDto {
-        return findLegalEntityOrThrow(bpn).toPoolLegalEntity()
+    fun findLegalEntityIgnoreCase(bpn: String): LegalEntityWithLegalAddressVerboseDto {
+        return findLegalEntityOrThrow(bpn).toLegalEntityWithLegalAddress()
     }
 
 
     /**
-     * Fetch a business partner by [identifierValue] (ignoring case) of [identifierType] and return as [PoolLegalEntityVerboseDto]
+     * Fetch a business partner by [identifierValue] (ignoring case) of [identifierType] and return as [LegalEntityWithLegalAddressVerboseDto]
      */
     @Transactional
-    fun findLegalEntityIgnoreCase(identifierType: String, identifierValue: String): PoolLegalEntityVerboseDto {
-        return findLegalEntityOrThrow(identifierType, identifierValue).toPoolLegalEntity()
+    fun findLegalEntityIgnoreCase(identifierType: String, identifierValue: String): LegalEntityWithLegalAddressVerboseDto {
+        return findLegalEntityOrThrow(identifierType, identifierValue).toLegalEntityWithLegalAddress()
     }
 
     /**
@@ -73,8 +73,8 @@ class BusinessPartnerFetchService(
      * Fetch business partners by BPN in [bpns] and map to dtos
      */
     @Transactional
-    fun fetchDtosByBpns(bpns: Collection<String>): Collection<PoolLegalEntityVerboseDto> {
-        return fetchByBpns(bpns).map { it.toPoolLegalEntity() }
+    fun fetchDtosByBpns(bpns: Collection<String>): Collection<LegalEntityWithLegalAddressVerboseDto> {
+        return fetchByBpns(bpns).map { it.toLegalEntityWithLegalAddress() }
     }
 
     /**

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
@@ -20,9 +20,9 @@
 package org.eclipse.tractusx.bpdm.pool.service
 
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
-import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierType
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntity
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityIdentifier

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
@@ -24,10 +24,10 @@ import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.dto.response.CountrySubdivisionDto
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.response.RegionDto
 import org.eclipse.tractusx.bpdm.common.service.toPageRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.dto.AddressMetadataDto
 import org.eclipse.tractusx.bpdm.pool.dto.LegalEntityMetadataDto

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -26,7 +26,9 @@ import org.eclipse.tractusx.bpdm.common.dto.StreetDto
 import org.eclipse.tractusx.bpdm.common.dto.response.*
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.toDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.*
 import org.eclipse.tractusx.bpdm.pool.entity.*
 import org.springframework.data.domain.Page
 
@@ -255,8 +257,8 @@ fun GeographicCoordinate.toDto(): GeoCoordinateDto {
     return GeoCoordinateDto(longitude, latitude, altitude)
 }
 
-fun LegalEntityClassification.toDto(): ClassificationVerboseDto {
-    return ClassificationVerboseDto(value, code, type.toDto())
+fun LegalEntityClassification.toDto(): LegalEntityClassificationVerboseDto {
+    return LegalEntityClassificationVerboseDto(value, code, type.toDto())
 }
 
 fun Relation.toDto(): RelationVerboseDto {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -26,9 +26,8 @@ import org.eclipse.tractusx.bpdm.common.dto.StreetDto
 import org.eclipse.tractusx.bpdm.common.dto.response.*
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.service.toDto
-import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.api.model.*
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.*
 import org.eclipse.tractusx.bpdm.pool.entity.*
 import org.springframework.data.domain.Page
 
@@ -41,7 +40,6 @@ fun LegalEntity.toMatchDto(score: Float): LegalEntityMatchVerboseDto {
     return LegalEntityMatchVerboseDto(
         score = score,
         legalEntity = this.toDto(),
-        legalName = this.legalName.value,
         legalAddress = legalAddress.toDto(),
     )
 }
@@ -50,36 +48,24 @@ fun LegalEntity.toUpsertDto(entryId: String?): LegalEntityPartnerCreateVerboseDt
     return LegalEntityPartnerCreateVerboseDto(
         legalEntity = toDto(),
         legalAddress = legalAddress.toDto(),
-        index = entryId,
-        legalName = legalName.value,
+        index = entryId
     )
 }
 
-fun LegalEntity.toPoolLegalEntity(): PoolLegalEntityVerboseDto {
-    return PoolLegalEntityVerboseDto(
-        legalName = legalName.value,
+fun LegalEntity.toLegalEntityWithLegalAddress(): LegalEntityWithLegalAddressVerboseDto {
+    return LegalEntityWithLegalAddressVerboseDto(
         legalAddress = legalAddress.toDto(),
-        legalEntity = LegalEntityVerboseDto(
-            bpnl = bpn,
-            identifiers = identifiers.map { it.toDto() },
-            legalShortName = legalName.shortName,
-            legalForm = legalForm?.toDto(),
-            states = states.map { it.toDto() },
-            classifications = classifications.map { it.toDto() },
-            relations = startNodeRelations.plus(endNodeRelations).map { it.toDto() },
-            currentness = currentness,
-            createdAt = createdAt,
-            updatedAt = updatedAt,
-        )
+        legalEntity = toDto()
     )
 }
 
 fun LegalEntity.toDto(): LegalEntityVerboseDto {
     return LegalEntityVerboseDto(
         bpnl = bpn,
-        identifiers = identifiers.map { it.toDto() },
+        legalName = legalName.value,
         legalShortName = legalName.shortName,
         legalForm = legalForm?.toDto(),
+        identifiers = identifiers.map { it.toDto() },
         states = states.map { it.toDto() },
         classifications = classifications.map { it.toDto() },
         relations = startNodeRelations.plus(endNodeRelations).map { it.toDto() },

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
@@ -21,9 +21,9 @@ package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
-import org.eclipse.tractusx.bpdm.common.dto.LegalEntityIdentifierDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityIdentifierDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerNonVerboseValues
 import org.eclipse.tractusx.bpdm.pool.util.LegalEntityStructureRequest

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -25,12 +25,8 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityCreateError
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityUpdateError
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerNonVerboseValues.addressIdentifier
 import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerNonVerboseValues.logisticAddress3
@@ -721,7 +717,7 @@ class LegalEntityControllerIT @Autowired constructor(
         .get()
         .uri(EndpointValues.CATENA_LEGAL_ENTITY_PATH + "/${bpn}")
         .exchange().expectStatus().isOk
-        .returnResult<PoolLegalEntityVerboseDto>()
+        .returnResult<LegalEntityWithLegalAddressVerboseDto>()
         .responseBody
         .blockFirst()!!.legalEntity.currentness
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -22,15 +22,15 @@ package org.eclipse.tractusx.bpdm.pool.controller
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.common.dto.response.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityCreateError
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityUpdateError
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerNonVerboseValues.addressIdentifier
 import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerNonVerboseValues.logisticAddress3

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
@@ -24,10 +24,10 @@ import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -80,8 +80,8 @@ class LegalEntityControllerSearchIT @Autowired constructor(
         val givenStructure = testHelpers.createBusinessPartnerStructure(listOf(partnerStructure1, partnerStructure2))
         givenPartner1 = with(givenStructure[0].legalEntity) { legalEntity }
         givenPartner2 = with(givenStructure[1].legalEntity) { legalEntity }
-        legalName1 = givenStructure[0].legalEntity.legalName
-        legalName2 = givenStructure[1].legalEntity.legalName
+        legalName1 = givenStructure[0].legalEntity.legalEntity.legalName
+        legalName2 = givenStructure[1].legalEntity.legalEntity.legalName
         legalAddress1 = givenStructure[0].legalEntity.legalAddress
         legalAddress2 = givenStructure[1].legalEntity.legalAddress
     }
@@ -97,8 +97,8 @@ class LegalEntityControllerSearchIT @Autowired constructor(
         val expected = PageDto(
             2, 1, 0, 2,
             listOf(
-                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1),
-                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalAddress = legalAddress1),
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner2, legalAddress = legalAddress2)
             )
         )
 
@@ -117,12 +117,12 @@ class LegalEntityControllerSearchIT @Autowired constructor(
 
         val expectedFirstPage = PageDto(
             2, 2, 0, 1, listOf(
-                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalName = legalName1, legalAddress = legalAddress1)
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner1, legalAddress = legalAddress1)
             )
         )
         val expectedSecondPage = PageDto(
             2, 2, 1, 1, listOf(
-                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner2, legalName = legalName2, legalAddress = legalAddress2)
+                LegalEntityMatchVerboseDto(score = 0f, legalEntity = givenPartner2, legalAddress = legalAddress2)
             )
         )
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
@@ -20,7 +20,6 @@
 package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
@@ -28,6 +27,7 @@ import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePropertiesSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.util.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
@@ -26,10 +26,10 @@ import org.eclipse.tractusx.bpdm.common.dto.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.common.dto.QualityLevel
 import org.eclipse.tractusx.bpdm.common.dto.request.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.dto.response.LegalFormDto
 import org.eclipse.tractusx.bpdm.common.dto.response.PageDto
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.entity.FieldQualityRule
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierType

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -2,10 +2,9 @@ package org.eclipse.tractusx.bpdm.pool.service
 
 import com.neovisionaries.i18n.CountryCode
 import org.assertj.core.api.Assertions.assertThat
-import org.eclipse.tractusx.bpdm.common.dto.ClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
-import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityStateDto
 import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteStateDto
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
 import org.eclipse.tractusx.bpdm.common.dto.response.*
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
@@ -384,9 +383,9 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         )
     }
 
-    fun legalEntityState(name: String, id: Long, type: BusinessStateType): LegalEntityState {
+    fun legalEntityState(name: String, id: Long, type: BusinessStateType): LegalEntityStateDto {
 
-        return LegalEntityState(
+        return LegalEntityStateDto(
             description = "description_" + name + "_" + id,
             validFrom = LocalDateTime.now().plusDays(id),
             validTo = LocalDateTime.now().plusDays(id + 2),
@@ -405,9 +404,9 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     }
 
 
-    fun classificationDto(name: String, id: Long, type: ClassificationType): ClassificationDto {
+    fun classificationDto(name: String, id: Long, type: ClassificationType): LegalEntityClassificationDto {
 
-        return ClassificationDto(
+        return LegalEntityClassificationDto(
             code = "code_" + name + "_" + id,
             value = "value_" + name + "_" + id,
             type = type
@@ -576,7 +575,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         }
     }
 
-    fun compareStates(statesVerbose: Collection<LegalEntityStateVerboseDto>, states: Collection<IBaseLegalEntityStateDto>?) {
+    fun compareStates(statesVerbose: Collection<LegalEntityStateVerboseDto>, states: Collection<ILegalEntityStateDto>?) {
 
         assertThat(statesVerbose.size).isEqualTo(states?.size ?: 0)
         val sortedVerboseStates = statesVerbose.sortedBy { it.description }
@@ -615,7 +614,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         }
     }
 
-    fun compareClassifications(classificationsVerbose: Collection<ClassificationVerboseDto>, classifications: Collection<ClassificationDto>?) {
+    fun compareClassifications(classificationsVerbose: Collection<ClassificationVerboseDto>, classifications: Collection<LegalEntityClassificationDto>?) {
 
         assertThat(classificationsVerbose.size).isEqualTo(classifications?.size ?: 0)
         val sortedVerboseClassifications = classificationsVerbose.sortedBy { it.type.name }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -12,11 +12,11 @@ import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityClassificationVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityIdentifierVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityStateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityClassificationVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityIdentifierVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityStateVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.repository.BpnRequestIdentifierRepository
 import org.eclipse.tractusx.bpdm.pool.service.TaskStepBuildService.CleaningError
 import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerVerboseValues
@@ -500,7 +500,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
     }
 
-    fun compareLegalEntity(verboseRequest: PoolLegalEntityVerboseDto, legalEntity: LegalEntityDto?) {
+    fun compareLegalEntity(verboseRequest: LegalEntityWithLegalAddressVerboseDto, legalEntity: LegalEntityDto?) {
 
         val verboseLegalEntity = verboseRequest.legalEntity
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -13,6 +13,10 @@ import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePoolVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityClassificationVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityIdentifierVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.LegalEntityStateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.PoolLegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.repository.BpnRequestIdentifierRepository
 import org.eclipse.tractusx.bpdm.pool.service.TaskStepBuildService.CleaningError
 import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerVerboseValues
@@ -614,7 +618,10 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         }
     }
 
-    fun compareClassifications(classificationsVerbose: Collection<ClassificationVerboseDto>, classifications: Collection<LegalEntityClassificationDto>?) {
+    fun compareClassifications(
+        classificationsVerbose: Collection<LegalEntityClassificationVerboseDto>,
+        classifications: Collection<LegalEntityClassificationDto>?
+    ) {
 
         assertThat(classificationsVerbose.size).isEqualTo(classifications?.size ?: 0)
         val sortedVerboseClassifications = classificationsVerbose.sortedBy { it.type.name }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
@@ -211,7 +211,7 @@ object BusinessPartnerNonVerboseValues {
         physicalPostalAddress = postalAddress3,
     )
     private val logisticAddress4 = LogisticAddressDto(
-        physicalPostalAddress = postalAddress1, name = BusinessPartnerVerboseValues.legalEntityUpsert1.legalName
+        physicalPostalAddress = postalAddress1, name = BusinessPartnerVerboseValues.legalEntityUpsert1.legalEntity.legalName
     )
 
     val logisticAddress5 = LogisticAddressDto(
@@ -220,81 +220,77 @@ object BusinessPartnerNonVerboseValues {
 
     val legalEntityCreate1 = LegalEntityPartnerCreateRequest(
         legalEntity = LegalEntityDto(
+            legalName = BusinessPartnerVerboseValues.legalEntityUpsert1.legalEntity.legalName,
             legalShortName = null,
-            identifiers = listOf(identifier1),
             legalForm = BusinessPartnerVerboseValues.legalForm1.technicalKey,
+            identifiers = listOf(identifier1),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
         ),
         legalAddress = logisticAddress1,
-        legalName = BusinessPartnerVerboseValues.legalEntityUpsert1.legalName,
         index = BusinessPartnerVerboseValues.legalEntityUpsert1.index
     )
 
     val legalEntityCreate2 = LegalEntityPartnerCreateRequest(
         legalEntity = LegalEntityDto(
+            legalName = BusinessPartnerVerboseValues.legalEntityUpsert2.legalEntity.legalName,
             legalShortName = null,
-            identifiers = listOf(identifier2),
             legalForm = BusinessPartnerVerboseValues.legalForm2.technicalKey,
+            identifiers = listOf(identifier2),
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
         ),
         legalAddress = logisticAddress2,
-        legalName = BusinessPartnerVerboseValues.legalEntityUpsert2.legalName,
         index = BusinessPartnerVerboseValues.legalEntityUpsert2.index
     )
 
     val legalEntityCreate3 = LegalEntityPartnerCreateRequest(
         legalEntity = LegalEntityDto(
+            legalName = BusinessPartnerVerboseValues.legalEntityUpsert3.legalEntity.legalName,
             legalShortName = null,
-            identifiers = listOf(identifier3),
             legalForm = BusinessPartnerVerboseValues.legalForm3.technicalKey,
+            identifiers = listOf(identifier3),
             states = listOf(leStatus3),
             classifications = listOf(classification5),
         ),
         legalAddress = logisticAddress3,
-        legalName = BusinessPartnerVerboseValues.legalEntityUpsert3.legalName,
         index = BusinessPartnerVerboseValues.legalEntityUpsert3.index
     )
 
     val legalEntityCreateMultipleIdentifier = LegalEntityPartnerCreateRequest(
         legalEntity = LegalEntityDto(
+            legalName = BusinessPartnerVerboseValues.legalEntityUpsertMultipleIdentifier.legalEntity.legalName,
             legalShortName = null,
-            identifiers = listOf(identifier1, identifier2),
             legalForm = BusinessPartnerVerboseValues.legalForm1.technicalKey,
+            identifiers = listOf(identifier1, identifier2),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
         ),
         legalAddress = logisticAddress1,
-        legalName = BusinessPartnerVerboseValues.legalEntityUpsertMultipleIdentifier.legalName,
         index = BusinessPartnerVerboseValues.legalEntityUpsertMultipleIdentifier.index
     )
 
 
     val legalEntityUpdate1 = LegalEntityPartnerUpdateRequest(
         bpnl = BusinessPartnerVerboseValues.legalEntityUpsert1.legalEntity.bpnl,
-        legalName = legalEntityCreate1.legalName,
         legalEntity = legalEntityCreate1.legalEntity,
         legalAddress = legalEntityCreate1.legalAddress,
     )
 
     val legalEntityUpdate2 = LegalEntityPartnerUpdateRequest(
         bpnl = BusinessPartnerVerboseValues.legalEntityUpsert2.legalEntity.bpnl,
-        legalName = legalEntityCreate2.legalName,
         legalEntity = legalEntityCreate2.legalEntity,
         legalAddress = legalEntityCreate2.legalAddress,
     )
 
     val legalEntityUpdate3 = LegalEntityPartnerUpdateRequest(
         bpnl = BusinessPartnerVerboseValues.legalEntityUpsert3.legalEntity.bpnl,
-        legalName = legalEntityCreate3.legalName,
         legalEntity = legalEntityCreate3.legalEntity,
         legalAddress = legalEntityCreate3.legalAddress,
     )
 
     val legalEntityUpdateMultipleIdentifier = LegalEntityPartnerUpdateRequest(
         bpnl = BusinessPartnerVerboseValues.legalEntityUpsertMultipleIdentifier.legalEntity.bpnl,
-        legalName = legalEntityCreateMultipleIdentifier.legalName,
         legalEntity = legalEntityCreateMultipleIdentifier.legalEntity,
         legalAddress = legalEntityCreateMultipleIdentifier.legalAddress,
     )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
@@ -20,6 +20,10 @@
 package org.eclipse.tractusx.bpdm.pool.util
 
 import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityClassificationDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityStateDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.*
 
 object BusinessPartnerNonVerboseValues {
@@ -113,15 +117,35 @@ object BusinessPartnerNonVerboseValues {
     )
 
     private val classification1 =
-        ClassificationDto(BusinessPartnerVerboseValues.classificationType.technicalKey, BusinessPartnerVerboseValues.classification1.code, BusinessPartnerVerboseValues.classification1.value)
+        LegalEntityClassificationDto(
+            BusinessPartnerVerboseValues.classificationType.technicalKey,
+            BusinessPartnerVerboseValues.classification1.code,
+            BusinessPartnerVerboseValues.classification1.value
+        )
     private val classification2 =
-        ClassificationDto(BusinessPartnerVerboseValues.classificationType.technicalKey, BusinessPartnerVerboseValues.classification2.code, BusinessPartnerVerboseValues.classification2.value)
+        LegalEntityClassificationDto(
+            BusinessPartnerVerboseValues.classificationType.technicalKey,
+            BusinessPartnerVerboseValues.classification2.code,
+            BusinessPartnerVerboseValues.classification2.value
+        )
     private val classification3 =
-        ClassificationDto(BusinessPartnerVerboseValues.classificationType.technicalKey, BusinessPartnerVerboseValues.classification3.code, BusinessPartnerVerboseValues.classification3.value)
+        LegalEntityClassificationDto(
+            BusinessPartnerVerboseValues.classificationType.technicalKey,
+            BusinessPartnerVerboseValues.classification3.code,
+            BusinessPartnerVerboseValues.classification3.value
+        )
     private val classification4 =
-        ClassificationDto(BusinessPartnerVerboseValues.classificationType.technicalKey, BusinessPartnerVerboseValues.classification4.code, BusinessPartnerVerboseValues.classification4.value)
+        LegalEntityClassificationDto(
+            BusinessPartnerVerboseValues.classificationType.technicalKey,
+            BusinessPartnerVerboseValues.classification4.code,
+            BusinessPartnerVerboseValues.classification4.value
+        )
     private val classification5 =
-        ClassificationDto(BusinessPartnerVerboseValues.classificationType.technicalKey, BusinessPartnerVerboseValues.classification5.code, BusinessPartnerVerboseValues.classification5.value)
+        LegalEntityClassificationDto(
+            BusinessPartnerVerboseValues.classificationType.technicalKey,
+            BusinessPartnerVerboseValues.classification5.code,
+            BusinessPartnerVerboseValues.classification5.value
+        )
 
 
     private val postalAddress1 = PhysicalPostalAddressDto(

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
@@ -30,11 +30,11 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.service.toDto
-import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.api.model.*
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.verbose.*
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -250,12 +250,12 @@ object BusinessPartnerVerboseValues {
     )
 
 
-    val legalEntity1 = PoolLegalEntityVerboseDto(
-        legalName = "Business Partner Name",
+    val legalEntity1 = LegalEntityWithLegalAddressVerboseDto(
         LegalEntityVerboseDto(
             bpnl = "BPNL000000000001",
-            identifiers = listOf(identifier1),
+            legalName = "Business Partner Name",
             legalForm = legalForm1,
+            identifiers = listOf(identifier1),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
@@ -287,12 +287,12 @@ object BusinessPartnerVerboseValues {
         )
     )
 
-    val legalEntity2 = PoolLegalEntityVerboseDto(
-        legalName = "Another Organisation Corp",
+    val legalEntity2 = LegalEntityWithLegalAddressVerboseDto(
         LegalEntityVerboseDto(
             bpnl = "BPNL0000000001YN",
-            identifiers = listOf(identifier2),
+            legalName = "Another Organisation Corp",
             legalForm = legalForm2,
+            identifiers = listOf(identifier2),
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
@@ -324,12 +324,12 @@ object BusinessPartnerVerboseValues {
         )
     )
 
-    val legalEntity3 = PoolLegalEntityVerboseDto(
-        legalName = "好公司  合伙制企业",
+    val legalEntity3 = LegalEntityWithLegalAddressVerboseDto(
         LegalEntityVerboseDto(
             bpnl = "BPNL0000000002XY",
-            identifiers = listOf(identifier3),
+            legalName = "好公司  合伙制企业",
             legalForm = legalForm3,
+            identifiers = listOf(identifier3),
             states = listOf(leStatus3),
             classifications = listOf(classification5),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
@@ -362,18 +362,17 @@ object BusinessPartnerVerboseValues {
     )
 
     val legalEntityUpsert1 = LegalEntityPartnerCreateVerboseDto(
-        legalName = "Business Partner Name",
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL000000000001",
-            identifiers = listOf(LegalEntityIdentifierVerboseDto("ID-XYZ", identifierType1, "Agency X")),
+            legalName = "Business Partner Name",
             legalForm = legalForm1,
+            identifiers = listOf(LegalEntityIdentifierVerboseDto("ID-XYZ", identifierType1, "Agency X")),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             createdAt = Instant.now(),
-            updatedAt = Instant.now(),
-
-            ),
+            updatedAt = Instant.now()
+        ),
         legalAddress = addressPartner1.copy(
             bpnLegalEntity = legalEntity1.legalEntity.bpnl,
             isLegalAddress = true
@@ -382,16 +381,16 @@ object BusinessPartnerVerboseValues {
     )
 
     val legalEntityUpsert2 = LegalEntityPartnerCreateVerboseDto(
-        legalName = "Another Organisation Corp",
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL0000000001YN",
-            identifiers = listOf(LegalEntityIdentifierVerboseDto("Another ID Value", identifierType2, "Body Y")),
+            legalName = "Another Organisation Corp",
             legalForm = legalForm2,
+            identifiers = listOf(LegalEntityIdentifierVerboseDto("Another ID Value", identifierType2, "Body Y")),
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             createdAt = Instant.now(),
-            updatedAt = Instant.now(),
+            updatedAt = Instant.now()
         ),
         legalAddress = addressPartner2.copy(
             bpnLegalEntity = legalEntity2.legalEntity.bpnl,
@@ -401,16 +400,16 @@ object BusinessPartnerVerboseValues {
     )
 
     val legalEntityUpsert3 = LegalEntityPartnerCreateVerboseDto(
-        legalName = "好公司  合伙制企业",
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL0000000002XY",
-            identifiers = listOf(LegalEntityIdentifierVerboseDto("An ID Value", identifierType3, "Official Z")),
+            legalName = "好公司  合伙制企业",
             legalForm = legalForm3,
+            identifiers = listOf(LegalEntityIdentifierVerboseDto("An ID Value", identifierType3, "Official Z")),
             states = listOf(leStatus3),
             classifications = listOf(classification5),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             createdAt = Instant.now(),
-            updatedAt = Instant.now(),
+            updatedAt = Instant.now()
         ),
         legalAddress = addressPartner3.copy(
             bpnLegalEntity = legalEntity3.legalEntity.bpnl,
@@ -420,21 +419,20 @@ object BusinessPartnerVerboseValues {
     )
 
     val legalEntityUpsertMultipleIdentifier = LegalEntityPartnerCreateVerboseDto(
-        legalName = "Business Partner Name",
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL000000000001",
+            legalName = "Business Partner Name",
+            legalForm = legalForm1,
             identifiers = listOf(
                 LegalEntityIdentifierVerboseDto("ID-XYZ", identifierType1, "Agency X"),
                 LegalEntityIdentifierVerboseDto("Another ID Value", identifierType2, "Body Y")
             ),
-            legalForm = legalForm1,
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             createdAt = Instant.now(),
-            updatedAt = Instant.now(),
-
-            ),
+            updatedAt = Instant.now()
+        ),
         legalAddress = addressPartner1.copy(
             bpnLegalEntity = legalEntity1.legalEntity.bpnl,
             isLegalAddress = true

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
@@ -22,14 +22,19 @@ package org.eclipse.tractusx.bpdm.pool.util
 import com.neovisionaries.i18n.CountryCode
 import com.neovisionaries.i18n.LanguageCode
 import org.eclipse.tractusx.bpdm.common.dto.StreetDto
-import org.eclipse.tractusx.bpdm.common.dto.response.*
+import org.eclipse.tractusx.bpdm.common.dto.response.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.PhysicalPostalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.SiteStateVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.response.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.service.toDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalFormDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.verbose.*
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -91,11 +96,11 @@ object BusinessPartnerVerboseValues {
 
     val classificationType = TypeKeyNameVerboseDto(ClassificationType.NACE, ClassificationType.NACE.name)
 
-    val classification1 = ClassificationVerboseDto("Sale of motor vehicles", null, classificationType)
-    val classification2 = ClassificationVerboseDto("Data processing, hosting and related activities", null, classificationType)
-    val classification3 = ClassificationVerboseDto("Other information service activities", null, classificationType)
-    val classification4 = ClassificationVerboseDto("Financial and insurance activities", null, classificationType)
-    val classification5 = ClassificationVerboseDto("Accounting, bookkeeping and auditing activities; tax consultancy", null, classificationType)
+    val classification1 = LegalEntityClassificationVerboseDto("Sale of motor vehicles", null, classificationType)
+    val classification2 = LegalEntityClassificationVerboseDto("Data processing, hosting and related activities", null, classificationType)
+    val classification3 = LegalEntityClassificationVerboseDto("Other information service activities", null, classificationType)
+    val classification4 = LegalEntityClassificationVerboseDto("Financial and insurance activities", null, classificationType)
+    val classification5 = LegalEntityClassificationVerboseDto("Accounting, bookkeeping and auditing activities; tax consultancy", null, classificationType)
 
     val address1 = PhysicalPostalAddressVerboseDto(
         geographicCoordinates = null,


### PR DESCRIPTION
The DTOs related to legal entities were refactored, making sure all its data classes are located in the appropriate API modules (gate-api, pool-api and orchestrator-api). Common interfaces are used whenever possible.

This meant splitting up and adjusting some DTOs for the different modules which were formerly in the common module.
Some properties which for a specific module are always used besides `LegalEntityDto` were directly added: in the Pool `legalName`; in the Gate `legalNameParts` and `roles`.

I decided that the verbose DTOs should not be part of the normal interface hierarchy because this would add a lot more complexity and the verbose DTOs are only used in the Pool. 

This is another step towards #570