### PR TITLE
fix(Confidence): add default confidence criteria

### DIFF
--- a/bpdm-gate/src/main/resources/db/migration/V5_0_0_4__create_temp_confidence_criteria.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V5_0_0_4__create_temp_confidence_criteria.sql
@@ -1,0 +1,30 @@
+WITH mapping AS (
+    SELECT bp.id as business_partner_id, nextVal('bpdm_sequence') as confidence_id
+    FROM business_partners bp
+    WHERE bp.stage = 'Output' AND bp.legal_entity_confidence_id IS NULL
+),
+confidence AS (
+     INSERT INTO confidence_criteria (id, created_at, updated_at, uuid, shared_by_owner, checked_by_external_data_source, number_of_business_partners, last_confidence_check_at, next_confidence_check_at, confidence_level)
+     SELECT mapping.confidence_id, NOW(), NOW(), gen_random_uuid(), FALSE, FALSE, 1, NOW()::timestamp, NOW()::timestamp, 0
+     FROM mapping
+)
+UPDATE business_partners bp
+SET    legal_entity_confidence_id = mapping.confidence_id
+FROM   mapping
+WHERE  bp.id = mapping.business_partner_id;
+
+
+WITH mapping AS (
+    SELECT bp.id as business_partner_id, nextVal('bpdm_sequence') as confidence_id
+    FROM business_partners bp
+    WHERE bp.stage = 'Output' AND bp.address_confidence_id IS NULL
+),
+confidence AS (
+     INSERT INTO confidence_criteria (id, created_at, updated_at, uuid, shared_by_owner, checked_by_external_data_source, number_of_business_partners, last_confidence_check_at, next_confidence_check_at, confidence_level)
+     SELECT mapping.confidence_id, NOW(), NOW(), gen_random_uuid(), FALSE, FALSE, 1, NOW()::timestamp, NOW()::timestamp, 0
+     FROM mapping
+)
+UPDATE business_partners bp
+SET    address_confidence_id = mapping.confidence_id
+FROM   mapping
+WHERE  bp.id = mapping.business_partner_id;

--- a/bpdm-pool/src/main/resources/db/migration/V5_0_0_1__add_confidence_criteria.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V5_0_0_1__add_confidence_criteria.sql
@@ -1,24 +1,24 @@
 ALTER TABLE legal_entities
-ADD COLUMN shared_by_owner                  boolean     NOT NULL,
-ADD COLUMN checked_by_external_data_source  boolean     NOT NULL,
-ADD COLUMN number_of_business_partners      INT         NOT NULL,
-ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL,
-ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL,
-ADD COLUMN confidence_level                 INT         NOT NULL;
+ADD COLUMN shared_by_owner                  boolean     NOT NULL DEFAULT FALSE,
+ADD COLUMN checked_by_external_data_source  boolean     NOT NULL DEFAULT FALSE,
+ADD COLUMN number_of_business_partners      INT         NOT NULL DEFAULT 1,
+ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL DEFAULT NOW()::timestamp,
+ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL DEFAULT NOW()::timestamp,
+ADD COLUMN confidence_level                 INT         NOT NULL DEFAULT 0;
 
 ALTER TABLE sites
-ADD COLUMN shared_by_owner                  boolean     NOT NULL,
-ADD COLUMN checked_by_external_data_source  boolean     NOT NULL,
-ADD COLUMN number_of_business_partners      INT         NOT NULL,
-ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL,
-ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL,
-ADD COLUMN confidence_level                 INT         NOT NULL;
+ADD COLUMN shared_by_owner                  boolean     NOT NULL DEFAULT FALSE,
+ADD COLUMN checked_by_external_data_source  boolean     NOT NULL DEFAULT FALSE,
+ADD COLUMN number_of_business_partners      INT         NOT NULL DEFAULT 1,
+ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL DEFAULT NOW()::timestamp,
+ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL DEFAULT NOW()::timestamp,
+ADD COLUMN confidence_level                 INT         NOT NULL DEFAULT 0;
 
 ALTER TABLE logistic_addresses
-ADD COLUMN shared_by_owner                  boolean     NOT NULL,
-ADD COLUMN checked_by_external_data_source  boolean     NOT NULL,
-ADD COLUMN number_of_business_partners      INT         NOT NULL,
-ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL,
-ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL,
-ADD COLUMN confidence_level                 INT     NOT NULL;
+ADD COLUMN shared_by_owner                  boolean     NOT NULL DEFAULT FALSE,
+ADD COLUMN checked_by_external_data_source  boolean     NOT NULL DEFAULT FALSE,
+ADD COLUMN number_of_business_partners      INT         NOT NULL DEFAULT 1,
+ADD COLUMN last_confidence_check_at         TIMESTAMP   NOT NULL DEFAULT NOW()::timestamp,
+ADD COLUMN next_confidence_check_at         TIMESTAMP   NOT NULL DEFAULT NOW()::timestamp,
+ADD COLUMN confidence_level                 INT         NOT NULL DEFAULT 0;
 


### PR DESCRIPTION
## Description


This pull request adds default confidence criteria to existing business partners where needed. This solves a bug when trying to add confidence criteria to databases with existing business partners.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
