### PR TITLE
docs(README): add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ The BPDM solution contains the following applications:
 
 Subfolders for BPDM applications are easily recognizable by the `bpdm` prefix.
 
-## BPDM Charts
+## Installation
 
-With the source code for the applications this repository also contains [Helm Charts](charts) that demonstrate how to deploy the applications in a Kubernetes
-environment.
+Installation instructions for the BPDM services can be found in the following places:
+
+1. [Local Installation](docs/OPERATOR_VIEW.md): Details how to install and configure the BPDM services on a host machine.
+2. [Helm Installation](charts/bpdm/README.md): Explains how to use given Helm Charts to install the BPDM services on a kubernetes environment.
 
 ## Container images
 


### PR DESCRIPTION
## Description

This pull request adds installation instructions to the README file. 

Actually the instructions just provide links to our two main installation documentation: Local installation and Helm Chart installation.

I have the feeling that the TRGs have a slightly different strategy for documentation. But I believe that there is an advantage to put the relevant installation instructions for the Helm charts directly in the Helm Chart README and not in the docs folder or repo root. I guess this is debatable.

fixes #759

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
