### PR TITLE
Feat(Cleaning-Service-Dummy): Map to L/S/A separated generic business partner attributes

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -73,7 +73,7 @@ class CleaningServiceDummy(
 
         val addressPartner = createAddressRepresentation(genericBusinessPartner)
 
-        val addressType = genericBusinessPartner.postalAddress.addressType ?: AddressType.AdditionalAddress
+        val addressType = genericBusinessPartner.address.addressType ?: AddressType.AdditionalAddress
 
         val legalEntityDto = createLegalEntityRepresentation(addressPartner, addressType, genericBusinessPartner)
 
@@ -99,7 +99,7 @@ class CleaningServiceDummy(
     fun createSiteDtoIfNeeded(businessPartner: BusinessPartnerGenericDto, addressPartner: LogisticAddressDto): SiteDto? {
         if (!shouldCreateSite(businessPartner)) return null
 
-        val siteAddressReference = when (businessPartner.postalAddress.addressType) {
+        val siteAddressReference = when (businessPartner.address.addressType) {
             AddressType.SiteMainAddress, AddressType.LegalAndSiteMainAddress -> addressPartner.bpnAReference
             else -> generateNewBpnRequestIdentifier()
         }
@@ -121,20 +121,20 @@ class CleaningServiceDummy(
 
         val legalAddress = addressPartner.copy(bpnAReference = legalAddressBpnReference)
 
-        val bpnReferenceDto = createBpnReference(genericPartner.legalEntityBpn)
+        val bpnReferenceDto = createBpnReference(genericPartner.legalEntity.bpnL)
 
         return genericPartner.toLegalEntityDto(bpnReferenceDto, legalAddress)
 
     }
 
     fun createAddressRepresentation(genericPartner: BusinessPartnerGenericDto): LogisticAddressDto {
-        val bpnReferenceDto = createBpnReference(genericPartner.addressBpn)
+        val bpnReferenceDto = createBpnReference(genericPartner.address.bpnA)
         return genericPartner.toLogisticAddressDto(bpnReferenceDto)
     }
 
     fun createSiteRepresentation(genericPartner: BusinessPartnerGenericDto, siteAddressReference: LogisticAddressDto): SiteDto {
         val legalName = genericPartner.nameParts.joinToString(" ")
-        val bpnReferenceDto = createBpnReference(genericPartner.siteBpn)
+        val bpnReferenceDto = createBpnReference(genericPartner.site.bpnS)
         return genericPartner.toSiteDto(bpnReferenceDto, legalName, siteAddressReference)
     }
 
@@ -150,9 +150,9 @@ class CleaningServiceDummy(
     private fun generateNewBpnRequestIdentifier() = BpnReferenceDto(UUID.randomUUID().toString(), BpnReferenceType.BpnRequestIdentifier)
 
     fun shouldCreateSite(genericPartner: BusinessPartnerGenericDto): Boolean {
-        return genericPartner.postalAddress.addressType == AddressType.SiteMainAddress ||
-                genericPartner.postalAddress.addressType == AddressType.LegalAndSiteMainAddress ||
-                genericPartner.siteBpn != null
+        return genericPartner.address.addressType == AddressType.SiteMainAddress ||
+                genericPartner.address.addressType == AddressType.LegalAndSiteMainAddress ||
+                genericPartner.site.bpnS != null
     }
 
 

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -28,13 +28,13 @@ fun BusinessPartnerGenericDto.toLegalEntityDto(bpnReferenceDto: BpnReferenceDto,
 
     return LegalEntityDto(
         bpnLReference = bpnReferenceDto,
-        hasChanged = postalAddress.addressType in setOf(AddressType.LegalAddress, AddressType.LegalAndSiteMainAddress),
+        hasChanged = address.addressType in setOf(AddressType.LegalAddress, AddressType.LegalAndSiteMainAddress),
         legalName = nameParts.joinToString(" "),
-        legalShortName = shortName,
+        legalShortName = legalEntity.shortName,
         identifiers = identifiers.mapNotNull { it.toLegalEntityIdentifierDto() },
-        legalForm = legalForm,
+        legalForm = legalEntity.legalForm,
         states = states.mapNotNull { it.toLegalEntityState() },
-        classifications = classifications.map { it.toLegalEntityClassificationDto() },
+        classifications = legalEntity.classifications.map { it.toLegalEntityClassificationDto() },
         legalAddress = legalAddress
 
     )
@@ -70,12 +70,12 @@ fun BusinessPartnerGenericDto.toLogisticAddressDto(bpnReferenceDto: BpnReference
 
     return LogisticAddressDto(
         bpnAReference = bpnReferenceDto,
-        hasChanged = postalAddress.addressType == AddressType.AdditionalAddress,
+        hasChanged = address.addressType == AddressType.AdditionalAddress,
         name = nameParts.joinToString(" "),
         states = emptyList(),
         identifiers = emptyList(),
-        physicalPostalAddress = postalAddress.physicalPostalAddress,
-        alternativePostalAddress = postalAddress.alternativePostalAddress
+        physicalPostalAddress = address.physicalPostalAddress,
+        alternativePostalAddress = address.alternativePostalAddress
     )
 }
 
@@ -84,7 +84,7 @@ fun BusinessPartnerGenericDto.toSiteDto(bpnReferenceDto: BpnReferenceDto, legalN
 
     return SiteDto(
         bpnSReference = bpnReferenceDto,
-        hasChanged = postalAddress.addressType in setOf(AddressType.SiteMainAddress, AddressType.LegalAndSiteMainAddress),
+        hasChanged = address.addressType in setOf(AddressType.SiteMainAddress, AddressType.LegalAndSiteMainAddress),
         name = legalName,
         states = states.mapNotNull { it.toSiteState() },
         mainAddress = siteAddressReference

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummyTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummyTest.kt
@@ -51,7 +51,7 @@ class CleaningServiceDummyTest @Autowired constructor(
 
         val result = cleaningServiceDummy.processCleaningTask(taskStepReservationEntryDto)
 
-        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.addressBpn
+        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.address.bpnA
 
         val resultedAddress = result.businessPartner?.address
 
@@ -112,9 +112,9 @@ class CleaningServiceDummyTest @Autowired constructor(
 
         val result = cleaningServiceDummy.processCleaningTask(taskStepReservationEntryDto)
 
-        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.addressBpn
+        val expectedBpnA = taskStepReservationEntryDto.businessPartner.generic.address.bpnA
 
-        val expectedBpnL = taskStepReservationEntryDto.businessPartner.generic.legalEntityBpn
+        val expectedBpnL = taskStepReservationEntryDto.businessPartner.generic.legalEntity.bpnL
 
         val resultedAddress = result.businessPartner?.address
 
@@ -153,9 +153,9 @@ class CleaningServiceDummyTest @Autowired constructor(
 
         val resultedSite = result.businessPartner?.site
 
-        val expectedBpnA = taskStepReservationResponse.businessPartner.generic.addressBpn
+        val expectedBpnA = taskStepReservationResponse.businessPartner.generic.address.bpnA
 
-        val expectedBpnS = taskStepReservationResponse.businessPartner.generic.siteBpn
+        val expectedBpnS = taskStepReservationResponse.businessPartner.generic.site.bpnS
 
 
         // legalEntity should Generate new bpnL and legalAddress should use passed bpnA since address type is LegalAndSiteMainAddress

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -101,41 +101,77 @@ object CommonValues {
 
     private val businessPartnerWithEmptyBpns = BusinessPartnerGenericDto(
         nameParts = nameParts,
-        shortName = shortName,
         identifiers = identifiers,
-        legalForm = legalForm,
         states = states,
-        classifications = classifications,
         roles = roles,
-        ownerBpnL = "ownerBpnL2"
+        ownerBpnL = "ownerBpnL2",
+        legalEntity = LegalEntityComponent(
+            shortName = shortName,
+            legalForm = legalForm,
+            classifications = classifications
+        )
     )
 
 
-    val businessPartnerWithBpnA = businessPartnerWithEmptyBpns.copy(
-        postalAddress = postalAddressForAdditional,
-        addressBpn = "FixedBPNA"
-    )
+    val businessPartnerWithBpnA = with(businessPartnerWithEmptyBpns) {
+        copy(
+            address = address.copy(
+                bpnA = "FixedBPNA",
+                addressType = postalAddressForAdditional.addressType,
+                physicalPostalAddress = postalAddressForAdditional.physicalPostalAddress,
+                alternativePostalAddress = postalAddressForAdditional.alternativePostalAddress
+            )
+        )
+    }
 
 
-    val businessPartnerWithBpnLAndBpnAAndLegalAddressType = businessPartnerWithEmptyBpns.copy(
-        postalAddress = postalAddressForLegal,
-        addressBpn = "FixedBPNA",
-        legalEntityBpn = "FixedBPNL"
-    )
+    val businessPartnerWithBpnLAndBpnAAndLegalAddressType = with(businessPartnerWithEmptyBpns) {
+        copy(
+            address = address.copy(
+                bpnA = "FixedBPNA",
+                addressType = postalAddressForLegal.addressType,
+                physicalPostalAddress = postalAddressForLegal.physicalPostalAddress,
+                alternativePostalAddress = postalAddressForLegal.alternativePostalAddress
+            ),
+            legalEntity = legalEntity.copy(
+                bpnL = "FixedBPNL"
+            )
+        )
+    }
 
-    val businessPartnerWithEmptyBpnLAndAdditionalAddressType = businessPartnerWithEmptyBpns.copy(
-        postalAddress = postalAddressForAdditional,
-    )
+    val businessPartnerWithEmptyBpnLAndAdditionalAddressType = with(businessPartnerWithEmptyBpns) {
+        copy(
+            address = address.copy(
+                addressType = postalAddressForAdditional.addressType,
+                physicalPostalAddress = postalAddressForAdditional.physicalPostalAddress,
+                alternativePostalAddress = postalAddressForAdditional.alternativePostalAddress
+            )
+        )
+    }
 
-    val businessPartnerWithBpnSAndBpnAAndLegalAndSiteMainAddressType = businessPartnerWithEmptyBpns.copy(
-        postalAddress = postalAddressForLegalAndSite,
-        addressBpn = "FixedBPNA",
-        siteBpn = "FixedBPNS"
-    )
+    val businessPartnerWithBpnSAndBpnAAndLegalAndSiteMainAddressType = with(businessPartnerWithEmptyBpns) {
+        copy(
+            address = address.copy(
+                bpnA = "FixedBPNA",
+                addressType = postalAddressForLegalAndSite.addressType,
+                physicalPostalAddress = postalAddressForLegalAndSite.physicalPostalAddress,
+                alternativePostalAddress = postalAddressForLegalAndSite.alternativePostalAddress
+            ),
+            site = site.copy(
+                bpnS = "FixedBPNS"
+            )
+        )
+    }
 
-    val businessPartnerWithEmptyBpnAndSiteMainAddressType = businessPartnerWithEmptyBpns.copy(
-        postalAddress = postalAddressForSite
-    )
+    val businessPartnerWithEmptyBpnAndSiteMainAddressType = with(businessPartnerWithEmptyBpns) {
+        copy(
+            address = address.copy(
+                addressType = postalAddressForSite.addressType,
+                physicalPostalAddress = postalAddressForSite.physicalPostalAddress,
+                alternativePostalAddress = postalAddressForSite.alternativePostalAddress
+            )
+        )
+    }
 
     val expectedLegalEntityDto = LegalEntityDto(
         hasChanged = true,


### PR DESCRIPTION
## Description

In this pull request the Cleaning Service Dummy now correctly uses the new L/S/A separated attributes in the generic business partner model of the Orchestrator.

Contributes to #669 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
