### PR TITLE
docs(Charts): update copyright to 2024

### DIFF
--- a/charts/bpdm/.helmignore
+++ b/charts/bpdm/.helmignore
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - update BPDM Orchestrator Chart to version 2.0.0
 - update BPDM Cleaning Service Dummy Chart to version 2.0.0
 - update BPDM Bridge Chart to version 2.0.0
+- update copyright for 2024
 
 ## [3.1.2] - 2023-11-16
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 4.0.0-alpha.7
+version: 4.0.0-alpha.8
 appVersion: "5.0.0-alpha.6"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 5.0.0-alpha.7
+    version: 5.0.0-alpha.8
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 6.0.0-alpha.7
+    version: 6.0.0-alpha.8
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 2.0.0-alpha.7
+    version: 2.0.0-alpha.8
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 2.0.0-alpha.7
+    version: 2.0.0-alpha.8
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 2.0.0-alpha.7
+    version: 2.0.0-alpha.8
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: postgresql

--- a/charts/bpdm/README.md
+++ b/charts/bpdm/README.md
@@ -59,3 +59,15 @@ applicationConfig:
 postgres:
   enabled: false
 ```
+
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-bridge-dummy/.helmignore
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/.helmignore
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - update application version to 5.0.0
 - increase container's default groupid to 10001
 - container is now executed with read-only root file systems
+- update copyright for 2024
 
 ## [1.1.0] - 2023-11-03
 
@@ -35,3 +36,15 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - postgres chart dependency for persistence
+
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
 appVersion: "5.0.0-alpha.6"
-version: 2.0.0-alpha.7
+version: 2.0.0-alpha.8
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-bridge-dummy/README.md
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/README.md
@@ -93,3 +93,14 @@ applicationSecrets:
         secret: your_client_secret
 ```
 
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/NOTES.txt
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/NOTES.txt
@@ -14,3 +14,13 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/configMap.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/deployment.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/ingress.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/ingress.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -17,7 +18,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-{{ if .Values.ingress.enabled }}
+
+  {{ if .Values.ingress.enabled }}
 
 
 {{- $fullName := include "bpdm.fullname" . -}}

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/secret.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/service.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/.helmignore
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/.helmignore
@@ -1,3 +1,23 @@
+---
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
 - container is now executed with read-only root file systems
+- update copyright for 2024
 
 ## [1.0.2] - 2023-11-23
 
@@ -29,3 +30,15 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Chart for BPDM application cleaning service dummy
+
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
 appVersion: "5.0.0-alpha.6"
-version: 2.0.0-alpha.7
+version: 2.0.0-alpha.8
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
@@ -92,3 +92,14 @@ applicationSecrets:
         secret: your_client_secret
 ```
 
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/NOTES.txt
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/NOTES.txt
@@ -14,3 +14,15 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+
+Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/configMap.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/deployment.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/secret.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/service.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-gate/.helmignore
+++ b/charts/bpdm/charts/bpdm-gate/.helmignore
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
 - container is now executed with read-only root file systems
+- update copyright for 2024
 
 ## [4.1.0] - 2023-11-03
 
@@ -98,3 +99,15 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 ## Changed
 
 - Update application version to 3.0.0
+
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "5.0.0-alpha.6"
-version: 5.0.0-alpha.7
+version: 5.0.0-alpha.8
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/README.md
+++ b/charts/bpdm/charts/bpdm-gate/README.md
@@ -96,3 +96,14 @@ applicationSecrets:
         secret: your_client_secret
 ```
 
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-gate/templates/NOTES.txt
+++ b/charts/bpdm/charts/bpdm-gate/templates/NOTES.txt
@@ -14,3 +14,15 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+
+Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-gate/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-gate/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-gate/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/configMap.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-gate/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/deployment.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-gate/templates/ingress.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/ingress.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-gate/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/secret.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-gate/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/service.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-orchestrator/.helmignore
+++ b/charts/bpdm/charts/bpdm-orchestrator/.helmignore
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
 - container is now executed with read-only root file systems
+- update copyright for 2024
 
 ## [1.0.1] - 2023-11-23
 
@@ -23,3 +24,15 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Chart for BPDM application orchestrator
+
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-orchestrator
 appVersion: "5.0.0-alpha.6"
-version: 2.0.0-alpha.7
+version: 2.0.0-alpha.8
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/README.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/README.md
@@ -83,3 +83,14 @@ applicationSecrets:
         secret: your_client_secret
 ```
 
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/NOTES.txt
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/NOTES.txt
@@ -14,3 +14,14 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+
+Notice
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/configMap.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/deployment.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/ingress.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/ingress.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/secret.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-orchestrator/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/templates/service.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-orchestrator/values.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/values.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-pool/.helmignore
+++ b/charts/bpdm/charts/bpdm-pool/.helmignore
@@ -1,3 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - Update application version to 5.0.0
 - increase container's default groupid to 10001
 - container is now executed with read-only root file systems
+- update copyright for 2024
 
 ## [5.1.1] - 2023-11-16
 
@@ -102,3 +103,15 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 ## Changed
 
 - AppVersion to 3.0.0
+
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "5.0.0-alpha.6"
-version: 6.0.0-alpha.7
+version: 6.0.0-alpha.8
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/README.md
+++ b/charts/bpdm/charts/bpdm-pool/README.md
@@ -120,3 +120,15 @@ applicationConfig:
 postgres:
   enabled: false
 ```
+
+## Notice
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-pool/templates/NOTES.txt
+++ b/charts/bpdm/charts/bpdm-pool/templates/NOTES.txt
@@ -14,3 +14,14 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+
+Notice
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2023 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2023 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-pool/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-pool/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-pool/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/configMap.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-pool/templates/deployment.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/deployment.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-pool/templates/ingress.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/ingress.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  # Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-pool/templates/secret.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/secret.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-pool/templates/service.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/service.yaml
@@ -1,5 +1,6 @@
+---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -1,3 +1,23 @@
+---
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 bpdm-gate:
   enabled: true
   postgres:

--- a/charts/config/chart-testing-config.yaml
+++ b/charts/config/chart-testing-config.yaml
@@ -1,6 +1,6 @@
 ---
 ################################################################################
-# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.


### PR DESCRIPTION
## Description

Update the copyright for 2024 for BPDM charts

Contributes to eclipse-tractusx/sig-release#496

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
