### PR TITLE
fix(Docker): increase the default user group ID to over 10000

### DIFF
--- a/bpdm-bridge-dummy/Dockerfile
+++ b/bpdm-bridge-dummy/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=build /home/app/bpdm-bridge-dummy/target/bpdm-bridge-dummy.jar /usr/
 RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
-ARG GID=3000
+ARG GID=10001
 RUN addgroup -g $GID -S $USERNAME
 RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME

--- a/bpdm-cleaning-service-dummy/Dockerfile
+++ b/bpdm-cleaning-service-dummy/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=build /home/app/bpdm-cleaning-service-dummy/target/bpdm-cleaning-ser
 RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
-ARG GID=3000
+ARG GID=10001
 RUN addgroup -g $GID -S $USERNAME
 RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME

--- a/bpdm-gate/Dockerfile
+++ b/bpdm-gate/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=build $HOME/bpdm-gate/target/bpdm-gate.jar /usr/local/lib/bpdm/app.j
 RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
-ARG GID=3000
+ARG GID=10001
 RUN addgroup -g $GID -S $USERNAME
 RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME

--- a/bpdm-orchestrator/Dockerfile
+++ b/bpdm-orchestrator/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=build /home/app/bpdm-orchestrator/target/bpdm-orchestrator.jar /usr/
 RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
-ARG GID=3000
+ARG GID=10001
 RUN addgroup -g $GID -S $USERNAME
 RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME

--- a/bpdm-pool/Dockerfile
+++ b/bpdm-pool/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=build $HOME/bpdm-pool/target/bpdm-pool.jar /usr/local/lib/bpdm/app.j
 RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 ARG USERNAME=bpdm
 ARG USERID=10001
-ARG GID=3000
+ARG GID=10001
 RUN addgroup -g $GID -S $USERNAME
 RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME


### PR DESCRIPTION

## Description

This pull request increases the used GIDs in the Dockerfiles to a value over 10000 in order to increase the security.


Contributes to solve #728

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
