### PR TITLE
Feat/orchestrator pool validate improvement

### DIFF
--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
@@ -81,3 +81,10 @@ enum class AddressUpdateError : ErrorCode {
     IdentifierNotFound,
     AddressDuplicateIdentifier,
 }
+
+@Schema(description = "OrchestratorError")
+enum class OrchestratorError : ErrorCode {
+    AddressRegionNotFound,
+    AddressIdentifierNotFound,
+    AddressDuplicateIdentifier,
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceService.kt
@@ -66,7 +66,6 @@ class BusinessPartnerEquivalenceService {
     }
 
     private fun isEquivalent(original: LegalEntityState, updated: LegalEntityState): Boolean =
-        original.description != updated.description ||
                 original.validFrom != updated.validFrom ||
                 original.validTo != updated.validTo ||
                 original.type != updated.type

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -77,7 +77,10 @@ class TaskStepBuildService(
         if (businessPartnerDto.site != null) {
             siteEntity = upsertSite(businessPartnerDto.site, legalEntity, taskEntryBpnMapping, businessPartnerDto)
             siteResult = businessPartnerDto.site!!.copy(
-                bpnSReference = BpnReferenceDto(referenceValue = siteEntity.bpn, referenceType = BpnReferenceType.Bpn)
+                bpnSReference = BpnReferenceDto(referenceValue = siteEntity.bpn, referenceType = BpnReferenceType.Bpn),
+                mainAddress = businessPartnerDto.site!!.mainAddress!!.copy(
+                    bpnAReference = BpnReferenceDto(referenceValue = siteEntity.mainAddress.bpn, referenceType = BpnReferenceType.Bpn)
+                )
             )
             genericBpnA = siteEntity.mainAddress.bpn
         }
@@ -344,7 +347,7 @@ class TaskStepBuildService(
                 if (siteDto.hasChanged == true) {
                     val createSite = BusinessPartnerBuildService.createSite(siteDto, updateSite.bpn, legalEntity)
                     val siteMainAddress =
-                        if (genericBusinessPartner.generic.postalAddress.addressType == AddressType.LegalAndSiteMainAddress)
+                        if (genericBusinessPartner.generic.address.addressType == AddressType.LegalAndSiteMainAddress)
                             legalEntity.legalAddress
                         else
                             createLogisticAddress(mainAddress, taskEntryBpnMapping)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveService.kt
@@ -63,7 +63,7 @@ class TaskStepFetchAndReserveService(
 
         val taskEntryBpnMapping = TaskEntryBpnMapping(taskEntries, bpnRequestIdentifierRepository)
 
-        val invalidTaskResultsByTaskEntry = validateTasks(taskEntries)
+        val invalidTaskResultsByTaskEntry = validateTasks(taskEntries, taskEntryBpnMapping)
 
         val taskResults = taskEntries.map {
 
@@ -91,23 +91,10 @@ class TaskStepFetchAndReserveService(
         }
     }
 
-    private fun validateTasks(
-        taskEntries: List<TaskStepReservationEntryDto>
+    private fun validateTasks( taskEntries: List<TaskStepReservationEntryDto>,  requestMappings: TaskEntryBpnMapping
     ): Map<TaskStepReservationEntryDto, TaskStepResultEntryDto?> {
 
-        val legalEntitiesToCreate = taskEntries
-            .filter { it.businessPartner.legalEntity?.bpnLReference?.referenceType == BpnReferenceType.BpnRequestIdentifier }
-        val legalEntitiesToUpdate = taskEntries
-            .filter { it.businessPartner.legalEntity?.bpnLReference?.referenceType == BpnReferenceType.Bpn }
-        val sitesToCreate = taskEntries
-            .filter { it.businessPartner.site?.bpnSReference?.referenceType == BpnReferenceType.BpnRequestIdentifier }
-        val sitesToUpdate = taskEntries
-            .filter { it.businessPartner.site?.bpnSReference?.referenceType == BpnReferenceType.Bpn }
-
-        val validationErrorsByTaskEntry = requestValidationService.validateLegalEntitiesToCreateFromOrchestrator(legalEntitiesToCreate) +
-            requestValidationService.validateLegalEntitiesToUpdateFromOrchestrator(legalEntitiesToUpdate)+
-            requestValidationService.validateSitesToCreateFromOrchestrator(sitesToCreate) +
-            requestValidationService.validateSitesToUpdateFromOrchestrator(sitesToUpdate)
+        val validationErrorsByTaskEntry = requestValidationService.validateTasksFromOrchestrator(taskEntries, requestMappings)
 
         val taskResultsByTaskEntry = taskEntries
             .associateWith { taskEntry ->

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerComparator.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerComparator.kt
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import org.assertj.core.api.Assertions
+import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
+import org.eclipse.tractusx.bpdm.common.dto.ISiteStateDto
+import org.eclipse.tractusx.bpdm.pool.api.model.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
+import org.eclipse.tractusx.orchestrator.api.model.AddressIdentifierDto
+import org.eclipse.tractusx.orchestrator.api.model.AddressStateDto
+import org.eclipse.tractusx.orchestrator.api.model.LegalEntityClassificationDto
+import org.eclipse.tractusx.orchestrator.api.model.LegalEntityDto
+import org.eclipse.tractusx.orchestrator.api.model.LegalEntityIdentifierDto
+import org.eclipse.tractusx.orchestrator.api.model.LogisticAddressDto
+import org.eclipse.tractusx.orchestrator.api.model.SiteDto
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.function.BiPredicate
+
+fun compareLegalEntity(verboseRequest: LegalEntityWithLegalAddressVerboseDto, legalEntity: LegalEntityDto?) {
+
+    val verboseLegalEntity = verboseRequest.legalEntity
+
+    Assertions.assertThat(verboseLegalEntity.legalShortName).isEqualTo(legalEntity?.legalShortName)
+    Assertions.assertThat(verboseLegalEntity.legalFormVerbose?.technicalKey).isEqualTo(legalEntity?.legalForm)
+    compareStates(verboseLegalEntity.states, legalEntity?.states)
+    compareClassifications(verboseLegalEntity.classifications, legalEntity?.classifications)
+    compareIdentifiers(verboseLegalEntity.identifiers, legalEntity?.identifiers)
+
+    val verboseLegalAddress = verboseRequest.legalAddress
+    Assertions.assertThat(verboseLegalAddress.bpnLegalEntity).isEqualTo(legalEntity?.bpnLReference?.referenceValue)
+    Assertions.assertThat(verboseLegalAddress.isLegalAddress).isTrue()
+    compareLogisticAddress(verboseLegalAddress, legalEntity?.legalAddress)
+}
+
+fun compareSite(verboseRequest: SiteWithMainAddressVerboseDto, site: SiteDto?) {
+
+    val verboseSite = verboseRequest.site
+
+    Assertions.assertThat(verboseSite.name).isEqualTo(site?.name)
+    Assertions.assertThat(verboseSite.bpns).isEqualTo(site?.bpnSReference?.referenceValue)
+    compareSiteStates(verboseSite.states, site?.states)
+
+    val verboseMainAddress = verboseRequest.mainAddress
+    Assertions.assertThat(verboseMainAddress.bpnSite).isEqualTo(site?.bpnSReference?.referenceValue)
+    val mainAddress = site?.mainAddress
+    Assertions.assertThat(verboseMainAddress.isMainAddress).isTrue()
+    compareLogisticAddress(verboseMainAddress, mainAddress)
+}
+
+fun compareLogisticAddress(verboseAddress: LogisticAddressVerboseDto, address: LogisticAddressDto?) {
+
+    Assertions.assertThat(verboseAddress.name).isEqualTo(address?.name)
+    compareAddressStates(verboseAddress.states, address?.states)
+    compareAddressIdentifiers(verboseAddress.identifiers, address?.identifiers)
+
+
+    val verbosePhysicalAddress = verboseAddress.physicalPostalAddress
+    val physicalAddress = address?.physicalPostalAddress
+    Assertions.assertThat(verbosePhysicalAddress).usingRecursiveComparison()
+        .ignoringFields(PhysicalPostalAddressVerboseDto::countryVerbose.name, PhysicalPostalAddressVerboseDto::administrativeAreaLevel1Verbose.name)
+        .isEqualTo(physicalAddress)
+    Assertions.assertThat(verbosePhysicalAddress.country.name).isEqualTo(physicalAddress?.country?.name)
+    Assertions.assertThat(verbosePhysicalAddress.administrativeAreaLevel1).isEqualTo(physicalAddress?.administrativeAreaLevel1)
+    val verboseAlternAddress = verboseAddress.alternativePostalAddress
+    val alternAddress = address?.alternativePostalAddress
+    Assertions.assertThat(verboseAlternAddress).usingRecursiveComparison()
+        .ignoringFields(AlternativePostalAddressVerboseDto::countryVerbose.name, AlternativePostalAddressVerboseDto::administrativeAreaLevel1Verbose.name)
+        .isEqualTo(alternAddress)
+    Assertions.assertThat(verboseAlternAddress?.country?.name).isEqualTo(alternAddress?.country?.name)
+    Assertions.assertThat(verboseAlternAddress?.administrativeAreaLevel1).isEqualTo(alternAddress?.administrativeAreaLevel1)
+}
+
+fun compareAddressStates(statesVerbose: Collection<AddressStateVerboseDto>, states: Collection<AddressStateDto>?) {
+
+    Assertions.assertThat(statesVerbose.size).isEqualTo(states?.size ?: 0)
+    val sortedVerboseStates = statesVerbose.sortedBy { it.validFrom }
+    val sortedStates = states?.sortedBy { it.validFrom }
+    sortedVerboseStates.indices.forEach {
+        Assertions.assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates!![it].type.name)
+        Assertions.assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
+            .withEqualsForFields(isEqualToIgnoringMilliseconds(), AddressStateVerboseDto::validTo.name)
+            .withEqualsForFields(isEqualToIgnoringMilliseconds(), AddressStateVerboseDto::validFrom.name)
+            .ignoringFields(AddressStateVerboseDto::typeVerbose.name).isEqualTo(sortedStates[it])
+    }
+}
+
+fun compareAddressIdentifiers(identifiersVerbose: Collection<AddressIdentifierVerboseDto>, identifiers: Collection<AddressIdentifierDto>?) {
+
+    Assertions.assertThat(identifiersVerbose.size).isEqualTo(identifiers?.size ?: 0)
+    val sortedVerboseIdentifiers = identifiersVerbose.sortedBy { it.typeVerbose.name }
+    val sortedIdentifiers = identifiers!!.sortedBy { it.type }
+    sortedVerboseIdentifiers.indices.forEach {
+        Assertions.assertThat(sortedVerboseIdentifiers[it].typeVerbose.technicalKey).isEqualTo(sortedIdentifiers[it].type)
+        Assertions.assertThat(sortedVerboseIdentifiers[it]).usingRecursiveComparison()
+            .ignoringFields(AddressIdentifierVerboseDto::typeVerbose.name)
+            .isEqualTo(sortedIdentifiers[it])
+    }
+}
+
+fun compareStates(statesVerbose: Collection<LegalEntityStateVerboseDto>, states: Collection<ILegalEntityStateDto>?) {
+
+    Assertions.assertThat(statesVerbose.size).isEqualTo(states?.size ?: 0)
+    val sortedVerboseStates = statesVerbose.sortedBy { it.validFrom }
+    val sortedStates = states!!.sortedBy { it.validFrom }
+    sortedVerboseStates.indices.forEach {
+        Assertions.assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
+        Assertions.assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
+            .withEqualsForFields(isEqualToIgnoringMilliseconds(), LegalEntityStateVerboseDto::validTo.name )
+            .withEqualsForFields(isEqualToIgnoringMilliseconds(), LegalEntityStateVerboseDto::validFrom.name)
+            .ignoringFields(LegalEntityStateVerboseDto::typeVerbose.name)
+            .isEqualTo(sortedStates[it])
+    }
+}
+
+fun compareSiteStates(statesVerbose: Collection<SiteStateVerboseDto>, states: Collection<ISiteStateDto>?) {
+
+    Assertions.assertThat(statesVerbose.size).isEqualTo(states?.size ?: 0)
+    val sortedVerboseStates = statesVerbose.sortedBy { it.validFrom }
+    val sortedStates = states!!.sortedBy { it.validFrom }
+    sortedVerboseStates.indices.forEach {
+        Assertions.assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
+        Assertions.assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
+            .withEqualsForFields(isEqualToIgnoringMilliseconds(), SiteStateVerboseDto::validTo.name)
+            .withEqualsForFields(isEqualToIgnoringMilliseconds(), SiteStateVerboseDto::validFrom.name)
+            .ignoringFields(SiteStateVerboseDto::typeVerbose.name)
+            .isEqualTo(sortedStates[it])
+    }
+}
+
+fun isEqualToIgnoringMilliseconds(): BiPredicate<LocalDateTime?, LocalDateTime?> {
+    return BiPredicate<LocalDateTime?, LocalDateTime?> { d1, d2 ->
+        (d1 == null && d2 == null)
+                || d1.truncatedTo(ChronoUnit.SECONDS).equals(d2.truncatedTo(ChronoUnit.SECONDS))
+    }
+}
+
+fun compareClassifications(
+    classificationsVerbose: Collection<LegalEntityClassificationVerboseDto>,
+    classifications: Collection<LegalEntityClassificationDto>?
+) {
+
+    Assertions.assertThat(classificationsVerbose.size).isEqualTo(classifications?.size ?: 0)
+    val sortedVerboseClassifications = classificationsVerbose.sortedBy { it.typeVerbose.name }
+    val sortedClassifications = classifications!!.sortedBy { it.type.name }
+    sortedVerboseClassifications.indices.forEach {
+        Assertions.assertThat(sortedVerboseClassifications[it].typeVerbose.technicalKey.name).isEqualTo(sortedClassifications[it].type.name)
+        Assertions.assertThat(sortedVerboseClassifications[it]).usingRecursiveComparison()
+            .ignoringFields(LegalEntityClassificationVerboseDto::typeVerbose.name)
+            .isEqualTo(sortedClassifications[it])
+    }
+}
+
+fun compareIdentifiers(identifiersVerbose: Collection<LegalEntityIdentifierVerboseDto>, identifiers: Collection<LegalEntityIdentifierDto>?) {
+
+    Assertions.assertThat(identifiersVerbose.size).isEqualTo(identifiers?.size ?: 0)
+    val sortedVerboseIdentifiers = identifiersVerbose.sortedBy { it.typeVerbose.name }
+    val sortedIdentifiers = identifiers!!.sortedBy { it.type }
+    sortedVerboseIdentifiers.indices.forEach {
+        Assertions.assertThat(sortedVerboseIdentifiers[it].typeVerbose.technicalKey).isEqualTo(sortedIdentifiers[it].type)
+        Assertions.assertThat(sortedVerboseIdentifiers[it]).usingRecursiveComparison()
+            .ignoringFields(LegalEntityIdentifierVerboseDto::typeVerbose.name).isEqualTo(sortedIdentifiers[it])
+    }
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerCreator.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerCreator.kt
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import org.eclipse.tractusx.bpdm.common.model.ClassificationType
+import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
+import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerNonVerboseValues
+import org.eclipse.tractusx.bpdm.pool.util.BusinessPartnerVerboseValues
+import org.eclipse.tractusx.orchestrator.api.model.*
+import java.time.LocalDateTime
+
+fun minFullBusinessPartner(): BusinessPartnerFullDto {
+
+    return BusinessPartnerFullDto(generic = BusinessPartnerGenericDto())
+}
+
+fun emptyLegalEntity(): LegalEntityDto {
+
+    return LegalEntityDto()
+}
+
+fun minValidLegalEntity(bpnLReference: BpnReferenceDto, bpnAReference: BpnReferenceDto): LegalEntityDto {
+
+    return LegalEntityDto(
+        bpnLReference = bpnLReference,
+        legalName = "legalName_" + bpnLReference.referenceValue,
+        legalAddress = minLogisticAddress(bpnAReference = bpnAReference)
+    )
+}
+
+fun fullValidLegalEntity(bpnLReference: BpnReferenceDto, bpnAReference: BpnReferenceDto): LegalEntityDto {
+
+    return LegalEntityDto(
+        bpnLReference = bpnLReference,
+        legalName = "legalName_" + bpnLReference.referenceValue,
+        legalShortName = "shortName_" + bpnLReference.referenceValue,
+        legalForm = BusinessPartnerVerboseValues.legalForm1.technicalKey,
+        identifiers = listOf(
+            legalEntityIdentifierDto(bpnLReference.referenceValue, 1L, BusinessPartnerVerboseValues.identifierType1),
+            legalEntityIdentifierDto(bpnLReference.referenceValue, 2L, BusinessPartnerVerboseValues.identifierType2)
+        ),
+        states = listOf(
+            legalEntityState(bpnLReference.referenceValue, 1L, BusinessStateType.ACTIVE),
+            legalEntityState(bpnLReference.referenceValue, 2L, BusinessStateType.INACTIVE)
+        ),
+        classifications = listOf(
+            classificationDto(bpnLReference.referenceValue, 1L, ClassificationType.NACE),
+            classificationDto(bpnLReference.referenceValue, 2L, ClassificationType.NAICS)
+        ),
+        legalAddress = fullLogisticAddressDto(bpnAReference)
+    )
+}
+
+fun legalEntityIdentifierDto(name: String, id: Long, type: TypeKeyNameVerboseDto<String>): LegalEntityIdentifierDto {
+
+    return LegalEntityIdentifierDto(
+        value = "value_" + name + "_" + id,
+        issuingBody = "issuingBody_" + name + "_" + id,
+        type = type.technicalKey
+    )
+}
+
+fun addressIdentifierDto(name: String, id: Long, type: TypeKeyNameVerboseDto<String>): AddressIdentifierDto {
+
+    return AddressIdentifierDto(
+        value = "value_" + name + "_" + id,
+        type = type.technicalKey
+    )
+}
+
+fun legalEntityState(name: String, id: Long, type: BusinessStateType): LegalEntityStateDto {
+
+    return LegalEntityStateDto(
+        validFrom = LocalDateTime.now().plusDays(id),
+        validTo = LocalDateTime.now().plusDays(id + 2),
+        type = type
+    )
+}
+
+fun siteState(name: String, id: Long, type: BusinessStateType): SiteStateDto {
+
+    return SiteStateDto(
+        validFrom = LocalDateTime.now().plusDays(id),
+        validTo = LocalDateTime.now().plusDays(id + 2),
+        type = type
+    )
+}
+
+fun addressState(name: String, id: Long, type: BusinessStateType): AddressStateDto {
+
+    return AddressStateDto(
+        validFrom = LocalDateTime.now().plusDays(id),
+        validTo = LocalDateTime.now().plusDays(id + 2),
+        type = type
+    )
+}
+
+
+fun classificationDto(name: String, id: Long, type: ClassificationType): LegalEntityClassificationDto {
+
+    return LegalEntityClassificationDto(
+        code = "code_" + name + "_" + id,
+        value = "value_" + name + "_" + id,
+        type = type
+    )
+}
+
+fun minLogisticAddress(bpnAReference: BpnReferenceDto): LogisticAddressDto {
+
+    return LogisticAddressDto(
+        bpnAReference = bpnAReference,
+        physicalPostalAddress = minPhysicalPostalAddressDto(bpnAReference)
+    )
+}
+
+fun minPhysicalPostalAddressDto(bpnAReference: BpnReferenceDto) = PhysicalPostalAddressDto(
+    country = CountryCode.DE,
+    city = "City_" + bpnAReference.referenceValue
+)
+
+fun fullLogisticAddressDto(bpnAReference: BpnReferenceDto): LogisticAddressDto {
+
+    return LogisticAddressDto(
+        bpnAReference = bpnAReference,
+        name = "name_" + bpnAReference.referenceValue,
+        identifiers = listOf(
+            addressIdentifierDto(bpnAReference.referenceValue, 1L, TypeKeyNameVerboseDto(BusinessPartnerNonVerboseValues.addressIdentifierTypeDto1.technicalKey, "")),
+            addressIdentifierDto(bpnAReference.referenceValue, 2L, TypeKeyNameVerboseDto(BusinessPartnerNonVerboseValues.addressIdentifierTypeDto2.technicalKey, ""))
+        ),
+        states = listOf(
+            addressState(bpnAReference.referenceValue, 1L, BusinessStateType.ACTIVE),
+            addressState(bpnAReference.referenceValue, 2L, BusinessStateType.INACTIVE)
+        ),
+        physicalPostalAddress = PhysicalPostalAddressDto(
+            geographicCoordinates = GeoCoordinateDto(longitude = 1.1f, latitude = 2.2f, altitude = 3.3f),
+            country = CountryCode.DE,
+            administrativeAreaLevel1 = "AD-07",
+            administrativeAreaLevel2 = "adminArea2_" + bpnAReference.referenceValue,
+            administrativeAreaLevel3 = "adminArea3_" + bpnAReference.referenceValue,
+            postalCode = "postalCode_" + bpnAReference.referenceValue,
+            city = "city_" + bpnAReference.referenceValue,
+            street = StreetDto(
+                name = "name_" + bpnAReference.referenceValue,
+                houseNumber = "houseNumber_" + bpnAReference.referenceValue,
+                milestone = "milestone_" + bpnAReference.referenceValue,
+                direction = "direction_" + bpnAReference.referenceValue,
+                namePrefix = "namePrefix_" + bpnAReference.referenceValue,
+                additionalNamePrefix = "additionalNamePrefix_" + bpnAReference.referenceValue,
+                nameSuffix = "nameSuffix_" + bpnAReference.referenceValue,
+                additionalNameSuffix = "additionalNameSuffix_" + bpnAReference.referenceValue,
+            ),
+            district = "district_" + bpnAReference.referenceValue,
+            companyPostalCode = "companyPostalCode_" + bpnAReference.referenceValue,
+            industrialZone = "industrialZone_" + bpnAReference.referenceValue,
+            building = "building_" + bpnAReference.referenceValue,
+            floor = "floor_" + bpnAReference.referenceValue,
+            door = "door_" + bpnAReference.referenceValue,
+        ),
+        alternativePostalAddress = AlternativePostalAddressDto(
+            geographicCoordinates = GeoCoordinateDto(longitude = 12.3f, latitude = 4.56f, altitude = 7.89f),
+            country = CountryCode.DE,
+            administrativeAreaLevel1 = "DE-BW",
+            postalCode = "alternate_postalCode_" + bpnAReference.referenceValue,
+            city = "alternate_city_" + bpnAReference.referenceValue,
+            deliveryServiceType = DeliveryServiceType.PO_BOX,
+            deliveryServiceQualifier = "deliveryServiceQualifier_" + bpnAReference.referenceValue,
+            deliveryServiceNumber = "deliveryServiceNumber_" + bpnAReference.referenceValue,
+        )
+    )
+}
+
+fun minValidSite(bpnSReference: BpnReferenceDto, bpnAReference: BpnReferenceDto): SiteDto {
+
+    return SiteDto(
+        bpnSReference = bpnSReference,
+        name = "siteName_" + bpnSReference.referenceValue,
+        mainAddress = minLogisticAddress(bpnAReference = bpnAReference)
+    )
+}
+
+fun fullValidSite(bpnSReference: BpnReferenceDto, bpnAReference: BpnReferenceDto): SiteDto {
+
+    return SiteDto(
+        bpnSReference = bpnSReference,
+        name = "siteName_" + bpnSReference.referenceValue,
+        states = listOf(
+            siteState(bpnSReference.referenceValue, 1L, BusinessStateType.ACTIVE), siteState(bpnSReference.referenceValue, 2L, BusinessStateType.INACTIVE)
+        ),
+        mainAddress = fullLogisticAddressDto(bpnAReference)
+    )
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -38,7 +38,6 @@ import org.eclipse.tractusx.orchestrator.api.model.SiteDto
 import org.eclipse.tractusx.orchestrator.api.model.SiteStateDto
 import org.eclipse.tractusx.orchestrator.api.model.StreetDto
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -71,25 +70,27 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     @Test
     fun `create empty legal entity`() {
 
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = emptyLegalEntity()
         )
 
-        val result = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
-        assertTaskError(result[0], "TASK_1", CleaningError.LEGAL_ENTITY_IS_NULL)
+        val result = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
+        assertThat(result[0].taskId).isEqualTo("TASK_1")
+        assertThat(result[0].errors.size).isEqualTo(2)
+        assertThat(result[0].errors[0].description).isEqualTo(CleaningError.LEGAL_ENTITY_IS_NULL.message)
     }
 
     @Test
     fun `create legal entity without legal name`() {
 
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = emptyLegalEntity().copy(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
-                legalAddress = LogisticAddressDto()
+                legalAddress =  minLogisticAddress(BpnReferenceDto(referenceValue = "A777", referenceType = BpnRequestIdentifier))
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertTaskError(createResult[0], "TASK_1", CleaningError.LEGAL_NAME_IS_NULL)
     }
 
@@ -98,13 +99,13 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val leRefValue = "123"
         val leAddressRefValue = "222"
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
@@ -122,13 +123,13 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val leRefValue = "123"
         val leAddressRefValue = "222"
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = fullValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
@@ -148,14 +149,14 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val leRefValue = "123"
         val leAddressRefValue = "222"
         val additionalAddressRefValue = "333"
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
             ),
             address = minLogisticAddress(BpnReferenceDto(referenceValue = additionalAddressRefValue, referenceType = BpnRequestIdentifier))
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
@@ -178,7 +179,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `create legal entity with invalid identifiers`() {
 
         val leRef = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef,
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
@@ -189,7 +190,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
         assertThat(createResult[0].errors[0].description).isEqualTo("Legal Entity Identifier Type 'Invalid' does not exist")
@@ -198,7 +199,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     @Test
     fun `create legal entity with invalid legal form`() {
 
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
@@ -206,7 +207,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 legalForm = "Invalid Form"
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
         assertThat(createResult[0].errors[0].description).isEqualTo("Legal Form 'Invalid Form' does not exist")
@@ -216,7 +217,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `create legal entity with invalid duplicate identifier`() {
 
         val leRef = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef,
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
@@ -227,7 +228,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 ),
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
         assertThat(createResult[0].errors[0].description).isEqualTo("Duplicate Legal Entity Identifier: Value 'value_123_1' of type 'VAT_DE'")
@@ -237,10 +238,10 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `create 2 legal entities with invalid duplicate identifier`() {
 
         val leRef1 = BpnReferenceDto(referenceValue = "111", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef1,
-                bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
+                bpnAReference = BpnReferenceDto(referenceValue = "444", referenceType = BpnRequestIdentifier)
             ).copy(
                 identifiers = listOf(
                     legalEntityIdentifierDto(leRef1.referenceValue, 1L, BusinessPartnerVerboseValues.identifierType1),
@@ -248,12 +249,12 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 ),
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
         val leRef2 = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity2 = minFullBusinessPartner().copy(
+        val createLegalEntityRequest2 = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef2,
                 bpnAReference = BpnReferenceDto(referenceValue = "333", referenceType = BpnRequestIdentifier)
@@ -263,7 +264,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 ),
             )
         )
-        val resultSteps2 = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = fullBpWithLegalEntity2)
+        val resultSteps2 = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = createLegalEntityRequest2)
         assertThat(resultSteps2[0].taskId).isEqualTo("TASK_2")
         assertThat(resultSteps2[0].errors.size).isEqualTo(1)
         assertThat(resultSteps2[0].errors[0].description).isEqualTo("Duplicate Legal Entity Identifier: Value 'value_111_1' of type 'VAT_DE'")
@@ -273,7 +274,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `create legal entity with invalid address administrativeAreaLevel1`() {
 
         val bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = bpnAReference
@@ -285,7 +286,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
         assertThat(createResult[0].errors[0].description).isEqualTo("Address administrative area level1 'Invalid' does not exist")
@@ -295,7 +296,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `create legal entity with invalid address identifier`() {
 
         val bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = bpnAReference
@@ -308,7 +309,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
         assertThat(createResult[0].errors[0].description).isEqualTo("Address Identifier Type 'Invalid Ident' does not exist")
@@ -318,7 +319,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `create legal entity with invalid duplicated address identifier`() {
 
         val bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = bpnAReference
@@ -331,7 +332,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
         assertThat(createResult[0].errors[0].description).isEqualTo("Duplicate Address Identifier: Value 'value_222_1' of type 'ADDR_KEY_ONE'")
@@ -343,18 +344,18 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val leRefValue = "123"
         val leAddressRefValue = "222"
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors.size).isEqualTo(0)
         val createdLegalEntity1 = poolClient.legalEntities.getLegalEntity(createResult[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
 
-        val resultSteps2 = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = fullBpWithLegalEntity)
+        val resultSteps2 = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = createLegalEntityRequest)
         assertThat(resultSteps2[0].taskId).isEqualTo("TASK_2")
         assertThat(resultSteps2[0].errors.size).isEqualTo(0)
         assertThat(createdLegalEntity1.legalEntity.bpnl).isEqualTo(resultSteps2[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
@@ -365,27 +366,27 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val leRefValue = "123"
         val leAddressRefValue = "222"
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors.size).isEqualTo(0)
         val createdLegalEntity1 = poolClient.legalEntities.getLegalEntity(createResult[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
 
         val leRefValue2 = "diffenrentBpnL"
         val leAddressRefValue2 = "diffenrentBpnA"
-        val fullBpWithLegalEntity2 = minFullBusinessPartner().copy(
+        val createLegalEntityRequest2 = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue2, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue2, referenceType = BpnRequestIdentifier)
             )
         )
 
-        val resultSteps2 = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = fullBpWithLegalEntity2)
+        val resultSteps2 = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = createLegalEntityRequest2)
         val bpnMappings =
             bpnRequestIdentifierRepository.findDistinctByRequestIdentifierIn(listOf(leRefValue, leAddressRefValue, leRefValue2, leAddressRefValue2))
         assertThat(bpnMappings.size).isEqualTo(4)
@@ -398,31 +399,66 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     }
 
     @Test
-    fun `update legal entity with all fields`() {
+    fun `update legal entity with all fields by BPN`() {
 
         val leRefValue = "123"
         val leAddressRefValue = "222"
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = fullValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
-        val updatedFullBpLegalEntity = createResult[0].businessPartner?.copy(
+        val updateLegalEntityRequest = createResult[0].businessPartner?.copy(
             legalEntity = createResult[0].businessPartner?.legalEntity?.copy(
                 hasChanged = true,
                 legalName = "Changed Legal Entity",
-                        legalAddress = createResult[0].businessPartner?.legalEntity?.legalAddress?.copy(
-                            hasChanged = true,
-                            name = "Changed Address Name"
-                        )
+                legalAddress = createResult[0].businessPartner?.legalEntity?.legalAddress?.copy(
+                    hasChanged = true,
+                    name = "Changed Address Name"
+                )
             )
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updatedFullBpLegalEntity!!)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateLegalEntityRequest!!)
+        assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
+        assertThat(updateResult[0].errors.size).isEqualTo(0)
+
+        val updatedLegalEntity = poolClient.legalEntities.getLegalEntity(updateResult[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
+        assertThat(updatedLegalEntity.legalEntity.legalName).isEqualTo("Changed Legal Entity")
+        compareLegalEntity(updatedLegalEntity, updateResult[0].businessPartner?.legalEntity)
+    }
+
+    @Test
+    fun `update legal entity with all fields by BpnRequestIdentifier`() {
+
+        val leRefValue = "123"
+        val leAddressRefValue = "222"
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
+            legalEntity = fullValidLegalEntity(
+                bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
+                bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
+            )
+        )
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
+        assertThat(createResult[0].taskId).isEqualTo("TASK_1")
+        assertThat(createResult[0].errors.size).isEqualTo(0)
+
+        // Update legal entity with same BpnRequestIdentifier
+        val updateLegalEntityRequest = createLegalEntityRequest.copy(
+            legalEntity = createLegalEntityRequest.legalEntity?.copy(
+                hasChanged = true,
+                legalName = "Changed Legal Entity",
+                legalAddress = createLegalEntityRequest.legalEntity?.legalAddress?.copy(
+                    hasChanged = true,
+                    name = "Changed Address Name"
+                )
+            )
+        )
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateLegalEntityRequest)
         assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
         assertThat(updateResult[0].errors.size).isEqualTo(0)
 
@@ -435,16 +471,16 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `update legal entity invalid identifier type `() {
 
         val leRef = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef,
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
-        val updatedFullBpLegalEntity = createResult[0].businessPartner?.copy(
+        val updateLegalEntityRequest = createResult[0].businessPartner?.copy(
             legalEntity = createResult[0].businessPartner?.legalEntity?.copy(
                 hasChanged = true,
                 legalName = "Changed Legal Entity",
@@ -458,7 +494,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updatedFullBpLegalEntity!!)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateLegalEntityRequest!!)
         assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
         assertThat(updateResult[0].errors.size).isEqualTo(1)
         assertThat(updateResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
@@ -469,16 +505,16 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `update legal entity invalid legal form `() {
 
         val leRef = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef,
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
-        val updatedFullBpLegalEntity = createResult[0].businessPartner?.copy(
+        val updateLegalEntityRequest = createResult[0].businessPartner?.copy(
             legalEntity = createResult[0].businessPartner?.legalEntity?.copy(
                 hasChanged = true,
                 legalName = "Changed Legal Entity",
@@ -489,7 +525,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updatedFullBpLegalEntity!!)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateLegalEntityRequest!!)
         assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
         assertThat(updateResult[0].errors.size).isEqualTo(1)
         assertThat(updateResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
@@ -500,18 +536,18 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `update legal entity not existing bpn `() {
 
         val leRef = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef,
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
-        val updatedFullBpLegalEntity = createResult[0].businessPartner?.copy(
+        val updateLegalEntityRequest = createResult[0].businessPartner?.copy(
             legalEntity = createResult[0].businessPartner?.legalEntity?.copy(
-                bpnLReference= BpnReferenceDto(referenceValue = "InvalidBPN", referenceType = Bpn),
+                bpnLReference = BpnReferenceDto(referenceValue = "InvalidBPN", referenceType = Bpn),
                 hasChanged = true,
                 legalName = "Changed Legal Entity",
                 legalAddress = createResult[0].businessPartner?.legalEntity?.legalAddress?.copy(
@@ -520,7 +556,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updatedFullBpLegalEntity!!)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateLegalEntityRequest!!)
         assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
         assertThat(updateResult[0].errors.size).isEqualTo(1)
         assertThat(updateResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
@@ -531,7 +567,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `update legal entity with changed identifiers `() {
 
         val leRef = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef,
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier),
@@ -542,10 +578,10 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
-        val updatedFullBpLegalEntity = createResult[0].businessPartner?.copy(
+        val updateLegalEntityRequest = createResult[0].businessPartner?.copy(
             legalEntity = createResult[0].businessPartner?.legalEntity?.copy(
                 identifiers = listOf(
                     legalEntityIdentifierDto(leRef.referenceValue, 3L, BusinessPartnerVerboseValues.identifierType3),
@@ -559,7 +595,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             )
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updatedFullBpLegalEntity!!)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateLegalEntityRequest!!)
         assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
         assertThat(updateResult[0].errors.size).isEqualTo(0)
     }
@@ -568,30 +604,30 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun `update legal entity by reference value with invalid identifier type `() {
 
         val leRef = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier)
-        val fullBpWithLegalEntity = minFullBusinessPartner().copy(
+        val createLegalEntityRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = leRef,
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
             )
         )
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithLegalEntity)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntityRequest)
         assertThat(createResult[0].errors.size).isEqualTo(0)
 
-        val updatedFullBpLegalEntity = fullBpWithLegalEntity.copy(
-            legalEntity = fullBpWithLegalEntity.legalEntity?.copy(
+        val updateLegalEntityRequest = createLegalEntityRequest.copy(
+            legalEntity = createLegalEntityRequest.legalEntity?.copy(
                 hasChanged = true,
                 legalName = "Changed Legal Entity",
                 identifiers = listOf(
                     legalEntityIdentifierDto(leRef.referenceValue, 1L, BusinessPartnerVerboseValues.identifierType1),
                     legalEntityIdentifierDto(leRef.referenceValue, 2L, TypeKeyNameVerboseDto("Invalid", "Invalid"))
                 ),
-                legalAddress = fullBpWithLegalEntity.legalEntity?.legalAddress?.copy(
+                legalAddress = createLegalEntityRequest.legalEntity?.legalAddress?.copy(
                     hasChanged = true,
                     name = "Changed Address Name"
                 )
             )
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updatedFullBpLegalEntity)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateLegalEntityRequest)
         assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
         assertThat(updateResult[0].errors).hasSize(1)
         assertThat(updateResult[0].errors[0].type).isEqualTo(TaskErrorType.Unspecified)
@@ -605,7 +641,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val leAddressRefValue = "222"
         val siteRefValue = "siteRefValue"
         val mainAddressRefValue = "mainAddressRefValue"
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
@@ -616,11 +652,11 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
         val createdSite = poolClient.sites.getSite(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors).hasSize(0)
-        assertThat(createdSite.site.name).isEqualTo(fullBpWithSite.site?.name)
+        assertThat(createdSite.site.name).isEqualTo(createSiteRequest.site?.name)
     }
 
     @Test
@@ -630,7 +666,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val leAddressRefValue = "222"
         val siteRefValue = "siteRefValue"
         val mainAddressRefValue = "mainAddressRefValue"
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
@@ -641,11 +677,11 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
         val createdSite = poolClient.sites.getSite(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors).hasSize(0)
-        assertThat(createdSite.site.name).isEqualTo(fullBpWithSite.site?.name)
+        assertThat(createdSite.site.name).isEqualTo(createSiteRequest.site?.name)
         compareSite(createdSite, createResult[0].businessPartner?.site)
     }
 
@@ -657,7 +693,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val siteRefValue = "siteRefValue"
         val mainAddressRefValue = "mainAddressRefValue"
         val additionalAddressRefValue = "77"
-        val fullBpWithAddress = minFullBusinessPartner().copy(
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
@@ -671,12 +707,12 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithAddress)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
         val createdLeAddress = poolClient.addresses.getAddress(createResult[0].businessPartner?.legalEntity?.legalAddress?.bpnAReference?.referenceValue!!)
         val createdAdditionalAddress = poolClient.addresses.getAddress(createResult[0].businessPartner?.address?.bpnAReference?.referenceValue!!)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors).hasSize(0)
-        assertThat(createdLeAddress.name).isEqualTo(fullBpWithAddress.address?.name)
+        assertThat(createdLeAddress.name).isEqualTo(createSiteRequest.address?.name)
         compareLogisticAddress(createdAdditionalAddress, createResult[0].businessPartner?.address)
         assertThat(createdAdditionalAddress.bpnLegalEntity).isNull()
         assertThat(createdAdditionalAddress.bpnSite).isEqualTo(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue)
@@ -688,7 +724,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     @Test
     fun `create Site without main address`() {
 
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
@@ -701,11 +737,11 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
 
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors).hasSize(1)
-        assertThat(createResult[0].errors[0].description).isEqualTo("Site main address is Empty")
+        assertThat(createResult[0].errors[0].description).isEqualTo("Site main address or BpnA Reference is Empty")
     }
 
     @Test
@@ -713,7 +749,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
         val additionalReference = BpnReferenceDto(referenceValue = "additionalRef", referenceType = BpnRequestIdentifier)
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
@@ -740,24 +776,27 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             ),
 
-        )
+            )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
 
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
-        val errorDescriptions = createResult[0].errors.map{it.description}
-        assertThat(errorDescriptions).containsExactlyInAnyOrder("Address administrative area level1 'Invalid' does not exist"
-            ,"Address administrative area level1 'InvalidAdditional' does not exist"
-            ,"Address Identifier Type 'InvalidKey1' does not exist"
-            ,"Address Identifier Type 'InvalidKey2' does not exist")
+        val errorDescriptions = createResult[0].errors.map { it.description }
+        assertThat(errorDescriptions).containsExactlyInAnyOrder(
+            "Address administrative area level1 'Invalid' does not exist",
+            "Address administrative area level1 'InvalidAdditional' does not exist",
+            "Address Identifier Type 'InvalidKey1' does not exist",
+            "Address Identifier Type 'InvalidKey2' does not exist"
+        )
     }
 
     @Test
-    fun `create Site with duplicated identifier `() {
+    fun `create Site with same identifier in main address and additional address`() {
 
         val bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
         val additionalReference = BpnReferenceDto(referenceValue = "additionalRef", referenceType = BpnRequestIdentifier)
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val sameIdentifier = addressIdentifierDto(bpnAReference.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, ""))
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
@@ -768,21 +807,21 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             ).copy(
                 mainAddress = minLogisticAddress(bpnAReference).copy(
                     identifiers = listOf(
-                        addressIdentifierDto(bpnAReference.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                        sameIdentifier,
                     )
                 )
             ),
             address = minLogisticAddress(additionalReference).copy(
                 identifiers = listOf(
-                    addressIdentifierDto(bpnAReference.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                    sameIdentifier,
                 )
             ),
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
 
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
-        assertThat(createResult[0].errors).hasSize(2)
+        assertThat(createResult[0].errors).hasSize(1)
         assertThat(createResult[0].errors[0].description).isEqualTo("Duplicate Address Identifier: Value 'value_222_1' of type 'ADDR_KEY_ONE'")
     }
 
@@ -793,7 +832,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val leAddressRefValue = "222"
         val siteRefValue = "siteRefValue"
         val mainAddressRefValue = "mainAddressRefValue"
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = leRefValue, referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = leAddressRefValue, referenceType = BpnRequestIdentifier)
@@ -804,14 +843,14 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
         val createdSite = poolClient.sites.getSite(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
-        assertThat(createdSite.site.name).isEqualTo(fullBpWithSite.site?.name)
+        assertThat(createdSite.site.name).isEqualTo(createSiteRequest.site?.name)
 
-        val updateCopy = fullBpWithSite.copy(
-            site = fullBpWithSite.site?.copy(name = "ChangedName", hasChanged = true)
+        val updateSiteRequest = createResult[0].businessPartner?.copy(
+            site = createResult[0].businessPartner?.site?.copy(name = "ChangedName", hasChanged = true)
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = updateCopy)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = updateSiteRequest!!)
         val updatedSite = poolClient.sites.getSite(updateResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
         compareSite(updatedSite, updateResult[0].businessPartner?.site)
     }
@@ -821,7 +860,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val siteRefValue = "siteRefValue"
         val mainAddressRefValue = "mainAddressRefValue"
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val createSiteRquest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
                 bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
@@ -832,16 +871,18 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRquest)
         val createdSite = poolClient.sites.getSite(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
-        assertThat(createdSite.site.name).isEqualTo(fullBpWithSite.site?.name)
+        assertThat(createdSite.site.name).isEqualTo(createSiteRquest.site?.name)
 
-        val updateCopy = fullBpWithSite.copy(
-            site = fullBpWithSite.site?.copy(name = "ChangedName"
-                , hasChanged = true
-                , bpnSReference = BpnReferenceDto(referenceValue = "InvalidBPN", referenceType = Bpn),)
+        val updateSiteRequest = createSiteRquest.copy(
+            site = createSiteRquest.site?.copy(
+                name = "ChangedName",
+                hasChanged = true,
+                bpnSReference = BpnReferenceDto(referenceValue = "InvalidBPN", referenceType = Bpn),
+            )
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = updateCopy)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = updateSiteRequest)
         assertThat(updateResult[0].errors).hasSize(1)
         assertThat(updateResult[0].errors[0].description).isEqualTo("Business Partner with BPN 'InvalidBPN' can't be updated as it doesn't exist")
     }
@@ -849,13 +890,13 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     @Test
     fun `update Site with invalid address administration level 1 and invalid identifier`() {
 
-        val bpnASiteReference = BpnReferenceDto(referenceValue =  "222", referenceType = BpnRequestIdentifier)
-        val additionalReference = BpnReferenceDto(referenceValue =  "7777", referenceType = BpnRequestIdentifier)
+        val bpnASiteReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
+        val additionalReference = BpnReferenceDto(referenceValue = "7777", referenceType = BpnRequestIdentifier)
         val siteRefValue = "siteRefValue"
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val createSiteReuqest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
                 bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
-                bpnAReference = BpnReferenceDto(referenceValue =  "222", referenceType = BpnRequestIdentifier)
+                bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
             ),
             site = minValidSite(
                 bpnSReference = BpnReferenceDto(referenceValue = siteRefValue, referenceType = BpnRequestIdentifier),
@@ -863,11 +904,11 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteReuqest)
         val createdSite = poolClient.sites.getSite(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
-        assertThat(createdSite.site.name).isEqualTo(fullBpWithSite.site?.name)
+        assertThat(createdSite.site.name).isEqualTo(createSiteReuqest.site?.name)
 
-        val updatedFullBpSite = createResult[0].businessPartner?.copy(
+        val updateSiteRequest = createResult[0].businessPartner?.copy(
             site = createResult[0].businessPartner?.site?.copy(
                 name = "Changed Site",
                 hasChanged = true,
@@ -889,33 +930,35 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 )
             ),
         )
-        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updatedFullBpSite!!)
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateSiteRequest!!)
         assertThat(updateResult[0].taskId).isEqualTo("TASK_2")
-        val errorDescriptions = updateResult[0].errors.map{it.description}
-        assertThat(errorDescriptions).containsExactlyInAnyOrder("Address administrative area level1 'Invalid' does not exist"
-            ,"Address administrative area level1 'InvalidAdditional' does not exist"
-            ,"Address Identifier Type 'InvalidKey1' does not exist"
-            ,"Address Identifier Type 'InvalidKey2' does not exist")
+        val errorDescriptions = updateResult[0].errors.map { it.description }
+        assertThat(errorDescriptions).containsExactlyInAnyOrder(
+            "Address administrative area level1 'Invalid' does not exist",
+            "Address administrative area level1 'InvalidAdditional' does not exist",
+            "Address Identifier Type 'InvalidKey1' does not exist",
+            "Address Identifier Type 'InvalidKey2' does not exist"
+        )
     }
 
     @Test
-    fun `update Site with duplicated identifiers`() {
+    fun `update Site with same address identifiers in main address and additional address`() {
 
-        val bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
-        val mainAddressRefValue = "mainAddressRefValue"
-        val additionalAddressReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
-        val fullBpWithSite = minFullBusinessPartner().copy(
+        val mainAddressRefValue = BpnReferenceDto(referenceValue = "A222", referenceType = BpnRequestIdentifier)
+        val additionalAddressReference = BpnReferenceDto(referenceValue = "A333", referenceType = BpnRequestIdentifier)
+        val sameAddressIdentifier = addressIdentifierDto(additionalAddressReference.referenceValue, 2L, TypeKeyNameVerboseDto(addressIdentifierTypeDto2.technicalKey, ""))
+        val createSiteRequest = minFullBusinessPartner().copy(
             legalEntity = minValidLegalEntity(
-                bpnLReference = BpnReferenceDto(referenceValue = "123", referenceType = BpnRequestIdentifier),
-                bpnAReference = BpnReferenceDto(referenceValue = "222", referenceType = BpnRequestIdentifier)
+                bpnLReference = BpnReferenceDto(referenceValue = "LE123", referenceType = BpnRequestIdentifier),
+                bpnAReference = BpnReferenceDto(referenceValue = "A111LE", referenceType = BpnRequestIdentifier)
             ),
             site = minValidSite(
                 bpnSReference = BpnReferenceDto(referenceValue = "siteRefValue", referenceType = BpnRequestIdentifier),
-                bpnAReference = BpnReferenceDto(referenceValue = mainAddressRefValue, referenceType = BpnRequestIdentifier)
+                bpnAReference = mainAddressRefValue
             ).copy(
-                mainAddress = minLogisticAddress(bpnAReference).copy(
+                mainAddress = minLogisticAddress(mainAddressRefValue).copy(
                     identifiers = listOf(
-                        addressIdentifierDto(bpnAReference.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                        addressIdentifierDto(mainAddressRefValue.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
                     )
                 )
             ),
@@ -923,14 +966,14 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 bpnAReference = additionalAddressReference,
             ).copy(
                 identifiers = listOf(
-                    addressIdentifierDto(additionalAddressReference.referenceValue, 2L, TypeKeyNameVerboseDto(addressIdentifierTypeDto2.technicalKey, "")),
+                    sameAddressIdentifier,
                 )
             )
         )
 
-        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = fullBpWithSite)
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
         val createdSite = poolClient.sites.getSite(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
-        assertThat(createdSite.site.name).isEqualTo(fullBpWithSite.site?.name)
+        assertThat(createdSite.site.name).isEqualTo(createSiteRequest.site?.name)
 
         val updateCopy = createResult[0].businessPartner?.copy(
             site = createResult[0].businessPartner?.site?.copy(
@@ -938,16 +981,60 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 hasChanged = true,
                 mainAddress = createResult[0].businessPartner?.site?.mainAddress?.copy(
                     identifiers = listOf(
-                        addressIdentifierDto(bpnAReference.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
-                        addressIdentifierDto(additionalAddressReference.referenceValue, 2L, TypeKeyNameVerboseDto(addressIdentifierTypeDto2.technicalKey, "")),
+                        addressIdentifierDto(mainAddressRefValue.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                        sameAddressIdentifier,
                     )
                 )
             ),
 
-        )
+            )
         val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateCopy!!)
         assertThat(updateResult[0].errors).hasSize(1)
-        assertThat(updateResult[0].errors[0].description).isEqualTo("Duplicate Address Identifier: Value 'value_222_2' of type 'ADDR_KEY_TWO'")
+        assertThat(updateResult[0].errors[0].description).isEqualTo("Duplicate Address Identifier: Value 'value_A333_2' of type 'ADDR_KEY_TWO'")
+    }
+
+    @Test
+    fun `update Site with same reference value`() {
+
+        val mainAddressRefValue = BpnReferenceDto(referenceValue = "A222", referenceType = BpnRequestIdentifier)
+        val additionalAddressReference = BpnReferenceDto(referenceValue = "A333", referenceType = BpnRequestIdentifier)
+        val createSiteRequest = minFullBusinessPartner().copy(
+            legalEntity = minValidLegalEntity(
+                bpnLReference = BpnReferenceDto(referenceValue = "LE123", referenceType = BpnRequestIdentifier),
+                bpnAReference = BpnReferenceDto(referenceValue = "A111LE", referenceType = BpnRequestIdentifier)
+            ),
+            site = minValidSite(
+                bpnSReference = BpnReferenceDto(referenceValue = "siteRefValue", referenceType = BpnRequestIdentifier),
+                bpnAReference = mainAddressRefValue
+            ).copy(
+                mainAddress = minLogisticAddress(mainAddressRefValue).copy(
+                    identifiers = listOf(
+                        addressIdentifierDto(mainAddressRefValue.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                    )
+                )
+            ),
+            address = minLogisticAddress(
+                bpnAReference = additionalAddressReference,
+            ).copy(
+                identifiers = listOf(
+                    addressIdentifierDto(mainAddressRefValue.referenceValue, 2L, TypeKeyNameVerboseDto(addressIdentifierTypeDto2.technicalKey, "")),
+                )
+            )
+        )
+
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createSiteRequest)
+        val createdSite = poolClient.sites.getSite(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue!!)
+        assertThat(createdSite.site.name).isEqualTo(createSiteRequest.site?.name)
+
+        // use create request for update to have same identifier
+        val updateCopy = createSiteRequest.copy(
+            site = createSiteRequest.site?.copy(
+                name = "ChangedName",
+                hasChanged = true,
+            ),
+        )
+        val updateResult = upsertGoldenRecordIntoPool(taskId = "TASK_2", businessPartner = updateCopy)
+        assertThat(updateResult[0].errors).hasSize(0)
     }
 
     @Test
@@ -978,44 +1065,149 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     }
 
     @Test
-    @Disabled
-    fun `create multiple  legal entity without legal name`() {
+    fun `create multiple legal entity `() {
 
-        val referenceIds = (1.. 10000).toList()
-        val fullBpWithLegalEntity = referenceIds.map{
+        val numberOfEntitiesToTest = 100
+        val referenceIds = (1..numberOfEntitiesToTest).toList()
+        val fullBpWithLegalEntity = referenceIds.map {
             minFullBusinessPartner().copy(
                 legalEntity = fullValidLegalEntity(
-                    bpnLReference = BpnReferenceDto(referenceValue = ""+it, referenceType = BpnRequestIdentifier),
-                    bpnAReference = BpnReferenceDto(referenceValue = "address"+it, referenceType = BpnRequestIdentifier)
+                    bpnLReference = BpnReferenceDto(referenceValue = "" + it, referenceType = BpnRequestIdentifier),
+                    bpnAReference = BpnReferenceDto(referenceValue = "address" + it, referenceType = BpnRequestIdentifier)
                 )
             )
         }
 
         val taskSteps = multipleTaskStep(fullBpWithLegalEntity)
         val createResults = cleaningStepService.upsertGoldenRecordIntoPool(taskSteps)
-        assertThat(createResults).hasSize(10000)
+        assertThat(createResults).hasSize(numberOfEntitiesToTest)
         assertThat(createResults.filter { it.errors.isNotEmpty() }).hasSize(0)
 
         val updateResults = cleaningStepService.upsertGoldenRecordIntoPool(taskSteps)
-        assertThat(updateResults).hasSize(10000)
+        assertThat(updateResults).hasSize(numberOfEntitiesToTest)
         assertThat(updateResults.filter { it.errors.isNotEmpty() }).hasSize(0)
 
-        val referenceIds2 = (10001.. 20000).toList()
-        val fullBpWithLegalEntity2 = referenceIds2.map{
+        val referenceIds2 = ((numberOfEntitiesToTest + 1)..(2 * numberOfEntitiesToTest)).toList()
+        val fullBpWithLegalEntity2 = referenceIds2.map {
             minFullBusinessPartner().copy(
                 legalEntity = fullValidLegalEntity(
-                    bpnLReference = BpnReferenceDto(referenceValue = ""+it, referenceType = BpnRequestIdentifier),
-                    bpnAReference = BpnReferenceDto(referenceValue = "address"+it, referenceType = BpnRequestIdentifier)
+                    bpnLReference = BpnReferenceDto(referenceValue = "" + it, referenceType = BpnRequestIdentifier),
+                    bpnAReference = BpnReferenceDto(referenceValue = "address" + it, referenceType = BpnRequestIdentifier)
                 )
             )
         }
         val taskSteps2 = multipleTaskStep(fullBpWithLegalEntity2)
         val createResults2 = cleaningStepService.upsertGoldenRecordIntoPool(taskSteps2)
-        assertThat(createResults2).hasSize(10000)
+        assertThat(createResults2).hasSize(numberOfEntitiesToTest)
         assertThat(createResults2.filter { it.errors.isNotEmpty() }).hasSize(0)
     }
 
+    @Test
+    fun `update legal entity and create legal entity in one request with duplicated identifier`() {
 
+        val leCreateRef1 = BpnReferenceDto(referenceValue = "LE111", referenceType = BpnRequestIdentifier)
+        val leCreateAddressRef1 = BpnReferenceDto(referenceValue = "LE111A22", referenceType = BpnRequestIdentifier)
+        val createLegalEntity1 = minFullBusinessPartner().copy(
+            legalEntity = minValidLegalEntity(bpnLReference = leCreateRef1, bpnAReference = leCreateAddressRef1).copy(
+                identifiers = listOf(
+                    legalEntityIdentifierDto(leCreateRef1.referenceValue, 1L, BusinessPartnerVerboseValues.identifierType1),
+                    legalEntityIdentifierDto(leCreateRef1.referenceValue, 2L, BusinessPartnerVerboseValues.identifierType2)
+                )
+            )
+        )
+        val createResult = upsertGoldenRecordIntoPool(taskId = "TASK_1", businessPartner = createLegalEntity1)
+        assertThat(createResult[0].errors.size).isEqualTo(0)
+
+        val legalEntityUpdateIdentifier = legalEntityIdentifierDto(leCreateRef1.referenceValue, 3L, BusinessPartnerVerboseValues.identifierType3)
+        val updatedFullBpLegalEntity = createResult[0].businessPartner?.copy(
+            legalEntity = createResult[0].businessPartner?.legalEntity?.copy(
+                identifiers = listOf(
+                    legalEntityUpdateIdentifier, // use identifier in update
+                    legalEntityIdentifierDto(leCreateRef1.referenceValue, 2L, BusinessPartnerVerboseValues.identifierType2)
+                ),
+                hasChanged = true,
+                legalName = "Changed Legal Entity"
+            )
+        )
+        val leCreateRef2 = BpnReferenceDto(referenceValue = "LE222", referenceType = BpnRequestIdentifier)
+        val leCreateAddressRef2 = BpnReferenceDto(referenceValue = "LE222A333", referenceType = BpnRequestIdentifier)
+        val createLegalEntity2 = minFullBusinessPartner().copy(
+            legalEntity = minValidLegalEntity(bpnLReference = leCreateRef2, bpnAReference = leCreateAddressRef2).copy(
+                identifiers = listOf(
+                    legalEntityUpdateIdentifier, // use same identifier in create
+                    legalEntityIdentifierDto(leCreateRef2.referenceValue, 1L, BusinessPartnerVerboseValues.identifierType1)
+                )
+            )
+        )
+        val updateTask = TaskStepReservationEntryDto(taskId = "TASK_2", businessPartner = updatedFullBpLegalEntity!!)
+        val createTask2 = TaskStepReservationEntryDto(taskId = "TASK_3", businessPartner = createLegalEntity2)
+        val createUpdateResult = cleaningStepService.upsertGoldenRecordIntoPool(listOf(updateTask, createTask2))
+
+        assertThat(createUpdateResult[0].taskId).isEqualTo("TASK_2")
+        assertThat(createUpdateResult[1].taskId).isEqualTo("TASK_3")
+        assertThat(createUpdateResult[0].errors.size).isEqualTo(1)
+        assertThat(createUpdateResult[1].errors.size).isEqualTo(1)
+        assertThat(createUpdateResult[0].errors[0].description).isEqualTo("Duplicate Legal Entity Identifier: Value 'value_LE111_3' of type 'VAT_FR'")
+    }
+
+    @Test
+    fun `create legal entity and create site in one request with duplicated identifier`() {
+
+        val leCreateRef1 = BpnReferenceDto(referenceValue = "LE111", referenceType = BpnRequestIdentifier)
+        val leCreateAddressRef1 = BpnReferenceDto(referenceValue = "LE111A11", referenceType = BpnRequestIdentifier)
+        val additionalAddressLeRef1 = BpnReferenceDto(referenceValue = "LE111A33", referenceType = BpnRequestIdentifier)
+        val duplicatIdentifier = addressIdentifierDto(leCreateAddressRef1.referenceValue, 1L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, ""))
+        val createLegalEntity1 = minFullBusinessPartner().copy(
+            legalEntity = minValidLegalEntity(bpnLReference = leCreateRef1, bpnAReference = leCreateAddressRef1).copy(
+                legalAddress = minLogisticAddress(leCreateAddressRef1).copy(
+                    identifiers = listOf(
+                        duplicatIdentifier,
+                    )
+                )
+            ),
+            address = minLogisticAddress(additionalAddressLeRef1).copy(
+                identifiers = listOf(
+                    addressIdentifierDto(additionalAddressLeRef1.referenceValue, 2L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                )
+            )
+        )
+
+        val leCreateRef2 = BpnReferenceDto(referenceValue = "LE222", referenceType = BpnRequestIdentifier)
+        val leCreateAddressRef2 = BpnReferenceDto(referenceValue = "LE222A22", referenceType = BpnRequestIdentifier)
+        val createSiteRef2 = BpnReferenceDto(referenceValue = "SE333", referenceType = BpnRequestIdentifier)
+        val mainAddressRef2 = BpnReferenceDto(referenceValue = "SE333A66", referenceType = BpnRequestIdentifier)
+        val additionalAddressSiteRef2 = BpnReferenceDto(referenceValue = "SE333A88", referenceType = BpnRequestIdentifier)
+        val createSite1 = minFullBusinessPartner().copy(
+            legalEntity = minValidLegalEntity(bpnLReference = leCreateRef2, bpnAReference = leCreateAddressRef2).copy(
+                legalAddress = minLogisticAddress(leCreateAddressRef2).copy(
+                    identifiers = listOf(
+                        addressIdentifierDto(leCreateAddressRef2.referenceValue, 3L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                    )
+                )
+            ),
+            site = minValidSite(bpnSReference = createSiteRef2, bpnAReference = mainAddressRef2).copy(
+                mainAddress = minLogisticAddress(mainAddressRef2).copy(
+                    identifiers = listOf(
+                        addressIdentifierDto(mainAddressRef2.referenceValue, 4L, TypeKeyNameVerboseDto(addressIdentifierTypeDto1.technicalKey, "")),
+                    )
+                )
+            ),
+            address = minLogisticAddress(additionalAddressSiteRef2).copy(
+                identifiers = listOf(
+                    duplicatIdentifier,
+                )
+            )
+        )
+
+        val createLegalEntityTask = TaskStepReservationEntryDto(taskId = "TASK_1", businessPartner = createLegalEntity1)
+        val createSiteTask = TaskStepReservationEntryDto(taskId = "TASK_2", businessPartner = createSite1)
+        val createResult = cleaningStepService.upsertGoldenRecordIntoPool(listOf(createLegalEntityTask, createSiteTask))
+        assertThat(createResult[0].taskId).isEqualTo("TASK_1")
+        assertThat(createResult[1].taskId).isEqualTo("TASK_2")
+        assertThat(createResult[0].errors.size).isEqualTo(1)
+        assertThat(createResult[1].errors.size).isEqualTo(1)
+        assertThat(createResult[0].errors[0].description).isEqualTo("Duplicate Address Identifier: Value 'value_LE111A11_1' of type 'ADDR_KEY_ONE'")
+    }
 
     fun upsertGoldenRecordIntoPool(taskId: String, businessPartner: BusinessPartnerFullDto): List<TaskStepResultEntryDto> {
 
@@ -1035,7 +1227,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
     fun multipleTaskStep(businessPartners: List<BusinessPartnerFullDto>): List<TaskStepReservationEntryDto> {
 
-        return businessPartners.map{
+        return businessPartners.map {
             TaskStepReservationEntryDto(
                 taskId = it.legalEntity?.bpnLReference?.referenceValue!!,
                 businessPartner = it


### PR DESCRIPTION
## Description
Improve the validation for the golden record process so that it:

- validats duplicates over all addresses and all legal entities
- if the BPN request identifier is known to the pool, the task has to be considered as update
