### PR TITLE
Fix: Mount Chart container's root file systems as read-only

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - update application version to 5.0.0
+- update BPDM Pool Chart to version 6.0.0
+- update BPDM Gate Chart to version 5.0.0
+- update BPDM Orchestrator Chart to version 2.0.0
+- update BPDM Cleaning Service Dummy Chart to version 2.0.0
+- update BPDM Bridge Chart to version 2.0.0
 
 ## [3.1.2] - 2023-11-16
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 4.0.0-alpha.5
+version: 4.0.0-alpha.6
 appVersion: "5.0.0-alpha.5"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 5.0.0-alpha.5
+    version: 5.0.0-alpha.6
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 6.0.0-alpha.5
+    version: 6.0.0-alpha.6
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 2.0.0-alpha.5
+    version: 2.0.0-alpha.6
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 2.0.0-alpha.5
+    version: 2.0.0-alpha.6
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 2.0.0-alpha.5
+    version: 2.0.0-alpha.6
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: postgresql

--- a/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - update application version to 5.0.0
 - increase container's default groupid to 10001
+- container is now executed with read-only root file systems
 
 ## [1.1.0] - 2023-11-03
 

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
 appVersion: "5.0.0-alpha.5"
-version: 2.0.0-alpha.5
+version: 2.0.0-alpha.6
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             - mountPath: /etc/conf
               name: config
               readOnly: true
+            - mountPath: /tmp
+              name: cache
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -101,3 +103,6 @@ spec:
                   name: {{ include "bpdm.fullname" . }}
               - secret:
                   name: {{ include "bpdm.fullname" . }}
+        - name: cache
+          emptyDir:
+            sizeLimit: 200Mi

--- a/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
@@ -40,6 +40,7 @@ springProfiles: []
 securityContext:
   allowPrivilegeEscalation: false
   runAsNonRoot: true
+  readOnlyRootFilesystem: true
   runAsUser: 10001
   runAsGroup: 10001
   capabilities:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
+- container is now executed with read-only root file systems
 
 ## [1.0.2] - 2023-11-23
 

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
 appVersion: "5.0.0-alpha.5"
-version: 2.0.0-alpha.5
+version: 2.0.0-alpha.6
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
             - mountPath: /etc/conf
               name: config
               readOnly: true
+            - mountPath: /tmp
+              name: cache
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -96,3 +98,6 @@ spec:
                   name: {{ include "bpdm.fullname" . }}
               - secret:
                   name: {{ include "bpdm.fullname" . }}
+        - name: cache
+          emptyDir:
+            sizeLimit: 200Mi

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
@@ -42,6 +42,7 @@ securityContext:
     type: RuntimeDefault
   allowPrivilegeEscalation: false
   runAsNonRoot: true
+  readOnlyRootFilesystem: true
   runAsUser: 10001
   runAsGroup: 10001
   capabilities:

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
+- container is now executed with read-only root file systems
 
 ## [4.1.0] - 2023-11-03
 

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "5.0.0-alpha.5"
-version: 5.0.0-alpha.5
+version: 5.0.0-alpha.6
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             - mountPath: /etc/conf
               name: config
               readOnly: true
+            - mountPath: /tmp
+              name: cache
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -101,3 +103,6 @@ spec:
                   name: {{ include "bpdm.fullname" . }}
               - secret:
                   name: {{ include "bpdm.fullname" . }}
+        - name: cache
+          emptyDir:
+            sizeLimit: 200Mi

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -40,6 +40,7 @@ springProfiles: []
 securityContext:
   allowPrivilegeEscalation: false
   runAsNonRoot: true
+  readOnlyRootFilesystem: true
   runAsUser: 10001
   runAsGroup: 10001
   capabilities:

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
+- container is now executed with read-only root file systems
 
 ## [1.0.1] - 2023-11-23
 

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-orchestrator
 appVersion: "5.0.0-alpha.5"
-version: 2.0.0-alpha.5
+version: 2.0.0-alpha.6
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
             - mountPath: /etc/conf
               name: config
               readOnly: true
+            - mountPath: /tmp
+              name: cache
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -96,3 +98,6 @@ spec:
                   name: {{ include "bpdm.fullname" . }}
               - secret:
                   name: {{ include "bpdm.fullname" . }}
+        - name: cache
+          emptyDir:
+            sizeLimit: 200Mi

--- a/charts/bpdm/charts/bpdm-orchestrator/values.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/values.yaml
@@ -42,6 +42,7 @@ securityContext:
     type: RuntimeDefault
   allowPrivilegeEscalation: false
   runAsNonRoot: true
+  readOnlyRootFilesystem: true
   runAsUser: 10001
   runAsGroup: 10001
   capabilities:

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
+- container is now executed with read-only root file systems
 
 ## [5.1.1] - 2023-11-16
 

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "5.0.0-alpha.5"
-version: 6.0.0-alpha.5
+version: 6.0.0-alpha.6
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/deployment.yaml
@@ -80,6 +80,8 @@ spec:
             - mountPath: /etc/conf
               name: config
               readOnly: true
+            - mountPath: /tmp
+              name: cache
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -100,3 +102,6 @@ spec:
                   name: {{ include "bpdm.fullname" . }}
               - secret:
                   name: {{ include "bpdm.fullname" . }}
+        - name: cache
+          emptyDir:
+            sizeLimit: 200Mi

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -40,6 +40,7 @@ springProfiles: []
 securityContext:
   allowPrivilegeEscalation: false
   runAsNonRoot: true
+  readOnlyRootFilesystem: true
   runAsUser: 10001
   runAsGroup: 10001
   capabilities:


### PR DESCRIPTION
## Description

By default root file systems of the BPDM Chart container's are now mounted read-only for security reasons.

Solves #731

Can only be merged after #730 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
