### PR TITLE
Feat: Remove state description

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -67,8 +67,7 @@ fun gateToPoolLegalEntityState(gateDto: Gate_LegalEntityStateDto): Pool_LegalEnt
     return Pool_LegalEntityStateDto(
         validFrom = gateDto.validFrom,
         validTo = gateDto.validTo,
-        type = gateDto.type,
-        description = gateDto.description
+        type = gateDto.type
     )
 }
 
@@ -84,8 +83,7 @@ fun gateToPoolSiteState(gateDto: Gate_SiteStateDto): Pool_SiteStateDto {
     return Pool_SiteStateDto(
         validFrom = gateDto.validFrom,
         validTo = gateDto.validTo,
-        type = gateDto.type,
-        description = gateDto.description
+        type = gateDto.type
     )
 }
 
@@ -103,8 +101,7 @@ fun gateToPoolAddressState(gateDto: Gate_AddressStateDto): Pool_AddressStateDto 
     return Pool_AddressStateDto(
         validFrom = gateDto.validFrom,
         validTo = gateDto.validTo,
-        type = gateDto.type,
-        description = gateDto.description
+        type = gateDto.type
     )
 }
 
@@ -175,7 +172,7 @@ fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): Gate_LegalEntityD
     }
     val states = legalEntity.states.map {
         Gate_LegalEntityStateDto(
-            description = it.description,
+            description = null,
             validFrom = it.validFrom,
             validTo = it.validTo,
             type = it.typeVerbose.technicalKey
@@ -201,7 +198,7 @@ fun poolToGateLegalEntity(legalEntity: LegalEntityVerboseDto): Gate_LegalEntityD
 fun poolToGateSite(site: SiteVerboseDto): SiteGateDto {
     val states = site.states.map {
         Gate_SiteStateDto(
-            description = it.description,
+            description = null,
             validFrom = it.validFrom,
             validTo = it.validTo,
             type = it.typeVerbose.technicalKey
@@ -223,7 +220,7 @@ fun poolToGateAddressChild(address: Pool_LogisticAddressVerboseDto): AddressGate
 fun poolToGateLogisticAddress(address: Pool_LogisticAddressVerboseDto): Gate_LogisticAddressDto {
     val states = address.states.map {
         Gate_AddressStateDto(
-            description = it.description,
+            description = null,
             validFrom = it.validFrom,
             validTo = it.validTo,
             type = it.typeVerbose.technicalKey

--- a/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/BridgeSyncIT.kt
+++ b/bpdm-bridge-dummy/src/test/kotlin/com/catenax/bpdm/bridge/dummy/BridgeSyncIT.kt
@@ -458,7 +458,6 @@ class BridgeSyncIT @Autowired constructor(
 
     private fun assertEqualSite(gateVersion: SiteGateInputRequest, poolVersion: SiteWithMainAddressVerboseDto) {
         assertThat(poolVersion.site.name).isEqualTo(gateVersion.site.nameParts.first())
-        assertThat(poolVersion.site.states.map { it.description }).isEqualTo(gateVersion.site.states.map { it.description })
         assertThat(poolVersion.mainAddress.physicalPostalAddress.street?.name).isEqualTo(gateVersion.mainAddress.physicalPostalAddress.street?.name)
     }
 

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -57,12 +57,12 @@ fun BusinessPartnerIdentifierDto.toLegalEntityIdentifierDto(): LegalEntityIdenti
 
 fun BusinessPartnerStateDto.toLegalEntityState(): LegalEntityStateDto? {
 
-    return type?.let { LegalEntityStateDto(description, validFrom, validTo, it) }
+    return type?.let { LegalEntityStateDto(validFrom, validTo, it) }
 }
 
 fun BusinessPartnerStateDto.toSiteState(): SiteStateDto? {
 
-    return type?.let { SiteStateDto(description, validFrom, validTo, it) }
+    return type?.let { SiteStateDto(validFrom, validTo, it) }
 }
 
 fun BusinessPartnerGenericDto.toLogisticAddressDto(bpnReferenceDto: BpnReferenceDto):

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -55,8 +55,7 @@ object CommonValues {
         BusinessPartnerStateDto(
             validFrom = LocalDateTime.now(),
             validTo = LocalDateTime.now().plusDays(10),
-            type = BusinessStateType.ACTIVE,
-            description = "ActiveState"
+            type = BusinessStateType.ACTIVE
         )
     )
     private val classifications = listOf(

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IAddressStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IAddressStateDto.kt
@@ -27,9 +27,6 @@ import java.time.LocalDateTime
 @Schema(description = AddressStateDescription.header)
 interface IAddressStateDto : IBaseStateDto {
 
-    @get:Schema(description = AddressStateDescription.description)
-    override val description: String?
-
     @get:Schema(description = AddressStateDescription.validFrom)
     override val validFrom: LocalDateTime?
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseStateDto.kt
@@ -33,7 +33,4 @@ interface IBaseStateDto {
 
     @get:Schema(description = "The type of this specified status.")
     val type: BusinessStateType?
-
-    @get:Schema(description = "Denotation of the status.")
-    val description: String?
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ILegalEntityStateDto.kt
@@ -27,9 +27,6 @@ import java.time.LocalDateTime
 @Schema(description = LegalEntityStateDescription.header)
 interface ILegalEntityStateDto : IBaseStateDto {
 
-    @get:Schema(description = LegalEntityStateDescription.description)
-    override val description: String?
-
     @get:Schema(description = LegalEntityStateDescription.validFrom)
     override val validFrom: LocalDateTime?
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ISiteStateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/ISiteStateDto.kt
@@ -28,9 +28,6 @@ import java.time.LocalDateTime
 @Schema(description = SiteDescription.header)
 interface ISiteStateDto : IBaseStateDto {
 
-    @get:Schema(description = SiteStateDescription.description)
-    override val description: String?
-
     @get:Schema(description = SiteStateDescription.validFrom)
     override val validFrom: LocalDateTime?
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/AddressStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/AddressStateDto.kt
@@ -28,7 +28,7 @@ import java.time.LocalDateTime
 @Schema(description = AddressStateDescription.header)
 data class AddressStateDto(
 
-    override val description: String?,
+    val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/BusinessPartnerStateDto.kt
@@ -27,7 +27,6 @@ data class BusinessPartnerStateDto(
 
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
-    override val type: BusinessStateType?,
-    override val description: String?
+    override val type: BusinessStateType?
 
 ) : IBusinessPartnerStateDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityStateDto.kt
@@ -28,7 +28,7 @@ import java.time.LocalDateTime
 @Schema(description = LegalEntityStateDescription.header)
 data class LegalEntityStateDto(
 
-    override val description: String?,
+    val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/SiteStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/SiteStateDto.kt
@@ -28,7 +28,7 @@ import java.time.LocalDateTime
 @Schema(description = SiteStateDescription.header)
 data class SiteStateDto(
 
-    override val description: String?,
+    val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/State.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/State.kt
@@ -37,10 +37,7 @@ data class State(
 
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
-    var type: BusinessStateType,
-
-    @Column(name = "description")
-    var description: String?
+    var type: BusinessStateType
 
 ) : Comparable<State> {
 
@@ -49,6 +46,5 @@ data class State(
         compareBy(nullsFirst(), State::validFrom)       // here null means MIN
             .thenBy(nullsLast(), State::validTo)        // here null means MAX
             .thenBy(State::type)
-            .thenBy(State::description)
             .compare(this, other)
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -251,10 +251,10 @@ class BusinessPartnerMappings {
         }
 
     private fun toStateDto(entity: State) =
-        BusinessPartnerStateDto(type = entity.type, validFrom = entity.validFrom, validTo = entity.validTo, description = entity.description)
+        BusinessPartnerStateDto(type = entity.type, validFrom = entity.validFrom, validTo = entity.validTo)
 
     private fun toState(dto: BusinessPartnerStateDto) =
-        dto.type?.let { State(type = it, validFrom = dto.validFrom, validTo = dto.validTo, description = dto.description) }
+        dto.type?.let { State(type = it, validFrom = dto.validFrom, validTo = dto.validTo) }
 
     private fun toClassificationDto(entity: Classification) =
         BusinessPartnerClassificationDto(type = entity.type, code = entity.code, value = entity.value)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -272,7 +272,6 @@ class BusinessPartnerService(
         toState.apply {
             validFrom = fromState.validFrom
             validTo = fromState.validTo
-            description = fromState.description
             type = fromState.type
         }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -124,7 +124,7 @@ class OrchestratorMappings(
         )
 
     private fun toStateDto(entity: State) =
-        BusinessPartnerStateDto(type = entity.type, validFrom = entity.validFrom, validTo = entity.validTo, description = entity.description)
+        BusinessPartnerStateDto(type = entity.type, validFrom = entity.validFrom, validTo = entity.validTo)
 
     private fun toIdentifierDto(entity: Identifier) =
         BusinessPartnerIdentifierDto(type = entity.type, value = entity.value, issuingBody = entity.issuingBody)
@@ -173,7 +173,7 @@ class OrchestratorMappings(
         }
 
     private fun toState(dto: BusinessPartnerStateDto) =
-        dto.type?.let { State(type = it, validFrom = dto.validFrom, validTo = dto.validTo, description = dto.description) }
+        dto.type?.let { State(type = it, validFrom = dto.validFrom, validTo = dto.validTo) }
 
     private fun toClassification(dto: BusinessPartnerClassificationDto) =
         Classification(type = dto.type, code = dto.code, value = dto.value)

--- a/bpdm-gate/src/main/resources/db/migration/V5_0_0_1__add_site_address_name.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V5_0_0_1__add_site_address_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE business_partners_states
+DROP COLUMN description;

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -323,7 +323,6 @@ class BusinessPartnerControllerIT @Autowired constructor(
     val stateDtoComparator = compareBy(nullsFirst(), BusinessPartnerStateDto::validFrom)       // here null means MIN
         .thenBy(nullsLast(), BusinessPartnerStateDto::validTo)        // here null means MAX
         .thenBy(BusinessPartnerStateDto::type)
-        .thenBy(BusinessPartnerStateDto::description)
 
     val classificationDtoComparator = compareBy(
         BusinessPartnerClassificationDto::type,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -238,7 +238,6 @@ internal class BusinessPartnerIT @Autowired constructor(
 
     private fun createState(): State {
         return State(
-            description = "Active",
             type = BusinessStateType.ACTIVE,
             validFrom = LocalDateTime.now(),
             validTo = LocalDateTime.now().plusDays(365)

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -50,14 +50,12 @@ object BusinessPartnerGenericValues {
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
                 validTo = LocalDateTime.of(2023, 10, 23, 16, 40),
-                type = BusinessStateType.INACTIVE,
-                description = "business-state-description-1"
+                type = BusinessStateType.INACTIVE
             ),
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2000, 8, 21, 14, 30),
                 validTo = LocalDateTime.of(2020, 9, 22, 15, 50),
-                type = BusinessStateType.ACTIVE,
-                description = "business-state-description-2"
+                type = BusinessStateType.ACTIVE
             )
         ),
         roles = listOf(

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -80,15 +80,13 @@ object BusinessPartnerVerboseValues {
     val bpState1 = BusinessPartnerStateDto(
         validFrom = businessStatusValidFrom1,
         validTo = businessStatusValidUntil1,
-        type = BusinessStateType.ACTIVE,
-        description = businessStatusDescription1
+        type = BusinessStateType.ACTIVE
     )
 
     val bpState2 = BusinessPartnerStateDto(
         validFrom = businessStatusValidFrom2,
         validTo = businessStatusValidUntil2,
-        type = BusinessStateType.INACTIVE,
-        description = businessStatusDescription2
+        type = BusinessStateType.INACTIVE
     )
 
     val bpIdentifier1 = BusinessPartnerIdentifierDto(
@@ -716,14 +714,12 @@ object BusinessPartnerVerboseValues {
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
                 validTo = LocalDateTime.of(2023, 10, 23, 16, 40),
-                type = BusinessStateType.INACTIVE,
-                description = "business-state-description-1"
+                type = BusinessStateType.INACTIVE
             ),
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2000, 8, 21, 14, 30),
                 validTo = LocalDateTime.of(2020, 9, 22, 15, 50),
-                type = BusinessStateType.ACTIVE,
-                description = "business-state-description-2"
+                type = BusinessStateType.ACTIVE
             )
         ),
         roles = listOf(

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/AddressStateDto.kt
@@ -24,7 +24,6 @@ import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
 data class AddressStateDto(
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerStateDto.kt
@@ -27,7 +27,6 @@ data class BusinessPartnerStateDto(
 
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
-    override val type: BusinessStateType?,
-    override val description: String?
+    override val type: BusinessStateType?
 
 ) : IBusinessPartnerStateDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityStateDto.kt
@@ -24,8 +24,6 @@ import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
 data class LegalEntityStateDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteStateDto.kt
@@ -24,8 +24,6 @@ import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import java.time.LocalDateTime
 
 data class SiteStateDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -54,14 +54,12 @@ object BusinessPartnerTestValues {
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2020, 9, 22, 15, 50),
                 validTo = LocalDateTime.of(2023, 10, 23, 16, 40),
-                type = BusinessStateType.INACTIVE,
-                description = "business-state-description-1"
+                type = BusinessStateType.INACTIVE
             ),
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(2000, 8, 21, 14, 30),
                 validTo = LocalDateTime.of(2020, 9, 22, 15, 50),
-                type = BusinessStateType.ACTIVE,
-                description = "business-state-description-2"
+                type = BusinessStateType.ACTIVE
             )
         ),
         roles = listOf(
@@ -148,8 +146,7 @@ object BusinessPartnerTestValues {
             BusinessPartnerStateDto(
                 validFrom = LocalDateTime.of(1988, 10, 4, 22, 30),
                 validTo = LocalDateTime.of(2023, 1, 1, 10, 10),
-                type = BusinessStateType.ACTIVE,
-                description = "business-state-description-2"
+                type = BusinessStateType.ACTIVE
             )
         ),
         roles = listOf(
@@ -220,13 +217,11 @@ object BusinessPartnerTestValues {
         name = "Address Name 1",
         states = listOf(
             AddressStateDto(
-                description = "Address State 1",
                 validFrom = LocalDateTime.of(1970, 4, 4, 4, 4),
                 validTo = LocalDateTime.of(1975, 5, 5, 5, 5),
                 type = BusinessStateType.ACTIVE
             ),
             AddressStateDto(
-                description = "Address State 2",
                 validFrom = LocalDateTime.of(1975, 5, 5, 5, 5),
                 validTo = null,
                 type = BusinessStateType.INACTIVE
@@ -288,7 +283,6 @@ object BusinessPartnerTestValues {
         name = "Address Name 2",
         states = listOf(
             AddressStateDto(
-                description = "Address State 2",
                 validFrom = LocalDateTime.of(1971, 4, 4, 4, 4),
                 validTo = null,
                 type = BusinessStateType.ACTIVE
@@ -360,13 +354,11 @@ object BusinessPartnerTestValues {
         legalForm = "Legal Form 1",
         states = listOf(
             LegalEntityStateDto(
-                description = "Legal State Description 1",
                 validFrom = LocalDateTime.of(1995, 2, 2, 3, 3),
                 validTo = LocalDateTime.of(2000, 3, 3, 4, 4),
                 type = BusinessStateType.ACTIVE
             ),
             LegalEntityStateDto(
-                description = "Legal State Description 2",
                 validFrom = LocalDateTime.of(2000, 3, 3, 4, 4),
                 validTo = null,
                 type = BusinessStateType.INACTIVE
@@ -405,7 +397,6 @@ object BusinessPartnerTestValues {
         legalForm = "Legal Form 2",
         states = listOf(
             LegalEntityStateDto(
-                description = "Legal State Description 2",
                 validFrom = LocalDateTime.of(1900, 5, 5, 5, 5),
                 validTo = null,
                 type = BusinessStateType.ACTIVE
@@ -430,13 +421,11 @@ object BusinessPartnerTestValues {
         name = "Site Name 1",
         states = listOf(
             SiteStateDto(
-                description = "Site State Description 1",
                 validFrom = LocalDateTime.of(1991, 10, 10, 10, 10),
                 validTo = LocalDateTime.of(2001, 11, 11, 11, 11),
                 type = BusinessStateType.ACTIVE
             ),
             SiteStateDto(
-                description = "Site State Description 2",
                 validFrom = LocalDateTime.of(2001, 11, 11, 11, 11),
                 validTo = null,
                 type = BusinessStateType.INACTIVE
@@ -454,7 +443,6 @@ object BusinessPartnerTestValues {
         name = "Site Name 2",
         states = listOf(
             SiteStateDto(
-                description = "Site State Description 2",
                 validFrom = LocalDateTime.of(1997, 12, 12, 12, 12),
                 validTo = null,
                 type = BusinessStateType.ACTIVE

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressStateDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressStateDto.kt
@@ -27,8 +27,6 @@ import java.time.LocalDateTime
 
 @Schema(description = AddressStateDescription.header)
 data class AddressStateDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressStateVerboseDto.kt
@@ -30,8 +30,6 @@ import java.time.LocalDateTime
 
 @Schema(description = AddressStateDescription.header)
 data class AddressStateVerboseDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateDto.kt
@@ -27,8 +27,6 @@ import java.time.LocalDateTime
 
 @Schema(description = LegalEntityStateDescription.header)
 data class LegalEntityStateDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityStateVerboseDto.kt
@@ -30,8 +30,6 @@ import java.time.LocalDateTime
 
 @Schema(description = LegalEntityStateDescription.header)
 data class LegalEntityStateVerboseDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteStateDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteStateDto.kt
@@ -27,8 +27,6 @@ import java.time.LocalDateTime
 
 @Schema(description = SiteStateDescription.header)
 data class SiteStateDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
     override val type: BusinessStateType

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteStateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteStateVerboseDto.kt
@@ -30,8 +30,6 @@ import java.time.LocalDateTime
 
 @Schema(description = SiteStateDescription.header)
 data class SiteStateVerboseDto(
-
-    override val description: String?,
     override val validFrom: LocalDateTime?,
     override val validTo: LocalDateTime?,
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/AddressState.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/AddressState.kt
@@ -32,9 +32,6 @@ import java.time.LocalDateTime
     ]
 )
 class AddressState (
-    @Column(name = "description")
-    val description: String?,
-
     @Column(name = "valid_from")
     val validFrom: LocalDateTime?,
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntityState.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntityState.kt
@@ -32,8 +32,6 @@ import java.time.LocalDateTime
     ]
 )
 class LegalEntityState (
-    @Column(name = "description")
-    val description: String?,
 
     @Column(name = "valid_from")
     val validFrom: LocalDateTime?,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/SiteState.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/SiteState.kt
@@ -32,9 +32,6 @@ import java.time.LocalDateTime
     ]
 )
 class SiteState (
-    @Column(name = "description")
-    val description: String?,
-
     @Column(name = "valid_from")
     val validFrom: LocalDateTime?,
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -398,7 +398,6 @@ class BusinessPartnerBuildService(
 
         fun toLegalEntityState(dto: ILegalEntityStateDto, legalEntity: LegalEntity): LegalEntityState {
             return LegalEntityState(
-                description = dto.description,
                 validFrom = dto.validFrom,
                 validTo = dto.validTo,
                 type = dto.type,
@@ -408,7 +407,6 @@ class BusinessPartnerBuildService(
 
         fun toSiteState(dto: ISiteStateDto, site: Site): SiteState {
             return SiteState(
-                description = dto.description,
                 validFrom = dto.validFrom,
                 validTo = dto.validTo,
                 type = dto.type,
@@ -418,7 +416,6 @@ class BusinessPartnerBuildService(
 
         fun toAddressState(dto: IAddressStateDto, address: LogisticAddress): AddressState {
             return AddressState(
-                description = dto.description,
                 validFrom = dto.validFrom,
                 validTo = dto.validTo,
                 type = dto.type,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -94,15 +94,15 @@ fun LegalForm.toDto(): LegalFormDto {
 }
 
 fun LegalEntityState.toDto(): LegalEntityStateVerboseDto {
-    return LegalEntityStateVerboseDto(description, validFrom, validTo, type.toDto())
+    return LegalEntityStateVerboseDto(validFrom, validTo, type.toDto())
 }
 
 fun SiteState.toDto(): SiteStateVerboseDto {
-    return SiteStateVerboseDto(description, validFrom, validTo, type.toDto())
+    return SiteStateVerboseDto(validFrom, validTo, type.toDto())
 }
 
 fun AddressState.toDto(): AddressStateVerboseDto {
-    return AddressStateVerboseDto(description, validFrom, validTo, type.toDto())
+    return AddressStateVerboseDto(validFrom, validTo, type.toDto())
 }
 
 fun LogisticAddress.toDto(): LogisticAddressVerboseDto {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -233,7 +233,6 @@ class TaskStepBuildService(
             clear()
             addAll(dto.states.map {
                 AddressState(
-                    description = it.description,
                     validFrom = it.validFrom,
                     validTo = it.validTo,
                     type = it.type,

--- a/bpdm-pool/src/main/resources/db/migration/V5_0_0_0__drop_state_descriptions.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V5_0_0_0__drop_state_descriptions.sql
@@ -1,0 +1,8 @@
+ALTER TABLE legal_entity_states
+DROP COLUMN description;
+
+ALTER TABLE site_states
+DROP COLUMN description;
+
+ALTER TABLE address_states
+DROP COLUMN description;

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1106,7 +1106,6 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun legalEntityState(name: String, id: Long, type: BusinessStateType): LegalEntityStateDto {
 
         return LegalEntityStateDto(
-            description = "description_" + name + "_" + id,
             validFrom = LocalDateTime.now().plusDays(id),
             validTo = LocalDateTime.now().plusDays(id + 2),
             type = type
@@ -1116,7 +1115,6 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun siteState(name: String, id: Long, type: BusinessStateType): SiteStateDto {
 
         return SiteStateDto(
-            description = "description_" + name + "_" + id,
             validFrom = LocalDateTime.now().plusDays(id),
             validTo = LocalDateTime.now().plusDays(id + 2),
             type = type
@@ -1126,7 +1124,6 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun addressState(name: String, id: Long, type: BusinessStateType): AddressStateDto {
 
         return AddressStateDto(
-            description = "description_" + name + "_" + id,
             validFrom = LocalDateTime.now().plusDays(id),
             validTo = LocalDateTime.now().plusDays(id + 2),
             type = type
@@ -1293,8 +1290,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun compareAddressStates(statesVerbose: Collection<AddressStateVerboseDto>, states: Collection<AddressStateDto>?) {
 
         assertThat(statesVerbose.size).isEqualTo(states?.size ?: 0)
-        val sortedVerboseStates = statesVerbose.sortedBy { it.description }
-        val sortedStates = states?.sortedBy { it.description }
+        val sortedVerboseStates = statesVerbose.sortedBy { it.validFrom }
+        val sortedStates = states?.sortedBy { it.validFrom }
         sortedVerboseStates.indices.forEach {
             assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates!![it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
@@ -1320,8 +1317,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun compareStates(statesVerbose: Collection<LegalEntityStateVerboseDto>, states: Collection<ILegalEntityStateDto>?) {
 
         assertThat(statesVerbose.size).isEqualTo(states?.size ?: 0)
-        val sortedVerboseStates = statesVerbose.sortedBy { it.description }
-        val sortedStates = states!!.sortedBy { it.description }
+        val sortedVerboseStates = statesVerbose.sortedBy { it.validFrom }
+        val sortedStates = states!!.sortedBy { it.validFrom }
         sortedVerboseStates.indices.forEach {
             assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()
@@ -1335,8 +1332,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun compareSiteStates(statesVerbose: Collection<SiteStateVerboseDto>, states: Collection<ISiteStateDto>?) {
 
         assertThat(statesVerbose.size).isEqualTo(states?.size ?: 0)
-        val sortedVerboseStates = statesVerbose.sortedBy { it.description }
-        val sortedStates = states!!.sortedBy { it.description }
+        val sortedVerboseStates = statesVerbose.sortedBy { it.validFrom }
+        val sortedStates = states!!.sortedBy { it.validFrom }
         sortedVerboseStates.indices.forEach {
             assertThat(sortedVerboseStates[it].typeVerbose.technicalKey.name).isEqualTo(sortedStates[it].type.name)
             assertThat(sortedVerboseStates[it]).usingRecursiveComparison()

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
@@ -94,38 +94,32 @@ object BusinessPartnerNonVerboseValues {
     )
 
     private val leStatus1 = LegalEntityStateDto(
-        BusinessPartnerVerboseValues.leStatus1.description,
         BusinessPartnerVerboseValues.leStatus1.validFrom,
         BusinessPartnerVerboseValues.leStatus1.validTo,
         BusinessPartnerVerboseValues.statusType1.technicalKey
     )
     private val leStatus2 = LegalEntityStateDto(
-        BusinessPartnerVerboseValues.leStatus2.description,
         BusinessPartnerVerboseValues.leStatus2.validFrom,
         BusinessPartnerVerboseValues.leStatus2.validTo,
         BusinessPartnerVerboseValues.statusType2.technicalKey
     )
     private val leStatus3 = LegalEntityStateDto(
-        BusinessPartnerVerboseValues.leStatus3.description,
         BusinessPartnerVerboseValues.leStatus3.validFrom,
         BusinessPartnerVerboseValues.leStatus3.validTo,
         BusinessPartnerVerboseValues.statusType3.technicalKey
     )
 
     val siteStatus1 = SiteStateDto(
-        BusinessPartnerVerboseValues.siteStatus1.description,
         BusinessPartnerVerboseValues.siteStatus1.validFrom,
         BusinessPartnerVerboseValues.siteStatus1.validTo,
         BusinessPartnerVerboseValues.statusType1.technicalKey
     )
     private val siteStatus2 = SiteStateDto(
-        BusinessPartnerVerboseValues.siteStatus2.description,
         BusinessPartnerVerboseValues.siteStatus2.validFrom,
         BusinessPartnerVerboseValues.siteStatus2.validTo,
         BusinessPartnerVerboseValues.statusType2.technicalKey
     )
     private val siteStatus3 = SiteStateDto(
-        BusinessPartnerVerboseValues.siteStatus3.description,
         BusinessPartnerVerboseValues.siteStatus3.validFrom,
         BusinessPartnerVerboseValues.siteStatus3.validTo,
         BusinessPartnerVerboseValues.statusType3.technicalKey

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
@@ -81,13 +81,13 @@ object BusinessPartnerVerboseValues {
     val statusType2 = TypeKeyNameVerboseDto(BusinessStateType.INACTIVE, BusinessStateType.INACTIVE.getTypeName())
     val statusType3 = TypeKeyNameVerboseDto(BusinessStateType.ACTIVE, BusinessStateType.ACTIVE.getTypeName())
 
-    val leStatus1 = LegalEntityStateVerboseDto("Active", LocalDateTime.of(2020, 1, 1, 0, 0), null, statusType1)
-    val leStatus2 = LegalEntityStateVerboseDto("Dissolved", LocalDateTime.of(2019, 1, 1, 0, 0), null, statusType2)
-    val leStatus3 = LegalEntityStateVerboseDto("Insolvent", LocalDateTime.of(2018, 1, 1, 0, 0), null, statusType3)
+    val leStatus1 = LegalEntityStateVerboseDto(LocalDateTime.of(2020, 1, 1, 0, 0), null, statusType1)
+    val leStatus2 = LegalEntityStateVerboseDto(LocalDateTime.of(2019, 1, 1, 0, 0), null, statusType2)
+    val leStatus3 = LegalEntityStateVerboseDto(LocalDateTime.of(2018, 1, 1, 0, 0), null, statusType3)
 
-    val siteStatus1 = SiteStateVerboseDto("Active", LocalDateTime.of(2020, 1, 1, 0, 0), null, BusinessStateType.ACTIVE.toDto())
-    val siteStatus2 = SiteStateVerboseDto("Dissolved", LocalDateTime.of(2019, 1, 1, 0, 0), null, BusinessStateType.INACTIVE.toDto())
-    val siteStatus3 = SiteStateVerboseDto("Insolvent", LocalDateTime.of(2018, 1, 1, 0, 0), null, BusinessStateType.ACTIVE.toDto())
+    val siteStatus1 = SiteStateVerboseDto(LocalDateTime.of(2020, 1, 1, 0, 0), null, BusinessStateType.ACTIVE.toDto())
+    val siteStatus2 = SiteStateVerboseDto(LocalDateTime.of(2019, 1, 1, 0, 0), null, BusinessStateType.INACTIVE.toDto())
+    val siteStatus3 = SiteStateVerboseDto(LocalDateTime.of(2018, 1, 1, 0, 0), null, BusinessStateType.ACTIVE.toDto())
 
     val classificationType = TypeKeyNameVerboseDto(ClassificationType.NACE, ClassificationType.NACE.name)
 


### PR DESCRIPTION
## Description

This pull request deletes the business partner's state description field from the API as well as from the Gate's generic and the Pool's L/S/A database.

Since we do not want to change the L/S/A endpoints in the Gate until they are deleted I kept the state descriptions as they are. They will be deleted with the whole endpoints when it's time to do so.

Solves #687

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
