### PR TITLE
Feat: Add Catena-X Member Field to LSA Business Partners

### DIFF
--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
@@ -55,6 +55,8 @@ data class LegalEntityVerboseDto(
 
     override val confidenceCriteria: ConfidenceCriteriaDto,
 
+    val isCatenaXMemberData: Boolean = false,
+
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
@@ -52,6 +52,8 @@ data class LogisticAddressVerboseDto(
     @get:Schema(name = "isMainAddress", description = LogisticAddressDescription.isMainAddress)
     val isMainAddress: Boolean = false,
 
+    val isCatenaXMemberData: Boolean = false,
+
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
@@ -34,6 +34,8 @@ data class SiteVerboseDto(
     override val name: String,
     override val states: Collection<SiteStateVerboseDto> = emptyList(),
 
+    val isCatenaXMemberData: Boolean = false,
+
     @get:Schema(description = SiteDescription.bpnLegalEntity)
     val bpnLegalEntity: String,
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description


This pull request adds the "isCatenaXMemberData" field to the LSA business partner models. This field indicates whether a business partner belongs to a registered Catena-X member.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
