### PR TITLE
fix(Cleaning-Service-Dummy): missing confidence criteria

### DIFF
--- a/bpdm-gate/src/main/resources/db/migration/V5_0_0_5__create_site_confidence_criteria.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V5_0_0_5__create_site_confidence_criteria.sql
@@ -1,0 +1,14 @@
+WITH mapping AS (
+    SELECT bp.id as business_partner_id, nextVal('bpdm_sequence') as confidence_id
+    FROM business_partners bp INNER JOIN postal_addresses pa ON bp.postal_address_id = pa.id
+    WHERE bp.stage = 'Output' AND bp.site_confidence_id IS NULL AND (pa.address_type = 'SiteMainAddress' OR pa.address_type = 'LegalAndSiteMainAddress')
+),
+confidence AS (
+     INSERT INTO confidence_criteria (id, created_at, updated_at, uuid, shared_by_owner, checked_by_external_data_source, number_of_business_partners, last_confidence_check_at, next_confidence_check_at, confidence_level)
+     SELECT mapping.confidence_id, NOW(), NOW(), gen_random_uuid(), FALSE, FALSE, 1, NOW()::timestamp, NOW()::timestamp, 0
+     FROM mapping
+)
+UPDATE business_partners bp
+SET    site_confidence_id = mapping.confidence_id
+FROM   mapping
+WHERE  bp.id = mapping.business_partner_id;


### PR DESCRIPTION
## Description

This pull request fixes the missing confidence criteria in the generic business partner. Basically the cleaning service now additionally to LSA also adds the confidence criteria to the generic business partner. This way when Gate requests the business partner data from the Orchestrator it will also find the confidence criteria there.

On the same note I also made the cleaning service add the correct address type to the generic business partner. So now it should never be null, even if it was not provided by the sharing member.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
