### PR TITLE
fix(Gate-Api): name of POST endpoint to set sharing state to ready

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
@@ -68,8 +68,8 @@ interface GateSharingStateApi {
             ApiResponse(responseCode = "404", description = "Business partners can't be put into ready state (e.g. external-ID not found, wrong sharing state)")
         ]
     )
-    @PostMapping
-    @PostExchange
+    @PostMapping("/ready")
+    @PostExchange("/ready")
     fun postSharingStateReady(@RequestBody request: PostSharingStateReadyRequest)
 
 


### PR DESCRIPTION
## Description

This pull request fixes the POST endpoint to set a given number of business partners into sharing state ready. The endpoint now correctly is named sharing-states/ready instead of just sharing-states. 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
