### PR TITLE
feat(Gate): add stats endpoint for counting address types per stage

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/StatsApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/StatsApi.kt
@@ -22,10 +22,13 @@ package org.eclipse.tractusx.bpdm.gate.api
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.eclipse.tractusx.bpdm.common.model.StageType
+import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsAddressTypesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsSharingStatesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsStagesResponse
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
@@ -54,6 +57,14 @@ interface StatsApi {
     @GetExchange("/stages")
     fun countPartnersPerStage(): StatsStagesResponse
 
-
+    @Operation
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200")
+        ]
+    )
+    @GetMapping("/{stage}/address-types")
+    @GetExchange("/{stage}/address-types")
+    fun countAddressTypes(@PathVariable("stage") stage: StageType): StatsAddressTypesResponse
 
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/StatsAddressTypesResponse.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/StatsAddressTypesResponse.kt
@@ -17,24 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.gate.repository.generic
+package org.eclipse.tractusx.bpdm.gate.api.model.response
 
-import org.eclipse.tractusx.bpdm.common.dto.AddressType
-import org.eclipse.tractusx.bpdm.common.model.StageType
-import org.eclipse.tractusx.bpdm.gate.entity.generic.PostalAddress
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.stereotype.Repository
-
-@Repository
-interface PostalAddressRepository : JpaRepository<PostalAddress, Long> {
-
-    @Query("SELECT a.addressType as type, COUNT(a.addressType) as count FROM BusinessPartner b JOIN b.postalAddress AS a WHERE b.stage = :stage GROUP BY a.addressType")
-    fun countAddressTypes(stage: StageType): List<AddressTypeCount>
-
-
-    interface AddressTypeCount {
-        val type: AddressType?
-        val count: Int
-    }
-}
+data class StatsAddressTypesResponse(
+    val legalAndSiteTotal: Int,
+    val legalTotal: Int,
+    val siteTotal: Int,
+    val additionalTotal: Int
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/StatsController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/StatsController.kt
@@ -19,7 +19,9 @@
 
 package org.eclipse.tractusx.bpdm.gate.controller
 
+import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.StatsApi
+import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsAddressTypesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsSharingStatesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsStagesResponse
 import org.eclipse.tractusx.bpdm.gate.service.StatsService
@@ -35,5 +37,9 @@ class StatsController(
 
     override fun countPartnersPerStage(): StatsStagesResponse {
         return statsService.countBusinessPartnersPerStage()
+    }
+
+    override fun countAddressTypes(stage: StageType): StatsAddressTypesResponse {
+        return statsService.countAddressTypes(stage)
     }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/StatsService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/StatsService.kt
@@ -19,18 +19,22 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
+import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsAddressTypesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsSharingStatesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsStagesResponse
 import org.eclipse.tractusx.bpdm.gate.repository.SharingStateRepository
 import org.eclipse.tractusx.bpdm.gate.repository.generic.BusinessPartnerRepository
+import org.eclipse.tractusx.bpdm.gate.repository.generic.PostalAddressRepository
 import org.springframework.stereotype.Service
 
 @Service
 class StatsService(
     private val sharingStateRepository: SharingStateRepository,
-    private val businessPartnerRepository: BusinessPartnerRepository
+    private val businessPartnerRepository: BusinessPartnerRepository,
+    private val postalAddressRepository: PostalAddressRepository
 ) {
 
     fun countSharingStates(): StatsSharingStatesResponse {
@@ -54,7 +58,18 @@ class StatsService(
             inputTotal = countsByType[StageType.Input] ?: 0,
             outputTotal = countsByType[StageType.Output] ?: 0
         )
+    }
 
+    fun countAddressTypes(stage: StageType): StatsAddressTypesResponse {
+        val counts = postalAddressRepository.countAddressTypes(stage)
+        val countsByType = counts.associate { Pair(it.type, it.count) }
+
+        return StatsAddressTypesResponse(
+            legalAndSiteTotal = countsByType[AddressType.LegalAndSiteMainAddress] ?: 0,
+            legalTotal = countsByType[AddressType.LegalAddress] ?: 0,
+            siteTotal = countsByType[AddressType.SiteMainAddress] ?: 0,
+            additionalTotal = countsByType[AddressType.AdditionalAddress] ?: 0
+        )
     }
 
 


### PR DESCRIPTION
## Description

This pull request adds an endpoint to count address types of business partners per stage. The stage must be given as a path variable to the query.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
