### PR TITLE
fix(Gate): maximum length of sharing process error

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
@@ -112,7 +112,7 @@ class GoldenRecordTaskService(
             SharingStateService.ErrorRequest(
                 SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
                 BusinessPartnerSharingError.SharingProcessError,
-                if (task.processingState.errors.isNotEmpty()) task.processingState.errors.joinToString(" // ") { it.description }.take(256) else null
+                if (task.processingState.errors.isNotEmpty()) task.processingState.errors.joinToString(" // ") { it.description }.take(255) else null
             )
         } ?: emptyList()).toMutableList()
 


### PR DESCRIPTION
## Description

This pull request sets the maximum length of the Gate's sharing process error message to exactly the columns size definition in order to avoid errors on persisting the sharing status.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
