### PR TITLE
fix(charts): fix default dependency service

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- update BPDM Pool Chart to version 6.0.2
+- update BPDM Gate Chart to version 5.0.2
+- update BPDM Orchestrator Chart to version 2.0.2
+- update BPDM Cleaning Service Dummy Chart to version 2.0.2
+- update BPDM Bridge Chart to version 2.0.2
+
+### Removed
+
+- postgres fullNameOverride
+
+## [4.0.1] - 2024-02-23
+
+### Changed
+
 - update BPDM Pool Chart to version 6.0.1
 - update BPDM Gate Chart to version 5.0.1
 - update BPDM Orchestrator Chart to version 2.0.1

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 4.0.1
+version: 4.0.2
 appVersion: "5.0.0"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 5.0.1
+    version: 5.0.2
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 6.0.1
+    version: 6.0.2
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-bridge-dummy
-    version: 2.0.1
+    version: 2.0.2
     alias: bpdm-bridge-dummy
     condition: bpdm-bridge-dummy.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 2.0.1
+    version: 2.0.2
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 2.0.1
+    version: 2.0.2
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: postgresql

--- a/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [2.0.2] - 2024-03-01
+
+### Changed
+
+- default dependency service names
+
 ## [2.0.1] - 2024-02-23
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-bridge-dummy
 appVersion: "5.0.0"
-version: 2.0.1
+version: 2.0.2
 description: A Helm chart for deploying the BPDM bridge dummy service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/_helpers.tpl
@@ -61,46 +61,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{- define "bpdm-bridge.poolServiceName" -}}
-{{- $config := .Values.applicationConfig -}}
-{{- if and $config (not (empty $config.bpdm)) -}}
-    {{- $bpdm := $config.bpdm -}}
-    {{- if and $bpdm (not (empty $bpdm.pool)) -}}
-        {{- $pool := $bpdm.pool -}}
-        {{- if and $pool (not (empty (index $pool "base-url"))) -}}
-            {{- index $pool "base-url" -}}
-        {{- else -}}
-            {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-        {{- end -}}
-    {{- else -}}
-        {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-    {{- end -}}
-{{- else -}}
-    {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-{{- end -}}
-{{- end }}
-
-{{- define "bpdm-bridge.gateServiceName" -}}
-{{- $config := .Values.applicationConfig -}}
-{{- if and $config (not (empty $config.bpdm)) -}}
-    {{- $bpdm := $config.bpdm -}}
-    {{- if and $bpdm (not (empty $bpdm.gate)) -}}
-        {{- $gate := $bpdm.gate -}}
-        {{- if and $gate (not (empty (index $gate "base-url"))) -}}
-            {{- index $gate "base-url" -}}
-        {{- else -}}
-            {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
-        {{- end -}}
-    {{- else -}}
-        {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
-    {{- end -}}
-{{- else -}}
-    {{- print "http://" (printf "%s-bpdm-gate" .Release.Name) ":8080" -}}
-{{- end -}}
-{{- end }}
-
-
-
 {{/*
 Selector labels
 */}}

--- a/charts/bpdm/charts/bpdm-bridge-dummy/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-bridge-dummy/templates/configMap.yaml
@@ -32,9 +32,9 @@ data:
       datasource:
         host: {{ include "bpdm.postgresDependency" . }}
       pool:
-        base-url: {{include "bpdm-bridge.poolServiceName" .}}
+        base-url: http://{{ include "bpdm.toReleaseName" (list . "bpdm-pool") }}
       gate:
-        base-url: {{include "bpdm-bridge.gateServiceName" .}}
+        base-url: http://{{ include "bpdm.toReleaseName" (list . "bpdm-gate") }}
   external.yml: |-
     # External properties for overwriting application config
     {{- if .Values.applicationConfig }}

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [2.0.2] - 2024-03-01
+
+### Changed
+
+- default dependency service names
+
 ## [2.0.1] - 2024-02-23
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
 appVersion: "5.0.0"
-version: 2.0.1
+version: 2.0.2
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/_helpers.tpl
@@ -99,8 +99,6 @@ Create name of application secret
 {{- end }}
 
 
-
-
 {{/*
 Invoke include on given definition with postgresql dependency context
 Usage: include "includeWithPostgresContext" (list $ "your_include_function_here")
@@ -109,4 +107,16 @@ Usage: include "includeWithPostgresContext" (list $ "your_include_function_here"
 {{- $ := index . 0 }}
 {{- $function := index . 1 }}
 {{- include $function (dict "Values" $.Values.postgres "Chart" (dict "Name" "postgres") "Release" $.Release) }}
+{{- end }}
+
+{{- define "bpdm.toReleaseName" -}}
+{{- $top := first . }}
+{{- $name := index . 1 }}
+{{- if contains $name $top.Release.Name }}
+{{- $top.Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else if hasPrefix $top.Release.Name $name  }}
+{{- $name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $top.Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/templates/configMap.yaml
@@ -30,7 +30,7 @@ data:
     # which can be overwritten by external.yml
     bpdm:
       orchestrator:
-        base-url: {{include "bpdm-cleaning-service-dummy.orchestratorServiceName" .}}
+        base-url: http://{{ include "bpdm.toReleaseName" (list . "bpdm-orchestrator") }}
   external.yml: |-
     # External properties for overwriting application config
     {{- if .Values.applicationConfig }}

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [5.0.2] - 2024-03-01
+
+### Changed
+
+- default dependency service names
+
 ## [5.0.1] - 2024-02-23
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "5.0.0"
-version: 5.0.1
+version: 5.0.2
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-gate/templates/_helpers.tpl
@@ -61,31 +61,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{- define "bpdm-gate.poolServiceName" -}}
-{{- $config := .Values.applicationConfig -}}
-{{- if and $config (not (empty $config.bpdm)) -}}
-    {{- $bpdm := $config.bpdm -}}
-    {{- if and $bpdm (not (empty $bpdm.pool)) -}}
-        {{- $pool := $bpdm.pool -}}
-        {{- if and $pool (not (empty (index $pool "base-url"))) -}}
-            {{- index $pool "base-url" -}}
-        {{- else -}}
-            {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-        {{- end -}}
-    {{- else -}}
-        {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-    {{- end -}}
-{{- else -}}
-    {{- print "http://" (printf "%s-bpdm-pool" .Release.Name) ":8080" -}}
-{{- end -}}
-{{- end }}
-
-
-
-
-
-
-
 {{/*
 Selector labels
 */}}
@@ -117,4 +92,16 @@ Usage: include "includeWithPostgresContext" (list $ "your_include_function_here"
 {{- $ := index . 0 }}
 {{- $function := index . 1 }}
 {{- include $function (dict "Values" $.Values.postgres "Chart" (dict "Name" "postgres") "Release" $.Release) }}
+{{- end }}
+
+{{- define "bpdm.toReleaseName" -}}
+{{- $top := first . }}
+{{- $name := index . 1 }}
+{{- if contains $name $top.Release.Name }}
+{{- $top.Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else if hasPrefix $top.Release.Name $name  }}
+{{- $name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $top.Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}

--- a/charts/bpdm/charts/bpdm-gate/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-gate/templates/configMap.yaml
@@ -32,7 +32,9 @@ data:
       datasource:
         host: {{ include "bpdm.postgresDependency" . }}
       pool:
-        base-url: {{include "bpdm-gate.poolServiceName" .}}
+        base-url: http://{{ include "bpdm.toReleaseName" (list . "bpdm-pool") }}
+      orchestrator:
+        base-url: http://{{ include "bpdm.toReleaseName" (list . "bpdm-orchestrator") }}
   external.yml: |-
     # External properties for overwriting application config
     {{- if .Values.applicationConfig }}

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [5.0.1] - 2024-02-23
+## [2.0.2] - 2024-03-01
+
+### Changed
+
+- default dependency service names
+
+## [2.0.1] - 2024-02-23
 
 ### Changed
 

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-orchestrator
 appVersion: "5.0.0"
-version: 2.0.1
+version: 2.0.2
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [6.0.2] - 2024-03-01
+
+### Changed
+
+- default dependency service names
+
 ## [6.0.1] - 2024-02-23
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "5.0.0"
-version: 6.0.1
+version: 6.0.2
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-pool/templates/_helpers.tpl
@@ -93,19 +93,14 @@ Usage: include "includeWithPostgresContext" (list $ "your_include_function_here"
 {{- include $function (dict "Values" $.Values.postgres "Chart" (dict "Name" "postgres") "Release" $.Release) }}
 {{- end }}
 
-{{/*
-Determine opensearch service/host name to connect to
-*/}}
-{{- define "bpdm.opensearchDependency" -}}
-     {{- include "includeWithOpensearchContext" (list $ "opensearch.masterService") }}
-{{- end }}}
-
-{{/*
-Invoke include on given definition with opensearch dependency context
-Usage: include "includeWithOpensearchContext" (list root "your_include_function_here")
-*/}}
-{{- define "includeWithOpensearchContext" -}}
-{{- $ := index . 0 }}
-{{- $function := index . 1 }}
-{{- include $function (dict "Values" $.Values.opensearch "Chart" (dict "Name" "opensearch") "Release" $.Release) }}
+{{- define "bpdm.toReleaseName" -}}
+{{- $top := first . }}
+{{- $name := index . 1 }}
+{{- if contains $name $top.Release.Name }}
+{{- $top.Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else if hasPrefix $top.Release.Name $name  }}
+{{- $name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $top.Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}

--- a/charts/bpdm/charts/bpdm-pool/templates/configMap.yaml
+++ b/charts/bpdm/charts/bpdm-pool/templates/configMap.yaml
@@ -30,6 +30,9 @@ data:
     bpdm:
       datasource:
         host: {{ include "bpdm.postgresDependency" . }}
+      client:
+        orchestrator:
+          base-url: http://{{ include "bpdm.toReleaseName" (list . "bpdm-orchestrator") }}
   external.yml: |-
     # External properties for overwriting application config
     {{- if .Values.applicationConfig }}

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -120,10 +120,9 @@ applicationConfig:
 #      host: ...
 
 applicationSecrets:
-  spring:
-    datasource:
-      # overwrite for security reasons
-      password: bpdm
+#  spring:
+#    datasource:
+#      password: ...
 
 postgres:
   enabled: true

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -21,20 +21,17 @@
 bpdm-gate:
   enabled: true
   postgres:
-    # use the name that was override on postgres.fullnameOverride to be used by the application on connection
-    fullnameOverride: ""
+    enabled: false
 
 bpdm-pool:
   enabled: true
   postgres:
-    # use the name that was override on postgres.fullnameOverride to be used by the application on connection
-    fullnameOverride: ""
+    enabled: false
 
 bpdm-bridge-dummy:
   enabled: true
   postgres:
-    # use the name that was override on postgres.fullnameOverride to be used by the application on connection
-    fullnameOverride: ""
+    enabled: false
 
 bpdm-cleaning-service-dummy:
   enabled: true
@@ -43,8 +40,6 @@ bpdm-orchestrator:
   enabled: true
 
 postgres:
-  # override the name of the postgres deploy
-  fullnameOverride: ""
   enabled: true
   auth:
     database: bpdm


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

This pull request fixes how the BPDM Charts resolve default service names of dependencies. The umbrella and subcharts now find the postgres dependency and the password on default without any configuration needed.

Also fixed how the Charts resolve the default service names for other BPDM charts that they are dependend on.

Fixes #786 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
