### PR TITLE
Fix trivy findings on spring boot image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [4.1.1] - [unreleased]
+
+### Fixed
+
+- BPDM Modules: Update Spring version to 3.1.7 to fix vulnerabilities 
+
+
 ## [4.1.0] - 2023-11-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [4.1.1] - [unreleased]
+## [5.0.0] - [unreleased]
 
 ### Fixed
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
-maven/mavencentral/ch.qos.logback/logback-classic/1.4.11, EPL-1.0 OR LGPL-2.1-only, approved, #3435
-maven/mavencentral/ch.qos.logback/logback-core/1.4.11, EPL-1.0 OR LGPL-2.1-only, approved, #3373
+maven/mavencentral/ch.qos.logback/logback-classic/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3435
+maven/mavencentral/ch.qos.logback/logback-core/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
@@ -27,9 +27,9 @@ maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1,
 maven/mavencentral/com.zaxxer/HikariCP/5.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
 maven/mavencentral/io.github.microutils/kotlin-logging-jvm/2.1.23, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-commons/1.11.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
-maven/mavencentral/io.micrometer/micrometer-core/1.11.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
-maven/mavencentral/io.micrometer/micrometer-observation/1.11.5, Apache-2.0, approved, #9242
+maven/mavencentral/io.micrometer/micrometer-commons/1.11.7, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
+maven/mavencentral/io.micrometer/micrometer-core/1.11.7, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
+maven/mavencentral/io.micrometer/micrometer-observation/1.11.7, Apache-2.0, approved, #9242
 maven/mavencentral/io.mockk/mockk-agent-api/1.12.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-agent-common/1.12.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-agent-jvm/1.12.1, Apache-2.0, approved, clearlydefined
@@ -37,26 +37,26 @@ maven/mavencentral/io.mockk/mockk-common/1.12.1, Apache-2.0, approved, clearlyde
 maven/mavencentral/io.mockk/mockk-dsl-jvm/1.12.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-dsl/1.12.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk/1.12.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.netty/netty-buffer/4.1.100.Final, Apache-2.0, approved, CQ21842
-maven/mavencentral/io.netty/netty-codec-dns/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-socks/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-common/4.1.100.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-maven/mavencentral/io.netty/netty-handler-proxy/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.100.Final, Apache-2.0, approved, #6367
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.100.Final, Apache-2.0, approved, #7004
-maven/mavencentral/io.netty/netty-resolver-dns/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.100.Final, Apache-2.0, approved, #6366
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.12, Apache-2.0, approved, #5946
+maven/mavencentral/io.netty/netty-buffer/4.1.104.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-codec-dns/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-socks/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-common/4.1.104.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+maven/mavencentral/io.netty/netty-handler-proxy/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.104.Final, Apache-2.0, approved, #6367
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.104.Final, Apache-2.0, approved, #7004
+maven/mavencentral/io.netty/netty-resolver-dns/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.104.Final, Apache-2.0, approved, #6366
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.14, Apache-2.0, approved, #5946
 maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.13, Apache-2.0, approved, #6999
-maven/mavencentral/io.projectreactor/reactor-core/3.5.11, Apache-2.0, approved, #5934
+maven/mavencentral/io.projectreactor/reactor-core/3.5.13, Apache-2.0, approved, #5934
 maven/mavencentral/io.smallrye/jandex/3.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
@@ -69,8 +69,8 @@ maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.1, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.9, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.9, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.10, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.10, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.12.1, Apache-2.0 OR LGPL-2.1-or-later, approved, #3217
 maven/mavencentral/net.minidev/accessors-smart/2.4.11, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.11, Apache-2.0, approved, #3288
@@ -81,28 +81,28 @@ maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.20.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.20.0, Apache-2.0, approved, #8799
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.15, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.15, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.15, Apache-2.0, approved, #7920
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.17, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.17, Apache-2.0, approved, #6997
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.17, Apache-2.0, approved, #7920
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, EPL-1.0, approved, tools.aspectj
+maven/mavencentral/org.aspectj/aspectjweaver/1.9.21, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.checkerframework/checker-qual/3.31.0, MIT, approved, clearlydefined
 maven/mavencentral/org.eclipse.angus/angus-activation/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
-maven/mavencentral/org.eclipse.tractusx/bpdm-common/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/4.1.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-common/5.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/5.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/5.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/5.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/5.0.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/9.16.3, Apache-2.0, approved, #7935
-maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.3, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.3, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/org.glassfish.jaxb/txw2/4.0.3, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/txw2/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/org.hamcrest/hamcrest-core/2.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, BSD-2-Clause OR LicenseRef-Public-Domain, approved, CQ13192
 maven/mavencentral/org.hibernate.common/hibernate-commons-annotations/6.0.6.Final, LGPL-2.1-only, approved, #6962
-maven/mavencentral/org.hibernate.orm/hibernate-core/6.2.13.Final, LGPL-2.1-only AND Apache-2.0 AND MIT AND CC-PDDC AND (EPL-2.0 OR BSD-3-Clause), approved, #9121
+maven/mavencentral/org.hibernate.orm/hibernate-core/6.2.17.Final, LGPL-2.1-only AND Apache-2.0 AND MIT AND CC-PDDC AND (EPL-2.0 OR BSD-3-Clause), approved, #9121
 maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss.logging/jboss-logging/3.5.3.Final, Apache-2.0, approved, #9471
 maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect/1.7.21, Apache-2.0, approved, clearlydefined
@@ -131,54 +131,54 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.0, Apache-2.0, approved, #5920
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.0, Apache-2.0, approved, #5950
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.0, Apache-2.0, approved, #5923
-maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.1.5, Apache-2.0, approved, #9348
-maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.1.5, Apache-2.0, approved, #9342
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.5, Apache-2.0, approved, #9341
-maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.1.5, Apache-2.0, approved, #11406
-maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.1.5, Apache-2.0, approved, #9344
-maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.5, Apache-2.0, approved, #9338
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.1.5, Apache-2.0, approved, #9733
-maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.1.5, Apache-2.0, approved, #9737
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.5, Apache-2.0, approved, #9336
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.5, Apache-2.0, approved, #9343
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.1.5, Apache-2.0, approved, #8806
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.1.5, Apache-2.0, approved, #8804
-maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.1.5, Apache-2.0, approved, #9738
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.1.5, Apache-2.0, approved, #9337
-maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.1.5, Apache-2.0, approved, #9353
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.5, Apache-2.0, approved, #9351
-maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.1.5, Apache-2.0, approved, #9335
-maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.1.5, Apache-2.0, approved, #9347
-maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.1.5, Apache-2.0, approved, #9739
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.5, Apache-2.0, approved, #9349
-maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.1.5, Apache-2.0, approved, #9339
-maven/mavencentral/org.springframework.boot/spring-boot-test/3.1.5, Apache-2.0, approved, #9346
-maven/mavencentral/org.springframework.boot/spring-boot/3.1.5, Apache-2.0, approved, #9352
-maven/mavencentral/org.springframework.data/spring-data-commons/3.1.5, Apache-2.0, approved, #8805
-maven/mavencentral/org.springframework.data/spring-data-jpa/3.1.5, Apache-2.0, approved, #9120
-maven/mavencentral/org.springframework.security/spring-security-config/6.1.5, Apache-2.0, approved, #9736
-maven/mavencentral/org.springframework.security/spring-security-core/6.1.5, Apache-2.0, approved, #9801
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.5, Apache-2.0 AND ISC, approved, #9735
-maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.1.5, Apache-2.0, approved, #9740
-maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.5, Apache-2.0, approved, #9741
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.5, Apache-2.0, approved, #9345
-maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.1.5, Apache-2.0, approved, #8798
-maven/mavencentral/org.springframework.security/spring-security-test/6.1.5, Apache-2.0, approved, #10674
-maven/mavencentral/org.springframework.security/spring-security-web/6.1.5, Apache-2.0, approved, #9800
-maven/mavencentral/org.springframework/spring-aop/6.0.13, Apache-2.0, approved, #5940
-maven/mavencentral/org.springframework/spring-aspects/6.0.13, Apache-2.0, approved, #5930
-maven/mavencentral/org.springframework/spring-beans/6.0.13, Apache-2.0, approved, #5937
-maven/mavencentral/org.springframework/spring-context/6.0.13, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.13, Apache-2.0 AND BSD-3-Clause, approved, #5948
-maven/mavencentral/org.springframework/spring-expression/6.0.13, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-jcl/6.0.13, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-jdbc/6.0.13, Apache-2.0, approved, #5924
-maven/mavencentral/org.springframework/spring-orm/6.0.13, Apache-2.0, approved, #5925
-maven/mavencentral/org.springframework/spring-test/6.0.13, Apache-2.0, approved, #7003
-maven/mavencentral/org.springframework/spring-tx/6.0.13, Apache-2.0, approved, #5926
-maven/mavencentral/org.springframework/spring-web/6.0.13, Apache-2.0, approved, #5942
-maven/mavencentral/org.springframework/spring-webflux/6.0.13, Apache-2.0, approved, #6964
-maven/mavencentral/org.springframework/spring-webmvc/6.0.13, Apache-2.0, approved, #5944
+maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.1.7, Apache-2.0, approved, #9348
+maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.1.7, Apache-2.0, approved, #9342
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.7, Apache-2.0, approved, #9341
+maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.1.7, Apache-2.0, approved, #11406
+maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.1.7, Apache-2.0, approved, #9344
+maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.7, Apache-2.0, approved, #9338
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.1.7, Apache-2.0, approved, #9733
+maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.1.7, Apache-2.0, approved, #9737
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.7, Apache-2.0, approved, #9336
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.7, Apache-2.0, approved, #9343
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.1.7, Apache-2.0, approved, #8806
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.1.7, Apache-2.0, approved, #8804
+maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.1.7, Apache-2.0, approved, #9738
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.1.7, Apache-2.0, approved, #9337
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.1.7, Apache-2.0, approved, #9353
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.7, Apache-2.0, approved, #9351
+maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.1.7, Apache-2.0, approved, #9335
+maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.1.7, Apache-2.0, approved, #9347
+maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.1.7, Apache-2.0, approved, #9739
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.7, Apache-2.0, approved, #9349
+maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.1.7, Apache-2.0, approved, #9339
+maven/mavencentral/org.springframework.boot/spring-boot-test/3.1.7, Apache-2.0, approved, #9346
+maven/mavencentral/org.springframework.boot/spring-boot/3.1.7, Apache-2.0, approved, #9352
+maven/mavencentral/org.springframework.data/spring-data-commons/3.1.7, Apache-2.0, approved, #8805
+maven/mavencentral/org.springframework.data/spring-data-jpa/3.1.7, Apache-2.0, approved, #9120
+maven/mavencentral/org.springframework.security/spring-security-config/6.1.6, Apache-2.0, approved, #9736
+maven/mavencentral/org.springframework.security/spring-security-core/6.1.6, Apache-2.0, approved, #9801
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.6, Apache-2.0 AND ISC, approved, #9735
+maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.1.6, Apache-2.0, approved, #9740
+maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.6, Apache-2.0, approved, #9741
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.6, Apache-2.0, approved, #9345
+maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.1.6, Apache-2.0, approved, #8798
+maven/mavencentral/org.springframework.security/spring-security-test/6.1.6, Apache-2.0, approved, #10674
+maven/mavencentral/org.springframework.security/spring-security-web/6.1.6, Apache-2.0, approved, #9800
+maven/mavencentral/org.springframework/spring-aop/6.0.15, Apache-2.0, approved, #5940
+maven/mavencentral/org.springframework/spring-aspects/6.0.15, Apache-2.0, approved, #5930
+maven/mavencentral/org.springframework/spring-beans/6.0.15, Apache-2.0, approved, #5937
+maven/mavencentral/org.springframework/spring-context/6.0.15, Apache-2.0, approved, #5936
+maven/mavencentral/org.springframework/spring-core/6.0.15, Apache-2.0 AND BSD-3-Clause, approved, #5948
+maven/mavencentral/org.springframework/spring-expression/6.0.15, Apache-2.0, approved, #3284
+maven/mavencentral/org.springframework/spring-jcl/6.0.15, Apache-2.0, approved, #3283
+maven/mavencentral/org.springframework/spring-jdbc/6.0.15, Apache-2.0, approved, #5924
+maven/mavencentral/org.springframework/spring-orm/6.0.15, Apache-2.0, approved, #5925
+maven/mavencentral/org.springframework/spring-test/6.0.15, Apache-2.0, approved, #7003
+maven/mavencentral/org.springframework/spring-tx/6.0.15, Apache-2.0, approved, #5926
+maven/mavencentral/org.springframework/spring-web/6.0.15, Apache-2.0, approved, #5942
+maven/mavencentral/org.springframework/spring-webflux/6.0.15, Apache-2.0, approved, #6964
+maven/mavencentral/org.springframework/spring-webmvc/6.0.15, Apache-2.0, approved, #5944
 maven/mavencentral/org.testcontainers/database-commons/1.18.3, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/jdbc/1.18.3, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/junit-jupiter/1.18.3, MIT, approved, #7941

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.7</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
## Description
Fix Spring vulnerability's reported by Trivy Scan

https://github.com/eclipse-tractusx/bpdm/issues/706

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
