### PR TITLE
Refactor: Unify DTOs for normal/verbose model

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -204,7 +204,7 @@ fun poolToGateSite(site: SiteVerboseDto): SiteGateDto {
             description = it.description,
             validFrom = it.validFrom,
             validTo = it.validTo,
-            type = it.type.technicalKey
+            type = it.typeVerbose.technicalKey
         )
     }
     return SiteGateDto(

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -169,7 +169,7 @@ fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): Gate_LegalEntityD
     val identifiers = legalEntity.identifiers.map {
         Gate_LegalEntityIdentifierDto(
             value = it.value,
-            type = it.type.technicalKey,
+            type = it.typeVerbose.technicalKey,
             issuingBody = it.issuingBody
         )
     }
@@ -178,12 +178,12 @@ fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): Gate_LegalEntityD
             description = it.description,
             validFrom = it.validFrom,
             validTo = it.validTo,
-            type = it.type.technicalKey
+            type = it.typeVerbose.technicalKey
         )
     }
     val classifications = legalEntity.classifications.map {
         Gate_LegalEntityClassificationDto(
-            type = it.type.technicalKey,
+            type = it.typeVerbose.technicalKey,
             code = it.code,
             value = it.value
         )
@@ -191,7 +191,7 @@ fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): Gate_LegalEntityD
     return Gate_LegalEntityDto(
         legalNameParts = listOfNotNull(legalEntity.legalName),
         legalShortName = legalEntity.legalShortName,
-        legalForm = legalEntity.legalForm?.technicalKey,
+        legalForm = legalEntity.legalFormVerbose?.technicalKey,
         identifiers = identifiers,
         states = states,
         classifications = classifications

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -226,13 +226,13 @@ fun poolToGateLogisticAddress(address: Pool_LogisticAddressVerboseDto): Gate_Log
             description = it.description,
             validFrom = it.validFrom,
             validTo = it.validTo,
-            type = it.type.technicalKey
+            type = it.typeVerbose.technicalKey
         )
     }
     val identifiers = address.identifiers.map {
         Gate_AddressIdentifierDto(
             value = it.value,
-            type = it.type.technicalKey
+            type = it.typeVerbose.technicalKey
         )
     }
     return Gate_LogisticAddressDto(
@@ -255,10 +255,10 @@ private fun poolToGatePhysicalAddress(address: PhysicalPostalAddressVerboseDto):
     }
     return Gate_PhysicalPostalAddressDto(
         geographicCoordinates = address.geographicCoordinates,
-        country = address.country.technicalKey,
+        country = address.country,
         postalCode = address.postalCode,
         city = address.city,
-        administrativeAreaLevel1 = address.administrativeAreaLevel1?.regionCode,
+        administrativeAreaLevel1 = address.administrativeAreaLevel1,
         administrativeAreaLevel2 = address.administrativeAreaLevel2,
         administrativeAreaLevel3 = address.administrativeAreaLevel3,
         district = address.district,
@@ -274,10 +274,10 @@ private fun poolToGatePhysicalAddress(address: PhysicalPostalAddressVerboseDto):
 private fun poolToGateAlternativeAddress(address: AlternativePostalAddressVerboseDto): org.eclipse.tractusx.bpdm.gate.api.model.AlternativePostalAddressDto {
     return org.eclipse.tractusx.bpdm.gate.api.model.AlternativePostalAddressDto(
         geographicCoordinates = address.geographicCoordinates,
-        country = address.country.technicalKey,
+        country = address.country,
         postalCode = address.postalCode,
         city = address.city,
-        administrativeAreaLevel1 = address.administrativeAreaLevel1?.regionCode,
+        administrativeAreaLevel1 = address.administrativeAreaLevel1,
         deliveryServiceNumber = address.deliveryServiceNumber,
         deliveryServiceType = address.deliveryServiceType,
         deliveryServiceQualifier = address.deliveryServiceQualifier

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAlternativePostalAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseAlternativePostalAddressDto.kt
@@ -33,10 +33,10 @@ interface IBaseAlternativePostalAddressDto {
     val geographicCoordinates: GeoCoordinateDto?
 
     @get:Schema(description = PostalAddressDescription.country)
-    val country: Any?
+    val country: CountryCode?
 
     @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
-    val administrativeAreaLevel1: Any?
+    val administrativeAreaLevel1: String?
 
     @get:Schema(description = PostalAddressDescription.postalCode)
     val postalCode: String?
@@ -52,8 +52,4 @@ interface IBaseAlternativePostalAddressDto {
 
     @get:Schema(description = PostalAddressDescription.deliveryServiceNumber)
     val deliveryServiceNumber: String?
-
-    fun adminLevel1Key(): String?
-
-    fun countryCode(): CountryCode?
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBasePhysicalPostalAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBasePhysicalPostalAddressDto.kt
@@ -32,10 +32,10 @@ interface IBasePhysicalPostalAddressDto {
     val geographicCoordinates: GeoCoordinateDto?
 
     @get:Schema(description = PostalAddressDescription.country)
-    val country: Any?
+    val country: CountryCode?
 
     @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
-    val administrativeAreaLevel1: Any?
+    val administrativeAreaLevel1: String?
 
     @get:Schema(description = PostalAddressDescription.administrativeAreaLevel2)
     val administrativeAreaLevel2: String?
@@ -69,8 +69,4 @@ interface IBasePhysicalPostalAddressDto {
 
     @get:Schema(description = PostalAddressDescription.door)
     val door: String?
-
-    fun adminLevel1Key(): String?
-
-    fun countryCode(): CountryCode?
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
@@ -31,8 +31,4 @@ interface IBaseSiteDto {
 
     @get:ArraySchema(arraySchema = Schema(description = SiteDescription.states))
     val states: Collection<ISiteStateDto>
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = SiteDescription.mainAddress)
-    val mainAddress: IBaseLogisticAddressDto?
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/DataClassUnwrappedJsonDeserializer.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/service/DataClassUnwrappedJsonDeserializer.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.common.service
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.*
@@ -58,7 +59,7 @@ private class DataClassUnwrappedJsonDeserializerForType(destinationJavaType: Jav
         this.primaryConstructor = destinationClass.primaryConstructor
             ?: throw IllegalStateException("Primary constructor required for '$destinationClass'")
 
-        // Annotation @field:JsonUnwrapped is stored on the Java field, not the constructor parameter.
+        // Annotations @field:JsonUnwrapped and @field:JsonProperty are stored on the Java field, not the constructor parameter.
         val propertiesByName = destinationClass.memberProperties.associateBy { it.name }
 
         this.constructorParameters = primaryConstructor.parameters.map { param ->
@@ -66,7 +67,9 @@ private class DataClassUnwrappedJsonDeserializerForType(destinationJavaType: Jav
                 ?: throw IllegalStateException("Some primary constructor parameter of '$destinationClass' doesn't have a name")
             val type = param.type
             val jsonUnwrapped = propertiesByName[name]?.javaField?.getAnnotation(JsonUnwrapped::class.java) != null
-            ConstructorParameter(name, type, jsonUnwrapped)
+            val altName = propertiesByName[name]?.javaField?.getAnnotation(JsonProperty::class.java)?.value
+            val finalName = if (altName.isNullOrEmpty()) name else altName
+            ConstructorParameter(finalName, type, jsonUnwrapped)
         }
     }
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/AlternativePostalAddressDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/AlternativePostalAddressDto.kt
@@ -41,12 +41,4 @@ data class AlternativePostalAddressDto(
     override val deliveryServiceQualifier: String? = null,
     override val deliveryServiceNumber: String? = null
 
-) : IBaseAlternativePostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1
-    }
-
-    override fun countryCode(): CountryCode? {
-        return country
-    }
-}
+) : IBaseAlternativePostalAddressDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/PhysicalPostalAddressDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/PhysicalPostalAddressDto.kt
@@ -46,12 +46,4 @@ data class PhysicalPostalAddressDto(
     override val floor: String? = null,
     override val door: String? = null
 
-) : IBasePhysicalPostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1
-    }
-
-    override fun countryCode(): CountryCode? {
-        return country
-    }
-}
+) : IBasePhysicalPostalAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AlternativePostalAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AlternativePostalAddressDto.kt
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.IBaseAlternativePostalAddressDto
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
 
 data class AlternativePostalAddressDto(
+
     override val geographicCoordinates: GeoCoordinateDto? = null,
     override val country: CountryCode? = null,
     override val administrativeAreaLevel1: String? = null,
@@ -34,11 +35,4 @@ data class AlternativePostalAddressDto(
     override val deliveryServiceQualifier: String? = null,
     override val deliveryServiceNumber: String? = null
 
-) : IBaseAlternativePostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1
-    }
-    override fun countryCode(): CountryCode? {
-        return country
-    }
-}
+) : IBaseAlternativePostalAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PhysicalPostalAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/PhysicalPostalAddressDto.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
 import org.eclipse.tractusx.bpdm.common.dto.IBasePhysicalPostalAddressDto
 
 data class PhysicalPostalAddressDto(
+
     override val geographicCoordinates: GeoCoordinateDto? = null,
     override val country: CountryCode? = null,
     override val administrativeAreaLevel1: String? = null,
@@ -39,12 +40,4 @@ data class PhysicalPostalAddressDto(
     override val floor: String? = null,
     override val door: String? = null
 
-) : IBasePhysicalPostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1
-    }
-
-    override fun countryCode(): CountryCode? {
-        return country
-    }
-}
+) : IBasePhysicalPostalAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 
 data class SiteDto(
 
@@ -32,9 +31,8 @@ data class SiteDto(
     val hasChanged: Boolean? = null,
 
     override val name: String? = null,
-
     override val states: Collection<SiteStateDto> = emptyList(),
 
-    override val mainAddress: LogisticAddressDto? = null
+    val mainAddress: LogisticAddressDto? = null
 
 ) : IBaseSiteDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressIdentifierVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressIdentifierVerboseDto.kt
@@ -19,7 +19,10 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IAddressIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressIdentifierDescription
 
@@ -27,8 +30,15 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressIdentifier
 data class AddressIdentifierVerboseDto(
 
     @get:Schema(description = AddressIdentifierDescription.value)
-    val value: String,
+    override val value: String,
 
+    @field:JsonProperty("type")
     @get:Schema(description = AddressIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
-)
+    val typeVerbose: TypeKeyNameVerboseDto<String>,
+
+    ) : IAddressIdentifierDto {
+
+    @get:JsonIgnore
+    override val type: String
+        get() = typeVerbose.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressStateVerboseDto.kt
@@ -19,7 +19,10 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IAddressStateDto
 import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.AddressStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
@@ -28,16 +31,18 @@ import java.time.LocalDateTime
 @Schema(description = AddressStateDescription.header)
 data class AddressStateVerboseDto(
 
-    @get:Schema(description = AddressStateDescription.description)
-    val description: String?,
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
 
-    @get:Schema(description = AddressStateDescription.validFrom)
-    val validFrom: LocalDateTime?,
-
-    @get:Schema(description = AddressStateDescription.validTo)
-    val validTo: LocalDateTime?,
-
+    @field:JsonProperty("type")
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = AddressStateDescription.type)
-    val type: TypeKeyNameVerboseDto<BusinessStateType>
-)
+    val typeVerbose: TypeKeyNameVerboseDto<BusinessStateType>
+
+) : IAddressStateDto {
+
+    @get:JsonIgnore
+    override val type: BusinessStateType
+        get() = typeVerbose.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AlternativePostalAddressDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AlternativePostalAddressDto.kt
@@ -44,12 +44,4 @@ data class AlternativePostalAddressDto(
     override val deliveryServiceQualifier: String?,
     override val deliveryServiceNumber: String
 
-) : IBaseAlternativePostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1
-    }
-
-    override fun countryCode(): CountryCode {
-        return country
-    }
-}
+) : IBaseAlternativePostalAddressDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AlternativePostalAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AlternativePostalAddressVerboseDto.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.neovisionaries.i18n.CountryCode
 import io.swagger.v3.oas.annotations.media.Schema
@@ -34,8 +36,15 @@ import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializ
 data class AlternativePostalAddressVerboseDto(
 
     override val geographicCoordinates: GeoCoordinateDto?,
-    override val country: TypeKeyNameVerboseDto<CountryCode>,
-    override val administrativeAreaLevel1: RegionDto?,
+
+    @field:JsonProperty("country")
+    @get:Schema(description = PostalAddressDescription.country)
+    val countryVerbose: TypeKeyNameVerboseDto<CountryCode>,
+
+    @field:JsonProperty("administrativeAreaLevel1")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
+    val administrativeAreaLevel1Verbose: RegionDto?,
+
     override val postalCode: String?,
     override val city: String,
     override val deliveryServiceType: DeliveryServiceType,
@@ -43,11 +52,12 @@ data class AlternativePostalAddressVerboseDto(
     override val deliveryServiceNumber: String
 
 ) : IBaseAlternativePostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1?.regionCode
-    }
-    override fun countryCode(): CountryCode {
-        return country.technicalKey
-    }
-}
 
+    @get:JsonIgnore
+    override val country: CountryCode
+        get() = countryVerbose.technicalKey
+
+    @get:JsonIgnore
+    override val administrativeAreaLevel1: String?
+        get() = administrativeAreaLevel1Verbose?.regionCode
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityClassificationVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityClassificationVerboseDto.kt
@@ -19,7 +19,10 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.ClassificationDescription
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
@@ -27,13 +30,16 @@ import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 @Schema(description = ClassificationDescription.header)
 data class LegalEntityClassificationVerboseDto(
 
-    @get:Schema(description = ClassificationDescription.value)
-    val value: String? = null,
+    override val value: String? = null,
+    override val code: String? = null,
 
-    @get:Schema(description = ClassificationDescription.code)
-    val code: String? = null,
-
-    // TODO OpenAPI description for complex field does not work!!
+    @field:JsonProperty("type")
     @get:Schema(description = ClassificationDescription.type)
-    val type: TypeKeyNameVerboseDto<ClassificationType>
-)
+    val typeVerbose: TypeKeyNameVerboseDto<ClassificationType>
+
+) : ILegalEntityClassificationDto {
+
+    @get:JsonIgnore
+    override val type: ClassificationType
+        get() = typeVerbose.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityIdentifierVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityIdentifierVerboseDto.kt
@@ -19,20 +19,27 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityIdentifierDto
 import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityIdentifierDescription
 
 @Schema(description = LegalEntityIdentifierDescription.header)
 data class LegalEntityIdentifierVerboseDto(
 
-    @get:Schema(description = LegalEntityIdentifierDescription.value)
-    val value: String,
+    override val value: String,
 
-    // TODO OpenAPI description for complex field does not work!!
+    @field:JsonProperty("type")
     @get:Schema(description = LegalEntityIdentifierDescription.type)
-    val type: TypeKeyNameVerboseDto<String>,
+    val typeVerbose: TypeKeyNameVerboseDto<String>,
 
-    @get:Schema(description = LegalEntityIdentifierDescription.issuingBody)
-    val issuingBody: String? = null
-)
+    override val issuingBody: String? = null
+
+) : ILegalEntityIdentifierDto {
+
+    @get:JsonIgnore
+    override val type: String
+        get() = typeVerbose.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateVerboseDto.kt
@@ -19,7 +19,10 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
 import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
@@ -28,16 +31,17 @@ import java.time.LocalDateTime
 @Schema(description = LegalEntityStateDescription.header)
 data class LegalEntityStateVerboseDto(
 
-    @get:Schema(description = LegalEntityStateDescription.description)
-    val description: String?,
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
 
-    @get:Schema(description = LegalEntityStateDescription.validFrom)
-    val validFrom: LocalDateTime?,
-
-    @get:Schema(description = LegalEntityStateDescription.validTo)
-    val validTo: LocalDateTime?,
-
-    // TODO OpenAPI description for complex field does not work!!
+    @field:JsonProperty("type")
     @get:Schema(description = LegalEntityStateDescription.type)
-    val type: TypeKeyNameVerboseDto<BusinessStateType>
-)
+    val typeVerbose: TypeKeyNameVerboseDto<BusinessStateType>
+
+) : ILegalEntityStateDto {
+
+    @get:JsonIgnore
+    override val type: BusinessStateType
+        get() = typeVerbose.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
@@ -19,8 +19,11 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
 import java.time.Instant
@@ -34,21 +37,15 @@ data class LegalEntityVerboseDto(
     @get:Schema(description = LegalEntityDescription.legalName)
     val legalName: String,
 
-    @get:Schema(description = LegalEntityDescription.legalShortName)
-    val legalShortName: String? = null,
+    override val legalShortName: String? = null,
 
+    @field:JsonProperty("legalForm")
     @get:Schema(description = LegalEntityDescription.legalForm)
-    val legalForm: LegalFormDto? = null,
+    val legalFormVerbose: LegalFormDto? = null,
 
-    // TODO OpenAPI description for complex field does not work!!
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.identifiers))
-    val identifiers: Collection<LegalEntityIdentifierVerboseDto> = emptyList(),
-
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.states))
-    val states: Collection<LegalEntityStateVerboseDto> = emptyList(),
-
-    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications))
-    val classifications: Collection<LegalEntityClassificationVerboseDto> = emptyList(),
+    override val identifiers: Collection<LegalEntityIdentifierVerboseDto> = emptyList(),
+    override val states: Collection<LegalEntityStateVerboseDto> = emptyList(),
+    override val classifications: Collection<LegalEntityClassificationVerboseDto> = emptyList(),
 
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.relations))
     val relations: Collection<RelationVerboseDto> = emptyList(),
@@ -60,5 +57,11 @@ data class LegalEntityVerboseDto(
     val createdAt: Instant,
 
     @get:Schema(description = CommonDescription.updatedAt)
-    val updatedAt: Instant,
-)
+    val updatedAt: Instant
+
+) : IBaseLegalEntityDto {
+
+    @get:JsonIgnore
+    override val legalForm: String?
+        get() = legalFormVerbose?.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
@@ -19,8 +19,8 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLogisticAddressDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
 import java.time.Instant
@@ -34,19 +34,10 @@ data class LogisticAddressVerboseDto(
     @get:Schema(description = LogisticAddressDescription.name)
     val name: String? = null,
 
-    @ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.states))
-    val states: Collection<AddressStateVerboseDto> = emptyList(),
-
-    @ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.identifiers))
-    val identifiers: Collection<AddressIdentifierVerboseDto> = emptyList(),
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LogisticAddressDescription.physicalPostalAddress)
-    val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
-
-    // TODO OpenAPI description for complex field does not work!!
-    @get:Schema(description = LogisticAddressDescription.alternativePostalAddress)
-    val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
+    override val states: Collection<AddressStateVerboseDto> = emptyList(),
+    override val identifiers: Collection<AddressIdentifierVerboseDto> = emptyList(),
+    override val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
+    override val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
 
     @get:Schema(description = LogisticAddressDescription.bpnLegalEntity)
     val bpnLegalEntity: String?,
@@ -65,4 +56,5 @@ data class LogisticAddressVerboseDto(
 
     @get:Schema(description = CommonDescription.updatedAt)
     val updatedAt: Instant
-)
+
+) : IBaseLogisticAddressDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/PhysicalPostalAddressDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/PhysicalPostalAddressDto.kt
@@ -46,12 +46,4 @@ data class PhysicalPostalAddressDto(
     override val floor: String?,
     override val door: String?
 
-) : IBasePhysicalPostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1
-    }
-
-    override fun countryCode(): CountryCode {
-        return country
-    }
-}
+) : IBasePhysicalPostalAddressDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/PhysicalPostalAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/PhysicalPostalAddressVerboseDto.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.neovisionaries.i18n.CountryCode
 import io.swagger.v3.oas.annotations.media.Schema
@@ -33,8 +35,15 @@ import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializ
 data class PhysicalPostalAddressVerboseDto(
 
     override val geographicCoordinates: GeoCoordinateDto?,
-    override val country: TypeKeyNameVerboseDto<CountryCode>,
-    override val administrativeAreaLevel1: RegionDto?,
+
+    @field:JsonProperty("country")
+    @get:Schema(description = PostalAddressDescription.country)
+    val countryVerbose: TypeKeyNameVerboseDto<CountryCode>,
+
+    @field:JsonProperty("administrativeAreaLevel1")
+    @get:Schema(description = PostalAddressDescription.administrativeAreaLevel1)
+    val administrativeAreaLevel1Verbose: RegionDto?,
+
     override val administrativeAreaLevel2: String?,
     override val administrativeAreaLevel3: String?,
     override val postalCode: String?,
@@ -48,11 +57,12 @@ data class PhysicalPostalAddressVerboseDto(
     override val door: String?
 
 ) : IBasePhysicalPostalAddressDto {
-    override fun adminLevel1Key(): String? {
-        return administrativeAreaLevel1?.regionCode
-    }
 
-    override fun countryCode(): CountryCode {
-        return country.technicalKey
-    }
+    @get:JsonIgnore
+    override val country: CountryCode
+        get() = countryVerbose.technicalKey
+
+    @get:JsonIgnore
+    override val administrativeAreaLevel1: String?
+        get() = administrativeAreaLevel1Verbose?.regionCode
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteDto.kt
@@ -28,6 +28,7 @@ data class SiteDto(
 
     override val name: String,
     override val states: Collection<SiteStateDto> = emptyList(),
-    override val mainAddress: LogisticAddressDto
+
+    val mainAddress: LogisticAddressDto
 
 ) : IBaseSiteDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteStateVerboseDto.kt
@@ -19,7 +19,10 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.ISiteStateDto
 import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteStateDescription
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
@@ -28,16 +31,18 @@ import java.time.LocalDateTime
 @Schema(description = SiteStateDescription.header)
 data class SiteStateVerboseDto(
 
-    @get:Schema(description = SiteStateDescription.description)
-    val description: String?,
+    override val description: String?,
+    override val validFrom: LocalDateTime?,
+    override val validTo: LocalDateTime?,
 
-    @get:Schema(description = SiteStateDescription.validFrom)
-    val validFrom: LocalDateTime?,
-
-    @get:Schema(description = SiteStateDescription.validTo)
-    val validTo: LocalDateTime?,
-
+    @field:JsonProperty("type")
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = SiteStateDescription.type)
-    val type: TypeKeyNameVerboseDto<BusinessStateType>
-)
+    val typeVerbose: TypeKeyNameVerboseDto<BusinessStateType>
+
+) : ISiteStateDto {
+
+    @get:JsonIgnore
+    override val type: BusinessStateType
+        get() = typeVerbose.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
@@ -19,8 +19,8 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
 import java.time.Instant
@@ -31,11 +31,8 @@ data class SiteVerboseDto(
     @get:Schema(description = SiteDescription.bpns)
     val bpns: String,
 
-    @get:Schema(description = SiteDescription.name)
-    val name: String,
-
-    @ArraySchema(arraySchema = Schema(description = SiteDescription.states))
-    val states: Collection<SiteStateVerboseDto> = emptyList(),
+    override val name: String,
+    override val states: Collection<SiteStateVerboseDto> = emptyList(),
 
     @get:Schema(description = SiteDescription.bpnLegalEntity)
     val bpnLegalEntity: String,
@@ -45,4 +42,5 @@ data class SiteVerboseDto(
 
     @get:Schema(description = CommonDescription.updatedAt)
     val updatedAt: Instant
-)
+
+) : IBaseSiteDto

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -538,13 +538,13 @@ class BusinessPartnerBuildService(
 
         fun createPhysicalAddress(physicalAddress: IBasePhysicalPostalAddressDto, regions: Map<String, Region>): PhysicalPostalAddress {
 
-            if (physicalAddress.countryCode() == null || physicalAddress.city == null) {
+            if (physicalAddress.country == null || physicalAddress.city == null) {
                 throw BpdmValidationException(TaskStepBuildService.CleaningError.COUNTRY_CITY_IS_NULL.message)
             }
 
             return PhysicalPostalAddress(
                 geographicCoordinates = physicalAddress.geographicCoordinates?.let { GeographicCoordinate(it.latitude, it.longitude, it.altitude) },
-                country = physicalAddress.countryCode()!!,
+                country = physicalAddress.country!!,
                 administrativeAreaLevel1 = regions[physicalAddress.administrativeAreaLevel1],
                 administrativeAreaLevel2 = physicalAddress.administrativeAreaLevel2,
                 administrativeAreaLevel3 = physicalAddress.administrativeAreaLevel3,
@@ -569,7 +569,7 @@ class BusinessPartnerBuildService(
 
         fun createAlternativeAddress(alternativeAddress: IBaseAlternativePostalAddressDto, regions: Map<String, Region>): AlternativePostalAddress {
 
-            if (alternativeAddress.countryCode() == null || alternativeAddress.city == null ||
+            if (alternativeAddress.country == null || alternativeAddress.city == null ||
                 alternativeAddress.deliveryServiceType == null || alternativeAddress.deliveryServiceNumber == null
             ) {
 
@@ -578,7 +578,7 @@ class BusinessPartnerBuildService(
 
             return AlternativePostalAddress(
                 geographicCoordinates = alternativeAddress.geographicCoordinates?.let { GeographicCoordinate(it.latitude, it.longitude, it.altitude) },
-                country = alternativeAddress.countryCode()!!,
+                country = alternativeAddress.country!!,
                 administrativeAreaLevel1 = regions[alternativeAddress.administrativeAreaLevel1],
                 postCode = alternativeAddress.postalCode,
                 city = alternativeAddress.city!!,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
@@ -155,8 +155,8 @@ class MetadataService(
         val idTypeKeys = requests.flatMap { it.identifiers }.map { it.type }.toSet()
         val idTypes = identifierTypeRepository.findByBusinessPartnerTypeAndTechnicalKeyIn(IdentifierBusinessPartnerType.ADDRESS, idTypeKeys)
 
-        val regionKeys = requests.mapNotNull { it.physicalPostalAddress?.adminLevel1Key() }
-            .plus(requests.mapNotNull { it.alternativePostalAddress?.adminLevel1Key() })
+        val regionKeys = requests.mapNotNull { it.physicalPostalAddress?.administrativeAreaLevel1 }
+            .plus(requests.mapNotNull { it.alternativePostalAddress?.administrativeAreaLevel1 })
             .toSet()
         val regions = regionRepository.findByRegionCodeIn(regionKeys)
 
@@ -165,8 +165,8 @@ class MetadataService(
 
     fun getRegions(requests: Collection<IBaseLogisticAddressDto>): Set<Region> {
 
-        val regionKeys = requests.mapNotNull { it.physicalPostalAddress?.adminLevel1Key() }
-            .plus(requests.mapNotNull { it.alternativePostalAddress?.adminLevel1Key() })
+        val regionKeys = requests.mapNotNull { it.physicalPostalAddress?.administrativeAreaLevel1 }
+            .plus(requests.mapNotNull { it.alternativePostalAddress?.administrativeAreaLevel1 })
             .toSet()
         val regions = regionRepository.findByRegionCodeIn(regionKeys)
         return regions

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -145,10 +145,10 @@ fun LogisticAddress.toMainAddressResponse(): MainAddressVerboseDto {
 fun PhysicalPostalAddress.toDto(): PhysicalPostalAddressVerboseDto {
     return PhysicalPostalAddressVerboseDto(
         geographicCoordinates = geographicCoordinates?.toDto(),
-        country = country.toDto(),
+        countryVerbose = country.toDto(),
         postalCode = postCode,
         city = city,
-        administrativeAreaLevel1 = administrativeAreaLevel1?.let { RegionDto(it.countryCode, it.regionCode, it.regionName) },
+        administrativeAreaLevel1Verbose = administrativeAreaLevel1?.let { RegionDto(it.countryCode, it.regionCode, it.regionName) },
         administrativeAreaLevel2 = administrativeAreaLevel2,
         administrativeAreaLevel3 = administrativeAreaLevel3,
         district = districtLevel1,
@@ -164,10 +164,10 @@ fun PhysicalPostalAddress.toDto(): PhysicalPostalAddressVerboseDto {
 fun AlternativePostalAddress.toDto(): AlternativePostalAddressVerboseDto {
     return AlternativePostalAddressVerboseDto(
         geographicCoordinates = geographicCoordinates?.toDto(),
-        country = country.toDto(),
+        countryVerbose = country.toDto(),
         postalCode = postCode,
         city = city,
-        administrativeAreaLevel1 = administrativeAreaLevel1?.let { RegionDto(it.countryCode, it.regionCode, it.regionName) },
+        administrativeAreaLevel1Verbose = administrativeAreaLevel1?.let { RegionDto(it.countryCode, it.regionCode, it.regionName) },
         deliveryServiceType = deliveryServiceType,
         deliveryServiceNumber = deliveryServiceNumber,
         deliveryServiceQualifier = deliveryServiceQualifier

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -61,7 +61,7 @@ fun LegalEntity.toDto(): LegalEntityVerboseDto {
         bpnl = bpn,
         legalName = legalName.value,
         legalShortName = legalName.shortName,
-        legalForm = legalForm?.toDto(),
+        legalFormVerbose = legalForm?.toDto(),
         identifiers = identifiers.map { it.toDto() },
         states = states.map { it.toDto() },
         classifications = classifications.map { it.toDto() },

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -615,7 +615,7 @@ class LegalEntityControllerIT @Autowired constructor(
             .first() // search for first
 
         val identifierToFind = expected.identifiers.first()
-        val response = poolClient.legalEntities.getLegalEntity(identifierToFind.value, identifierToFind.type.technicalKey).legalEntity
+        val response = poolClient.legalEntities.getLegalEntity(identifierToFind.value, identifierToFind.typeVerbose.technicalKey).legalEntity
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -645,7 +645,7 @@ class LegalEntityControllerIT @Autowired constructor(
         var identifierToFind = expected.identifiers.first()
         identifierToFind = identifierToFind.copy(value = changeCase(identifierToFind.value))
 
-        val response = poolClient.legalEntities.getLegalEntity(identifierToFind.value, identifierToFind.type.technicalKey).legalEntity
+        val response = poolClient.legalEntities.getLegalEntity(identifierToFind.value, identifierToFind.typeVerbose.technicalKey).legalEntity
 
         assertThat(response)
             .usingRecursiveComparison()

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1340,16 +1340,14 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         sortedVerboseStates.indices.forEach {
             assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
-                .withEqualsForFields(isEqualToIgnoringMilliseconds(), ISiteStateDto::validTo.name)
-                .withEqualsForFields(isEqualToIgnoringMilliseconds(), ISiteStateDto::validFrom.name)
-                .ignoringFields(ISiteStateDto::type.name)
+                .withEqualsForFields(isEqualToIgnoringMilliseconds(), SiteStateVerboseDto::validTo.name)
+                .withEqualsForFields(isEqualToIgnoringMilliseconds(), SiteStateVerboseDto::validFrom.name)
+                .ignoringFields(SiteStateVerboseDto::typeVerbose.name)
                 .isEqualTo(sortedStates[it])
         }
     }
 
     fun isEqualToIgnoringMilliseconds(): BiPredicate<LocalDateTime?, LocalDateTime?> {
-
-
         return BiPredicate<LocalDateTime?, LocalDateTime?> { d1, d2 ->
             (d1 == null && d2 == null)
                     || d1.truncatedTo(ChronoUnit.SECONDS).equals(d2.truncatedTo(ChronoUnit.SECONDS))

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1325,9 +1325,9 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         sortedVerboseStates.indices.forEach {
             assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
-                .withEqualsForFields(isEqualToIgnoringMilliseconds(), ILegalEntityStateDto::validTo.name )
-                .withEqualsForFields(isEqualToIgnoringMilliseconds(), ILegalEntityStateDto::validFrom.name)
-                .ignoringFields(ILegalEntityStateDto::type.name)
+                .withEqualsForFields(isEqualToIgnoringMilliseconds(), LegalEntityStateVerboseDto::validTo.name )
+                .withEqualsForFields(isEqualToIgnoringMilliseconds(), LegalEntityStateVerboseDto::validFrom.name)
+                .ignoringFields(LegalEntityStateVerboseDto::typeVerbose.name)
                 .isEqualTo(sortedStates[it])
         }
     }
@@ -1360,12 +1360,12 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     ) {
 
         assertThat(classificationsVerbose.size).isEqualTo(classifications?.size ?: 0)
-        val sortedVerboseClassifications = classificationsVerbose.sortedBy { it.type.name }
+        val sortedVerboseClassifications = classificationsVerbose.sortedBy { it.typeVerbose.name }
         val sortedClassifications = classifications!!.sortedBy { it.type.name }
         sortedVerboseClassifications.indices.forEach {
             assertThat(sortedVerboseClassifications[it].typeVerbose.technicalKey.name).isEqualTo(sortedClassifications[it].type.name)
             assertThat(sortedVerboseClassifications[it]).usingRecursiveComparison()
-                .ignoringFields(LegalEntityClassificationVerboseDto::type.name)
+                .ignoringFields(LegalEntityClassificationVerboseDto::typeVerbose.name)
                 .isEqualTo(sortedClassifications[it])
         }
     }
@@ -1378,9 +1378,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         sortedVerboseIdentifiers.indices.forEach {
             assertThat(sortedVerboseIdentifiers[it].typeVerbose.technicalKey).isEqualTo(sortedIdentifiers[it].type)
             assertThat(sortedVerboseIdentifiers[it]).usingRecursiveComparison()
-                .ignoringFields(LegalEntityIdentifierVerboseDto::type.name).isEqualTo(sortedIdentifiers[it])
+                .ignoringFields(LegalEntityIdentifierVerboseDto::typeVerbose.name).isEqualTo(sortedIdentifiers[it])
         }
     }
-
 
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1241,7 +1241,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val verboseLegalEntity = verboseRequest.legalEntity
 
         assertThat(verboseLegalEntity.legalShortName).isEqualTo(legalEntity?.legalShortName)
-        assertThat(verboseLegalEntity.legalForm?.technicalKey).isEqualTo(legalEntity?.legalForm)
+        assertThat(verboseLegalEntity.legalFormVerbose?.technicalKey).isEqualTo(legalEntity?.legalForm)
         compareStates(verboseLegalEntity.states, legalEntity?.states)
         compareClassifications(verboseLegalEntity.classifications, legalEntity?.classifications)
         compareIdentifiers(verboseLegalEntity.identifiers, legalEntity?.identifiers)
@@ -1277,17 +1277,17 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val verbosePhysicalAddress = verboseAddress.physicalPostalAddress
         val physicalAddress = address?.physicalPostalAddress
         assertThat(verbosePhysicalAddress).usingRecursiveComparison()
-            .ignoringFields(PhysicalPostalAddressVerboseDto::country.name, PhysicalPostalAddressVerboseDto::administrativeAreaLevel1.name)
+            .ignoringFields(PhysicalPostalAddressVerboseDto::countryVerbose.name, PhysicalPostalAddressVerboseDto::administrativeAreaLevel1Verbose.name)
             .isEqualTo(physicalAddress)
-        assertThat(verbosePhysicalAddress.country.technicalKey.name).isEqualTo(physicalAddress?.country?.name)
-        assertThat(verbosePhysicalAddress.administrativeAreaLevel1?.regionCode).isEqualTo(physicalAddress?.administrativeAreaLevel1)
+        assertThat(verbosePhysicalAddress.country.name).isEqualTo(physicalAddress?.country?.name)
+        assertThat(verbosePhysicalAddress.administrativeAreaLevel1).isEqualTo(physicalAddress?.administrativeAreaLevel1)
         val verboseAlternAddress = verboseAddress.alternativePostalAddress
         val alternAddress = address?.alternativePostalAddress
         assertThat(verboseAlternAddress).usingRecursiveComparison()
-            .ignoringFields(AlternativePostalAddressDto::country.name , AlternativePostalAddressDto::administrativeAreaLevel1.name)
+            .ignoringFields(AlternativePostalAddressVerboseDto::countryVerbose.name, AlternativePostalAddressVerboseDto::administrativeAreaLevel1Verbose.name)
             .isEqualTo(alternAddress)
-        assertThat(verboseAlternAddress?.country?.technicalKey?.name).isEqualTo(alternAddress?.country?.name)
-        assertThat(verboseAlternAddress?.administrativeAreaLevel1?.regionCode).isEqualTo(alternAddress?.administrativeAreaLevel1)
+        assertThat(verboseAlternAddress?.country?.name).isEqualTo(alternAddress?.country?.name)
+        assertThat(verboseAlternAddress?.administrativeAreaLevel1).isEqualTo(alternAddress?.administrativeAreaLevel1)
     }
 
     fun compareAddressStates(statesVerbose: Collection<AddressStateVerboseDto>, states: Collection<AddressStateDto>?) {
@@ -1296,23 +1296,23 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val sortedVerboseStates = statesVerbose.sortedBy { it.description }
         val sortedStates = states?.sortedBy { it.description }
         sortedVerboseStates.indices.forEach {
-            assertThat(sortedVerboseStates[it].type.technicalKey.name).isEqualTo(sortedStates!![it].type.name)
+            assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates!![it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
-                .withEqualsForFields(isEqualToIgnoringMilliseconds(), AddressStateDto::validTo.name )
-                .withEqualsForFields(isEqualToIgnoringMilliseconds(),  AddressStateDto::validFrom.name )
-                .ignoringFields(AddressStateDto::type.name).isEqualTo(sortedStates[it])
+                .withEqualsForFields(isEqualToIgnoringMilliseconds(), AddressStateVerboseDto::validTo.name)
+                .withEqualsForFields(isEqualToIgnoringMilliseconds(), AddressStateVerboseDto::validFrom.name)
+                .ignoringFields(AddressStateVerboseDto::typeVerbose.name).isEqualTo(sortedStates[it])
         }
     }
 
     fun compareAddressIdentifiers(identifiersVerbose: Collection<AddressIdentifierVerboseDto>, identifiers: Collection<AddressIdentifierDto>?) {
 
         assertThat(identifiersVerbose.size).isEqualTo(identifiers?.size ?: 0)
-        val sortedVerboseIdentifiers = identifiersVerbose.sortedBy { it.type.name }
+        val sortedVerboseIdentifiers = identifiersVerbose.sortedBy { it.typeVerbose.name }
         val sortedIdentifiers = identifiers!!.sortedBy { it.type }
         sortedVerboseIdentifiers.indices.forEach {
-            assertThat(sortedVerboseIdentifiers[it].type.technicalKey).isEqualTo(sortedIdentifiers[it].type)
+            assertThat(sortedVerboseIdentifiers[it].typeVerbose.technicalKey).isEqualTo(sortedIdentifiers[it].type)
             assertThat(sortedVerboseIdentifiers[it]).usingRecursiveComparison()
-                .ignoringFields("type")
+                .ignoringFields(AddressIdentifierVerboseDto::typeVerbose.name)
                 .isEqualTo(sortedIdentifiers[it])
         }
     }
@@ -1323,7 +1323,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val sortedVerboseStates = statesVerbose.sortedBy { it.description }
         val sortedStates = states!!.sortedBy { it.description }
         sortedVerboseStates.indices.forEach {
-            assertThat(sortedVerboseStates[it].type.technicalKey.name).isEqualTo(sortedStates[it].type.name)
+            assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
                 .withEqualsForFields(isEqualToIgnoringMilliseconds(), ILegalEntityStateDto::validTo.name )
                 .withEqualsForFields(isEqualToIgnoringMilliseconds(), ILegalEntityStateDto::validFrom.name)
@@ -1338,7 +1338,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val sortedVerboseStates = statesVerbose.sortedBy { it.description }
         val sortedStates = states!!.sortedBy { it.description }
         sortedVerboseStates.indices.forEach {
-            assertThat(sortedVerboseStates[it].type.technicalKey.name).isEqualTo(sortedStates[it].type.name)
+            assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
                 .withEqualsForFields(isEqualToIgnoringMilliseconds(), ISiteStateDto::validTo.name)
                 .withEqualsForFields(isEqualToIgnoringMilliseconds(), ISiteStateDto::validFrom.name)
@@ -1365,7 +1365,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val sortedVerboseClassifications = classificationsVerbose.sortedBy { it.type.name }
         val sortedClassifications = classifications!!.sortedBy { it.type.name }
         sortedVerboseClassifications.indices.forEach {
-            assertThat(sortedVerboseClassifications[it].type.technicalKey.name).isEqualTo(sortedClassifications[it].type.name)
+            assertThat(sortedVerboseClassifications[it].typeVerbose.technicalKey.name).isEqualTo(sortedClassifications[it].type.name)
             assertThat(sortedVerboseClassifications[it]).usingRecursiveComparison()
                 .ignoringFields(LegalEntityClassificationVerboseDto::type.name)
                 .isEqualTo(sortedClassifications[it])
@@ -1375,10 +1375,10 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun compareIdentifiers(identifiersVerbose: Collection<LegalEntityIdentifierVerboseDto>, identifiers: Collection<LegalEntityIdentifierDto>?) {
 
         assertThat(identifiersVerbose.size).isEqualTo(identifiers?.size ?: 0)
-        val sortedVerboseIdentifiers = identifiersVerbose.sortedBy { it.type.name }
+        val sortedVerboseIdentifiers = identifiersVerbose.sortedBy { it.typeVerbose.name }
         val sortedIdentifiers = identifiers!!.sortedBy { it.type }
         sortedVerboseIdentifiers.indices.forEach {
-            assertThat(sortedVerboseIdentifiers[it].type.technicalKey).isEqualTo(sortedIdentifiers[it].type)
+            assertThat(sortedVerboseIdentifiers[it].typeVerbose.technicalKey).isEqualTo(sortedIdentifiers[it].type)
             assertThat(sortedVerboseIdentifiers[it]).usingRecursiveComparison()
                 .ignoringFields(LegalEntityIdentifierVerboseDto::type.name).isEqualTo(sortedIdentifiers[it])
         }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
@@ -165,7 +165,7 @@ object BusinessPartnerNonVerboseValues {
 
     private val postalAddress1 = PhysicalPostalAddressDto(
         geographicCoordinates = BusinessPartnerVerboseValues.address1.geographicCoordinates,
-        country = BusinessPartnerVerboseValues.address1.country.technicalKey,
+        country = BusinessPartnerVerboseValues.address1.country,
         postalCode = BusinessPartnerVerboseValues.address1.postalCode,
         city = BusinessPartnerVerboseValues.address1.city,
         administrativeAreaLevel1 = BusinessPartnerVerboseValues.address1.administrativeAreaLevel1?.toString(),
@@ -182,7 +182,7 @@ object BusinessPartnerNonVerboseValues {
 
     private val postalAddress2 = PhysicalPostalAddressDto(
         geographicCoordinates = BusinessPartnerVerboseValues.address2.geographicCoordinates,
-        country = BusinessPartnerVerboseValues.address2.country.technicalKey,
+        country = BusinessPartnerVerboseValues.address2.country,
         postalCode = BusinessPartnerVerboseValues.address2.postalCode,
         city = BusinessPartnerVerboseValues.address2.city,
         administrativeAreaLevel1 = BusinessPartnerVerboseValues.address2.administrativeAreaLevel1?.toString(),
@@ -199,7 +199,7 @@ object BusinessPartnerNonVerboseValues {
 
     private val postalAddress3 = PhysicalPostalAddressDto(
         geographicCoordinates = BusinessPartnerVerboseValues.address3.geographicCoordinates,
-        country = BusinessPartnerVerboseValues.address3.country.technicalKey,
+        country = BusinessPartnerVerboseValues.address3.country,
         postalCode = BusinessPartnerVerboseValues.address3.postalCode,
         city = BusinessPartnerVerboseValues.address3.city,
         administrativeAreaLevel1 = BusinessPartnerVerboseValues.address3.administrativeAreaLevel1?.toString(),

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
@@ -249,7 +249,7 @@ object BusinessPartnerVerboseValues {
         LegalEntityVerboseDto(
             bpnl = "BPNL000000000001",
             legalName = "Business Partner Name",
-            legalForm = legalForm1,
+            legalFormVerbose = legalForm1,
             identifiers = listOf(identifier1),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
@@ -286,7 +286,7 @@ object BusinessPartnerVerboseValues {
         LegalEntityVerboseDto(
             bpnl = "BPNL0000000001YN",
             legalName = "Another Organisation Corp",
-            legalForm = legalForm2,
+            legalFormVerbose = legalForm2,
             identifiers = listOf(identifier2),
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
@@ -323,7 +323,7 @@ object BusinessPartnerVerboseValues {
         LegalEntityVerboseDto(
             bpnl = "BPNL0000000002XY",
             legalName = "好公司  合伙制企业",
-            legalForm = legalForm3,
+            legalFormVerbose = legalForm3,
             identifiers = listOf(identifier3),
             states = listOf(leStatus3),
             classifications = listOf(classification5),
@@ -360,7 +360,7 @@ object BusinessPartnerVerboseValues {
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL000000000001",
             legalName = "Business Partner Name",
-            legalForm = legalForm1,
+            legalFormVerbose = legalForm1,
             identifiers = listOf(LegalEntityIdentifierVerboseDto("ID-XYZ", identifierType1, "Agency X")),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
@@ -379,7 +379,7 @@ object BusinessPartnerVerboseValues {
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL0000000001YN",
             legalName = "Another Organisation Corp",
-            legalForm = legalForm2,
+            legalFormVerbose = legalForm2,
             identifiers = listOf(LegalEntityIdentifierVerboseDto("Another ID Value", identifierType2, "Body Y")),
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
@@ -398,7 +398,7 @@ object BusinessPartnerVerboseValues {
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL0000000002XY",
             legalName = "好公司  合伙制企业",
-            legalForm = legalForm3,
+            legalFormVerbose = legalForm3,
             identifiers = listOf(LegalEntityIdentifierVerboseDto("An ID Value", identifierType3, "Official Z")),
             states = listOf(leStatus3),
             classifications = listOf(classification5),
@@ -417,7 +417,7 @@ object BusinessPartnerVerboseValues {
         legalEntity = LegalEntityVerboseDto(
             bpnl = "BPNL000000000001",
             legalName = "Business Partner Name",
-            legalForm = legalForm1,
+            legalFormVerbose = legalForm1,
             identifiers = listOf(
                 LegalEntityIdentifierVerboseDto("ID-XYZ", identifierType1, "Agency X"),
                 LegalEntityIdentifierVerboseDto("Another ID Value", identifierType2, "Body Y")

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
@@ -99,10 +99,10 @@ object BusinessPartnerVerboseValues {
 
     val address1 = PhysicalPostalAddressVerboseDto(
         geographicCoordinates = null,
-        country = country1,
+        countryVerbose = country1,
         postalCode = "71059 ",
         city = "Böblingen",
-        administrativeAreaLevel1 = null,
+        administrativeAreaLevel1Verbose = null,
         administrativeAreaLevel2 = "Böblingen",
         administrativeAreaLevel3 = null,
         district = "Sindelfingen-Ost",
@@ -116,10 +116,10 @@ object BusinessPartnerVerboseValues {
 
     val address2 = PhysicalPostalAddressVerboseDto(
         geographicCoordinates = null,
-        country = country2,
+        countryVerbose = country2,
         postalCode = "70547",
         city = "Atlanta",
-        administrativeAreaLevel1 = null,
+        administrativeAreaLevel1Verbose = null,
         administrativeAreaLevel2 = " Fulton County",
         administrativeAreaLevel3 = null,
         district = "District Level 1",
@@ -133,10 +133,10 @@ object BusinessPartnerVerboseValues {
 
     val address3 = PhysicalPostalAddressVerboseDto(
         geographicCoordinates = null,
-        country = country3,
+        countryVerbose = country3,
         postalCode = "30346",
         city = "Atlanta",
-        administrativeAreaLevel1 = null,
+        administrativeAreaLevel1Verbose = null,
         administrativeAreaLevel2 = " Fulton County",
         administrativeAreaLevel3 = null,
         district = "DL 1",
@@ -261,10 +261,10 @@ object BusinessPartnerVerboseValues {
             bpna = "BPNA000000000001",
             physicalPostalAddress = PhysicalPostalAddressVerboseDto(
                 geographicCoordinates = null,
-                country = country1,
+                countryVerbose = country1,
                 postalCode = null,
                 city = "Stuttgart",
-                administrativeAreaLevel1 = null,
+                administrativeAreaLevel1Verbose = null,
                 administrativeAreaLevel2 = null,
                 administrativeAreaLevel3 = null,
                 district = null,
@@ -298,10 +298,10 @@ object BusinessPartnerVerboseValues {
             bpna = "BPNA000000000001",
             physicalPostalAddress = PhysicalPostalAddressVerboseDto(
                 geographicCoordinates = null,
-                country = country2,
+                countryVerbose = country2,
                 postalCode = null,
                 city = "5th Congressional District",
-                administrativeAreaLevel1 = null,
+                administrativeAreaLevel1Verbose = null,
                 administrativeAreaLevel2 = null,
                 administrativeAreaLevel3 = null,
                 district = null,
@@ -335,10 +335,10 @@ object BusinessPartnerVerboseValues {
             bpna = "BPNA000000000001",
             physicalPostalAddress = PhysicalPostalAddressVerboseDto(
                 geographicCoordinates = null,
-                country = country3,
+                countryVerbose = country3,
                 postalCode = null,
                 city = "北京市",
-                administrativeAreaLevel1 = null,
+                administrativeAreaLevel1Verbose = null,
                 administrativeAreaLevel2 = null,
                 administrativeAreaLevel3 = null,
                 district = null,


### PR DESCRIPTION
Verbose DTOs, like `PhysicalPostalAddressVerboseDto` or `LegalEntityVerboseDto`, are very tricky to integrate in our DTO interface hierarchy, because although they have the same properties, some properties have a completely different type (`String` vs some generic `TypeKeyNameVerboseDto`) and so don't allow easy sub-classing. As a workaroud we sometimes leave the type completely undefined (`Any`) or the verbose classes stay completely unrelated to the normal classes.

This PR proposes a solution: 
With this a verbose DTO can be a subtype of its non-verbose version both containing full type information. In the Kotlin model the verbose property is a separate field (e.g. "typeVerbose") from which the key field (e.g. "type") is derived using a property getter. Just for the API model this separate field is renamed to the base name using `@JsonProperty` and `@JsonIgnore`.
The custom `DataClassUnwrappedJsonDeserializer` had to be adjusted that it now supports `@JsonProperty`.

This PR concludes #570