### PR TITLE
fix(Gate): empty owner BPNL leading to forbidden errors

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/CustomJwtAuthenticationConverter.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/CustomJwtAuthenticationConverter.kt
@@ -52,7 +52,7 @@ import java.util.stream.Collectors
  * }
  *
  */
-class CustomJwtAuthenticationConverter(private val resourceId: String, private val requiredBpn: String? = null) : Converter<Jwt, AbstractAuthenticationToken> {
+class CustomJwtAuthenticationConverter(private val resourceId: String, private val requiredBpn: String = "") : Converter<Jwt, AbstractAuthenticationToken> {
     private val defaultGrantedAuthoritiesConverter = JwtGrantedAuthoritiesConverter()
 
     override fun convert(source: Jwt): AbstractAuthenticationToken {
@@ -63,8 +63,8 @@ class CustomJwtAuthenticationConverter(private val resourceId: String, private v
 
     @Suppress("UNCHECKED_CAST")
     companion object {
-        private fun extractResourceRoles(jwt: Jwt, resourceId: String, requiredBpn: String? = null): Collection<GrantedAuthority> {
-            if (requiredBpn != null && requiredBpn != jwt.claims["bpn"]) {
+        private fun extractResourceRoles(jwt: Jwt, resourceId: String, requiredBpn: String = ""): Collection<GrantedAuthority> {
+            if (requiredBpn.isNotBlank() && requiredBpn != jwt.claims["bpn"]) {
                 return emptyList()
             }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/BpnConfigProperties.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/BpnConfigProperties.kt
@@ -27,5 +27,5 @@ data class BpnConfigProperties(
     val agencyName: String = "Catena-X",
     var name: String = "Business Partner Number",
     val id: String = "CX_BPN",
-    val ownerBpnL: String? = null
+    val ownerBpnL: String = ""
 )

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -31,7 +31,8 @@ bpdm:
         agency-name: Catena-X
         id: CX_BPN
         name: Business Partner Number
-        owner-bpn-l: '# Insert owner BPNL here'
+        # Insert owner BPNL here
+        owner-bpn-l:
     api:
         upsert-limit: 100
 


### PR DESCRIPTION
## Description

When setting null to owner BPNL in Gate, no endpoint can't be accessed anymore as Forbidden is returned.

This pull request fixes empty owner BPNL leading to forbidden errors in Gate

- Made the owner BPNL now not nullable because of binding behaviour of Spring (https://github.com/spring-projects/spring-framework/issues/19986)
- Rather check whether BPNL is blank than null since property normally will not be bound as null anyway


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
