### PR TITLE
feat(Gate): Configuration for Automatic Ready State

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
@@ -65,7 +65,7 @@ interface GateSharingStateApi {
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "204", description = "All business partners put in ready to be shared state"),
-            ApiResponse(responseCode = "404", description = "Business partners can't be put into ready state (e.g. external-ID not found, wrong sharing state)")
+            ApiResponse(responseCode = "400", description = "Business partners can't be put into ready state (e.g. external-ID not found, wrong sharing state)")
         ]
     )
     @PostMapping("/ready")

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessConfigProperties.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessConfigProperties.kt
@@ -20,21 +20,25 @@
 package org.eclipse.tractusx.bpdm.gate.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.stereotype.Component
 
-@Component
 @ConfigurationProperties(prefix = "bpdm.tasks")
 data class GoldenRecordTaskConfigProperties(
     val creation: CreationProperties = CreationProperties(),
     val check: TaskProcessProperties = TaskProcessProperties()
 ) {
     data class CreationProperties(
-        val fromSharingMember: TaskProcessProperties = TaskProcessProperties(),
+        val fromSharingMember: CreationTaskProperties = CreationTaskProperties(),
         val fromPool: TaskProcessProperties = TaskProcessProperties()
     )
 
     data class TaskProcessProperties(
-        var batchSize: Int = 100,
-        var cron: String = "-",
+        val batchSize: Int = 100,
+        val cron: String = "-",
+    )
+
+    data class CreationTaskProperties(
+        val startsAsReady: Boolean = false,
+        val batchSize: Int = 100,
+        val cron: String = "-",
     )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordTaskConfiguration.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordTaskConfiguration.kt
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.config
+
+import jakarta.annotation.PostConstruct
+import org.eclipse.tractusx.bpdm.gate.service.GoldenRecordTaskService
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.support.CronTrigger
+
+@Configuration
+class GoldenRecordTaskConfiguration(
+    private val configProperties: GoldenRecordTaskConfigProperties,
+    private val taskScheduler: TaskScheduler,
+    private val service: GoldenRecordTaskService
+) {
+
+    @PostConstruct
+    fun scheduleGoldenRecordTasks() {
+        taskScheduler.scheduleIfEnabled(
+            { service.createTasksForReadyBusinessPartners() },
+            configProperties.creation.fromSharingMember.cron
+        )
+
+        taskScheduler.scheduleIfEnabled(
+            { service.createTasksForGoldenRecordUpdates() },
+            configProperties.creation.fromPool.cron
+        )
+
+        taskScheduler.scheduleIfEnabled(
+            { service.resolvePendingTasks() },
+            configProperties.check.cron
+        )
+    }
+
+    private fun TaskScheduler.scheduleIfEnabled(task: Runnable, cronExpression: String) {
+        if (cronExpression != "-") {
+            schedule(task, CronTrigger(cronExpression))
+        }
+    }
+
+
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class SharingStateController(
-    val sharingStateService: SharingStateService
+    private val sharingStateService: SharingStateService
 ) : GateSharingStateApi {
     private val logger = KotlinLogging.logger { }
 
@@ -45,6 +45,7 @@ class SharingStateController(
     ): PageDto<SharingStateDto> {
         return sharingStateService.findSharingStates(paginationRequest, businessPartnerType, externalIds)
     }
+
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_INPUT_AUTHORITY})")
     override fun postSharingStateReady(request: PostSharingStateReadyRequest) {

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
@@ -35,7 +35,6 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.data.domain.Pageable
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -53,7 +52,6 @@ class GoldenRecordTaskService(
 ) {
     private val logger = KotlinLogging.logger { }
 
-    @Scheduled(cron = "#{@goldenRecordTaskConfigProperties.getCreation().getFromSharingMember().getCron()}")
     @Transactional
     fun createTasksForReadyBusinessPartners() {
         logger.info { "Started scheduled task to create golden record tasks from ready business partners" }
@@ -84,7 +82,6 @@ class GoldenRecordTaskService(
         logger.info { "Created ${createdTasks.size} new golden record tasks from ready business partners" }
     }
 
-    @Scheduled(cron = "#{@goldenRecordTaskConfigProperties.getCheck().getCron()}")
     @Transactional
     fun resolvePendingTasks() {
         logger.info { "Started scheduled task to resolve pending golden record tasks" }
@@ -129,7 +126,6 @@ class GoldenRecordTaskService(
         logger.info { "Resolved ${businessPartnersToUpsert.size} tasks as successful and ${errorRequests.size} as errors" }
     }
 
-    @Scheduled(cron = "#{@goldenRecordTaskConfigProperties.getCreation().getFromPool().getCron()}")
     @Transactional
     fun createTasksForGoldenRecordUpdates() {
         logger.info { "Started scheduled task to create golden record tasks from Pool updates" }

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -37,21 +37,23 @@ bpdm:
     tasks:
         creation:
             fromSharingMember:
-              # When and how often the Gate checks for new business partner data to be shared
-              cron: '-'
-              # Up to how many golden record tasks can be created when checking
-              batchSize: 100
-            fromPool:
-              # When and how often the Gate checks for golden record updates from the Pool
+                # If true, new business partner input data will be directly ready to be shared
+                # If false, new business partner input data need to be manually set to ready
+                starts-as-ready: false
+                # When and how often the Gate checks for new business partner data to be shared
                 cron: '-'
-              # Up to how many golden record tasks can be created when checking
+                # Up to how many golden record tasks can be created when checking
                 batchSize: 100
+            fromPool:
+                # When and how often the Gate checks for golden record updates from the Pool
+                batchSize: 100
+                # Up to how many golden record tasks can be created when checking
+                cron: '-'
         check:
-          # When and how often the status of golden record tasks should be checked
-            cron: '-'
-          # How many golden record tasks can be checked in one request
             batchSize: 100
-  # Client connection configuration
+            cron: '-'
+
+    # Connection to the pool and orchestrator  [No auth on default]
     client:
         orchestrator:
           # The base-url of the Orchestrator-API


### PR DESCRIPTION
## Description

This pull request adds a configuration property for the Gate enabling new business partner data to be automatically set to ready to be shared state.

- added new configuration property under tasks
- added documentation for all task properties
- refactor: made the configuration properties class immutable
- refactor: added a configuration class for scheduling task service methods (so no SpEL needed)
- added initial or ready logic in sharing state service

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
