### PR TITLE
fix(Cleaning Service): generic LSA names being null in cleaning result

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.cleaning.service
 
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.cleaning.util.md5
+import org.eclipse.tractusx.bpdm.cleaning.util.toUUID
 import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
 import org.eclipse.tractusx.orchestrator.api.model.*
@@ -119,7 +119,7 @@ class CleaningServiceDummy(
     }
 
     fun createAddressRepresentation(genericPartner: BusinessPartnerGenericDto): LogisticAddressDto {
-        val bpnReferenceDto = generateNewBpnRequestIdentifier(genericPartner.createAdditionalAddressReferenceValue())
+        val bpnReferenceDto = generateBpnRequestIdentifier(genericPartner.createAdditionalAddressReferenceValue())
         return genericPartner.toLogisticAddressDto(bpnReferenceDto)
     }
 
@@ -127,8 +127,6 @@ class CleaningServiceDummy(
         val bpnReferenceDto = generateBpnRequestIdentifier(genericPartner.createSiteReferenceValue())
         return genericPartner.toSiteDto(bpnReferenceDto, siteAddressReference)
     }
-
-    private fun generateNewBpnRequestIdentifier(fromString: String) = BpnReferenceDto(fromString.md5(), BpnReferenceType.BpnRequestIdentifier)
 
     fun shouldCreateSite(genericPartner: BusinessPartnerGenericDto): Boolean {
         return genericPartner.ownerBpnL != null && genericPartner.site.name != null
@@ -148,14 +146,14 @@ class CleaningServiceDummy(
         }
 
         return copy(
-            legalEntity = legalEntity.copy(confidenceCriteria = legalEntityDto.confidenceCriteria),
-            site = site.copy(confidenceCriteria = siteDto?.confidenceCriteria),
-            address = address.copy(addressType = addressType, confidenceCriteria = relevantAddress.confidenceCriteria)
+            legalEntity = legalEntity.copy(legalName = legalEntityDto.legalName, confidenceCriteria = legalEntityDto.confidenceCriteria),
+            site = site.copy(name = siteDto?.name, confidenceCriteria = siteDto?.confidenceCriteria),
+            address = address.copy(name = logisticAddress?.name, addressType = addressType, confidenceCriteria = relevantAddress.confidenceCriteria)
         )
     }
 
     private fun BusinessPartnerGenericDto.createLegalEntityReferenceValue() =
-        "LEGAL_ENTITY" + (legalEntity.legalName ?: nameParts.joinToString { " " })
+        "LEGAL_ENTITY" + (legalEntity.legalName ?: nameParts.joinToString(" "))
 
     private fun BusinessPartnerGenericDto.createLegalAddressReferenceValue() =
         "LEGAL_ADDRESS" + createLegalEntityReferenceValue()
@@ -172,7 +170,8 @@ class CleaningServiceDummy(
     private fun BusinessPartnerGenericDto.createAdditionalAddressReferenceValue() =
         "ADDITIONAL_ADDRESS" + createSiteReferenceValue()
 
-    private fun generateBpnRequestIdentifier(fromString: String) = BpnReferenceDto(fromString.md5(), BpnReferenceType.BpnRequestIdentifier)
+    private fun generateBpnRequestIdentifier(fromString: String) =
+        BpnReferenceDto(fromString.toUUID().toString(), BpnReferenceType.BpnRequestIdentifier)
 
 
 }

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/util/StringExtensions.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/util/StringExtensions.kt
@@ -19,12 +19,11 @@
 
 package org.eclipse.tractusx.bpdm.cleaning.util
 
-import java.math.BigInteger
-import java.security.MessageDigest
+import java.nio.charset.Charset
+import java.util.*
 
 
-fun String.md5(): String {
-    val md = MessageDigest.getInstance("MD5")
-    val digest = md.digest(this.toByteArray())
-    return BigInteger(1, digest).toString(16).padStart(32, '0')
+fun String.toUUID(): UUID {
+    val byteArray = this.toByteArray(Charset.forName("UTF-8"))
+    return UUID.nameUUIDFromBytes(byteArray)
 }


### PR DESCRIPTION
## Description

this pull request fixes a bug in which the legal, site and address name stays null in the cleaned generic business partner, when the BPDM cleaning service dummy performs a cleaning of a golden record task.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
