### PR TITLE
Feat: Add confidence criteria to generic business partner model

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.orchestrator.api.model.*
 import java.time.LocalDateTime
 
 
-val dummyConfidenceCriteria = ConfidenceCriteria(
+val dummyConfidenceCriteria = ConfidenceCriteriaDto(
     sharedByOwner = false,
     numberOfBusinessPartners = 1,
     checkedByExternalDataSource = false,

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -106,7 +106,8 @@ object CommonValues {
         legalEntity = LegalEntityRepresentation(
             shortName = shortName,
             legalForm = legalForm,
-            classifications = classifications
+            classifications = classifications,
+            confidenceCriteria = dummyConfidenceCriteria
         ),
         site = SiteRepresentation(name = siteName),
         address = AddressRepresentation(name = addressName)

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseBusinessPartnerDto.kt
@@ -37,13 +37,13 @@ interface IBaseBusinessPartnerDto {
     val roles: Collection<BusinessPartnerRole>
 
     @get:Schema(description = "The legal entity, on which the business partner provides a view.")
-    val legalEntity: IBaseLegalEntityRepresentation
+    val legalEntity: IBaseLegalEntityRepresentation?
 
     @get:Schema(description = "The site, on which the business partner provides a view.")
-    val site: IBaseSiteRepresentation
+    val site: IBaseSiteRepresentation?
 
     @get:Schema(description = "The address, on which the business partner provides a view. ")
-    val address: IBaseAddressRepresentation
+    val address: IBaseAddressRepresentation?
 }
 
 @Schema(description = "A legal entity representation adds context information to the legal entity, on which the business partner provides a view. Additionally, it contains some of the information from the assigned legal entity.")

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseSiteDto.kt
@@ -32,5 +32,5 @@ interface IBaseSiteDto {
     @get:ArraySchema(arraySchema = Schema(description = SiteDescription.states))
     val states: Collection<ISiteStateDto>
 
-    val confidenceCriteria: IConfidenceCriteriaDto
+    val confidenceCriteria: IConfidenceCriteriaDto?
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/BusinessPartnerOutputDto.kt
@@ -38,7 +38,7 @@ data class BusinessPartnerOutputDto(
     override val roles: Collection<BusinessPartnerRole> = emptyList(),
     override val isOwnCompanyData: Boolean = false,
     override val legalEntity: LegalEntityRepresentationOutputDto,
-    override val site: SiteRepresentationOutputDto = SiteRepresentationOutputDto(),
+    override val site: SiteRepresentationOutputDto?,
     override val address: AddressComponentOutputDto,
 
     @get:Schema(description = CommonDescription.createdAt)
@@ -58,15 +58,17 @@ data class LegalEntityRepresentationOutputDto(
     override val legalName: String? = null,
     override val shortName: String? = null,
     override val legalForm: String? = null,
-    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList()
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
+    val confidenceCriteria: ConfidenceCriteriaDto
 ) : IBaseLegalEntityRepresentation
 
 @Schema(
     description = "Site properties of business partner output data"
 )
 data class SiteRepresentationOutputDto(
-    override val siteBpn: String? = null,
-    override val name: String? = null
+    override val siteBpn: String,
+    override val name: String? = null,
+    val confidenceCriteria: ConfidenceCriteriaDto
 ) : IBaseSiteRepresentation
 
 @Schema(
@@ -79,4 +81,5 @@ data class AddressComponentOutputDto(
     override val addressType: AddressType?,
     override val physicalPostalAddress: PhysicalPostalAddressDto = PhysicalPostalAddressDto(),
     override val alternativePostalAddress: AlternativePostalAddressDto = AlternativePostalAddressDto(),
+    val confidenceCriteria: ConfidenceCriteriaDto
 ) : IBaseAddressRepresentation

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartner.kt
@@ -96,7 +96,19 @@ class BusinessPartner(
 
     @Column(name = "parent_type")
     @Enumerated(EnumType.STRING)
-    var parentType: BusinessPartnerType? = null
+    var parentType: BusinessPartnerType? = null,
+
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "legal_entity_confidence_id", unique = true)
+    var legalEntityConfidence: ConfidenceCriteria?,
+
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "site_confidence_id", unique = true)
+    var siteConfidence: ConfidenceCriteria?,
+
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "address_confidence_id", unique = true)
+    var addressConfidence: ConfidenceCriteria?,
 
 ) : BaseEntity()
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/ConfidenceCriteria.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/ConfidenceCriteria.kt
@@ -17,16 +17,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.gate.entity.generic
 
-import org.eclipse.tractusx.bpdm.common.dto.IConfidenceCriteriaDto
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import java.time.LocalDateTime
 
-data class ConfidenceCriteria(
-    override val sharedByOwner: Boolean? = null,
-    override val checkedByExternalDataSource: Boolean? = null,
-    override val numberOfBusinessPartners: Int? = null,
-    override val lastConfidenceCheckAt: LocalDateTime? = null,
-    override val nextConfidenceCheckAt: LocalDateTime? = null,
-    override val confidenceLevel: Int? = null
-) : IConfidenceCriteriaDto
+
+@Entity
+@Table(name = "confidence_criteria")
+class ConfidenceCriteria(
+    @Column(name = "shared_by_owner", nullable = false)
+    val sharedByOwner: Boolean,
+    @Column(name = "checked_by_external_data_source", nullable = false)
+    val checkedByExternalDataSource: Boolean,
+    @Column(name = "number_of_business_partners", nullable = false)
+    val numberOfBusinessPartners: Int,
+    @Column(name = "last_confidence_check_at", nullable = false)
+    val lastConfidenceCheckAt: LocalDateTime,
+    @Column(name = "next_confidence_check_at", nullable = false)
+    val nextConfidenceCheckAt: LocalDateTime,
+    @Column(name = "confidence_level", nullable = false)
+    val confidenceLevel: Int,
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -55,12 +55,14 @@ class OrchestratorMappings(
         legalName = entity.legalName,
         shortName = entity.shortName,
         legalForm = entity.legalForm,
-        classifications = entity.classifications.map { toClassificationDto(it) }
+        classifications = entity.classifications.map { toClassificationDto(it) },
+        confidenceCriteria = entity.legalEntityConfidence?.let { toConfidenceCriteria(it) }
     )
 
     private fun toSiteComponentDto(entity: BusinessPartner) = SiteRepresentation(
         siteBpn = entity.bpnS,
-        name = entity.siteName
+        name = entity.siteName,
+        confidenceCriteria = entity.siteConfidence?.let { toConfidenceCriteria(it) }
     )
 
     private fun toAddressComponentDto(entity: BusinessPartner) = AddressRepresentation(
@@ -68,7 +70,8 @@ class OrchestratorMappings(
         name = entity.addressName,
         addressType = entity.postalAddress.addressType,
         physicalPostalAddress = entity.postalAddress.physicalPostalAddress?.let(::toPhysicalPostalAddressDto),
-        alternativePostalAddress = entity.postalAddress.alternativePostalAddress?.let(this::toAlternativePostalAddressDto)
+        alternativePostalAddress = entity.postalAddress.alternativePostalAddress?.let(this::toAlternativePostalAddressDto),
+        confidenceCriteria = entity.addressConfidence?.let { toConfidenceCriteria(it) }
     )
 
     private fun toClassificationDto(entity: Classification) =
@@ -139,6 +142,16 @@ class OrchestratorMappings(
         }
     }
 
+    private fun toConfidenceCriteria(entity: ConfidenceCriteria) =
+        ConfidenceCriteriaDto(
+            sharedByOwner = entity.sharedByOwner,
+            checkedByExternalDataSource = entity.checkedByExternalDataSource,
+            numberOfBusinessPartners = entity.numberOfBusinessPartners,
+            lastConfidenceCheckAt = entity.lastConfidenceCheckAt,
+            nextConfidenceCheckAt = entity.nextConfidenceCheckAt,
+            confidenceLevel = entity.confidenceLevel
+        )
+
     fun toSharingStateType(resultState: ResultState) = when (resultState) {
         ResultState.Pending -> SharingStateType.Pending
         ResultState.Success -> SharingStateType.Success
@@ -162,7 +175,10 @@ class OrchestratorMappings(
         bpnL = dto.legalEntity.legalEntityBpn,
         bpnS = dto.site.siteBpn,
         bpnA = dto.address.addressBpn,
-        stage = StageType.Output
+        stage = StageType.Output,
+        legalEntityConfidence = dto.legalEntity.confidenceCriteria?.let { toConfidenceCriteria(it) },
+        siteConfidence = dto.site.confidenceCriteria?.let { toConfidenceCriteria(it) },
+        addressConfidence = dto.address.confidenceCriteria?.let { toConfidenceCriteria(it) },
     )
 
     private fun toIdentifier(dto: BusinessPartnerIdentifierDto) =
@@ -229,4 +245,14 @@ class OrchestratorMappings(
 
     private fun toGeographicCoordinate(dto: GeoCoordinateDto) =
         GeographicCoordinate(latitude = dto.latitude, longitude = dto.longitude, altitude = dto.altitude)
+
+    private fun toConfidenceCriteria(dto: ConfidenceCriteriaDto) =
+        ConfidenceCriteria(
+            sharedByOwner = dto.sharedByOwner,
+            checkedByExternalDataSource = dto.checkedByExternalDataSource,
+            numberOfBusinessPartners = dto.numberOfBusinessPartners,
+            lastConfidenceCheckAt = dto.lastConfidenceCheckAt,
+            nextConfidenceCheckAt = dto.nextConfidenceCheckAt,
+            confidenceLevel = dto.confidenceLevel
+        )
 }

--- a/bpdm-gate/src/main/resources/db/migration/V5_0_0_2__create_confidence_criteria.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V5_0_0_2__create_confidence_criteria.sql
@@ -1,0 +1,28 @@
+CREATE TABLE confidence_criteria(
+    id BIGINT NOT NULL,
+    created_at TIMESTAMP WITH time zone NOT NULL,
+    updated_at TIMESTAMP WITH time zone NOT NULL,
+    uuid UUID NOT NULL,
+	shared_by_owner                  boolean     NOT NULL,
+    checked_by_external_data_source  boolean     NOT NULL,
+    number_of_business_partners      INT         NOT NULL,
+    last_confidence_check_at         TIMESTAMP   NOT NULL,
+    next_confidence_check_at         TIMESTAMP   NOT NULL,
+    confidence_level                 INT         NOT NULL,
+    CONSTRAINT pk_confidence_criteria PRIMARY KEY (id)
+);
+
+ALTER TABLE business_partners
+ADD COLUMN legal_entity_confidence_id   BIGINT,
+ADD COLUMN site_confidence_id   BIGINT,
+ADD COLUMN address_confidence_id   BIGINT;
+
+ALTER TABLE business_partners
+ADD CONSTRAINT fk_business_partners_confidence_l FOREIGN KEY (legal_entity_confidence_id) REFERENCES confidence_criteria (id),
+ADD CONSTRAINT fk_business_partners_confidence_s FOREIGN KEY (site_confidence_id) REFERENCES confidence_criteria (id),
+ADD CONSTRAINT fk_business_partners_confidence_a FOREIGN KEY (address_confidence_id) REFERENCES confidence_criteria (id);
+
+
+
+
+

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -479,7 +479,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
                     changelogType = ChangelogType.UPDATE
                 ),
                 ChangelogEntryVerboseDto(
-                    bpn = BusinessPartnerVerboseValues.bpOutputDtoCleaned.site.siteBpn!!,
+                    bpn = BusinessPartnerVerboseValues.bpOutputDtoCleaned.site!!.siteBpn!!,
                     businessPartnerType = BusinessPartnerType.SITE,
                     timestamp = Instant.now(),
                     changelogType = ChangelogType.UPDATE

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -172,7 +172,10 @@ internal class BusinessPartnerIT @Autowired constructor(
             classifications = sortedSetOf(createClassification()),
             stage = StageType.Input,
             parentId = null,
-            parentType = null
+            parentType = null,
+            legalEntityConfidence = null,
+            addressConfidence = null,
+            siteConfidence = null
         )
     }
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -79,11 +79,27 @@ object BusinessPartnerGenericValues {
                     code = "code-2-cleaned",
                     value = "value-2-cleaned"
                 ),
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
             )
         ),
         site = SiteRepresentation(
             siteBpn = "000000123BBB222",
-            name = "Site Name"
+            name = "Site Name",
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = false,
+                checkedByExternalDataSource = false,
+                numberOfBusinessPartners = 8,
+                lastConfidenceCheckAt = LocalDateTime.of(2023, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2024, 4, 3, 2, 1),
+                confidenceLevel = 2
+            )
         ),
         address = AddressRepresentation(
             addressBpn = "000000123CCC333",
@@ -124,6 +140,14 @@ object BusinessPartnerGenericValues {
                 deliveryServiceNumber = "delivery-service-number-cleaned",
                 deliveryServiceQualifier = "delivery-service-qualifier-cleaned",
                 deliveryServiceType = DeliveryServiceType.PO_BOX
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = false,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 4,
+                lastConfidenceCheckAt = LocalDateTime.of(2020, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2028, 4, 3, 2, 1),
+                confidenceLevel = 5
             )
         )
     )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -742,11 +742,27 @@ object BusinessPartnerVerboseValues {
                     code = "code-2-cleaned",
                     value = "value-2-cleaned"
                 ),
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
             )
         ),
         site = SiteRepresentationOutputDto(
             siteBpn = "000000123BBB222",
-            name = "Site Name"
+            name = "Site Name",
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = false,
+                checkedByExternalDataSource = false,
+                numberOfBusinessPartners = 8,
+                lastConfidenceCheckAt = LocalDateTime.of(2023, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2024, 4, 3, 2, 1),
+                confidenceLevel = 2
+            )
         ),
         address = AddressComponentOutputDto(
             addressBpn = "000000123CCC333",
@@ -787,6 +803,14 @@ object BusinessPartnerVerboseValues {
                 deliveryServiceNumber = "delivery-service-number-cleaned",
                 deliveryServiceQualifier = "delivery-service-qualifier-cleaned",
                 deliveryServiceType = DeliveryServiceType.PO_BOX
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = false,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 4,
+                lastConfidenceCheckAt = LocalDateTime.of(2020, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2028, 4, 3, 2, 1),
+                confidenceLevel = 5
             )
         ),
         isOwnCompanyData = false,

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerGenericDto.kt
@@ -43,12 +43,14 @@ data class LegalEntityRepresentation(
     override val legalName: String? = null,
     override val shortName: String? = null,
     override val legalForm: String? = null,
-    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList()
+    override val classifications: Collection<BusinessPartnerClassificationDto> = emptyList(),
+    val confidenceCriteria: ConfidenceCriteriaDto? = null
 ) : IBaseLegalEntityRepresentation
 
 data class SiteRepresentation(
     override val siteBpn: String? = null,
-    override val name: String? = null
+    override val name: String? = null,
+    val confidenceCriteria: ConfidenceCriteriaDto? = null
 ) : IBaseSiteRepresentation
 
 data class AddressRepresentation(
@@ -57,6 +59,7 @@ data class AddressRepresentation(
     override val addressType: AddressType? = null,
     override val physicalPostalAddress: PhysicalPostalAddressDto? = null,
     override val alternativePostalAddress: AlternativePostalAddressDto? = null,
+    val confidenceCriteria: ConfidenceCriteriaDto? = null
 ) : IBaseAddressRepresentation
 
 

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ConfidenceCriteriaDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ConfidenceCriteriaDto.kt
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.api.model
+package org.eclipse.tractusx.orchestrator.api.model
 
 import org.eclipse.tractusx.bpdm.common.dto.IConfidenceCriteriaDto
 import java.time.LocalDateTime
@@ -29,5 +29,4 @@ data class ConfidenceCriteriaDto(
     override val lastConfidenceCheckAt: LocalDateTime,
     override val nextConfidenceCheckAt: LocalDateTime,
     override val confidenceLevel: Int
-
 ) : IConfidenceCriteriaDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
@@ -46,6 +46,6 @@ data class LegalEntityDto(
 
     val legalAddress: LogisticAddressDto? = null,
 
-    override val confidenceCriteria: ConfidenceCriteria = ConfidenceCriteria()
+    override val confidenceCriteria: ConfidenceCriteriaDto? = null
 
 ) : IBaseLegalEntityDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddressDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LogisticAddressDto.kt
@@ -42,6 +42,6 @@ data class LogisticAddressDto(
 
     override val alternativePostalAddress: AlternativePostalAddressDto? = null,
 
-    override val confidenceCriteria: ConfidenceCriteria = ConfidenceCriteria()
+    override val confidenceCriteria: ConfidenceCriteriaDto? = null
 
 ) : IBaseLogisticAddressDto

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/SiteDto.kt
@@ -35,6 +35,6 @@ data class SiteDto(
 
     val mainAddress: LogisticAddressDto? = null,
 
-    override val confidenceCriteria: ConfidenceCriteria = ConfidenceCriteria()
+    override val confidenceCriteria: ConfidenceCriteriaDto? = null
 
 ) : IBaseSiteDto

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -82,11 +82,27 @@ object BusinessPartnerTestValues {
                     code = "code-2",
                     value = "value-2"
                 ),
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
             )
         ),
         site = SiteRepresentation(
             siteBpn = "BPNSTEST",
-            name = "site name"
+            name = "site name",
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
+            )
         ),
         address = AddressRepresentation(
             addressBpn = "BPNATEST",
@@ -127,6 +143,14 @@ object BusinessPartnerTestValues {
                 deliveryServiceNumber = "delivery-service-number",
                 deliveryServiceQualifier = "delivery-service-qualifier",
                 deliveryServiceType = DeliveryServiceType.PO_BOX
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
             )
         ),
         ownerBpnL = "BPNL_OWNER_TEST_1"
@@ -163,11 +187,27 @@ object BusinessPartnerTestValues {
                     code = "code-2",
                     value = "value-2"
                 )
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
             )
         ),
         site = SiteRepresentation(
             siteBpn = "BPNSTEST-2",
-            name = "site name 2"
+            name = "site name 2",
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
+            )
         ),
         address = AddressRepresentation(
             addressBpn = "BPNATEST-2",
@@ -208,6 +248,14 @@ object BusinessPartnerTestValues {
                 deliveryServiceNumber = "delivery-service-number-2",
                 deliveryServiceQualifier = "delivery-service-qualifier-2",
                 deliveryServiceType = DeliveryServiceType.BOITE_POSTALE
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = true,
+                numberOfBusinessPartners = 7,
+                lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
+                nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
+                confidenceLevel = 1
             )
         ),
         ownerBpnL = "BPNL_OWNER_TEST_2"
@@ -277,7 +325,7 @@ object BusinessPartnerTestValues {
             referenceValue = "BPNATEST-1"
         ),
         hasChanged = true,
-        confidenceCriteria = ConfidenceCriteria(
+        confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = true,
             checkedByExternalDataSource = true,
             numberOfBusinessPartners = 7,
@@ -342,7 +390,7 @@ object BusinessPartnerTestValues {
             referenceValue = "BPN_REQUEST_ID_TEST"
         ),
         hasChanged = true,
-        confidenceCriteria = ConfidenceCriteria(
+        confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
             numberOfBusinessPartners = 2,
@@ -398,7 +446,7 @@ object BusinessPartnerTestValues {
             referenceType = BpnReferenceType.Bpn
         ),
         hasChanged = false,
-        confidenceCriteria = ConfidenceCriteria(
+        confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
             numberOfBusinessPartners = 2,
@@ -439,7 +487,7 @@ object BusinessPartnerTestValues {
             referenceType = BpnReferenceType.BpnRequestIdentifier
         ),
         hasChanged = false,
-        confidenceCriteria = ConfidenceCriteria(
+        confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
             numberOfBusinessPartners = 2,
@@ -469,7 +517,7 @@ object BusinessPartnerTestValues {
             referenceType = BpnReferenceType.Bpn
         ),
         hasChanged = false,
-        confidenceCriteria = ConfidenceCriteria(
+        confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
             numberOfBusinessPartners = 2,
@@ -494,7 +542,7 @@ object BusinessPartnerTestValues {
             referenceType = BpnReferenceType.BpnRequestIdentifier
         ),
         hasChanged = true,
-        confidenceCriteria = ConfidenceCriteria(
+        confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
             numberOfBusinessPartners = 2,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -472,7 +472,7 @@ class BusinessPartnerBuildService(
             site.states.clear()
             site.states.addAll(siteDto.states.map { toSiteState(it, site) })
 
-            site.confidenceCriteria = createConfidenceCriteria(siteDto.confidenceCriteria)
+            site.confidenceCriteria = createConfidenceCriteria(siteDto.confidenceCriteria!!)
         }
 
         fun createSite(
@@ -483,7 +483,7 @@ class BusinessPartnerBuildService(
 
             val name = siteDto.name ?: throw BpdmValidationException(TaskStepBuildService.CleaningError.SITE_NAME_IS_NULL.message)
 
-            val site = Site(bpn = bpnS, name = name, legalEntity = partner, confidenceCriteria = createConfidenceCriteria(siteDto.confidenceCriteria))
+            val site = Site(bpn = bpnS, name = name, legalEntity = partner, confidenceCriteria = createConfidenceCriteria(siteDto.confidenceCriteria!!))
 
             site.states.addAll(siteDto.states
                 .map { toSiteState(it, site) })

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -194,7 +194,7 @@ class TaskStepBuildService(
                 )
             },
             name = dto.name,
-            confidenceCriteria = BusinessPartnerBuildService.createConfidenceCriteria(dto.confidenceCriteria)
+            confidenceCriteria = BusinessPartnerBuildService.createConfidenceCriteria(dto.confidenceCriteria!!)
         )
         updateAddressIdentifiersAndStates(address, dto, addressMetadataMap.idTypes)
 
@@ -211,7 +211,7 @@ class TaskStepBuildService(
         address.name = dto.name
         address.physicalPostalAddress = BusinessPartnerBuildService.createPhysicalAddress(dto.physicalPostalAddress!!, metadataMap.regions)
         address.alternativePostalAddress = dto.alternativePostalAddress?.let { BusinessPartnerBuildService.createAlternativeAddress(it, metadataMap.regions) }
-        address.confidenceCriteria = BusinessPartnerBuildService.createConfidenceCriteria(dto.confidenceCriteria)
+        address.confidenceCriteria = BusinessPartnerBuildService.createConfidenceCriteria(dto.confidenceCriteria!!)
 
         updateAddressIdentifiersAndStates(address, dto, metadataMap.idTypes)
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -27,6 +27,7 @@ import org.eclipse.tractusx.orchestrator.api.model.AddressStateDto
 import org.eclipse.tractusx.orchestrator.api.model.AlternativePostalAddressDto
 import org.eclipse.tractusx.orchestrator.api.model.BpnReferenceType.Bpn
 import org.eclipse.tractusx.orchestrator.api.model.BpnReferenceType.BpnRequestIdentifier
+import org.eclipse.tractusx.orchestrator.api.model.ConfidenceCriteriaDto
 import org.eclipse.tractusx.orchestrator.api.model.LegalEntityClassificationDto
 import org.eclipse.tractusx.orchestrator.api.model.LegalEntityDto
 import org.eclipse.tractusx.orchestrator.api.model.LegalEntityIdentifierDto
@@ -1232,7 +1233,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     }
 
     fun fullConfidenceCriteria() =
-        ConfidenceCriteria(
+        ConfidenceCriteriaDto(
             sharedByOwner = true,
             numberOfBusinessPartners = 1,
             checkedByExternalDataSource = true,


### PR DESCRIPTION
## Description


This pull request adds confidence criteria fields to the generic business partner model.

- add confidence criteria fields to generic API DTOs
- added persistence for the confidence criteria in the Gate
- changed test and test values accordingly
- made adjustments to the common base DTO interfaces for better integration

Solves #670 after #692 has been merged

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
