### PR TITLE
Feat(Orchestrator): Separate LSA attributes in generic business partner

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.common.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -27,37 +28,82 @@ interface IBaseBusinessPartnerDto {
     @get:ArraySchema(arraySchema = Schema(description = "The list of name parts to accommodate the different number of name fields in different systems."))
     val nameParts: List<String>
 
-    @get:Schema(description = "Abbreviated name or shorthand.")
-    val shortName: String?
-
     @get:ArraySchema(arraySchema = Schema(description = "The list of identifiers of the business partner. Sorted and duplicates removed by the service."))
     val identifiers: Collection<IBusinessPartnerIdentifierDto>
-
-    @get:Schema(description = "The name according to official registers.")
-    val legalName: String?
-
-    @get:Schema(description = "Technical key of the legal form.")
-    val legalForm: String?
 
     @get:ArraySchema(arraySchema = Schema(description = "The list of (temporary) states of the business partner. Sorted and duplicates removed by the service."))
     val states: Collection<IBusinessPartnerStateDto>
 
-    @get:ArraySchema(arraySchema = Schema(description = "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service."))
-    val classifications: Collection<IBusinessPartnerClassificationDto>
-
     @get:ArraySchema(arraySchema = Schema(description = "Roles this business partner takes in relation to the sharing member. Sorted and duplicates removed by the service."))
     val roles: Collection<BusinessPartnerRole>
 
-    @get:Schema(description = "Address of the official seat of this business partner.")
-    val postalAddress: IBaseBusinessPartnerPostalAddressDto
+    val legalEntity: IBaseLegalEntityComponent
 
-    // TODO: rename to bpnL, bpnS, bpnA (breaking change!)
-    @get:Schema(description = "BPNL of the golden record legal entity this business partner refers to")
+    val site: IBaseSiteComponent
+
+    val address: IBaseAddressComponent
+
+    // Overrides to satisfy the base class but will be not shown on API level.
+    // That way other modules using this business partner are still backwards compatible and can be adapted one after another
+    // ToDo: Once all other BPDM module models and mappings are adapted, update the Base Interface and delete the overrides
+
     val legalEntityBpn: String?
+        @JsonIgnore
+        get() = legalEntity.bpnL
 
-    @get:Schema(description = "BPNS of the golden record site this business partner refers to")
+    val legalName: String?
+        @JsonIgnore
+        get() = legalEntity.legalName
+
+    val shortName: String?
+        @JsonIgnore
+        get() = legalEntity.shortName
+
+    val legalForm: String?
+        @JsonIgnore
+        get() = legalEntity.legalForm
+
+    val classifications: Collection<IBusinessPartnerClassificationDto>
+        @JsonIgnore
+        get() = legalEntity.classifications
+
     val siteBpn: String?
+        @JsonIgnore
+        get() = site.bpnS
 
-    @get:Schema(description = "BPNA of the golden record address this business partner refers to")
     val addressBpn: String?
+        @JsonIgnore
+        get() = address.bpnA
+
+    val postalAddress: IBaseBusinessPartnerPostalAddressDto
+        @JsonIgnore
+        get() = address
+}
+
+interface IBaseLegalEntityComponent {
+
+    @get:Schema(description = "BPNL of the golden record legal entity this business partner refers to")
+    val bpnL: String?
+
+    @get:Schema(description = "The name according to official registers.")
+    val legalName: String?
+
+    @get:Schema(description = "Abbreviated name or shorthand.")
+    val shortName: String?
+
+    @get:Schema(description = "Technical key of the legal form.")
+    val legalForm: String?
+
+    @get:ArraySchema(arraySchema = Schema(description = "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service."))
+    val classifications: Collection<IBusinessPartnerClassificationDto>
+}
+
+interface IBaseSiteComponent {
+    @get:Schema(description = "BPNS of the golden record site this business partner refers to")
+    val bpnS: String?
+}
+
+interface IBaseAddressComponent : IBaseBusinessPartnerPostalAddressDto {
+    @get:Schema(description = "BPNA of the golden record address this business partner refers to")
+    val bpnA: String?
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/IBaseBusinessPartnerGateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/IBaseBusinessPartnerGateDto.kt
@@ -19,12 +19,8 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.model
 
-import com.fasterxml.jackson.annotation.JsonIgnore
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerDto
-import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerPostalAddressDto
-import org.eclipse.tractusx.bpdm.common.dto.IBusinessPartnerClassificationDto
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 
 interface IBaseBusinessPartnerGateDto : IBaseBusinessPartnerDto {
@@ -34,74 +30,5 @@ interface IBaseBusinessPartnerGateDto : IBaseBusinessPartnerDto {
 
     @get:Schema(description = "True if the sharing member declares itself as the owner of the business partner.")
     val isOwnCompanyData: Boolean
-
-    val legalEntity: IBaseLegalEntityComponent
-
-    val site: IBaseSiteComponent
-
-    val address: IBaseAddressComponent
-
-    // Overrides to satisfy the base class but will be not shown on API level.
-    // That way we inherit from the base but keep the Gate model changes separate from now
-    // ToDo: Once all other BPDM module models are adapted, update the Base Interface and delete the overrides
-
-    override val legalEntityBpn: String?
-        @JsonIgnore
-        get() = legalEntity.bpnL
-
-    override val legalName: String?
-        @JsonIgnore
-        get() = legalEntity.legalName
-
-    override val shortName: String?
-        @JsonIgnore
-        get() = legalEntity.shortName
-
-    override val legalForm: String?
-        @JsonIgnore
-        get() = legalEntity.legalForm
-
-    override val classifications: Collection<IBusinessPartnerClassificationDto>
-        @JsonIgnore
-        get() = legalEntity.classifications
-
-    override val siteBpn: String?
-        @JsonIgnore
-        get() = site.bpnS
-
-    override val addressBpn: String?
-        @JsonIgnore
-        get() = address.bpnA
-
-    override val postalAddress: IBaseBusinessPartnerPostalAddressDto
-        @JsonIgnore
-        get() = address
 }
 
-interface IBaseLegalEntityComponent {
-
-    @get:Schema(description = "BPNL of the golden record legal entity this business partner refers to")
-    val bpnL: String?
-
-    @get:Schema(description = "The name according to official registers.")
-    val legalName: String?
-
-    @get:Schema(description = "Abbreviated name or shorthand.")
-    val shortName: String?
-
-    @get:Schema(description = "Technical key of the legal form.")
-    val legalForm: String?
-
-    @get:ArraySchema(arraySchema = Schema(description = "The list of classifications of the business partner, such as a specific industry. Sorted and duplicates removed by the service."))
-    val classifications: Collection<IBusinessPartnerClassificationDto>
-}
-
-interface IBaseSiteComponent {
-    @get:Schema(description = "BPNS of the golden record site this business partner refers to")
-    val bpnS: String?
-}
-
-interface IBaseAddressComponent : IBaseBusinessPartnerPostalAddressDto {
-    @get:Schema(description = "BPNA of the golden record address this business partner refers to")
-    val bpnA: String?
-}

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerDto.kt
@@ -20,8 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.AddressType
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 import java.time.Instant

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
@@ -20,8 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.AddressType
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
 import org.eclipse.tractusx.bpdm.gate.api.model.*
 import java.time.Instant

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
@@ -19,30 +19,120 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
-import org.eclipse.tractusx.bpdm.common.dto.IBaseBusinessPartnerDto
+import org.eclipse.tractusx.bpdm.common.dto.*
 
 
 @Schema(
     description = "Generic business partner with external id"
 )
 data class BusinessPartnerGenericDto(
-
     override val nameParts: List<String> = emptyList(),
-    override val shortName: String? = null,
     override val identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
-    override val legalName: String? = null,
-    override val legalForm: String? = null,
     override val states: Collection<BusinessPartnerStateDto> = emptyList(),
-    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
-    override val postalAddress: PostalAddressDto = PostalAddressDto(),
-    override val legalEntityBpn: String? = null,
-    override val siteBpn: String? = null,
-    override val addressBpn: String? = null,
-
+    override val legalEntity: LegalEntityComponent = LegalEntityComponent(),
+    override val site: SiteComponent = SiteComponent(),
+    override val address: AddressComponent = AddressComponent(),
     @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
     val ownerBpnL: String? = null
+) : IBaseBusinessPartnerDto {
+    // Backwards compatibility so changes to this DTO can be done one module at a time
+    constructor(
+        nameParts: List<String> = emptyList(),
+        shortName: String? = null,
+        identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
+        legalName: String? = null,
+        legalForm: String? = null,
+        states: Collection<BusinessPartnerStateDto> = emptyList(),
+        classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
+        roles: Collection<BusinessPartnerRole> = emptyList(),
+        postalAddress: PostalAddressDto = PostalAddressDto(),
+        legalEntityBpn: String? = null,
+        siteBpn: String? = null,
+        addressBpn: String? = null,
+        ownerBpnL: String? = null
+    ) : this(
+        nameParts = nameParts,
+        identifiers = identifiers,
+        states = states,
+        roles = roles,
+        ownerBpnL = ownerBpnL,
+        legalEntity = LegalEntityComponent(
+            bpnL = legalEntityBpn,
+            legalName = legalName,
+            shortName = shortName,
+            legalForm = legalForm,
+            classifications = classifications
+        ),
+        site = SiteComponent(
+            bpnS = siteBpn
+        ),
+        address = AddressComponent(
+            bpnA = addressBpn,
+            addressType = postalAddress.addressType,
+            physicalPostalAddress = postalAddress.physicalPostalAddress,
+            alternativePostalAddress = postalAddress.alternativePostalAddress
+        )
+    )
 
-) : IBaseBusinessPartnerDto
+    override val classifications: Collection<BusinessPartnerClassificationDto>
+        @JsonIgnore
+        get() = legalEntity.classifications
+
+    override val postalAddress: PostalAddressDto
+        @JsonIgnore
+        get() = PostalAddressDto(address.addressType, address.physicalPostalAddress, address.alternativePostalAddress)
+
+    fun copy(
+        nameParts: List<String> = this.nameParts,
+        shortName: String? = this.shortName,
+        identifiers: Collection<BusinessPartnerIdentifierDto> = this.identifiers,
+        legalName: String? = this.legalName,
+        legalForm: String? = this.legalForm,
+        states: Collection<BusinessPartnerStateDto> = this.states,
+        classifications: Collection<BusinessPartnerClassificationDto> = this.classifications,
+        roles: Collection<BusinessPartnerRole> = this.roles,
+        postalAddress: PostalAddressDto = this.postalAddress,
+        legalEntityBpn: String? = this.legalEntityBpn,
+        siteBpn: String? = this.siteBpn,
+        addressBpn: String? = this.addressBpn,
+        ownerBpnL: String? = this.ownerBpnL
+    ) = BusinessPartnerGenericDto(
+        nameParts,
+        shortName,
+        identifiers,
+        legalName,
+        legalForm,
+        states,
+        classifications,
+        roles,
+        postalAddress,
+        legalEntityBpn,
+        siteBpn,
+        addressBpn,
+        ownerBpnL
+    )
+}
+
+data class LegalEntityComponent(
+    override val bpnL: String? = null,
+    override val legalName: String? = null,
+    override val shortName: String? = null,
+    override val legalForm: String? = null,
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList()
+) : IBaseLegalEntityComponent
+
+data class SiteComponent(
+    override val bpnS: String? = null
+) : IBaseSiteComponent
+
+data class AddressComponent(
+    override val bpnA: String? = null,
+    override val addressType: AddressType? = null,
+    override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
+    override val alternativePostalAddress: AlternativePostalAddressDto? = null
+) : IBaseAddressComponent
+
+

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskControllerIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskControllerIT.kt
@@ -223,9 +223,11 @@ class GoldenRecordTaskControllerIT @Autowired constructor(
 
         // resolve task again
         val businessPartnerFull2 = businessPartnerFull1.copy(
-            generic = businessPartnerFull1.generic.copy(
-                legalEntityBpn = "BPNL-test"
-            )
+            generic = with(businessPartnerFull1.generic) {
+                copy(
+                    legalEntity = legalEntity.copy(bpnL = "BPNL-test")
+                )
+            }
         )
         val resultEntry2 = TaskStepResultEntryDto(
             taskId = taskId,

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -38,7 +38,6 @@ object BusinessPartnerTestValues {
     //Business Partner with two entries in every collection
     val businessPartner1 = BusinessPartnerGenericDto(
         nameParts = listOf("NamePart1", "NamePart2"),
-        shortName = "shortname",
         identifiers = listOf(
             BusinessPartnerIdentifierDto(
                 type = "identifier-type-1",
@@ -51,8 +50,6 @@ object BusinessPartnerTestValues {
                 issuingBody = "issuingBody-2"
             ),
         ),
-        legalName = "legal-name",
-        legalForm = "legal-form",
         states = listOf(
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
@@ -67,23 +64,33 @@ object BusinessPartnerTestValues {
                 description = "business-state-description-2"
             )
         ),
-        classifications = listOf(
-            BusinessPartnerClassificationDto(
-                type = ClassificationType.NACE,
-                code = "code-1",
-                value = "value-1"
-            ),
-            BusinessPartnerClassificationDto(
-                type = ClassificationType.NAF,
-                code = "code-2",
-                value = "value-2"
-            ),
-        ),
         roles = listOf(
             BusinessPartnerRole.CUSTOMER,
             BusinessPartnerRole.SUPPLIER
         ),
-        postalAddress = PostalAddressDto(
+        legalEntity = LegalEntityComponent(
+            bpnL = "BPNLTEST",
+            legalName = "legal-name",
+            shortName = "shortname",
+            legalForm = "legal-form",
+            classifications = listOf(
+                BusinessPartnerClassificationDto(
+                    type = ClassificationType.NACE,
+                    code = "code-1",
+                    value = "value-1"
+                ),
+                BusinessPartnerClassificationDto(
+                    type = ClassificationType.NAF,
+                    code = "code-2",
+                    value = "value-2"
+                ),
+            )
+        ),
+        site = SiteComponent(
+            bpnS = "BPNSTEST"
+        ),
+        address = AddressComponent(
+            bpnA = "BPNATEST",
             addressType = AddressType.AdditionalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),
@@ -122,16 +129,12 @@ object BusinessPartnerTestValues {
                 deliveryServiceType = DeliveryServiceType.PO_BOX
             )
         ),
-        ownerBpnL = "BPNL_OWNER_TEST_1",
-        legalEntityBpn = "BPNLTEST",
-        siteBpn = "BPNSTEST",
-        addressBpn = "BPNATEST"
+        ownerBpnL = "BPNL_OWNER_TEST_1"
     )
 
     //Business Partner with single entry in every collection
     val businessPartner2 = BusinessPartnerGenericDto(
         nameParts = listOf("name-part-2"),
-        shortName = "shortname-2",
         identifiers = listOf(
             BusinessPartnerIdentifierDto(
                 type = "identifier-type-2",
@@ -139,8 +142,6 @@ object BusinessPartnerTestValues {
                 issuingBody = "issuingBody-2"
             )
         ),
-        legalName = "legal-name-2",
-        legalForm = "legal-form-2",
         states = listOf(
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(1988, 10, 4, 22, 30),
@@ -149,17 +150,27 @@ object BusinessPartnerTestValues {
                 description = "business-state-description-2"
             )
         ),
-        classifications = listOf(
-            BusinessPartnerClassificationDto(
-                type = ClassificationType.SIC,
-                code = "code-2",
-                value = "value-2"
-            )
-        ),
         roles = listOf(
             BusinessPartnerRole.CUSTOMER
         ),
-        postalAddress = PostalAddressDto(
+        legalEntity = LegalEntityComponent(
+            bpnL = "BPNLTEST-2",
+            legalName = "legal-name-2",
+            shortName = "shortname-2",
+            legalForm = "legal-form-2",
+            classifications = listOf(
+                BusinessPartnerClassificationDto(
+                    type = ClassificationType.SIC,
+                    code = "code-2",
+                    value = "value-2"
+                )
+            )
+        ),
+        site = SiteComponent(
+            bpnS = "BPNSTEST-2"
+        ),
+        address = AddressComponent(
+            bpnA = "BPNATEST-2",
             addressType = AddressType.LegalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.4f, 0.4f, 0.4f),
@@ -198,10 +209,7 @@ object BusinessPartnerTestValues {
                 deliveryServiceType = DeliveryServiceType.BOITE_POSTALE
             )
         ),
-        ownerBpnL = "BPNL_OWNER_TEST_2",
-        legalEntityBpn = "BPNLTEST-2",
-        siteBpn = "BPNSTEST-2",
-        addressBpn = "BPNATEST-2"
+        ownerBpnL = "BPNL_OWNER_TEST_2"
     )
 
     val logisticAddress1 = LogisticAddressDto(


### PR DESCRIPTION
## Description

This pull request moves L/S/A specific attirbutes in the generic business partner model of the Orchestrator to L/S/A subclasses. This way such attributes are categorized in the model.

In order to keep backwards compatibility with the other modules for now I also added an additional constructor and copy method. When other modules have integrated the new structure we can remove these additional constructs.

This pull request contributes to #669 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
