### PR TITLE
fix(Pool): orchestrator client config properties binding

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/OrchestratorClientConfigProperties.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/OrchestratorClientConfigProperties.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.config
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 
-@ConfigurationProperties(prefix = "bpdm.pool-orchestrator")
+@ConfigurationProperties(prefix = "bpdm.client.pool-orchestrator")
 data class OrchestratorClientConfigProperties(
     val baseUrl: String = "http://localhost:8085/"
 )


### PR DESCRIPTION
## Description

This pull request fixes the path of the orchestrator client base-url configuration property. The properties file specifies correctly bpdm.client.orchestrator-pool but the config properties bind to bpdm.orchestrator-pool. I adapted the binding to the correct path.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
