### PR TITLE
feat(Gate): add endpoint for confidence criteria stats

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/StatsApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/StatsApi.kt
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsAddressTypesResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsConfidenceCriteriaResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsSharingStatesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsStagesResponse
 import org.springframework.http.MediaType
@@ -66,5 +67,16 @@ interface StatsApi {
     @GetMapping("/{stage}/address-types")
     @GetExchange("/{stage}/address-types")
     fun countAddressTypes(@PathVariable("stage") stage: StageType): StatsAddressTypesResponse
+
+    @Operation
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200")
+        ]
+    )
+    @GetMapping("/confidence-criteria")
+    @GetExchange("/confidence-criteria")
+    fun getConfidenceCriteriaStats(): StatsConfidenceCriteriaResponse
+
 
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/StatsConfidenceCriteriaResponse.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/StatsConfidenceCriteriaResponse.kt
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.api.model.response
+
+data class StatsConfidenceCriteriaResponse(
+    val numberOfBusinessPartnersAverage: Float,
+    val uniqueTotal: Long,
+    val sharedByOwnerTotal: Long,
+    val checkedByExternalDataSourceTotal: Long,
+    val confidenceLevelAverage: Float
+)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/StatsController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/StatsController.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdm.gate.controller
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.StatsApi
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsAddressTypesResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsConfidenceCriteriaResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsSharingStatesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsStagesResponse
 import org.eclipse.tractusx.bpdm.gate.service.StatsService
@@ -41,5 +42,9 @@ class StatsController(
 
     override fun countAddressTypes(stage: StageType): StatsAddressTypesResponse {
         return statsService.countAddressTypes(stage)
+    }
+
+    override fun getConfidenceCriteriaStats(): StatsConfidenceCriteriaResponse {
+        return statsService.getConfidenceCriteriaStats()
     }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/BusinessPartnerRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/BusinessPartnerRepository.kt
@@ -54,5 +54,4 @@ interface BusinessPartnerRepository : JpaRepository<BusinessPartner, Long>, Crud
         val stage: StageType
         val count: Int
     }
-
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/ConfidenceCriteriaRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/generic/ConfidenceCriteriaRepository.kt
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.repository.generic
+
+import org.eclipse.tractusx.bpdm.gate.entity.generic.ConfidenceCriteria
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.CrudRepository
+
+interface ConfidenceCriteriaRepository : JpaRepository<ConfidenceCriteria, Long>, CrudRepository<ConfidenceCriteria, Long> {
+
+    @Query("SELECT AVG(c.numberOfBusinessPartners) FROM ConfidenceCriteria AS c")
+    fun averageNumberOfBusinessPartners(): Float?
+
+    @Query("SELECT COUNT(c.numberOfBusinessPartners) FROM ConfidenceCriteria AS c WHERE c.numberOfBusinessPartners <= 1")
+    fun countUnique(): Long?
+
+    @Query("SELECT COUNT(c.sharedByOwner) FROM ConfidenceCriteria AS c")
+    fun countSharedByOwner(): Long?
+
+    @Query("SELECT COUNT(c.checkedByExternalDataSource) FROM ConfidenceCriteria AS c")
+    fun countCheckedByExternalDataSource(): Long?
+
+    @Query("SELECT AVG(c.confidenceLevel) FROM ConfidenceCriteria AS c")
+    fun averageConfidenceLevel(): Float?
+
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/StatsService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/StatsService.kt
@@ -23,18 +23,22 @@ import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsAddressTypesResponse
+import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsConfidenceCriteriaResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsSharingStatesResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.StatsStagesResponse
 import org.eclipse.tractusx.bpdm.gate.repository.SharingStateRepository
 import org.eclipse.tractusx.bpdm.gate.repository.generic.BusinessPartnerRepository
+import org.eclipse.tractusx.bpdm.gate.repository.generic.ConfidenceCriteriaRepository
 import org.eclipse.tractusx.bpdm.gate.repository.generic.PostalAddressRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class StatsService(
     private val sharingStateRepository: SharingStateRepository,
     private val businessPartnerRepository: BusinessPartnerRepository,
-    private val postalAddressRepository: PostalAddressRepository
+    private val postalAddressRepository: PostalAddressRepository,
+    private val confidenceCriteriaRepository: ConfidenceCriteriaRepository
 ) {
 
     fun countSharingStates(): StatsSharingStatesResponse {
@@ -69,6 +73,17 @@ class StatsService(
             legalTotal = countsByType[AddressType.LegalAddress] ?: 0,
             siteTotal = countsByType[AddressType.SiteMainAddress] ?: 0,
             additionalTotal = countsByType[AddressType.AdditionalAddress] ?: 0
+        )
+    }
+
+    @Transactional
+    fun getConfidenceCriteriaStats(): StatsConfidenceCriteriaResponse {
+        return StatsConfidenceCriteriaResponse(
+            numberOfBusinessPartnersAverage = confidenceCriteriaRepository.averageNumberOfBusinessPartners() ?: 0F,
+            uniqueTotal = confidenceCriteriaRepository.countUnique() ?: 0L,
+            sharedByOwnerTotal = confidenceCriteriaRepository.countSharedByOwner() ?: 0L,
+            checkedByExternalDataSourceTotal = confidenceCriteriaRepository.countCheckedByExternalDataSource() ?: 0L,
+            confidenceLevelAverage = confidenceCriteriaRepository.averageConfidenceLevel() ?: 0F
         )
     }
 


### PR DESCRIPTION
## Description

This pull request add an endpoint for the gate showing aggregation stats for confidence criteria:

* numberOfBusinessPartnersAverage: average number of how many sharing members have shared the same business partners
* unqiueTotal: number of business partners that are unique to the sharing members
* sharedByOwnerTotal: number of business partners that have been shared by the owning sharing member
* checkedByExternalDataSourceTotal: number of business partners that have been validated against an external data source
* confidenceLevelAverage : average confidence level among business partner records in the gate

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
