### PR TITLE
Fix(Pool): Property for Golden Record Task Processing

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/GoldenRecordTaskConfigProperties.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/GoldenRecordTaskConfigProperties.kt
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.config
+
+import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties.Companion.PREFIX
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(PREFIX)
+data class GoldenRecordTaskConfigProperties(
+    val cron: String = "-",
+    val batchSize: Int = 100
+) {
+    companion object {
+        const val PREFIX = "bpdm.tasks"
+        private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties"
+        private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
+
+        const val GET_CRON = "@$BEAN_QUALIFIER.getCron()"
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveService.kt
@@ -23,6 +23,7 @@ import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.RequestWithKey
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorCode
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
+import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties
 import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
 import org.eclipse.tractusx.bpdm.pool.repository.BpnRequestIdentifierRepository
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
@@ -35,15 +36,16 @@ class TaskStepFetchAndReserveService(
     private val orchestrationClient: OrchestrationApiClient,
     private val taskStepBuildService: TaskStepBuildService,
     private val requestValidationService: RequestValidationService,
-    private val bpnRequestIdentifierRepository: BpnRequestIdentifierRepository
+    private val bpnRequestIdentifierRepository: BpnRequestIdentifierRepository,
+    private val goldenRecordTaskConfigProperties: GoldenRecordTaskConfigProperties
 ) {
     private val logger = KotlinLogging.logger { }
 
-    @Scheduled(cron = "\${bpdm.client.pool-orchestrator.golden-record-scheduler-cron-expr:-}", zone = "UTC")
+    @Scheduled(cron = "#{${GoldenRecordTaskConfigProperties.GET_CRON}}", zone = "UTC")
     fun fetchAndReserve() {
         try {
             logger.info { "Starting polling for cleaning tasks from Orchestrator..." }
-            val reservationRequest = TaskStepReservationRequest(step = TaskStep.PoolSync, amount = 10)
+            val reservationRequest = TaskStepReservationRequest(step = TaskStep.PoolSync, amount = goldenRecordTaskConfigProperties.batchSize)
             val taskStepReservation = orchestrationClient.goldenRecordTasks.reserveTasksForStep(reservationRequest = reservationRequest)
 
             logger.info { "${taskStepReservation.reservedTasks.size} tasks found for cleaning. Proceeding with cleaning..." }

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -42,7 +42,11 @@ bpdm:
   client:
     orchestrator:
       base-url: http://localhost:8085/
-      golden-record-scheduler-cron-expr: '-'
+
+  # Golden Record Task Processing
+  tasks:
+    cron: '-'
+    batchSize: 100
 
   # Disable Security on default
   security:


### PR DESCRIPTION

## Description

Currently, the configuration property in Pool for scheduling the golden record task processing is not working. 

Fixed it by:
- moved the property to a more fitting prefix under 'tasks'
- use bound property in scheduler to reduce mismatch chance

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
