### PR TITLE
Cicd(Pom): Change repo URL for deployment to eclipse-tractux/bpdm

### DIFF
--- a/bpdm-common/pom.xml
+++ b/bpdm-common/pom.xml
@@ -109,7 +109,7 @@
         <repository>
             <id>github</id>
             <name>GitHub CatenaX-NG Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/catenax-ng/tx-bpdm</url>
+            <url>https://maven.pkg.github.com/eclipse-tractusx/bpdm</url>
         </repository>
     </distributionManagement>
 </project>

--- a/bpdm-gate-api/pom.xml
+++ b/bpdm-gate-api/pom.xml
@@ -66,7 +66,7 @@
         <repository>
             <id>github</id>
             <name>GitHub CatenaX-NG Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/catenax-ng/tx-bpdm</url>
+            <url>https://maven.pkg.github.com/eclipse-tractusx/bpdm</url>
         </repository>
     </distributionManagement>
 

--- a/bpdm-pool-api/pom.xml
+++ b/bpdm-pool-api/pom.xml
@@ -68,7 +68,7 @@
         <repository>
             <id>github</id>
             <name>GitHub CatenaX-NG Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/catenax-ng/tx-bpdm</url>
+            <url>https://maven.pkg.github.com/eclipse-tractusx/bpdm</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
## Description

This pull request changes the URL in the POM distributionManagement to the exclipse-tractusx bpdm repository. This way we lose dependencies to other github repositories.

Fixes #648

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
