### PR TITLE
feat(Gate): generic business partners can now be shared on demand

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
@@ -28,12 +28,14 @@ import jakarta.validation.Valid
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.request.PostSharingStateReadyRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PostExchange
 import org.springframework.web.service.annotation.PutExchange
 
 @RequestMapping("/api/catena/sharing-state", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -57,6 +59,22 @@ interface GateSharingStateApi {
     ): PageDto<SharingStateDto>
 
     @Operation(
+        summary = "Sets the given business partners into ready to be shared state",
+        description = "The business partners to set the ready state for are identified by their external-id. Only business partners in an initial or error state can be set to ready. If any given business partner could not be set into ready state for any reason (for example, it has not been found or it is in the wrong state) the whole request fails (all or nothing approach)."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "All business partners put in ready to be shared state"),
+            ApiResponse(responseCode = "404", description = "Business partners can't be put into ready state (e.g. external-ID not found, wrong sharing state)")
+        ]
+    )
+    @PostMapping
+    @PostExchange
+    fun postSharingStateReady(@RequestBody request: PostSharingStateReadyRequest)
+
+
+
+    @Operation(
         summary = "Creates or updates a sharing state of a business partner",
         deprecated = true
     )
@@ -69,4 +87,6 @@ interface GateSharingStateApi {
     @PutMapping
     @PutExchange
     fun upsertSharingState(@RequestBody request: SharingStateDto)
+
+
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/PostSharingStateReadyRequest.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/PostSharingStateReadyRequest.kt
@@ -17,12 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model
+package org.eclipse.tractusx.bpdm.gate.api.model.request
 
-enum class SharingStateType {
-    Pending,
-    Success,
-    Error,
-    Initial,
-    Ready
-}
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request for setting business partners into ready to be shared to golden record state")
+data class PostSharingStateReadyRequest(
+    val externalIds: List<String>
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessConfigProperties.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessConfigProperties.kt
@@ -17,12 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model
+package org.eclipse.tractusx.bpdm.gate.config
 
-enum class SharingStateType {
-    Pending,
-    Success,
-    Error,
-    Initial,
-    Ready
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "bpdm.tasks")
+data class GoldenRecordTaskConfigProperties(
+    val creation: CreationProperties = CreationProperties(),
+    val check: TaskProcessProperties = TaskProcessProperties()
+) {
+    data class CreationProperties(
+        val fromSharingMember: TaskProcessProperties = TaskProcessProperties(),
+        val fromPool: TaskProcessProperties = TaskProcessProperties()
+    )
+
+    data class TaskProcessProperties(
+        var batchSize: Int = 100,
+        var cron: String = "-",
+    )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.gate.api.GateSharingStateApi
+import org.eclipse.tractusx.bpdm.gate.api.model.request.PostSharingStateReadyRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
 import org.eclipse.tractusx.bpdm.gate.service.SharingStateService
 import org.springframework.security.access.prepost.PreAuthorize
@@ -42,6 +43,10 @@ class SharingStateController(
         externalIds: Collection<String>?
     ): PageDto<SharingStateDto> {
         return sharingStateService.findSharingStates(paginationRequest, businessPartnerType, externalIds)
+    }
+
+    override fun postSharingStateReady(request: PostSharingStateReadyRequest) {
+        sharingStateService.setReady(request.externalIds)
     }
 
     @PreAuthorize("hasAuthority(@gateSecurityConfigProperties.getChangeCompanyOutputDataAsRole())")

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/exception/BpdmInvalidStateException.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/exception/BpdmInvalidStateException.kt
@@ -17,12 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model
+package org.eclipse.tractusx.bpdm.gate.exception
 
-enum class SharingStateType {
-    Pending,
-    Success,
-    Error,
-    Initial,
-    Ready
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class BpdmInvalidStateException(
+    invalidStates: List<InvalidState>
+) : RuntimeException("The following business partners are in an invalid state: ${invalidStates.joinToString { it.toString() }}") {
+    data class InvalidState(
+        val externalId: String,
+        val stateType: SharingStateType
+    )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/exception/BpdmMissingPartnerException.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/exception/BpdmMissingPartnerException.kt
@@ -17,12 +17,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model
+package org.eclipse.tractusx.bpdm.gate.exception
 
-enum class SharingStateType {
-    Pending,
-    Success,
-    Error,
-    Initial,
-    Ready
-}
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class BpdmMissingPartnerException(
+    externalIds: List<String>
+) : RuntimeException("Business partners with the following external ids not found: ${externalIds.joinToString()}")

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
@@ -22,6 +22,8 @@ package org.eclipse.tractusx.bpdm.gate.repository
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.entity.SharingState
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.repository.CrudRepository
@@ -55,5 +57,7 @@ interface SharingStateRepository : PagingAndSortingRepository<SharingState, Long
 
     fun findBySharingStateType(sharingStateType: SharingStateType): Set<SharingState>
 
-    fun findBySharingStateTypeAndTaskIdNotNull(sharingStateType: SharingStateType): Set<SharingState>
+    fun findBySharingStateType(sharingStateType: SharingStateType, pageable: Pageable): Page<SharingState>
+
+    fun findBySharingStateTypeAndTaskIdNotNull(sharingStateType: SharingStateType, pageable: Pageable): Page<SharingState>
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.service
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.model.StageType
+import org.eclipse.tractusx.bpdm.gate.api.exception.BusinessPartnerSharingError
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
+import org.eclipse.tractusx.bpdm.gate.config.GoldenRecordTaskConfigProperties
+import org.eclipse.tractusx.bpdm.gate.entity.SyncType
+import org.eclipse.tractusx.bpdm.gate.repository.SharingStateRepository
+import org.eclipse.tractusx.bpdm.gate.repository.generic.BusinessPartnerRepository
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.springframework.data.domain.Pageable
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GoldenRecordTaskService(
+    private val sharingStateRepository: SharingStateRepository,
+    private val sharingStateService: SharingStateService,
+    private val businessPartnerRepository: BusinessPartnerRepository,
+    private val businessPartnerService: BusinessPartnerService,
+    private val orchestratorMappings: OrchestratorMappings,
+    private val orchestrationApiClient: OrchestrationApiClient,
+    private val properties: GoldenRecordTaskConfigProperties,
+    private val syncRecordService: SyncRecordService,
+    private val poolClient: PoolApiClient
+) {
+    private val logger = KotlinLogging.logger { }
+
+    @Scheduled(cron = "#{@goldenRecordTaskConfigProperties.getCreation().getFromSharingMember().getCron()}")
+    @Transactional
+    fun createTasksForReadyBusinessPartners() {
+        logger.info { "Started scheduled task to create golden record tasks from ready business partners" }
+
+        val pageRequest = Pageable.ofSize(properties.creation.fromSharingMember.batchSize)
+        val foundStates = sharingStateRepository.findBySharingStateType(SharingStateType.Ready, pageRequest).content
+
+        logger.debug { "Found ${foundStates.size} business partners in ready state" }
+
+        val partners = businessPartnerRepository.findByStageAndExternalIdIn(StageType.Input, foundStates.map { it.externalId })
+
+        val orchestratorBusinessPartnersDto = partners.map { orchestratorMappings.toBusinessPartnerGenericDto(it) }
+
+        val createdTasks = createGoldenRecordTasks(TaskMode.UpdateFromSharingMember, orchestratorBusinessPartnersDto)
+
+        val pendingRequests = partners.zip(createdTasks)
+            .map { (partner, task) ->
+                SharingStateService.PendingRequest(
+                    SharingStateService.SharingStateIdentifierDto(
+                        partner.externalId,
+                        BusinessPartnerType.GENERIC
+                    ), task.taskId
+                )
+            }
+
+        sharingStateService.setPending(pendingRequests)
+
+        logger.info { "Created ${createdTasks.size} new golden record tasks from ready business partners" }
+    }
+
+    @Scheduled(cron = "#{@goldenRecordTaskConfigProperties.getCheck().getCron()}")
+    @Transactional
+    fun resolvePendingTasks() {
+        logger.info { "Started scheduled task to resolve pending golden record tasks" }
+
+        val pageRequest = Pageable.ofSize(properties.check.batchSize)
+        val sharingStates = sharingStateRepository.findBySharingStateTypeAndTaskIdNotNull(SharingStateType.Pending, pageRequest).content
+
+        logger.debug { "Found ${sharingStates.size} business partners in pending state" }
+
+        val tasks = orchestrationApiClient.goldenRecordTasks.searchTaskStates(TaskStateRequest(sharingStates.map { it.taskId!! })).tasks
+        val sharingStateMap = sharingStates.associateBy { it.taskId }
+
+        val taskStatesByResult = tasks
+            .map { Pair(it, sharingStateMap[it.taskId]!!) }
+            .groupBy { (task, _) -> task.processingState.resultState }
+
+        val sharingStatesWithoutTasks = sharingStates.filter { it.taskId !in tasks.map { task -> task.taskId } }
+
+        val businessPartnersToUpsert = taskStatesByResult[ResultState.Success]?.map { (task, sharingState) ->
+            orchestratorMappings.toBusinessPartner(task.businessPartnerResult!!, sharingState.externalId)
+        } ?: emptyList()
+        businessPartnerService.upsertBusinessPartnersOutputFromCandidates(businessPartnersToUpsert)
+
+        val errorRequests = (taskStatesByResult[ResultState.Error]?.map { (task, sharingState) ->
+            SharingStateService.ErrorRequest(
+                SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
+                BusinessPartnerSharingError.SharingProcessError,
+                if (task.processingState.errors.isNotEmpty()) task.processingState.errors.joinToString(" // ") { it.description } else null
+            )
+        } ?: emptyList()).toMutableList()
+
+        errorRequests.addAll(sharingStatesWithoutTasks.map { sharingState ->
+            SharingStateService.ErrorRequest(
+                SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
+                BusinessPartnerSharingError.MissingTaskID,
+                errorMessage = "Missing Task in Orchestrator"
+            )
+        })
+
+        sharingStateService.setError(errorRequests)
+
+        logger.info { "Resolved ${businessPartnersToUpsert.size} tasks as successful and ${errorRequests.size} as errors" }
+    }
+
+    @Scheduled(cron = "#{@goldenRecordTaskConfigProperties.getCreation().getFromPool().getCron()}")
+    @Transactional
+    fun createTasksForGoldenRecordUpdates() {
+        logger.info { "Started scheduled task to create golden record tasks from Pool updates" }
+
+        val syncRecord = syncRecordService.getOrCreateRecord(SyncType.POOL_TO_GATE_OUTPUT)
+
+        val pageRequest = PaginationRequest(0, properties.creation.fromPool.batchSize)
+        val changelogSearchRequest = ChangelogSearchRequest(syncRecord.finishedAt)
+        val poolChangelogEntries = poolClient.changelogs.getChangelogEntries(changelogSearchRequest, pageRequest)
+
+        val poolUpdatedEntries = poolChangelogEntries.content.filter { it.changelogType == ChangelogType.UPDATE }
+
+        val bpnA =
+            poolUpdatedEntries.filter { it.businessPartnerType == BusinessPartnerType.ADDRESS }.map { it.bpn }
+        val bpnL = poolUpdatedEntries.filter { it.businessPartnerType == BusinessPartnerType.LEGAL_ENTITY }
+            .map { it.bpn }
+        val bpnS =
+            poolUpdatedEntries.filter { it.businessPartnerType == BusinessPartnerType.SITE }.map { it.bpn }
+
+        val gateOutputEntries = businessPartnerRepository.findByStageAndBpnLInOrBpnSInOrBpnAIn(StageType.Output, bpnL, bpnS, bpnA)
+
+        val businessPartnerGenericDtoList = gateOutputEntries.map { bp ->
+            orchestratorMappings.toBusinessPartnerGenericDto(bp)
+        }
+
+        val tasks = createGoldenRecordTasks(TaskMode.UpdateFromPool, businessPartnerGenericDtoList)
+
+        val pendingRequests = gateOutputEntries.zip(tasks)
+            .map { (partner, task) ->
+                SharingStateService.PendingRequest(
+                    SharingStateService.SharingStateIdentifierDto(
+                        partner.externalId,
+                        partner.parentType ?: BusinessPartnerType.GENERIC
+                    ), task.taskId
+                )
+            }
+        sharingStateService.setPending(pendingRequests)
+
+        if (poolUpdatedEntries.isNotEmpty()) {
+            syncRecordService.setSynchronizationStart(SyncType.POOL_TO_GATE_OUTPUT)
+            syncRecordService.setSynchronizationSuccess(SyncType.POOL_TO_GATE_OUTPUT, poolUpdatedEntries.last().timestamp)
+        }
+
+        logger.info { "Created ${tasks.size} new golden record tasks from pool updates" }
+    }
+
+    private fun createGoldenRecordTasks(mode: TaskMode, orchestratorBusinessPartnersDto: List<BusinessPartnerGenericDto>): List<TaskClientStateDto> {
+        if (orchestratorBusinessPartnersDto.isEmpty())
+            return emptyList()
+
+        return orchestrationApiClient.goldenRecordTasks.createTasks(TaskCreateRequest(mode, orchestratorBusinessPartnersDto)).createdTasks
+    }
+}

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -35,9 +35,18 @@ bpdm:
     api:
         upsert-limit: 100
 
-    # Cleaning Task Job Configurations
-    goldenRecordTask:
-        pollingCron: '-'
+    # Configuration for golden record tasks
+    tasks:
+        creation:
+            fromSharingMember:
+                batchSize: 100
+                cron: '-'
+            fromPool:
+                batchSize: 100
+                cron: '-'
+        check:
+            batchSize: 100
+            cron: '-'
 
     # Connection to the pool and orchestrator  [No auth on default]
     client:


### PR DESCRIPTION
## Description


This pull request now introduces the feature to share business partners to the golden record process on demand. This means, when upserting business partners they are not shared automatically.

- created API endpoint to set sharing state to ready
- created scheduled function to poll ready business partners and share them to the orchestrator
- moved all scheduled functions to their own golden record task service
- aligned the configuration properties and made them less error prone
- created additional tests for the new API endpoint and adapted existing tests accordingly

Solves #613

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
