### PR TITLE
Feat: add house number supplement

### DIFF
--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -72,7 +72,7 @@ object CommonValues {
         postalCode = "PostalCode",
         city = "City",
         district = "District",
-        street = StreetDto("StreetName"),
+        street = StreetDto("StreetName", houseNumberSupplement = "House Number Supplement"),
         companyPostalCode = "CompanyPostalCode",
         industrialZone = "IndustrialZone",
         building = "Building",

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseStreetDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseStreetDto.kt
@@ -30,6 +30,8 @@ interface IBaseStreetDto {
     @get:Schema(description = StreetDescription.houseNumber)
     val houseNumber: String?
 
+    val houseNumberSupplement: String?
+
     @get:Schema(description = StreetDescription.milestone)
     val milestone: String?
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/StreetDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/StreetDto.kt
@@ -32,7 +32,8 @@ data class StreetDto(
     override val nameSuffix: String? = null,
     override val additionalNameSuffix: String? = null,
     override val houseNumber: String? = null,
+    override val houseNumberSupplement: String? = null,
     override val milestone: String? = null,
-    override val direction: String? = null
+    override val direction: String? = null,
 
 ) : IStreetDetailedDto

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/PhysicalPostalAddress.kt
@@ -74,6 +74,7 @@ data class PhysicalPostalAddress(
     @Embedded
     @AttributeOverride(name = "name", column = Column(name = "phy_street_name"))
     @AttributeOverride(name = "houseNumber", column = Column(name = "phy_street_number"))
+    @AttributeOverride(name = "houseNumberSupplement", column = Column(name = "phy_street_number_supplement"))
     @AttributeOverride(name = "milestone", column = Column(name = "phy_street_milestone"))
     @AttributeOverride(name = "direction", column = Column(name = "phy_street_direction"))
     @AttributeOverride(name = "namePrefix", column = Column(name = "phy_name_prefix"))

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Street.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/Street.kt
@@ -30,6 +30,9 @@ data class Street(
     @Column
     val houseNumber: String? = null,
 
+    @Column
+    val houseNumberSupplement: String? = null,
+
     /**
      * The Milestone is relevant for long roads without specific house numbers.
      */

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -249,6 +249,7 @@ class BusinessPartnerMappings {
         StreetDto(
             name = entity.name,
             houseNumber = entity.houseNumber,
+            houseNumberSupplement = entity.houseNumberSupplement,
             milestone = entity.milestone,
             direction = entity.direction,
             namePrefix = entity.namePrefix,
@@ -262,6 +263,7 @@ class BusinessPartnerMappings {
         Street(
             name = dto.name,
             houseNumber = dto.houseNumber,
+            houseNumberSupplement = dto.houseNumberSupplement,
             milestone = dto.milestone,
             direction = dto.direction,
             namePrefix = dto.namePrefix,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -118,6 +118,7 @@ class OrchestratorMappings(
         StreetDto(
             name = entity.name,
             houseNumber = entity.houseNumber,
+            houseNumberSupplement = entity.houseNumberSupplement,
             milestone = entity.milestone,
             direction = entity.direction,
             namePrefix = entity.namePrefix,
@@ -235,6 +236,7 @@ class OrchestratorMappings(
         Street(
             name = dto.name,
             houseNumber = dto.houseNumber,
+            houseNumberSupplement = dto.houseNumberSupplement,
             milestone = dto.milestone,
             direction = dto.direction,
             namePrefix = dto.namePrefix,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -117,6 +117,7 @@ private fun StreetDto.toStreetEntity(): Street {
     return Street(
         name = name,
         houseNumber = houseNumber,
+        houseNumberSupplement = houseNumberSupplement,
         milestone = milestone,
         direction = direction,
         namePrefix = namePrefix,
@@ -343,6 +344,7 @@ private fun Street.toStreetDto(): StreetDto {
     return StreetDto(
         name = name,
         houseNumber = houseNumber,
+        houseNumberSupplement = houseNumberSupplement,
         milestone = milestone,
         direction = direction,
         namePrefix = namePrefix,

--- a/bpdm-gate/src/main/resources/db/migration/V5_0_0_3__add_house_number_supplement.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V5_0_0_3__add_house_number_supplement.sql
@@ -1,0 +1,5 @@
+ALTER TABLE logistic_addresses
+ADD COLUMN phy_street_number_supplement VARCHAR(255);
+
+ALTER TABLE postal_addresses
+ADD COLUMN phy_street_number_supplement VARCHAR(255);

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -203,6 +203,7 @@ internal class BusinessPartnerIT @Autowired constructor(
             district = "district9",
             street = Street(
                 name = "unknown street",
+                houseNumberSupplement = "house-number-supplement",
                 namePrefix = "Un",
                 nameSuffix = "know",
                 additionalNamePrefix = "empty"

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -117,6 +117,7 @@ object BusinessPartnerGenericValues {
                 street = StreetDto(
                     name = "name",
                     houseNumber = "house-number",
+                    houseNumberSupplement = "house-number-supplement",
                     milestone = "milestone",
                     direction = "direction",
                     namePrefix = "name-prefix",

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerVerboseValues.kt
@@ -248,7 +248,7 @@ object BusinessPartnerVerboseValues {
         building = "Bauteil A",
         floor = "Etage 1",
         door = "Door One",
-        street = StreetDto(name = "Mercedesstraße", houseNumber = "", direction = "direction1"),
+        street = StreetDto(name = "Mercedesstraße", houseNumber = "", direction = "direction1", houseNumberSupplement = "A"),
     )
 
     val postalAddress2 = PhysicalPostalAddressDto(
@@ -265,7 +265,7 @@ object BusinessPartnerVerboseValues {
         building = "Building Two",
         floor = "Floor Two",
         door = "Door Two",
-        street = StreetDto(name = "TODO", houseNumber = "", direction = "direction1"),
+        street = StreetDto(name = "TODO", houseNumber = "", direction = "direction1", houseNumberSupplement = "B"),
     )
 
     val postalAddress3 = PhysicalPostalAddressDto(
@@ -282,7 +282,7 @@ object BusinessPartnerVerboseValues {
         building = "Bauteil A",
         floor = "Etage 1",
         door = "Door One",
-        street = StreetDto(name = "Mercedesstraße", houseNumber = "", direction = "direction1"),
+        street = StreetDto(name = "Mercedesstraße", houseNumber = "", direction = "direction1", houseNumberSupplement = "C"),
     )
 
     val bpPostalAddressInputDtoFull = BusinessPartnerPostalAddressDto(
@@ -346,7 +346,7 @@ object BusinessPartnerVerboseValues {
         building = "Bauteil A",
         floor = "Etage 1",
         door = "Door One",
-        street = StreetDto(name = "Mercedesstraße", houseNumber = "", direction = "direction1"),
+        street = StreetDto(name = "Mercedesstraße", houseNumber = "", direction = "direction1", houseNumberSupplement = "A"),
     )
 
     val postalAddressLogisticAddress2 = PhysicalPostalAddressDto(
@@ -363,7 +363,7 @@ object BusinessPartnerVerboseValues {
         building = "Building Two",
         floor = "Floor Two",
         door = "Door Two",
-        street = StreetDto(name = "TODO", houseNumber = "", direction = "direction1"),
+        street = StreetDto(name = "TODO", houseNumber = "", direction = "direction1", houseNumberSupplement = "B"),
     )
 
     //New Values for Logistic Address Tests
@@ -780,6 +780,7 @@ object BusinessPartnerVerboseValues {
                 street = StreetDto(
                     name = "name",
                     houseNumber = "house-number",
+                    houseNumberSupplement = "house-number-supplement",
                     milestone = "milestone",
                     direction = "direction",
                     namePrefix = "name-prefix",

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/StreetDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/StreetDto.kt
@@ -24,11 +24,12 @@ import org.eclipse.tractusx.bpdm.common.dto.IStreetDetailedDto
 data class StreetDto(
     override val name: String? = null,
     override val houseNumber: String? = null,
+    override val houseNumberSupplement: String? = null,
     override val milestone: String? = null,
     override val direction: String? = null,
     override val namePrefix: String? = null,
     override val additionalNamePrefix: String? = null,
     override val nameSuffix: String? = null,
-    override val additionalNameSuffix: String? = null
+    override val additionalNameSuffix: String? = null,
 
 ) : IStreetDetailedDto

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/testdata/BusinessPartnerTestValues.kt
@@ -120,6 +120,7 @@ object BusinessPartnerTestValues {
                 street = StreetDto(
                     name = "name",
                     houseNumber = "house-number",
+                    houseNumberSupplement = "house-number-supplement",
                     milestone = "milestone",
                     direction = "direction",
                     namePrefix = "name-prefix",
@@ -225,6 +226,7 @@ object BusinessPartnerTestValues {
                 street = StreetDto(
                     name = "name-2",
                     houseNumber = "house-number-2",
+                    houseNumberSupplement = "house-number-supplement-2",
                     milestone = "milestone-2",
                     direction = "direction-2",
                     namePrefix = "name-prefix-2",
@@ -297,6 +299,7 @@ object BusinessPartnerTestValues {
             street = StreetDto(
                 name = "Street Name 1",
                 houseNumber = "House Number 1",
+                houseNumberSupplement = "house-number-supplement-1",
                 milestone = "Milestone 1",
                 direction = "Direction 1",
                 namePrefix = "Name Prefix 1",
@@ -362,6 +365,7 @@ object BusinessPartnerTestValues {
             street = StreetDto(
                 name = "Street Name 2",
                 houseNumber = "House Number 2",
+                houseNumberSupplement = "house-number-supplement-2",
                 milestone = "Milestone 2",
                 direction = "Direction 2",
                 namePrefix = "Name Prefix 2",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/StreetDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/StreetDto.kt
@@ -28,7 +28,8 @@ data class StreetDto(
 
     override val name: String? = null,
     override val houseNumber: String? = null,
+    override val houseNumberSupplement: String? = null,
     override val milestone: String? = null,
-    override val direction: String? = null
+    override val direction: String? = null,
 
 ) : IBaseStreetDto

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/PhysicalPostalAddress.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/PhysicalPostalAddress.kt
@@ -86,6 +86,7 @@ class PhysicalPostalAddress(
     @Embedded
     @AttributeOverride(name = "name", column = Column(name = "phy_street_name"))
     @AttributeOverride(name = "houseNumber", column = Column(name = "phy_street_number"))
+    @AttributeOverride(name = "houseNumberSupplement", column = Column(name = "phy_street_number_supplement"))
     @AttributeOverride(name = "milestone", column = Column(name = "phy_street_milestone"))
     @AttributeOverride(name = "direction", column = Column(name = "phy_street_direction"))
     val street: Street? = null,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/Street.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/Street.kt
@@ -30,6 +30,9 @@ class Street(
     @Column
     val houseNumber: String? = null,
 
+    @Column
+    val houseNumberSupplement: String? = null,
+
     /**
      * The Milestone is relevant for long roads without specific house numbers.
      */

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -557,6 +557,7 @@ class BusinessPartnerBuildService(
                     Street(
                         name = it.name,
                         houseNumber = it.houseNumber,
+                        houseNumberSupplement = it.houseNumberSupplement,
                         milestone = it.milestone,
                         direction = it.direction
                     )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -180,6 +180,7 @@ private fun Street.toDto(): StreetDto {
     return StreetDto(
         name = name,
         houseNumber = houseNumber,
+        houseNumberSupplement = houseNumberSupplement,
         milestone = milestone,
         direction = direction
     )

--- a/bpdm-pool/src/main/resources/db/migration/V5_0_0_2__add_house_number_supplement.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V5_0_0_2__add_house_number_supplement.sql
@@ -1,0 +1,2 @@
+ALTER TABLE logistic_addresses
+ADD COLUMN phy_street_number_supplement VARCHAR(255);

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1181,6 +1181,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 street = StreetDto(
                     name = "name_" + bpnAReference.referenceValue,
                     houseNumber = "houseNumber_" + bpnAReference.referenceValue,
+                    houseNumberSupplement = "houseNumberSupplement_" + bpnAReference.referenceValue,
                     milestone = "milestone_" + bpnAReference.referenceValue,
                     direction = "direction_" + bpnAReference.referenceValue,
                     namePrefix = "namePrefix_" + bpnAReference.referenceValue,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/BusinessPartnerVerboseValues.kt
@@ -138,7 +138,7 @@ object BusinessPartnerVerboseValues {
         building = "Gebäude eins",
         floor = "Stockerk eins",
         door = "Raum eins",
-        street = StreetDto("Bela-Barenyi-Straße", ""),
+        street = StreetDto("Bela-Barenyi-Straße", houseNumber = "", houseNumberSupplement = "A"),
     )
 
     val address2 = PhysicalPostalAddressVerboseDto(
@@ -155,7 +155,7 @@ object BusinessPartnerVerboseValues {
         building = "Building Two",
         floor = "Floor Two",
         door = "Door Two",
-        street = StreetDto("", ""),
+        street = StreetDto(name = "", houseNumber = "", houseNumberSupplement = "B"),
     )
 
     val address3 = PhysicalPostalAddressVerboseDto(
@@ -172,7 +172,7 @@ object BusinessPartnerVerboseValues {
         building = "tedifício  três",
         floor = "piso três",
         door = "peça três",
-        street = StreetDto("", ""),
+        street = StreetDto(name = "", houseNumber = "", houseNumberSupplement = "C"),
     )
 
     val addressPartner1 = LogisticAddressVerboseDto(


### PR DESCRIPTION
## Description

This pull requests adds a new field to the business partner street: house number supplement. The field is added to both the LSA and generic business partner models.

- added field to API model
- added new field and column to persistence
- adjusted mappings accordingly
- adjusted tests accordingly

Solves #679. Requires pull request #690 to be merged first.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
