### PR TITLE
feat(app): increase BPDM version to snapshot 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [6.0.0] - [tbd]
+
+
 ## [5.0.0] - [2024-02-10]
 
 ## Added

--- a/bpdm-bridge-dummy/pom.xml
+++ b/bpdm-bridge-dummy/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bpdm-cleaning-service-dummy/pom.xml
+++ b/bpdm-cleaning-service-dummy/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bpdm-common/pom.xml
+++ b/bpdm-common/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bpdm-gate-api/pom.xml
+++ b/bpdm-gate-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <artifactId>bpdm-parent</artifactId>
         <groupId>org.eclipse.tractusx</groupId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/bpdm-gate/pom.xml
+++ b/bpdm-gate/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bpdm-orchestrator-api/pom.xml
+++ b/bpdm-orchestrator-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/bpdm-orchestrator/pom.xml
+++ b/bpdm-orchestrator/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bpdm-pool-api/pom.xml
+++ b/bpdm-pool-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/bpdm-pool/pom.xml
+++ b/bpdm-pool/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>bpdm-parent</artifactId>
     <name>Business Partner Data Management Parent</name>
     <description>Parent pom of Business Partner Data Management</description>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION

## Description

This pull request increases the BPDM version in the POM files to 6.0.0-SNAPSHOT. With this the main branch will now follow the BPDM release 6.0.0

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
