### PR TITLE
chore: Add application-developer.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ target
 /charts/bpdm/charts/bpdm-pool/Chart.lock
 #Developer application properties
 application-developer.properties
+application-developer.yml
 *.drawio.svg.bkp


### PR DESCRIPTION
After changing from Spring `properties` to `yml` files, we need to add `application-developer.yml` to .gitignore.
