### PR TITLE
fix(Common-Test): POM referencing outdated BPDM version

### DIFF
--- a/bpdm-common-test/pom.xml
+++ b/bpdm-common-test/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
## Description

This pull request fixes the currently broken main due to the BPDM Common Test module referencing the outdated POM 5.0.1-SNAPSHOT. Increased it to the now correct version 6.0.0-SNAPSHOT

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
