### PR TITLE
feat(Gate): add BPN claim check for extracting grants from a JWT

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/CustomJwtAuthenticationConverter.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/CustomJwtAuthenticationConverter.kt
@@ -52,7 +52,7 @@ import java.util.stream.Collectors
  * }
  *
  */
-class CustomJwtAuthenticationConverter(private val resourceId: String) : Converter<Jwt, AbstractAuthenticationToken> {
+class CustomJwtAuthenticationConverter(private val resourceId: String, private val requiredBpn: String? = null) : Converter<Jwt, AbstractAuthenticationToken> {
     private val defaultGrantedAuthoritiesConverter = JwtGrantedAuthoritiesConverter()
 
     override fun convert(source: Jwt): AbstractAuthenticationToken {
@@ -63,7 +63,11 @@ class CustomJwtAuthenticationConverter(private val resourceId: String) : Convert
 
     @Suppress("UNCHECKED_CAST")
     companion object {
-        private fun extractResourceRoles(jwt: Jwt, resourceId: String): Collection<GrantedAuthority> {
+        private fun extractResourceRoles(jwt: Jwt, resourceId: String, requiredBpn: String? = null): Collection<GrantedAuthority> {
+            if (requiredBpn != null && requiredBpn != jwt.claims["bpn"]) {
+                return emptyList()
+            }
+
             val resourceAccess = jwt.getClaim<Map<String, Any>>("resource_access")
             val resource: Map<String?, Any?>? = resourceAccess?.get(resourceId) as Map<String?, Any?>?
             val resourceRoles: Collection<String>? = resource?.get("roles") as Collection<String>?

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/BpdmSecurityConfigurerAdapterImpl.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/BpdmSecurityConfigurerAdapterImpl.kt
@@ -30,7 +30,8 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMa
 
 @Configuration
 class BpdmSecurityConfigurerAdapterImpl(
-    val securityConfigProperties: SecurityConfigProperties
+    val securityConfigProperties: SecurityConfigProperties,
+    val bpnConfigProperties: BpnConfigProperties
 ) : BpdmSecurityConfigurerAdapter {
 
     override fun configure(http: HttpSecurity) {
@@ -48,7 +49,7 @@ class BpdmSecurityConfigurerAdapterImpl(
         }
         http.oauth2ResourceServer {
             it.jwt { jwt ->
-                jwt.jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId))
+                jwt.jwtAuthenticationConverter(CustomJwtAuthenticationConverter(securityConfigProperties.clientId, bpnConfigProperties.ownerBpnL))
             }
         }
     }


### PR DESCRIPTION

## Description

This pull request enhances the JWT validation services to consider only grants if the JWT has a matching BPN claim.

The Gate makes use of that functionality by passing its own registired BPN. Other services like the Pool are not BPN specific and do not need to specify a BPN for token validation. If no BPN is specified grants are extracted without any BPN check.

Closes #723 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
