### PR TITLE
fix(Pool): changelog entry shown timestamp milliseconds

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -266,7 +266,7 @@ fun Relation.toDto(): RelationVerboseDto {
 }
 
 fun PartnerChangelogEntry.toDto(): ChangelogEntryVerboseDto {
-    return ChangelogEntryVerboseDto(bpn, businessPartnerType, createdAt, changelogType)
+    return ChangelogEntryVerboseDto(bpn, businessPartnerType, updatedAt, changelogType)
 }
 
 fun Region.toRegionDto(): RegionDto {


### PR DESCRIPTION
## Description


Currently the Pool's changelog entries show the DB created timestamp but for filtering purposes use the DB updated timestamp. I changed the mapping to use the updated timestamp instead.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
