### PR TITLE
docs(CC-BY-4.0): fix CC-BY-4.0 LICENSE Info

### DIFF
--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,7 @@
+License Agreement
+=================
+
+This works is licensed under Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0).
+
+It is free for personal or commercial use with attribution required by mentioning the use of this works as follows: 
+This site or product includes IP2Location™ ISO 3166-2 Subdivision Code which available from https://www.ip2location.com. 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -35,19 +35,16 @@ in the GitHub organization https://github.com/eclipse-tractusx:
 
 This project leverages the following third party content.
 
+### Dependencies
+
 See [DEPENDENCIES](DEPENDENCIES) file.
 
-### Regions
+### Administrative Areas Level 1
 
-The initial load of the regions according to ISO-3166-2 is done from the CSV file at:
-
-`bpdm-pool/src/main/resources/regions/IP2LOCATION-ISO3166-2.CSV`
-
-This file is under the following license:
-
-`This works is licensed under Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0).`
-
-`"This site or product includes IP2Location™ ISO 3166-2 Subdivision Code which available from https://www.ip2location.com."`
+- Description: CSV file content for ISO-3166-2
+- SPDX-License-Identifier: [CC-BY-4.0](LICENSES/CC-BY-4.0.txt)
+- File Location: [IP2LOCATION-ISO3166-2.CSV](bpdm-pool/src/main/resources/regions/IP2LOCATION-ISO3166-2.CSV)
+- Source URL: https://www.ip2location.com
 
 ## Cryptography
 


### PR DESCRIPTION
## Description

This pull request add the CC-BY-4.0 license file to the additional LICENSES file location. Also the NOTICE file now properly refers to that license, the source of the licensed file and the where it is being used in our project.

#761 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
