### PR TITLE
feat(Charts): increase appversion to 5.0.0-alpha.2

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 4.0.0-alpha.1
-appVersion: "5.0.0-alpha.1"
+version: 4.0.0-alpha.2
+appVersion: "5.0.0-alpha.2"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 5.0.0-alpha.1
+    version: 5.0.0-alpha.2
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 6.0.0-alpha.1
+    version: 6.0.0-alpha.2
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 2.0.0-alpha.1
+    version: 2.0.0-alpha.2
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 2.0.0-alpha.1
+    version: 2.0.0-alpha.2
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 2.0.0-alpha.1
+    version: 2.0.0-alpha.2
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: postgresql

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
-appVersion: "5.0.0-alpha.1"
-version: 2.0.0-alpha.1
+appVersion: "5.0.0-alpha.2"
+version: 2.0.0-alpha.2
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "5.0.0-alpha.1"
-version: 2.0.0-alpha.1
+appVersion: "5.0.0-alpha.2"
+version: 2.0.0-alpha.2
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "5.0.0-alpha.1"
-version: 5.0.0-alpha.1
+appVersion: "5.0.0-alpha.2"
+version: 5.0.0-alpha.2
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "5.0.0-alpha.1"
-version: 2.0.0-alpha.1
+appVersion: "5.0.0-alpha.2"
+version: 2.0.0-alpha.2
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "5.0.0-alpha.1"
-version: 6.0.0-alpha.1
+appVersion: "5.0.0-alpha.2"
+version: 6.0.0-alpha.2
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:


### PR DESCRIPTION
## Description

This pull request increases the appversion of the BPDM Charts to 5.0.0-alpha.2

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
