### PR TITLE
Refactor(Gate): Map to L/S/A separated generic business partner attributes 

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.tractusx.bpdm.common.dto
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -42,42 +41,6 @@ interface IBaseBusinessPartnerDto {
     val site: IBaseSiteComponent
 
     val address: IBaseAddressComponent
-
-    // Overrides to satisfy the base class but will be not shown on API level.
-    // That way other modules using this business partner are still backwards compatible and can be adapted one after another
-    // ToDo: Once all other BPDM module models and mappings are adapted, update the Base Interface and delete the overrides
-
-    val legalEntityBpn: String?
-        @JsonIgnore
-        get() = legalEntity.bpnL
-
-    val legalName: String?
-        @JsonIgnore
-        get() = legalEntity.legalName
-
-    val shortName: String?
-        @JsonIgnore
-        get() = legalEntity.shortName
-
-    val legalForm: String?
-        @JsonIgnore
-        get() = legalEntity.legalForm
-
-    val classifications: Collection<IBusinessPartnerClassificationDto>
-        @JsonIgnore
-        get() = legalEntity.classifications
-
-    val siteBpn: String?
-        @JsonIgnore
-        get() = site.bpnS
-
-    val addressBpn: String?
-        @JsonIgnore
-        get() = address.bpnA
-
-    val postalAddress: IBaseBusinessPartnerPostalAddressDto
-        @JsonIgnore
-        get() = address
 }
 
 interface IBaseLegalEntityComponent {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -565,7 +565,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
                 sharingStateType = SharingStateType.Success,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = BusinessPartnerGenericValues.businessPartner1.addressBpn,
+                bpn = BusinessPartnerGenericValues.businessPartner1.address.bpnA,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -34,7 +34,6 @@ object BusinessPartnerGenericValues {
     //Business Partner with two entries in every collection
     val businessPartner1 = BusinessPartnerGenericDto(
         nameParts = listOf("part-cleaned-1", "name-cleaned-2"),
-        shortName = "shot-name-cleaned",
         identifiers = listOf(
             BusinessPartnerIdentifierDto(
                 type = "identifier-type-1-cleaned",
@@ -47,8 +46,6 @@ object BusinessPartnerGenericValues {
                 issuingBody = "issuingBody-2-cleaned"
             ),
         ),
-        legalName = "legal-name-cleaned",
-        legalForm = "legal-form-cleaned",
         states = listOf(
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
@@ -63,23 +60,34 @@ object BusinessPartnerGenericValues {
                 description = "business-state-description-2"
             )
         ),
-        classifications = listOf(
-            BusinessPartnerClassificationDto(
-                type = ClassificationType.NACE,
-                code = "code-1-cleaned",
-                value = "value-1-cleaned"
-            ),
-            BusinessPartnerClassificationDto(
-                type = ClassificationType.NAF,
-                code = "code-2-cleaned",
-                value = "value-2-cleaned"
-            ),
-        ),
         roles = listOf(
             BusinessPartnerRole.CUSTOMER,
             BusinessPartnerRole.SUPPLIER
         ),
-        postalAddress = PostalAddressDto(
+        ownerBpnL = "BPNL_CLEANED_VALUES",
+        legalEntity = LegalEntityComponent(
+            bpnL = "000000123AAA123",
+            legalName = "legal-name-cleaned",
+            shortName = "shot-name-cleaned",
+            legalForm = "legal-form-cleaned",
+            classifications = listOf(
+                BusinessPartnerClassificationDto(
+                    type = ClassificationType.NACE,
+                    code = "code-1-cleaned",
+                    value = "value-1-cleaned"
+                ),
+                BusinessPartnerClassificationDto(
+                    type = ClassificationType.NAF,
+                    code = "code-2-cleaned",
+                    value = "value-2-cleaned"
+                ),
+            )
+        ),
+        site = SiteComponent(
+            bpnS = "000000123BBB222",
+        ),
+        address = AddressComponent(
+            bpnA = "000000123CCC333",
             addressType = AddressType.AdditionalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),
@@ -117,11 +125,7 @@ object BusinessPartnerGenericValues {
                 deliveryServiceQualifier = "delivery-service-qualifier-cleaned",
                 deliveryServiceType = DeliveryServiceType.PO_BOX
             )
-        ),
-        ownerBpnL = "BPNL_CLEANED_VALUES",
-        legalEntityBpn = "000000123AAA123",
-        siteBpn = "000000123BBB222",
-        addressBpn = "000000123CCC333"
+        )
     )
 
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.*
 
@@ -37,84 +36,7 @@ data class BusinessPartnerGenericDto(
     override val address: AddressComponent = AddressComponent(),
     @get:Schema(description = "The BPNL of the company sharing and claiming this business partner as its own")
     val ownerBpnL: String? = null
-) : IBaseBusinessPartnerDto {
-    // Backwards compatibility so changes to this DTO can be done one module at a time
-    constructor(
-        nameParts: List<String> = emptyList(),
-        shortName: String? = null,
-        identifiers: Collection<BusinessPartnerIdentifierDto> = emptyList(),
-        legalName: String? = null,
-        legalForm: String? = null,
-        states: Collection<BusinessPartnerStateDto> = emptyList(),
-        classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
-        roles: Collection<BusinessPartnerRole> = emptyList(),
-        postalAddress: PostalAddressDto = PostalAddressDto(),
-        legalEntityBpn: String? = null,
-        siteBpn: String? = null,
-        addressBpn: String? = null,
-        ownerBpnL: String? = null
-    ) : this(
-        nameParts = nameParts,
-        identifiers = identifiers,
-        states = states,
-        roles = roles,
-        ownerBpnL = ownerBpnL,
-        legalEntity = LegalEntityComponent(
-            bpnL = legalEntityBpn,
-            legalName = legalName,
-            shortName = shortName,
-            legalForm = legalForm,
-            classifications = classifications
-        ),
-        site = SiteComponent(
-            bpnS = siteBpn
-        ),
-        address = AddressComponent(
-            bpnA = addressBpn,
-            addressType = postalAddress.addressType,
-            physicalPostalAddress = postalAddress.physicalPostalAddress,
-            alternativePostalAddress = postalAddress.alternativePostalAddress
-        )
-    )
-
-    override val classifications: Collection<BusinessPartnerClassificationDto>
-        @JsonIgnore
-        get() = legalEntity.classifications
-
-    override val postalAddress: PostalAddressDto
-        @JsonIgnore
-        get() = PostalAddressDto(address.addressType, address.physicalPostalAddress, address.alternativePostalAddress)
-
-    fun copy(
-        nameParts: List<String> = this.nameParts,
-        shortName: String? = this.shortName,
-        identifiers: Collection<BusinessPartnerIdentifierDto> = this.identifiers,
-        legalName: String? = this.legalName,
-        legalForm: String? = this.legalForm,
-        states: Collection<BusinessPartnerStateDto> = this.states,
-        classifications: Collection<BusinessPartnerClassificationDto> = this.classifications,
-        roles: Collection<BusinessPartnerRole> = this.roles,
-        postalAddress: PostalAddressDto = this.postalAddress,
-        legalEntityBpn: String? = this.legalEntityBpn,
-        siteBpn: String? = this.siteBpn,
-        addressBpn: String? = this.addressBpn,
-        ownerBpnL: String? = this.ownerBpnL
-    ) = BusinessPartnerGenericDto(
-        nameParts,
-        shortName,
-        identifiers,
-        legalName,
-        legalForm,
-        states,
-        classifications,
-        roles,
-        postalAddress,
-        legalEntityBpn,
-        siteBpn,
-        addressBpn,
-        ownerBpnL
-    )
-}
+) : IBaseBusinessPartnerDto
 
 data class LegalEntityComponent(
     override val bpnL: String? = null,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -92,11 +92,13 @@ class TaskStepBuildService(
         return TaskStepResultEntryDto(
             taskId = taskEntry.taskId,
             businessPartner = BusinessPartnerFullDto(
-                generic = businessPartnerDto.generic.copy(
-                    legalEntityBpn = legalEntity.bpn,
-                    siteBpn = siteEntity?.bpn,
-                    addressBpn = genericBpnA
-                ),
+                generic = with(businessPartnerDto.generic) {
+                    copy(
+                        legalEntity = this.legalEntity.copy(bpnL = legalEntity.bpn),
+                        site = this.site.copy(bpnS = siteEntity?.bpn),
+                        address = this.address.copy(bpnA = genericBpnA)
+                    )
+                },
                 legalEntity = businessPartnerDto.legalEntity!!.copy(
                     bpnLReference = BpnReferenceDto(referenceValue = legalEntity.bpn, referenceType = BpnReferenceType.Bpn) ,
                     legalAddress = businessPartnerDto.legalEntity!!.legalAddress!!.copy(
@@ -304,7 +306,7 @@ class TaskStepBuildService(
             taskEntryBpnMapping.addMapping(bpnSReference, bpnS)
 
             val siteMainAddress =
-                if (genericBusinessPartner.generic.postalAddress.addressType == AddressType.LegalAndSiteMainAddress)
+                if (genericBusinessPartner.generic.address.addressType == AddressType.LegalAndSiteMainAddress)
                     legalEntity.legalAddress
                 else
                     createLogisticAddress(mainAddress, taskEntryBpnMapping)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -112,7 +112,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val createdLegalEntity = poolClient.legalEntities.getLegalEntity(createResult[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
         assertThat(createdLegalEntity.legalAddress.bpnLegalEntity).isNotNull()
-        assertThat(createResult[0].businessPartner?.generic?.legalEntityBpn).isEqualTo(createdLegalEntity.legalEntity.bpnl)
+        assertThat(createResult[0].businessPartner?.generic?.legalEntity?.bpnL).isEqualTo(createdLegalEntity.legalEntity.bpnl)
         compareLegalEntity(createdLegalEntity, createResult[0].businessPartner?.legalEntity)
     }
 
@@ -136,7 +136,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val createdLegalEntity = poolClient.legalEntities.getLegalEntity(createResult[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
         assertThat(createdLegalEntity.legalAddress.bpnLegalEntity).isNotNull()
-        assertThat(createResult[0].businessPartner?.generic?.legalEntityBpn).isEqualTo(createdLegalEntity.legalEntity.bpnl)
+        assertThat(createResult[0].businessPartner?.generic?.legalEntity?.bpnL).isEqualTo(createdLegalEntity.legalEntity.bpnl)
         compareLegalEntity(createdLegalEntity, createResult[0].businessPartner?.legalEntity)
     }
 
@@ -165,7 +165,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         assertThat(createdLegalEntity.legalAddress.bpnLegalEntity).isEqualTo(createdLegalEntity.legalEntity.bpnl)
         assertThat(createdLegalEntity.legalAddress.isLegalAddress).isTrue()
         assertThat(createdLegalEntity.legalAddress.isMainAddress).isFalse()
-        assertThat(createResult[0].businessPartner?.generic?.legalEntityBpn).isEqualTo(createdLegalEntity.legalEntity.bpnl)
+        assertThat(createResult[0].businessPartner?.generic?.legalEntity?.bpnL).isEqualTo(createdLegalEntity.legalEntity.bpnl)
         compareLegalEntity(createdLegalEntity, createResult[0].businessPartner?.legalEntity)
         val createdAdditionalAddress = poolClient.addresses.getAddress(createResult[0].businessPartner?.address?.bpnAReference?.referenceValue!!)
         assertThat(createdAdditionalAddress.bpnLegalEntity).isEqualTo(createdLegalEntity.legalEntity.bpnl)
@@ -393,7 +393,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         assertThat(resultSteps2[0].errors.size).isEqualTo(0)
         assertThat(createdLegalEntity1.legalEntity.bpnl).isNotEqualTo(resultSteps2[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
         val createdLegalEntity2 = poolClient.legalEntities.getLegalEntity(resultSteps2[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
-        assertThat(resultSteps2[0].businessPartner?.generic?.legalEntityBpn).isEqualTo(createdLegalEntity2.legalEntity.bpnl)
+        assertThat(resultSteps2[0].businessPartner?.generic?.legalEntity?.bpnL).isEqualTo(createdLegalEntity2.legalEntity.bpnl)
     }
 
     @Test


### PR DESCRIPTION
## Description

This pull request adapts the gate orchestration mappings for the generic business partner to the L/S/A separated attributes.

Since this was the last BPDM module needing bigger changes to accomodate the L/S/A separation in the generic business partner I also removed the legacy attributes ensuring backwards compatibility.

Contributes to #669


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
