### PR TITLE
Feat: Add confidence criteria to L/S/A business partner model

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/dto/DtoConversionHelper.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.gate.api.model.AddressGateOutputChildRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.SiteGateDto
 import org.eclipse.tractusx.bpdm.pool.api.model.*
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressDto
+import java.time.LocalDateTime
 import kotlin.reflect.KProperty
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressIdentifierDto as Gate_AddressIdentifierDto
 import org.eclipse.tractusx.bpdm.gate.api.model.AddressStateDto as Gate_AddressStateDto
@@ -44,6 +45,15 @@ import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto as Poo
 import org.eclipse.tractusx.bpdm.pool.api.model.PhysicalPostalAddressDto as Pool_PhysicalPostalAddressDto1
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteStateDto as Pool_SiteStateDto
 
+val dummyConfidenceCriteria = ConfidenceCriteriaDto(
+    sharedByOwner = false,
+    numberOfBusinessPartners = 1,
+    checkedByExternalDataSource = false,
+    lastConfidenceCheckAt = LocalDateTime.now(),
+    nextConfidenceCheckAt = LocalDateTime.now().plusDays(5),
+    confidenceLevel = 0
+)
+
 fun gateToPoolLegalEntity(gateDto: Gate_LegalEntityDto): Pool_LegalEntityDto {
     return Pool_LegalEntityDto(
         identifiers = gateDto.identifiers.map(::gateToPoolLegalEntityIdentifier),
@@ -51,7 +61,8 @@ fun gateToPoolLegalEntity(gateDto: Gate_LegalEntityDto): Pool_LegalEntityDto {
         legalShortName = gateDto.legalShortName,
         legalForm = gateDto.legalForm,
         states = gateDto.states.map(::gateToPoolLegalEntityState),
-        classifications = gateDto.classifications.map(::gateToPoolLegalEntityClassification)
+        classifications = gateDto.classifications.map(::gateToPoolLegalEntityClassification),
+        confidenceCriteria = dummyConfidenceCriteria
     )
 }
 
@@ -93,7 +104,8 @@ fun gateToPoolLogisticAddress(gateDto: Gate_LogisticAddressDto): LogisticAddress
         states = gateDto.states.map(::gateToPoolAddressState),
         identifiers = gateDto.identifiers.map(::gateToPoolAddressIdentifier),
         physicalPostalAddress = gateToPoolPhysicalAddress(gateDto.physicalPostalAddress),
-        alternativePostalAddress = gateDto.alternativePostalAddress?.let(::gateToPoolAlternativeAddress)
+        alternativePostalAddress = gateDto.alternativePostalAddress?.let(::gateToPoolAlternativeAddress),
+        confidenceCriteria = dummyConfidenceCriteria
     )
 }
 

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -77,6 +77,7 @@ class PoolUpdateService(
                             name = entry.site.nameParts.firstOrNull() ?: "",
                             states = entry.site.states.map(::gateToPoolSiteState),
                             mainAddress = gateToPoolLogisticAddress(entry.mainAddress),
+                            confidenceCriteria = dummyConfidenceCriteria
                         ),
                         index = entry.externalId,
                         bpnlParent = leParentBpn
@@ -101,6 +102,7 @@ class PoolUpdateService(
                     name = it.site.nameParts.firstOrNull() ?: "",
                     states = it.site.states.map(::gateToPoolSiteState),
                     mainAddress = gateToPoolLogisticAddress(it.mainAddress),
+                    confidenceCriteria = dummyConfidenceCriteria
                 ),
                 bpns = it.bpn!!
             )
@@ -141,7 +143,8 @@ class PoolUpdateService(
                             states = entry.address.states.map(::gateToPoolAddressState),
                             identifiers = entry.address.identifiers.map(::gateToPoolAddressIdentifier),
                             physicalPostalAddress = gateToPoolPhysicalAddress(entry.address.physicalPostalAddress),
-                            alternativePostalAddress = entry.address.alternativePostalAddress?.let(::gateToPoolAlternativeAddress)
+                            alternativePostalAddress = entry.address.alternativePostalAddress?.let(::gateToPoolAlternativeAddress),
+                            confidenceCriteria = dummyConfidenceCriteria
                         ),
                         index = entry.externalId,
                         bpnParent = siteParentBpn
@@ -181,7 +184,8 @@ class PoolUpdateService(
                     states = it.address.states.map(::gateToPoolAddressState),
                     identifiers = it.address.identifiers.map(::gateToPoolAddressIdentifier),
                     physicalPostalAddress = gateToPoolPhysicalAddress(it.address.physicalPostalAddress),
-                    alternativePostalAddress = it.address.alternativePostalAddress?.let(::gateToPoolAlternativeAddress)
+                    alternativePostalAddress = it.address.alternativePostalAddress?.let(::gateToPoolAlternativeAddress),
+                    confidenceCriteria = dummyConfidenceCriteria
                 ),
                 bpna = it.bpn!!
             )
@@ -190,5 +194,4 @@ class PoolUpdateService(
         return poolClient.addresses.updateAddresses(updateRequests)
             .also { logger.info { "Pool accepted ${it.entityCount} updated addresses, ${it.errorCount} were refused" } }
     }
-
 }

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -22,7 +22,17 @@ package org.eclipse.tractusx.bpdm.cleaning.service
 
 import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.orchestrator.api.model.*
+import java.time.LocalDateTime
 
+
+val dummyConfidenceCriteria = ConfidenceCriteria(
+    sharedByOwner = false,
+    numberOfBusinessPartners = 1,
+    checkedByExternalDataSource = false,
+    lastConfidenceCheckAt = LocalDateTime.now(),
+    nextConfidenceCheckAt = LocalDateTime.now().plusDays(5),
+    confidenceLevel = 0
+)
 
 fun BusinessPartnerGenericDto.toLegalEntityDto(bpnReferenceDto: BpnReferenceDto, legalAddress: LogisticAddressDto): LegalEntityDto {
 
@@ -35,8 +45,8 @@ fun BusinessPartnerGenericDto.toLegalEntityDto(bpnReferenceDto: BpnReferenceDto,
         legalForm = legalEntity.legalForm,
         states = states.mapNotNull { it.toLegalEntityState() },
         classifications = legalEntity.classifications.map { it.toLegalEntityClassificationDto() },
-        legalAddress = legalAddress
-
+        legalAddress = legalAddress,
+        confidenceCriteria = dummyConfidenceCriteria
     )
 }
 
@@ -75,7 +85,8 @@ fun BusinessPartnerGenericDto.toLogisticAddressDto(bpnReferenceDto: BpnReference
         states = emptyList(),
         identifiers = emptyList(),
         physicalPostalAddress = address.physicalPostalAddress,
-        alternativePostalAddress = address.alternativePostalAddress
+        alternativePostalAddress = address.alternativePostalAddress,
+        confidenceCriteria = dummyConfidenceCriteria
     )
 }
 
@@ -87,8 +98,8 @@ fun BusinessPartnerGenericDto.toSiteDto(bpnReferenceDto: BpnReferenceDto, siteAd
         hasChanged = address.addressType in setOf(AddressType.SiteMainAddress, AddressType.LegalAndSiteMainAddress),
         name = site.name,
         states = states.mapNotNull { it.toSiteState() },
-        mainAddress = siteAddressReference
-
+        mainAddress = siteAddressReference,
+        confidenceCriteria = dummyConfidenceCriteria
     )
 }
 

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -20,10 +20,7 @@
 package org.eclipse.tractusx.bpdm.cleaning.testdata
 
 import com.neovisionaries.i18n.CountryCode
-import org.eclipse.tractusx.bpdm.cleaning.service.toLegalEntityClassificationDto
-import org.eclipse.tractusx.bpdm.cleaning.service.toLegalEntityIdentifierDto
-import org.eclipse.tractusx.bpdm.cleaning.service.toLegalEntityState
-import org.eclipse.tractusx.bpdm.cleaning.service.toSiteState
+import org.eclipse.tractusx.bpdm.cleaning.service.*
 import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
 import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
@@ -183,13 +180,15 @@ object CommonValues {
         identifiers = identifiers.mapNotNull { it.toLegalEntityIdentifierDto() },
         legalForm = legalForm,
         states = states.mapNotNull { it.toLegalEntityState() },
-        classifications = classifications.map { it.toLegalEntityClassificationDto() }
+        classifications = classifications.map { it.toLegalEntityClassificationDto() },
+        confidenceCriteria = dummyConfidenceCriteria
     )
 
     val expectedSiteDto = SiteDto(
         hasChanged = true,
         name = siteName,
         states = states.mapNotNull { it.toSiteState() },
+        confidenceCriteria = dummyConfidenceCriteria
     )
 
     val expectedLogisticAddressDto = LogisticAddressDto(
@@ -198,7 +197,8 @@ object CommonValues {
         name = addressName,
         states = emptyList(),
         identifiers = emptyList(),
-        physicalPostalAddress = physicalPostalAddress
+        physicalPostalAddress = physicalPostalAddress,
+        confidenceCriteria = dummyConfidenceCriteria
     )
 
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
@@ -40,4 +40,6 @@ interface IBaseLegalEntityDto {
 
     @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.classifications, required = false))
     val classifications: Collection<ILegalEntityClassificationDto>
+
+    val confidenceCriteria: IConfidenceCriteriaDto?
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLogisticAddressDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLogisticAddressDto.kt
@@ -39,4 +39,6 @@ interface IBaseLogisticAddressDto {
     // TODO OpenAPI description for complex field does not work!!
     @get:Schema(description = LogisticAddressDescription.alternativePostalAddress)
     val alternativePostalAddress: IBaseAlternativePostalAddressDto?
+
+    val confidenceCriteria: IConfidenceCriteriaDto?
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
@@ -31,4 +31,6 @@ interface IBaseSiteDto {
 
     @get:ArraySchema(arraySchema = Schema(description = SiteDescription.states))
     val states: Collection<ISiteStateDto>
+
+    val confidenceCriteria: IConfidenceCriteriaDto
 }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IConfidenceCriteriaDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IConfidenceCriteriaDto.kt
@@ -17,20 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model
+package org.eclipse.tractusx.bpdm.common.dto
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import java.time.LocalDateTime
 
-@Schema(description = SiteDescription.header)
-data class SiteDto(
-
-    override val name: String,
-    override val states: Collection<SiteStateDto> = emptyList(),
-
-    val mainAddress: LogisticAddressDto,
-
-    override val confidenceCriteria: ConfidenceCriteriaDto
-
-) : IBaseSiteDto
+interface IConfidenceCriteriaDto {
+    val sharedByOwner: Boolean?
+    val checkedByExternalDataSource: Boolean?
+    val numberOfBusinessPartners: Int?
+    val lastConfidenceCheckAt: LocalDateTime?
+    val nextConfidenceCheckAt: LocalDateTime?
+    val confidenceLevel: Int?
+}

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/ConfidenceCriteriaDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/ConfidenceCriteriaDto.kt
@@ -17,20 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model
+package org.eclipse.tractusx.bpdm.gate.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.common.dto.IConfidenceCriteriaDto
+import java.time.LocalDateTime
 
-@Schema(description = SiteDescription.header)
-data class SiteDto(
+data class ConfidenceCriteriaDto(
+    override val sharedByOwner: Boolean?,
+    override val checkedByExternalDataSource: Boolean?,
+    override val numberOfBusinessPartners: Int?,
+    override val lastConfidenceCheckAt: LocalDateTime?,
+    override val nextConfidenceCheckAt: LocalDateTime?,
+    override val confidenceLevel: Int?
 
-    override val name: String,
-    override val states: Collection<SiteStateDto> = emptyList(),
-
-    val mainAddress: LogisticAddressDto,
-
-    override val confidenceCriteria: ConfidenceCriteriaDto
-
-) : IBaseSiteDto
+) : IConfidenceCriteriaDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
@@ -39,6 +39,8 @@ data class LegalEntityDto(
     override val classifications: Collection<LegalEntityClassificationDto> = emptyList(),
 
     @get:ArraySchema(arraySchema = Schema(description = CommonDescription.roles))
-    val roles: Collection<BusinessPartnerRole> = emptyList()
+    val roles: Collection<BusinessPartnerRole> = emptyList(),
+
+    override val confidenceCriteria: ConfidenceCriteriaDto? = null
 
 ) : IBaseLegalEntityDto

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LogisticAddressDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LogisticAddressDto.kt
@@ -37,6 +37,8 @@ data class LogisticAddressDto(
     override val alternativePostalAddress: AlternativePostalAddressDto? = null,
 
     @get:ArraySchema(arraySchema = Schema(description = LogisticAddressDescription.roles))
-    val roles: Collection<BusinessPartnerRole> = emptyList()
+    val roles: Collection<BusinessPartnerRole> = emptyList(),
+
+    override val confidenceCriteria: ConfidenceCriteriaDto? = null
 
 ) : IBaseLogisticAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ConfidenceCriteria.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ConfidenceCriteria.kt
@@ -17,20 +17,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model
+package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.common.dto.IConfidenceCriteriaDto
+import java.time.LocalDateTime
 
-@Schema(description = SiteDescription.header)
-data class SiteDto(
-
-    override val name: String,
-    override val states: Collection<SiteStateDto> = emptyList(),
-
-    val mainAddress: LogisticAddressDto,
-
-    override val confidenceCriteria: ConfidenceCriteriaDto
-
-) : IBaseSiteDto
+data class ConfidenceCriteria(
+    override val sharedByOwner: Boolean? = null,
+    override val checkedByExternalDataSource: Boolean? = null,
+    override val numberOfBusinessPartners: Int? = null,
+    override val lastConfidenceCheckAt: LocalDateTime? = null,
+    override val nextConfidenceCheckAt: LocalDateTime? = null,
+    override val confidenceLevel: Int? = null
+) : IConfidenceCriteriaDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
@@ -44,6 +44,8 @@ data class LegalEntityDto(
 
     override val classifications: Collection<LegalEntityClassificationDto> = emptyList(),
 
-    val legalAddress: LogisticAddressDto? = null
+    val legalAddress: LogisticAddressDto? = null,
+
+    override val confidenceCriteria: ConfidenceCriteria = ConfidenceCriteria()
 
 ) : IBaseLegalEntityDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddressDto.kt
@@ -40,6 +40,8 @@ data class LogisticAddressDto(
 
     override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
 
-    override val alternativePostalAddress: AlternativePostalAddressDto? = null
+    override val alternativePostalAddress: AlternativePostalAddressDto? = null,
+
+    override val confidenceCriteria: ConfidenceCriteria = ConfidenceCriteria()
 
 ) : IBaseLogisticAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
@@ -33,6 +33,8 @@ data class SiteDto(
     override val name: String? = null,
     override val states: Collection<SiteStateDto> = emptyList(),
 
-    val mainAddress: LogisticAddressDto? = null
+    val mainAddress: LogisticAddressDto? = null,
+
+    override val confidenceCriteria: ConfidenceCriteria = ConfidenceCriteria()
 
 ) : IBaseSiteDto

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -276,7 +276,15 @@ object BusinessPartnerTestValues {
             referenceType = BpnReferenceType.Bpn,
             referenceValue = "BPNATEST-1"
         ),
-        hasChanged = true
+        hasChanged = true,
+        confidenceCriteria = ConfidenceCriteria(
+            sharedByOwner = true,
+            checkedByExternalDataSource = true,
+            numberOfBusinessPartners = 7,
+            lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+            nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+            confidenceLevel = 1
+        )
     )
 
     val logisticAddress2 = LogisticAddressDto(
@@ -333,7 +341,15 @@ object BusinessPartnerTestValues {
             referenceType = BpnReferenceType.BpnRequestIdentifier,
             referenceValue = "BPN_REQUEST_ID_TEST"
         ),
-        hasChanged = true
+        hasChanged = true,
+        confidenceCriteria = ConfidenceCriteria(
+            sharedByOwner = false,
+            checkedByExternalDataSource = false,
+            numberOfBusinessPartners = 2,
+            lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
+            nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
+            confidenceLevel = 2
+        )
     )
 
     val legalEntity1 = LegalEntityDto(
@@ -381,7 +397,15 @@ object BusinessPartnerTestValues {
             referenceValue = "BPNL1-TEST",
             referenceType = BpnReferenceType.Bpn
         ),
-        hasChanged = false
+        hasChanged = false,
+        confidenceCriteria = ConfidenceCriteria(
+            sharedByOwner = false,
+            checkedByExternalDataSource = false,
+            numberOfBusinessPartners = 2,
+            lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
+            nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
+            confidenceLevel = 3
+        )
     )
 
     val legalEntity2 = LegalEntityDto(
@@ -414,7 +438,15 @@ object BusinessPartnerTestValues {
             referenceValue = "BPNL-REQUEST_ID_TEST",
             referenceType = BpnReferenceType.BpnRequestIdentifier
         ),
-        hasChanged = false
+        hasChanged = false,
+        confidenceCriteria = ConfidenceCriteria(
+            sharedByOwner = false,
+            checkedByExternalDataSource = false,
+            numberOfBusinessPartners = 2,
+            lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
+            nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
+            confidenceLevel = 4
+        )
     )
 
     val site1 = SiteDto(
@@ -436,7 +468,15 @@ object BusinessPartnerTestValues {
             referenceValue = "BPNS_TEST",
             referenceType = BpnReferenceType.Bpn
         ),
-        hasChanged = false
+        hasChanged = false,
+        confidenceCriteria = ConfidenceCriteria(
+            sharedByOwner = false,
+            checkedByExternalDataSource = false,
+            numberOfBusinessPartners = 2,
+            lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
+            nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
+            confidenceLevel = 5
+        )
     )
 
     val site2 = SiteDto(
@@ -453,7 +493,15 @@ object BusinessPartnerTestValues {
             referenceValue = "BPNS_REQUEST_ID_TEST",
             referenceType = BpnReferenceType.BpnRequestIdentifier
         ),
-        hasChanged = true
+        hasChanged = true,
+        confidenceCriteria = ConfidenceCriteria(
+            sharedByOwner = false,
+            checkedByExternalDataSource = false,
+            numberOfBusinessPartners = 2,
+            lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
+            nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
+            confidenceLevel = 6
+        )
     )
 
     val businessPartner1Full = BusinessPartnerFullDto(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/ConfidenceCriteriaDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/ConfidenceCriteriaDto.kt
@@ -19,18 +19,14 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.model
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.common.dto.IConfidenceCriteriaDto
+import java.time.LocalDateTime
 
-@Schema(description = SiteDescription.header)
-data class SiteDto(
-
-    override val name: String,
-    override val states: Collection<SiteStateDto> = emptyList(),
-
-    val mainAddress: LogisticAddressDto,
-
-    override val confidenceCriteria: ConfidenceCriteriaDto
-
-) : IBaseSiteDto
+data class ConfidenceCriteriaDto(
+    override val sharedByOwner: Boolean,
+    override val checkedByExternalDataSource: Boolean,
+    override val numberOfBusinessPartners: Int,
+    override val lastConfidenceCheckAt: LocalDateTime,
+    override val nextConfidenceCheckAt: LocalDateTime,
+    override val confidenceLevel: Int
+) : IConfidenceCriteriaDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
@@ -33,6 +33,7 @@ data class LegalEntityDto(
     override val legalForm: String? = null,
     override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
     override val states: Collection<LegalEntityStateDto> = emptyList(),
-    override val classifications: Collection<LegalEntityClassificationDto> = emptyList()
+    override val classifications: Collection<LegalEntityClassificationDto> = emptyList(),
+    override val confidenceCriteria: ConfidenceCriteriaDto
 
 ) : IBaseLegalEntityDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
@@ -53,11 +53,13 @@ data class LegalEntityVerboseDto(
     @get:Schema(description = LegalEntityDescription.currentness)
     val currentness: Instant,
 
+    override val confidenceCriteria: ConfidenceCriteriaDto,
+
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,
 
     @get:Schema(description = CommonDescription.updatedAt)
-    val updatedAt: Instant
+    val updatedAt: Instant,
 
 ) : IBaseLegalEntityDto {
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressDto.kt
@@ -38,6 +38,8 @@ data class LogisticAddressDto(
 
     override val physicalPostalAddress: PhysicalPostalAddressDto,
 
-    override val alternativePostalAddress: AlternativePostalAddressDto? = null
+    override val alternativePostalAddress: AlternativePostalAddressDto? = null,
+
+    override val confidenceCriteria: ConfidenceCriteriaDto
 
 ) : IBaseLogisticAddressDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
@@ -55,6 +55,8 @@ data class LogisticAddressVerboseDto(
     val createdAt: Instant,
 
     @get:Schema(description = CommonDescription.updatedAt)
-    val updatedAt: Instant
+    val updatedAt: Instant,
+
+    override val confidenceCriteria: ConfidenceCriteriaDto
 
 ) : IBaseLogisticAddressDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
@@ -41,6 +41,8 @@ data class SiteVerboseDto(
     val createdAt: Instant,
 
     @get:Schema(description = CommonDescription.updatedAt)
-    val updatedAt: Instant
+    val updatedAt: Instant,
+
+    override val confidenceCriteria: ConfidenceCriteriaDto
 
 ) : IBaseSiteDto

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/ConfidenceCriteria.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/ConfidenceCriteria.kt
@@ -17,20 +17,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model
+package org.eclipse.tractusx.bpdm.pool.entity
 
-import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.time.LocalDateTime
 
-@Schema(description = SiteDescription.header)
-data class SiteDto(
 
-    override val name: String,
-    override val states: Collection<SiteStateDto> = emptyList(),
-
-    val mainAddress: LogisticAddressDto,
-
-    override val confidenceCriteria: ConfidenceCriteriaDto
-
-) : IBaseSiteDto
+@Embeddable
+data class ConfidenceCriteria(
+    @Column(name = "shared_by_owner", nullable = false)
+    val sharedByOwner: Boolean,
+    @Column(name = "checked_by_external_data_source", nullable = false)
+    val checkedByExternalDataSource: Boolean,
+    @Column(name = "number_of_business_partners", nullable = false)
+    val numberOfBusinessPartners: Int,
+    @Column(name = "last_confidence_check_at", nullable = false)
+    val lastConfidenceCheckAt: LocalDateTime,
+    @Column(name = "next_confidence_check_at", nullable = false)
+    val nextConfidenceCheckAt: LocalDateTime,
+    @Column(name = "confidence_level", nullable = false)
+    val confidenceLevel: Int,
+)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntity.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntity.kt
@@ -40,7 +40,10 @@ class LegalEntity(
     var legalForm: LegalForm?,
 
     @Column(name = "currentness", nullable = false)
-    var currentness: Instant
+    var currentness: Instant,
+
+    @Embedded
+    var confidenceCriteria: ConfidenceCriteria
 
 ) : BaseEntity() {
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LogisticAddress.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LogisticAddress.kt
@@ -49,7 +49,10 @@ class LogisticAddress(
     var physicalPostalAddress: PhysicalPostalAddress,
 
     @Embedded
-    var alternativePostalAddress: AlternativePostalAddress?
+    var alternativePostalAddress: AlternativePostalAddress?,
+
+    @Embedded
+    var confidenceCriteria: ConfidenceCriteria
 
 ) : BaseEntity() {
     @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/Site.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/Site.kt
@@ -31,6 +31,9 @@ class Site(
     @Column(name = "name", nullable = false)
     var name: String,
 
+    @Embedded
+    var confidenceCriteria: ConfidenceCriteria,
+
     @ManyToOne
     @JoinColumn(name = "legal_entity_id", nullable = false)
     var legalEntity: LegalEntity,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -344,7 +344,8 @@ class BusinessPartnerBuildService(
             site = null,
             physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap.regions),
             alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap.regions) },
-            name = dto.name
+            name = dto.name,
+            confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
         )
 
         updateLogisticAddress(address, dto, metadataMap)
@@ -365,6 +366,8 @@ class BusinessPartnerBuildService(
             clear()
             addAll(dto.states.map { toAddressState(it, address) })
         }
+
+        address.confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
     }
 
     private fun LegalEntityMetadataDto.toMapping() =
@@ -467,8 +470,9 @@ class BusinessPartnerBuildService(
             site.name = name
 
             site.states.clear()
-            site.states.addAll(siteDto.states
-                .map { toSiteState(it, site) })
+            site.states.addAll(siteDto.states.map { toSiteState(it, site) })
+
+            site.confidenceCriteria = createConfidenceCriteria(siteDto.confidenceCriteria)
         }
 
         fun createSite(
@@ -479,7 +483,7 @@ class BusinessPartnerBuildService(
 
             val name = siteDto.name ?: throw BpdmValidationException(TaskStepBuildService.CleaningError.SITE_NAME_IS_NULL.message)
 
-            val site = Site( bpn = bpnS, name = name,  legalEntity = partner)
+            val site = Site(bpn = bpnS, name = name, legalEntity = partner, confidenceCriteria = createConfidenceCriteria(siteDto.confidenceCriteria))
 
             site.states.addAll(siteDto.states
                 .map { toSiteState(it, site) })
@@ -506,6 +510,7 @@ class BusinessPartnerBuildService(
                 legalName = legalName,
                 legalForm = legalForm,
                 currentness = Instant.now().truncatedTo(ChronoUnit.MICROS),
+                confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria!!)
             )
             updateLegalEntity(newLegalEntity, legalEntityDto, legalNameValue, metadataMap)
 
@@ -529,8 +534,8 @@ class BusinessPartnerBuildService(
 
             legalEntity.identifiers.replace(legalEntityDto.identifiers.map { toLegalEntityIdentifier(it, metadataMap.idTypes, legalEntity) })
             legalEntity.states.replace(legalEntityDto.states.map { toLegalEntityState(it, legalEntity) })
-            legalEntity.classifications.replace( legalEntityDto.classifications.map { toLegalEntityClassification(it, legalEntity) }.toSet()
-            )
+            legalEntity.classifications.replace(legalEntityDto.classifications.map { toLegalEntityClassification(it, legalEntity) }.toSet())
+            legalEntity.confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria!!)
         }
 
         fun createPhysicalAddress(physicalAddress: IBasePhysicalPostalAddressDto, regions: Map<String, Region>): PhysicalPostalAddress {
@@ -584,6 +589,16 @@ class BusinessPartnerBuildService(
                 deliveryServiceQualifier = alternativeAddress.deliveryServiceQualifier
             )
         }
+
+        fun createConfidenceCriteria(confidenceCriteria: IConfidenceCriteriaDto) =
+            ConfidenceCriteria(
+                sharedByOwner = confidenceCriteria.sharedByOwner!!,
+                checkedByExternalDataSource = confidenceCriteria.checkedByExternalDataSource!!,
+                numberOfBusinessPartners = confidenceCriteria.numberOfBusinessPartners!!,
+                lastConfidenceCheckAt = confidenceCriteria.lastConfidenceCheckAt!!,
+                nextConfidenceCheckAt = confidenceCriteria.nextConfidenceCheckAt!!,
+                confidenceLevel = confidenceCriteria.confidenceLevel!!
+            )
     }
 
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -67,6 +67,7 @@ fun LegalEntity.toDto(): LegalEntityVerboseDto {
         classifications = classifications.map { it.toDto() },
         relations = startNodeRelations.plus(endNodeRelations).map { it.toDto() },
         currentness = currentness,
+        confidenceCriteria = confidenceCriteria.toDto(),
         createdAt = createdAt,
         updatedAt = updatedAt,
     )
@@ -118,7 +119,8 @@ fun LogisticAddress.toDto(): LogisticAddressVerboseDto {
         states = states.map { it.toDto() },
         identifiers = identifiers.map { it.toDto() },
         physicalPostalAddress = physicalPostalAddress.toDto(),
-        alternativePostalAddress = alternativePostalAddress?.toDto()
+        alternativePostalAddress = alternativePostalAddress?.toDto(),
+        confidenceCriteria = confidenceCriteria.toDto(),
     )
 }
 
@@ -215,6 +217,7 @@ fun Site.toDto(): SiteVerboseDto {
         name,
         states = states.map { it.toDto() },
         bpnLegalEntity = legalEntity.bpn,
+        confidenceCriteria = confidenceCriteria.toDto(),
         createdAt = createdAt,
         updatedAt = updatedAt,
     )
@@ -228,6 +231,7 @@ fun Site.toPoolDto(): SiteWithMainAddressVerboseDto {
             name,
             states = states.map { it.toDto() },
             bpnLegalEntity = legalEntity.bpn,
+            confidenceCriteria = confidenceCriteria.toDto(),
             createdAt = createdAt,
             updatedAt = updatedAt,
         ),
@@ -265,3 +269,13 @@ fun Region.toRegionDto(): RegionDto {
 fun Region.toCountrySubdivisionDto(): CountrySubdivisionDto {
     return CountrySubdivisionDto(countryCode = countryCode, code = regionCode, name = regionName)
 }
+
+fun ConfidenceCriteria.toDto(): ConfidenceCriteriaDto =
+    ConfidenceCriteriaDto(
+        sharedByOwner,
+        checkedByExternalDataSource,
+        numberOfBusinessPartners,
+        lastConfidenceCheckAt,
+        nextConfidenceCheckAt,
+        confidenceLevel
+    )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -193,7 +193,8 @@ class TaskStepBuildService(
                     addressMetadataMap.regions
                 )
             },
-            name = dto.name
+            name = dto.name,
+            confidenceCriteria = BusinessPartnerBuildService.createConfidenceCriteria(dto.confidenceCriteria)
         )
         updateAddressIdentifiersAndStates(address, dto, addressMetadataMap.idTypes)
 
@@ -210,6 +211,7 @@ class TaskStepBuildService(
         address.name = dto.name
         address.physicalPostalAddress = BusinessPartnerBuildService.createPhysicalAddress(dto.physicalPostalAddress!!, metadataMap.regions)
         address.alternativePostalAddress = dto.alternativePostalAddress?.let { BusinessPartnerBuildService.createAlternativeAddress(it, metadataMap.regions) }
+        address.confidenceCriteria = BusinessPartnerBuildService.createConfidenceCriteria(dto.confidenceCriteria)
 
         updateAddressIdentifiersAndStates(address, dto, metadataMap.idTypes)
     }

--- a/bpdm-pool/src/main/resources/db/migration/V5_0_0_1__add_confidence_criteria.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V5_0_0_1__add_confidence_criteria.sql
@@ -1,0 +1,24 @@
+ALTER TABLE legal_entities
+ADD COLUMN shared_by_owner                  boolean     NOT NULL,
+ADD COLUMN checked_by_external_data_source  boolean     NOT NULL,
+ADD COLUMN number_of_business_partners      INT         NOT NULL,
+ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL,
+ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL,
+ADD COLUMN confidence_level                 INT         NOT NULL;
+
+ALTER TABLE sites
+ADD COLUMN shared_by_owner                  boolean     NOT NULL,
+ADD COLUMN checked_by_external_data_source  boolean     NOT NULL,
+ADD COLUMN number_of_business_partners      INT         NOT NULL,
+ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL,
+ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL,
+ADD COLUMN confidence_level                 INT         NOT NULL;
+
+ALTER TABLE logistic_addresses
+ADD COLUMN shared_by_owner                  boolean     NOT NULL,
+ADD COLUMN checked_by_external_data_source  boolean     NOT NULL,
+ADD COLUMN number_of_business_partners      INT         NOT NULL,
+ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL,
+ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL,
+ADD COLUMN confidence_level                 INT     NOT NULL;
+

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -24,7 +24,10 @@ import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
-import org.eclipse.tractusx.bpdm.pool.api.model.*
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.eclipse.tractusx.bpdm.pool.util.*
@@ -225,7 +228,7 @@ class SiteControllerIT @Autowired constructor(
         val request1 = with(BusinessPartnerNonVerboseValues.siteCreate1) {
             copy(
                 index = BusinessPartnerNonVerboseValues.siteCreate1.index,
-                site = SiteDto(
+                site = site.copy(
                     name = BusinessPartnerNonVerboseValues.siteCreate1.site.name,
                     states = listOf(BusinessPartnerNonVerboseValues.siteStatus1),
                     mainAddress = BusinessPartnerNonVerboseValues.logisticAddress3.copy(
@@ -237,7 +240,7 @@ class SiteControllerIT @Autowired constructor(
         val request2 = with(BusinessPartnerNonVerboseValues.siteCreate2) {
             copy(
                 index = BusinessPartnerNonVerboseValues.siteCreate1.index,
-                site = SiteDto(
+                site = site.copy(
                     name = BusinessPartnerNonVerboseValues.siteCreate1.site.name,
                     states = listOf(BusinessPartnerNonVerboseValues.siteStatus1),
                     mainAddress = BusinessPartnerNonVerboseValues.logisticAddress2.copy(
@@ -296,7 +299,7 @@ class SiteControllerIT @Autowired constructor(
         val toUpdate1 = with(BusinessPartnerNonVerboseValues.siteUpdate1) {
             copy(
                 bpns = bpnList[0],
-                site = SiteDto(
+                site = site.copy(
                     name = BusinessPartnerNonVerboseValues.siteUpdate1.site.name,
                     states = listOf(BusinessPartnerNonVerboseValues.siteStatus1),
                     mainAddress = BusinessPartnerNonVerboseValues.logisticAddress3.copy(
@@ -308,7 +311,7 @@ class SiteControllerIT @Autowired constructor(
         val toUpdate2 = with(BusinessPartnerNonVerboseValues.siteUpdate2) {
             copy(
                 bpns = bpnList[1],
-                site = SiteDto(
+                site = site.copy(
                     name = BusinessPartnerNonVerboseValues.siteUpdate1.site.name,
                     states = listOf(BusinessPartnerNonVerboseValues.siteStatus1),
                     mainAddress = BusinessPartnerNonVerboseValues.logisticAddress2.copy(

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1059,7 +1059,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         return LegalEntityDto(
             bpnLReference = bpnLReference,
             legalName = "legalName_" + bpnLReference.referenceValue,
-            legalAddress = minLogisticAddress(bpnAReference = bpnAReference)
+            legalAddress = minLogisticAddress(bpnAReference = bpnAReference),
+            confidenceCriteria = fullConfidenceCriteria()
         )
     }
 
@@ -1082,7 +1083,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 classificationDto(bpnLReference.referenceValue, 1L, ClassificationType.NACE),
                 classificationDto(bpnLReference.referenceValue, 2L, ClassificationType.NAICS)
             ),
-            legalAddress = fullLogisticAddressDto(bpnAReference)
+            legalAddress = fullLogisticAddressDto(bpnAReference),
+            confidenceCriteria = fullConfidenceCriteria()
         )
     }
 
@@ -1144,7 +1146,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         return LogisticAddressDto(
             bpnAReference = bpnAReference,
-            physicalPostalAddress = minPhysicalPostalAddressDto(bpnAReference)
+            physicalPostalAddress = minPhysicalPostalAddressDto(bpnAReference),
+            confidenceCriteria = fullConfidenceCriteria()
         )
     }
 
@@ -1200,7 +1203,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 deliveryServiceType = DeliveryServiceType.PO_BOX,
                 deliveryServiceQualifier = "deliveryServiceQualifier_" + bpnAReference.referenceValue,
                 deliveryServiceNumber = "deliveryServiceNumber_" + bpnAReference.referenceValue,
-            )
+            ),
+            confidenceCriteria = fullConfidenceCriteria()
         )
     }
 
@@ -1209,7 +1213,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         return SiteDto(
             bpnSReference = bpnSReference,
             name = "siteName_" + bpnSReference.referenceValue,
-            mainAddress = minLogisticAddress(bpnAReference = bpnAReference)
+            mainAddress = minLogisticAddress(bpnAReference = bpnAReference),
+            confidenceCriteria = fullConfidenceCriteria()
         )
     }
 
@@ -1221,9 +1226,20 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             states = listOf(
                 siteState(bpnSReference.referenceValue, 1L, BusinessStateType.ACTIVE), siteState(bpnSReference.referenceValue, 2L, BusinessStateType.INACTIVE)
             ),
-            mainAddress = fullLogisticAddressDto(bpnAReference)
+            mainAddress = fullLogisticAddressDto(bpnAReference),
+            confidenceCriteria = fullConfidenceCriteria()
         )
     }
+
+    fun fullConfidenceCriteria() =
+        ConfidenceCriteria(
+            sharedByOwner = true,
+            numberOfBusinessPartners = 1,
+            checkedByExternalDataSource = true,
+            lastConfidenceCheckAt = LocalDateTime.now(),
+            nextConfidenceCheckAt = LocalDateTime.now().plusDays(1),
+            confidenceLevel = 10
+        )
 
     fun assertTaskError(step: TaskStepResultEntryDto, taskId: String, error: CleaningError) {
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerNonVerboseValues.kt
@@ -208,23 +208,30 @@ object BusinessPartnerNonVerboseValues {
         street = BusinessPartnerVerboseValues.address3.street,
     )
 
-    private val logisticAddress1 = LogisticAddressDto(
-        physicalPostalAddress = postalAddress1
+    val logisticAddress1 = LogisticAddressDto(
+        physicalPostalAddress = postalAddress1,
+        confidenceCriteria = BusinessPartnerVerboseValues.addressPartner1.confidenceCriteria
     )
 
     val logisticAddress2 = LogisticAddressDto(
         physicalPostalAddress = postalAddress2,
+        confidenceCriteria = BusinessPartnerVerboseValues.addressPartner2.confidenceCriteria
     )
 
     val logisticAddress3 = LogisticAddressDto(
         physicalPostalAddress = postalAddress3,
+        confidenceCriteria = BusinessPartnerVerboseValues.addressPartner3.confidenceCriteria
     )
-    private val logisticAddress4 = LogisticAddressDto(
-        physicalPostalAddress = postalAddress1, name = BusinessPartnerVerboseValues.legalEntityUpsert1.legalEntity.legalName
+    val logisticAddress4 = LogisticAddressDto(
+        physicalPostalAddress = postalAddress1,
+        name = BusinessPartnerVerboseValues.legalEntityUpsert1.legalEntity.legalName,
+        confidenceCriteria = BusinessPartnerVerboseValues.addressPartner1.confidenceCriteria
     )
 
     val logisticAddress5 = LogisticAddressDto(
-        physicalPostalAddress = postalAddress1, identifiers = listOf(addressIdentifier)
+        physicalPostalAddress = postalAddress1,
+        identifiers = listOf(addressIdentifier),
+        confidenceCriteria = BusinessPartnerVerboseValues.addressPartner1.confidenceCriteria
     )
 
     val legalEntityCreate1 = LegalEntityPartnerCreateRequest(
@@ -235,6 +242,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier1),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria
         ),
         legalAddress = logisticAddress1,
         index = BusinessPartnerVerboseValues.legalEntityUpsert1.index
@@ -248,6 +256,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier2),
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity2.legalEntity.confidenceCriteria
         ),
         legalAddress = logisticAddress2,
         index = BusinessPartnerVerboseValues.legalEntityUpsert2.index
@@ -261,6 +270,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier3),
             states = listOf(leStatus3),
             classifications = listOf(classification5),
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity3.legalEntity.confidenceCriteria
         ),
         legalAddress = logisticAddress3,
         index = BusinessPartnerVerboseValues.legalEntityUpsert3.index
@@ -274,6 +284,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier1, identifier2),
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria
         ),
         legalAddress = logisticAddress1,
         index = BusinessPartnerVerboseValues.legalEntityUpsertMultipleIdentifier.index
@@ -308,7 +319,8 @@ object BusinessPartnerNonVerboseValues {
         site = SiteDto(
             name = BusinessPartnerVerboseValues.siteUpsert1.site.name,
             states = listOf(siteStatus1),
-            mainAddress = logisticAddress1
+            mainAddress = logisticAddress1,
+            confidenceCriteria = BusinessPartnerVerboseValues.site1.confidenceCriteria
         ),
         index = BusinessPartnerVerboseValues.siteUpsert1.index,
         bpnlParent = legalEntityUpdate1.bpnl
@@ -318,7 +330,8 @@ object BusinessPartnerNonVerboseValues {
         site = SiteDto(
             name = BusinessPartnerVerboseValues.siteUpsert2.site.name,
             states = listOf(siteStatus2),
-            mainAddress = logisticAddress2
+            mainAddress = logisticAddress2,
+            confidenceCriteria = BusinessPartnerVerboseValues.site2.confidenceCriteria
         ),
         index = BusinessPartnerVerboseValues.siteUpsert2.index,
         bpnlParent = legalEntityUpdate2.bpnl
@@ -328,7 +341,8 @@ object BusinessPartnerNonVerboseValues {
         site = SiteDto(
             name = BusinessPartnerVerboseValues.siteUpsert3.site.name,
             states = listOf(siteStatus3),
-            mainAddress = logisticAddress3
+            mainAddress = logisticAddress3,
+            confidenceCriteria = BusinessPartnerVerboseValues.site3.confidenceCriteria
         ),
         index = BusinessPartnerVerboseValues.siteUpsert3.index,
         bpnlParent = legalEntityUpdate3.bpnl

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
@@ -97,6 +97,33 @@ object BusinessPartnerVerboseValues {
     val classification4 = LegalEntityClassificationVerboseDto("Financial and insurance activities", null, classificationType)
     val classification5 = LegalEntityClassificationVerboseDto("Accounting, bookkeeping and auditing activities; tax consultancy", null, classificationType)
 
+    private val confidenceCriteria1 = ConfidenceCriteriaDto(
+        sharedByOwner = true,
+        checkedByExternalDataSource = true,
+        numberOfBusinessPartners = 1,
+        lastConfidenceCheckAt = LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+        nextConfidenceCheckAt = LocalDateTime.of(2024, 10, 10, 10, 10, 10),
+        confidenceLevel = 10
+    )
+
+    private val confidenceCriteria2 = ConfidenceCriteriaDto(
+        sharedByOwner = false,
+        checkedByExternalDataSource = false,
+        numberOfBusinessPartners = 3,
+        lastConfidenceCheckAt = LocalDateTime.of(2022, 10, 10, 10, 10, 10),
+        nextConfidenceCheckAt = LocalDateTime.of(2025, 10, 10, 10, 10, 10),
+        confidenceLevel = 6
+    )
+
+    private val confidenceCriteria3 = ConfidenceCriteriaDto(
+        sharedByOwner = true,
+        checkedByExternalDataSource = false,
+        numberOfBusinessPartners = 10,
+        lastConfidenceCheckAt = LocalDateTime.of(2021, 10, 10, 10, 10, 10),
+        nextConfidenceCheckAt = LocalDateTime.of(2026, 10, 10, 10, 10, 10),
+        confidenceLevel = 3
+    )
+
     val address1 = PhysicalPostalAddressVerboseDto(
         geographicCoordinates = null,
         countryVerbose = country1,
@@ -153,6 +180,7 @@ object BusinessPartnerVerboseValues {
         physicalPostalAddress = address1,
         bpnLegalEntity = null,
         bpnSite = null,
+        confidenceCriteria = confidenceCriteria1,
         createdAt = Instant.now(),
         updatedAt = Instant.now()
     )
@@ -162,6 +190,7 @@ object BusinessPartnerVerboseValues {
         physicalPostalAddress = address2,
         bpnLegalEntity = null,
         bpnSite = null,
+        confidenceCriteria = confidenceCriteria2,
         createdAt = Instant.now(),
         updatedAt = Instant.now()
     )
@@ -171,6 +200,7 @@ object BusinessPartnerVerboseValues {
         physicalPostalAddress = address3,
         bpnLegalEntity = null,
         bpnSite = null,
+        confidenceCriteria = confidenceCriteria3,
         createdAt = Instant.now(),
         updatedAt = Instant.now()
     )
@@ -195,6 +225,7 @@ object BusinessPartnerVerboseValues {
         name = "Stammwerk A",
         states = listOf(siteStatus1),
         bpnLegalEntity = "BPNL000000000001",
+        confidenceCriteria = confidenceCriteria1,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -204,6 +235,7 @@ object BusinessPartnerVerboseValues {
         name = "Halle B1",
         states = listOf(siteStatus2),
         bpnLegalEntity = "BPNL0000000001YN",
+        confidenceCriteria = confidenceCriteria2,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -213,6 +245,7 @@ object BusinessPartnerVerboseValues {
         name = "主厂房 C",
         states = listOf(siteStatus3),
         bpnLegalEntity = "BPNL0000000002XY",
+        confidenceCriteria = confidenceCriteria3,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -254,6 +287,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
+            confidenceCriteria = confidenceCriteria1,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -277,6 +311,7 @@ object BusinessPartnerVerboseValues {
             ),
             bpnLegalEntity = null,
             bpnSite = null,
+            confidenceCriteria = confidenceCriteria1,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -291,6 +326,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
+            confidenceCriteria = confidenceCriteria2,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -314,6 +350,7 @@ object BusinessPartnerVerboseValues {
             ),
             bpnLegalEntity = null,
             bpnSite = null,
+            confidenceCriteria = confidenceCriteria2,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -328,6 +365,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus3),
             classifications = listOf(classification5),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
+            confidenceCriteria = confidenceCriteria3,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -351,6 +389,7 @@ object BusinessPartnerVerboseValues {
             ),
             bpnLegalEntity = null,
             bpnSite = null,
+            confidenceCriteria = confidenceCriteria3,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -365,6 +404,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
+            confidenceCriteria = confidenceCriteria1,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -384,6 +424,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus2),
             classifications = listOf(classification3, classification4),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
+            confidenceCriteria = confidenceCriteria2,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -403,6 +444,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus3),
             classifications = listOf(classification5),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
+            confidenceCriteria = confidenceCriteria3,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -425,6 +467,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             classifications = listOf(classification1, classification2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
+            confidenceCriteria = confidenceCriteria1,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),


### PR DESCRIPTION
## Description

This pull request adds confidence criteria fields to the L/S/A business partner model.

- added confidence criteria on all LSA business partner API dtos
- added persistence for the confidence criteria in the Pool
- changed test and test values accordingly

Contributes to #670

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
