### PR TITLE
Fix: Pool Changelog Timestamp After Filter Also Including Equal

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/PartnerChangelogEntryRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/PartnerChangelogEntryRepository.kt
@@ -49,7 +49,7 @@ interface PartnerChangelogEntryRepository : JpaRepository<PartnerChangelogEntry,
         fun byUpdatedGreaterThan(modifiedAfter: Instant?) =
             Specification<PartnerChangelogEntry> { root, _, builder ->
                 modifiedAfter?.let {
-                    builder.greaterThanOrEqualTo(root.get(PartnerChangelogEntry::updatedAt.name), modifiedAfter)
+                    builder.greaterThan(root.get(PartnerChangelogEntry::updatedAt.name), modifiedAfter)
                 }
             }
 


### PR DESCRIPTION


## Description

This pull request fixes the timestampAfter filter for changelog entries of the Pool. Instead of returning changelogs with a timestamp greater and equals the filter now correctly only returns timestamps greater than the specified one.

Fixes #721 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
