### PR TITLE
Feat: Add Site Name and Address Name to Generic Business Partner Model

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -133,9 +133,8 @@ class CleaningServiceDummy(
     }
 
     fun createSiteRepresentation(genericPartner: BusinessPartnerGenericDto, siteAddressReference: LogisticAddressDto): SiteDto {
-        val legalName = genericPartner.nameParts.joinToString(" ")
         val bpnReferenceDto = createBpnReference(genericPartner.site.siteBpn)
-        return genericPartner.toSiteDto(bpnReferenceDto, legalName, siteAddressReference)
+        return genericPartner.toSiteDto(bpnReferenceDto, siteAddressReference)
     }
 
     fun createBpnReference(bpn: String?): BpnReferenceDto {

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -71,7 +71,7 @@ fun BusinessPartnerGenericDto.toLogisticAddressDto(bpnReferenceDto: BpnReference
     return LogisticAddressDto(
         bpnAReference = bpnReferenceDto,
         hasChanged = address.addressType == AddressType.AdditionalAddress,
-        name = nameParts.joinToString(" "),
+        name = address.name,
         states = emptyList(),
         identifiers = emptyList(),
         physicalPostalAddress = address.physicalPostalAddress,
@@ -79,13 +79,13 @@ fun BusinessPartnerGenericDto.toLogisticAddressDto(bpnReferenceDto: BpnReference
     )
 }
 
-fun BusinessPartnerGenericDto.toSiteDto(bpnReferenceDto: BpnReferenceDto, legalName: String, siteAddressReference: LogisticAddressDto): SiteDto {
+fun BusinessPartnerGenericDto.toSiteDto(bpnReferenceDto: BpnReferenceDto, siteAddressReference: LogisticAddressDto): SiteDto {
 
 
     return SiteDto(
         bpnSReference = bpnReferenceDto,
         hasChanged = address.addressType in setOf(AddressType.SiteMainAddress, AddressType.LegalAndSiteMainAddress),
-        name = legalName,
+        name = site.name,
         states = states.mapNotNull { it.toSiteState() },
         mainAddress = siteAddressReference
 

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -40,6 +40,8 @@ object CommonValues {
     const val fixedTaskId = "taskid-123123"
 
     private val nameParts = listOf("Part1", "Part2")
+    private val siteName = "Site Name"
+    private val addressName = "Address Name"
     private const val shortName = "ShortName"
     private val identifiers = listOf(
         BusinessPartnerIdentifierDto(
@@ -109,7 +111,9 @@ object CommonValues {
             shortName = shortName,
             legalForm = legalForm,
             classifications = classifications
-        )
+        ),
+        site = SiteRepresentation(name = siteName),
+        address = AddressRepresentation(name = addressName)
     )
 
 
@@ -185,14 +189,14 @@ object CommonValues {
 
     val expectedSiteDto = SiteDto(
         hasChanged = true,
-        name = nameParts.joinToString(" "),
+        name = siteName,
         states = states.mapNotNull { it.toSiteState() },
     )
 
     val expectedLogisticAddressDto = LogisticAddressDto(
 
         hasChanged = true,
-        name = nameParts.joinToString(" "),
+        name = addressName,
         states = emptyList(),
         identifiers = emptyList(),
         physicalPostalAddress = physicalPostalAddress

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -69,12 +69,18 @@ interface IBaseLegalEntityRepresentation {
 interface IBaseSiteRepresentation {
     @get:Schema(description = "The BPNS of the site, on which the business partner provides a view.")
     val siteBpn: String?
+
+    @get:Schema(description = "The name of the site, on which the business partner provides a view. This is not according to official registers but according to the name the owner chooses.")
+    val name: String?
 }
 
 @Schema(description = "An address representation adds context information to the address, on which the business partner provides a view. Additionally, it contains most of the information from the assigned address.")
 interface IBaseAddressRepresentation : IBaseBusinessPartnerPostalAddressDto {
     @get:Schema(description = "The BPNA of the address, on which the business partner provides a view.")
     val addressBpn: String?
+
+    @get:Schema(description = "The name of the address, on which the business partner provides a view. This is not according to official registers but according to the name the sharing members agree on, such as the name of a gate or any other additional names that designate the address in common parlance.")
+    val name: String?
 
     @get:Schema(description = "One of the address types: Legal Address, Site Main Address, Legal and Site Main Address, Additional Address. ")
     override val addressType: AddressType?

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerDto.kt
@@ -59,12 +59,14 @@ data class LegalEntityRepresentationInputDto(
 ) : IBaseLegalEntityRepresentation
 
 data class SiteRepresentationInputDto(
-    override val siteBpn: String? = null
+    override val siteBpn: String? = null,
+    override val name: String? = null
 ) : IBaseSiteRepresentation
 
 data class AddressRepresentationInputDto(
     override val addressBpn: String? = null,
+    override val name: String? = null,
     override val addressType: AddressType? = null,
     override val physicalPostalAddress: PhysicalPostalAddressDto = PhysicalPostalAddressDto(),
-    override val alternativePostalAddress: AlternativePostalAddressDto = AlternativePostalAddressDto()
+    override val alternativePostalAddress: AlternativePostalAddressDto = AlternativePostalAddressDto(),
 ) : IBaseAddressRepresentation

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
@@ -65,7 +65,8 @@ data class LegalEntityRepresentationOutputDto(
     description = "Site properties of business partner output data"
 )
 data class SiteRepresentationOutputDto(
-    override val siteBpn: String? = null
+    override val siteBpn: String? = null,
+    override val name: String? = null
 ) : IBaseSiteRepresentation
 
 @Schema(
@@ -74,7 +75,8 @@ data class SiteRepresentationOutputDto(
 )
 data class AddressComponentOutputDto(
     override val addressBpn: String,
-    override val addressType: AddressType? = null,
+    override val name: String? = null,
+    override val addressType: AddressType?,
     override val physicalPostalAddress: PhysicalPostalAddressDto = PhysicalPostalAddressDto(),
-    override val alternativePostalAddress: AlternativePostalAddressDto = AlternativePostalAddressDto()
+    override val alternativePostalAddress: AlternativePostalAddressDto = AlternativePostalAddressDto(),
 ) : IBaseAddressRepresentation

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
@@ -62,6 +62,12 @@ class BusinessPartner(
     @Column(name = "legal_name")
     var legalName: String? = null,
 
+    @Column(name = "site_name")
+    var siteName: String? = null,
+
+    @Column(name = "address_name")
+    var addressName: String? = null,
+
     @Column(name = "legal_form")
     var legalForm: String? = null,
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -79,6 +79,8 @@ class BusinessPartnerMappings {
             classifications = dto.legalEntity.classifications.mapNotNull(::toClassification).toSortedSet(),
             shortName = dto.legalEntity.shortName,
             legalName = dto.legalEntity.legalName,
+            siteName = dto.site.name,
+            addressName = dto.address.name,
             legalForm = dto.legalEntity.legalForm,
             isOwnCompanyData = dto.isOwnCompanyData,
             bpnL = dto.legalEntity.legalEntityBpn,
@@ -100,13 +102,15 @@ class BusinessPartnerMappings {
 
     private fun toSiteComponentInputDto(entity: BusinessPartner): SiteRepresentationInputDto {
         return SiteRepresentationInputDto(
-            siteBpn = entity.bpnS
+            siteBpn = entity.bpnS,
+            name = entity.siteName
         )
     }
 
     private fun toAddressComponentInputDto(entity: BusinessPartner): AddressRepresentationInputDto {
         return AddressRepresentationInputDto(
             addressBpn = entity.bpnA,
+            name = entity.addressName,
             addressType = entity.postalAddress.addressType,
             physicalPostalAddress = entity.postalAddress.physicalPostalAddress?.toPhysicalPostalAddress() ?: PhysicalPostalAddressDto(),
             alternativePostalAddress = entity.postalAddress.alternativePostalAddress?.toAlternativePostalAddressDto() ?: AlternativePostalAddressDto()
@@ -130,7 +134,8 @@ class BusinessPartnerMappings {
 
     private fun toSiteComponentOutputDto(entity: BusinessPartner): SiteRepresentationOutputDto {
         return SiteRepresentationOutputDto(
-            siteBpn = entity.bpnS
+            siteBpn = entity.bpnS,
+            name = entity.siteName
         )
     }
 
@@ -142,6 +147,7 @@ class BusinessPartnerMappings {
                 BusinessPartner::bpnA,
                 entity.externalId
             ),
+            entity.addressName,
             addressType = entity.postalAddress.addressType,
             physicalPostalAddress = entity.postalAddress.physicalPostalAddress?.toPhysicalPostalAddress() ?: PhysicalPostalAddressDto(),
             alternativePostalAddress = entity.postalAddress.alternativePostalAddress?.toAlternativePostalAddressDto() ?: AlternativePostalAddressDto()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -196,6 +196,8 @@ class BusinessPartnerService(
                 entity.roles != persistedBP.roles ||
                 entity.shortName != persistedBP.shortName ||
                 entity.legalName != persistedBP.legalName ||
+                entity.siteName != persistedBP.siteName ||
+                entity.addressName != persistedBP.addressName ||
                 entity.legalForm != persistedBP.legalForm ||
                 entity.isOwnCompanyData != persistedBP.isOwnCompanyData ||
                 entity.bpnL != persistedBP.bpnL ||
@@ -245,6 +247,8 @@ class BusinessPartnerService(
             stage = fromPartner.stage
             shortName = fromPartner.shortName
             legalName = fromPartner.legalName
+            siteName = fromPartner.siteName
+            addressName = fromPartner.addressName
             legalForm = fromPartner.legalForm
             isOwnCompanyData = fromPartner.isOwnCompanyData
             bpnL = fromPartner.bpnL

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -46,7 +46,7 @@ class OrchestratorMappings(
         ownerBpnL = getOwnerBpnL(entity),
         legalEntity = toLegalEntityComponentDto(entity),
         site = toSiteComponentDto(entity),
-        address = toAddressComponentDto(entity.bpnA, entity.postalAddress)
+        address = toAddressComponentDto(entity)
 
     )
 
@@ -60,13 +60,15 @@ class OrchestratorMappings(
 
     private fun toSiteComponentDto(entity: BusinessPartner) = SiteRepresentation(
         siteBpn = entity.bpnS,
+        name = entity.siteName
     )
 
-    private fun toAddressComponentDto(bpnA: String?, entity: PostalAddress) = AddressRepresentation(
-        addressBpn = bpnA,
-        addressType = entity.addressType,
-        physicalPostalAddress = entity.physicalPostalAddress?.let(::toPhysicalPostalAddressDto),
-        alternativePostalAddress = entity.alternativePostalAddress?.let(this::toAlternativePostalAddressDto)
+    private fun toAddressComponentDto(entity: BusinessPartner) = AddressRepresentation(
+        addressBpn = entity.bpnA,
+        name = entity.addressName,
+        addressType = entity.postalAddress.addressType,
+        physicalPostalAddress = entity.postalAddress.physicalPostalAddress?.let(::toPhysicalPostalAddressDto),
+        alternativePostalAddress = entity.postalAddress.alternativePostalAddress?.let(this::toAlternativePostalAddressDto)
     )
 
     private fun toClassificationDto(entity: Classification) =
@@ -150,6 +152,8 @@ class OrchestratorMappings(
         shortName = dto.legalEntity.shortName,
         identifiers = dto.identifiers.mapNotNull { toIdentifier(it) }.toSortedSet(),
         legalName = dto.legalEntity.legalName,
+        siteName = dto.site.name,
+        addressName = dto.address.name,
         legalForm = dto.legalEntity.legalForm,
         states = dto.states.mapNotNull { toState(it) }.toSortedSet(),
         classifications = dto.legalEntity.classifications.map { toClassification(it) }.toSortedSet(),

--- a/bpdm-gate/src/main/resources/db/migration/V5_0_0_0__add_site_address_name.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V5_0_0_0__add_site_address_name.sql
@@ -1,0 +1,5 @@
+ALTER TABLE business_partners
+ADD COLUMN site_name VARCHAR(255);
+
+ALTER TABLE business_partners
+ADD COLUMN address_name VARCHAR(255);

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -158,6 +158,8 @@ internal class BusinessPartnerIT @Autowired constructor(
             nameParts = mutableListOf("testNameParts", "testNameParts2", "testNameParts3", "testNameParts4", "testNameParts5"),
             shortName = "testShortName",
             legalName = "testLegalName",
+            siteName = "testSiteName",
+            addressName = "testAddressName",
             legalForm = "testLegalForm",
             isOwnCompanyData = true,
             bpnA = "testAddressBpn",

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -85,9 +85,11 @@ object BusinessPartnerGenericValues {
         ),
         site = SiteRepresentation(
             siteBpn = "000000123BBB222",
+            name = "Site Name"
         ),
         address = AddressRepresentation(
             addressBpn = "000000123CCC333",
+            name = "Address Name",
             addressType = AddressType.AdditionalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerNonVerboseValues.kt
@@ -30,6 +30,7 @@ object BusinessPartnerNonVerboseValues {
 
     val bpPostalAddressInputDtoMinimal = AddressRepresentationInputDto(
         addressType = null,
+        name = null,
         physicalPostalAddress = physicalAddressMinimal
     )
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -320,10 +320,12 @@ object BusinessPartnerVerboseValues {
             classifications = listOf(bpClassification1, bpClassification2, bpClassification3)
         ),
         site = SiteRepresentationInputDto(
-            siteBpn = null
+            siteBpn = null,
+            name = "Site Name"
         ),
         address = AddressRepresentationInputDto(
             addressBpn = "BPNA0000000001XY",
+            name = "Address Name",
             addressType = AddressType.LegalAddress,
             physicalPostalAddress = postalAddress2,
             alternativePostalAddress = alternativeAddressFull
@@ -622,9 +624,11 @@ object BusinessPartnerVerboseValues {
         ),
         site = SiteRepresentationInputDto(
             siteBpn = "BPNS0000000003X9",
+            name = "Site Name 3"
         ),
         address = AddressRepresentationInputDto(
             addressBpn = "BPNA0000000001XY",
+            name = "Address Name 3",
             addressType = AddressType.LegalAndSiteMainAddress,
             physicalPostalAddress = physicalAddressChina,
             alternativePostalAddress = AlternativePostalAddressDto()
@@ -651,9 +655,11 @@ object BusinessPartnerVerboseValues {
         ),
         site = SiteRepresentationInputDto(
             siteBpn = "BPNS0000000003X9",
+            name = "Site Name 4"
         ),
         address = AddressRepresentationInputDto(
             addressBpn = "BPNA0000000001XY",
+            name = "Address Name 4",
             addressType = AddressType.LegalAddress,
             physicalPostalAddress = postalAddress2,
             alternativePostalAddress = alternativeAddressFull
@@ -680,9 +686,11 @@ object BusinessPartnerVerboseValues {
         ),
         site = SiteRepresentationInputDto(
             siteBpn = "BPNS0000000003X9",
+            name = "Site Name 5"
         ),
         address = AddressRepresentationInputDto(
             addressBpn = "BPNA0000000001XY",
+            name = "Address Name 5",
             addressType = AddressType.LegalAddress,
             physicalPostalAddress = postalAddress2,
             alternativePostalAddress = alternativeAddressFull
@@ -741,10 +749,12 @@ object BusinessPartnerVerboseValues {
             )
         ),
         site = SiteRepresentationOutputDto(
-            siteBpn = "000000123BBB222"
+            siteBpn = "000000123BBB222",
+            name = "Site Name"
         ),
         address = AddressComponentOutputDto(
             addressBpn = "000000123CCC333",
+            name = "Address Name",
             addressType = AddressType.AdditionalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
@@ -47,14 +47,16 @@ data class LegalEntityRepresentation(
 ) : IBaseLegalEntityRepresentation
 
 data class SiteRepresentation(
-    override val siteBpn: String? = null
+    override val siteBpn: String? = null,
+    override val name: String? = null
 ) : IBaseSiteRepresentation
 
 data class AddressRepresentation(
     override val addressBpn: String? = null,
+    override val name: String? = null,
     override val addressType: AddressType? = null,
     override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
-    override val alternativePostalAddress: AlternativePostalAddressDto? = null
+    override val alternativePostalAddress: AlternativePostalAddressDto? = null,
 ) : IBaseAddressRepresentation
 
 

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -87,10 +87,12 @@ object BusinessPartnerTestValues {
             )
         ),
         site = SiteRepresentation(
-            siteBpn = "BPNSTEST"
+            siteBpn = "BPNSTEST",
+            name = "site name"
         ),
         address = AddressRepresentation(
             addressBpn = "BPNATEST",
+            name = "address name",
             addressType = AddressType.AdditionalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),
@@ -167,10 +169,12 @@ object BusinessPartnerTestValues {
             )
         ),
         site = SiteRepresentation(
-            siteBpn = "BPNSTEST-2"
+            siteBpn = "BPNSTEST-2",
+            name = "site name 2"
         ),
         address = AddressRepresentation(
             addressBpn = "BPNATEST-2",
+            name = "address name 2",
             addressType = AddressType.LegalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.4f, 0.4f, 0.4f),


### PR DESCRIPTION
## Description

This pull request adds site name and address name to the generic business partner model. By this changing the gate and the orchestrator api. I also added a migration script for the Gate to persist the new names.

Since we now have specific names the cleaning service now uses site and address name of the generic business partner to fill the respective names in the L/S/A model. Legal name will be still taken from the name parts though because we don't expect sharing members to provide the legal name themselves.

Test values and tests have been adapted where appropriate.

Contributes to #672 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
