### PR TITLE
Charts: Update to 4.0.1

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [4.0.1] - 2024-02-23
+
+### Changed
+
+- update BPDM Pool Chart to version 6.0.1
+- update BPDM Gate Chart to version 5.0.1
+- update BPDM Orchestrator Chart to version 2.0.1
+- update BPDM Cleaning Service Dummy Chart to version 2.0.1
+- update BPDM Bridge Chart to version 2.0.1
+
 ## [4.0.0] - 2024-02-10
 
 ### Changed

--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - update BPDM Orchestrator Chart to version 2.0.1
 - update BPDM Cleaning Service Dummy Chart to version 2.0.1
 - update BPDM Bridge Chart to version 2.0.1
+  removed mentions of Opensearch from README
 
 ## [4.0.0] - 2024-02-10
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 4.0.0
+version: 4.0.1
 appVersion: "5.0.0"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 5.0.0
+    version: 5.0.1
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 6.0.0
+    version: 6.0.1
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 2.0.0
+    version: 2.0.1
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 2.0.0
+    version: 2.0.1
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 2.0.0
+    version: 2.0.1
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: postgresql

--- a/charts/bpdm/README.md
+++ b/charts/bpdm/README.md
@@ -44,11 +44,10 @@ image:
 
 ## Helm Dependencies
 
-On default, the Helm deployment also contains a PostgreSQL and Opensearch deployment.
+On default, the Helm deployment also contains a PostgreSQL deployment.
 You can configure these deployments in your value file as well.
-For this, consider the documentation of the correspondent dependency [PostgreSQL](https://artifacthub.io/packages/helm/bitnami/postgresql/11.9.13)
-or [Opensearch](https://opensearch.org/docs/latest/dashboards/install/helm/).
-In case you want to use an already deployed database or Opensearch instance you can also disable the respective dependency and overwrite the default host
+For this, consider the documentation of the correspondent dependency [PostgreSQL](https://artifacthub.io/packages/helm/bitnami/postgresql/11.9.13).
+In case you want to use an already deployed database instance you can also disable the respective dependency and overwrite the default host
 address in the `applicationConfig`:
 
 ```yaml

--- a/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [2.0.1] - 2024-02-23
+
+### Changed
+
+- set default memory limit and request to 512 Mi
+
 ## [2.0.0] - 2024-02-10
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
 appVersion: "5.0.0"
-version: 2.0.0
+version: 2.0.1
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/values.yaml
@@ -67,7 +67,7 @@ resources:
     memory: 512Mi
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
 
 nodeSelector: {}
 

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [2.0.1] - 2024-02-23
+
+### Changed
+
+- set default memory limit and request to 512 Mi
+
 ## [2.0.0] - 2024-02-10
 
 ### Change

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
 appVersion: "5.0.0"
-version: 2.0.0
+version: 2.0.1
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
@@ -63,7 +63,7 @@ resources:
     memory: 512Mi
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
 
 nodeSelector: {}
 

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [5.0.1] - 2024-02-23
+
+### Changed
+
+- set default memory limit and request to 512 Mi
+
 ## [5.0.0] - 2024-02-10
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "5.0.0"
-version: 5.0.0
+version: 5.0.1
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -64,10 +64,10 @@ ingress:
 resources:
   limits:
     cpu: 1000m
-    memory: 1Gi
+    memory: 512Mi
   requests:
     cpu: 200m
-    memory: 1Gi
+    memory: 512Mi
 
 nodeSelector: {}
 

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [5.0.1] - 2024-02-23
+
+### Changed
+
+- set default memory limit and request to 512 Mi
+
 ## [2.0.0] - 2024-02-10
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-orchestrator
 appVersion: "5.0.0"
-version: 2.0.0
+version: 2.0.1
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/values.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/values.yaml
@@ -69,7 +69,7 @@ resources:
     memory: 512Mi
   requests:
     cpu: 100m
-    memory: 256Mi
+    memory: 512Mi
 
 nodeSelector: {}
 

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [6.0.1] - 2024-02-23
+
+### Changed
+
+- set default memory limit and request to 512 Mi
+
 ## [6.0.0] - 2024-02-10
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - set default memory limit and request to 512 Mi
+- removed mentions of Opensearch from README
 
 ## [6.0.0] - 2024-02-10
 

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "5.0.0"
-version: 6.0.0
+version: 6.0.1
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/README.md
+++ b/charts/bpdm/charts/bpdm-pool/README.md
@@ -105,11 +105,10 @@ applicationSecrets:
 
 ## Helm Dependencies
 
-On default, the Helm deployment also contains a PostgreSQL and Opensearch deployment.
-You can configure these deployments in your value file as well.
-For this, consider the documentation of the correspondent dependency [PostgreSQL](https://artifacthub.io/packages/helm/bitnami/postgresql/11.9.13)
-or [Opensearch](https://opensearch.org/docs/latest/dashboards/install/helm/).
-In case you want to use an already deployed database or Opensearch instance you can also disable the respective dependency and overwrite the default host
+On default, the Helm deployment also contains a PostgreSQL.
+You can configure the deployment in your value file as well.
+For this, consider the documentation of the correspondent dependency [PostgreSQL](https://artifacthub.io/packages/helm/bitnami/postgresql/11.9.13).
+In case you want to use an already deployed database instance you can also disable the respective dependency and overwrite the default host
 address in the `applicationConfig`:
 
 ```yaml

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -63,10 +63,10 @@ ingress:
 resources:
   limits:
     cpu: 1000m
-    memory: 1Gi
+    memory: 512Mi
   requests:
     cpu: 300m
-    memory: 1Gi
+    memory: 512Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Description

This pull request aligns the BPDM Chart's memory request and memory limit by setting both to 512Mi on default values.

Additionally, I removed some mentions of Opensearch configuration from the chart's READMEs.

Fixes #767 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
