### PR TITLE
Feat: remove pool endpoints not specified in the BPDM standard

### DIFF
--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -34,7 +34,10 @@ import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -88,24 +91,6 @@ interface PoolLegalEntityApi {
         @Parameter(description = "Type of identifier to use, defaults to BPN when omitted", schema = Schema(defaultValue = "BPN"))
         @RequestParam idType: String? = "BPN"
     ): LegalEntityWithLegalAddressVerboseDto
-
-    @Operation(
-        summary = "Confirms that the data of a legal entity business partner is still up to date.",
-        description = "Confirms that the data of a business partner is still up to date " +
-                "by saving the current timestamp at the time this POST-request is made as this business partner's \"currentness\". Ignores case of bpnl."
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "Business partner's \"currentness\" successfully updated"),
-            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
-            ApiResponse(responseCode = "404", description = "No business partner found for specified bpnl", content = [Content()])
-        ]
-    )
-    @Tag(name = ApiTags.LEGAL_ENTITIES_NAME, description = ApiTags.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping("/{bpnl}/confirm-up-to-date")
-    fun setLegalEntityCurrentness(
-        @Parameter(description = "BPNL value") @PathVariable bpnl: String
-    )
 
     @Operation(
         summary = "Returns legal entities by an array of BPNL",
@@ -164,23 +149,6 @@ interface PoolLegalEntityApi {
         @Parameter(description = "BPNL value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
-
-    @Operation(
-        summary = "Search Legal Addresses",
-        description = "Search legal addresses of legal entities by BPNL"
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "The found legal addresses"),
-            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
-        ]
-    )
-    @Tag(name = ApiTags.LEGAL_ENTITIES_NAME, description = ApiTags.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping("/legal-addresses/search")
-    fun searchLegalAddresses(
-        @RequestBody
-        bpnLs: Collection<String>
-    ): Collection<LegalAddressVerboseDto>
 
     @Operation(
         summary = "Creates a new legal entity",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -130,37 +130,6 @@ interface PoolMetadataApi {
     fun getFieldQualityRules(@Parameter(description = "ISO 3166-1 alpha-2 country code") @RequestParam country: CountryCode): ResponseEntity<Collection<FieldQualityRuleDto>>
 
     @Operation(
-        summary = "Create new Region",
-        description = "Create a new region which can be referenced by business partner records.",
-        deprecated = true
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "New region successfully created"),
-            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
-
-        ]
-    )
-    @Tag(name = ApiTags.METADATA_NAME, description = ApiTags.METADATA_DESCRIPTION)
-    @PostMapping("/regions")
-    fun createRegion(@RequestBody type: RegionDto): RegionDto
-
-    @Operation(
-        summary = "Get page of regions",
-        description = "Lists all currently known regions in a paginated result",
-        deprecated = true
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "Page of existing regions, may be empty"),
-            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
-        ]
-    )
-    @Tag(name = ApiTags.METADATA_NAME, description = ApiTags.METADATA_DESCRIPTION)
-    @GetMapping("/regions")
-    fun getRegions(@ParameterObject paginationRequest: PaginationRequest): PageDto<RegionDto>
-
-    @Operation(
         summary = "Get page of country subdivisions suitable for the administrativeAreaLevel1 address property",
         description = "Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result"
     )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -31,31 +31,16 @@ import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 
 @RequestMapping("sites", produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolSiteApi {
-
-
-    @Operation(
-        summary = "Search for sites' main addresses",
-        description = "Search main addresses of site business partners by BPNS"
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "The found main addresses"),
-            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
-        ]
-    )
-    @Tag(name = ApiTags.SITE_NAME, description = ApiTags.SITE_DESCRIPTION)
-    @PostMapping("/main-addresses/search", produces = ["application/json"])
-    fun searchMainAddresses(
-        @RequestBody
-        bpnS: Collection<String>
-    ): Collection<MainAddressVerboseDto>
 
     @Operation(
         summary = "Returns a site by its BPNS",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/LegalEntityApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/LegalEntityApiClient.kt
@@ -29,7 +29,10 @@ import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
@@ -72,20 +75,10 @@ interface LegalEntityApiClient : PoolLegalEntityApi {
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteVerboseDto>
 
-    @PostExchange("/legal-addresses/search")
-    override fun searchLegalAddresses(
-        @RequestBody bpnLs: Collection<String>
-    ): Collection<LegalAddressVerboseDto>
-
     @PostExchange("/search")
     override fun searchLegalEntitys(
         @RequestBody bpnLs: Collection<String>
     ): ResponseEntity<Collection<LegalEntityWithLegalAddressVerboseDto>>
-
-    @PostExchange("/{bpnl}/confirm-up-to-date")
-    override fun setLegalEntityCurrentness(
-        @PathVariable bpnl: String
-    )
 
     @PutExchange
     override fun updateBusinessPartners(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MetadataApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MetadataApiClient.kt
@@ -42,9 +42,6 @@ interface MetadataApiClient: PoolMetadataApi {
     @PostExchange("/legal-forms")
     override fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormDto
 
-    @PostExchange("/regions")
-    override fun createRegion(@RequestBody type: RegionDto): RegionDto
-
     @GetExchange("/administrative-areas-level1")
     override fun getAdminAreasLevel1(@ParameterObject paginationRequest: PaginationRequest): PageDto<CountrySubdivisionDto>
 
@@ -60,8 +57,4 @@ interface MetadataApiClient: PoolMetadataApi {
 
     @GetExchange("/legal-forms")
     override fun getLegalForms(paginationRequest: PaginationRequest): PageDto<LegalFormDto>
-
-
-    @GetExchange("/regions")
-    override fun getRegions(paginationRequest: PaginationRequest): PageDto<RegionDto>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
@@ -25,7 +25,10 @@ import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
@@ -50,11 +53,6 @@ interface SiteApiClient : PoolSiteApi {
     override fun getSitesPaginated(
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteMatchVerboseDto>
-
-    @PostExchange("/main-addresses/search")
-    override fun searchMainAddresses(
-        @RequestBody bpnS: Collection<String>
-    ): Collection<MainAddressVerboseDto>
 
     @PostExchange("/search")
     override fun searchSites(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -28,7 +28,10 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchReq
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.config.BpnConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
@@ -68,11 +71,6 @@ class LegalEntityController(
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
-    override fun setLegalEntityCurrentness(bpnl: String) {
-        businessPartnerBuildService.setBusinessPartnerCurrentness(bpnl.uppercase())
-    }
-
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
     override fun searchLegalEntitys(
         bpnLs: Collection<String>
     ): ResponseEntity<Collection<LegalEntityWithLegalAddressVerboseDto>> {
@@ -96,13 +94,6 @@ class LegalEntityController(
         paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto> {
         return addressService.findByPartnerBpn(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
-    }
-
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
-    override fun searchLegalAddresses(
-        bpnLs: Collection<String>
-    ): Collection<LegalAddressVerboseDto> {
-        return addressService.findLegalAddresses(bpnLs)
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataController.kt
@@ -72,14 +72,4 @@ class MetadataController(
         return metadataService.getCountrySubdivisions(paginationRequest)
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_METADATA})")
-    override fun getRegions(paginationRequest: PaginationRequest): PageDto<RegionDto> {
-        return metadataService.getRegions(paginationRequest)
-    }
-
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_METADATA})")
-    override fun createRegion(type: RegionDto): RegionDto {
-        return metadataService.createRegion(type)
-    }
-
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -25,7 +25,10 @@ import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.*
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
 import org.eclipse.tractusx.bpdm.pool.service.AddressService
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService
@@ -41,13 +44,6 @@ class SiteController(
     private val addressService: AddressService,
     val searchService: SearchService,
 ) : PoolSiteApi {
-
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
-    override fun searchMainAddresses(
-        bpnS: Collection<String>
-    ): Collection<MainAddressVerboseDto> {
-        return addressService.findMainAddresses(bpnS)
-    }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
     override fun getSite(

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -31,7 +31,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
-import org.eclipse.tractusx.bpdm.pool.util.*
+import org.eclipse.tractusx.bpdm.pool.util.TestHelpers
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerVerboseValues
@@ -474,62 +474,6 @@ class SiteControllerIT @Autowired constructor(
         // 1 error
         assertThat(response.errorCount).isEqualTo(1)
         testHelpers.assertErrorResponse(response.errors.first(), SiteUpdateError.SiteNotFound, "NONEXISTENT")
-    }
-
-    /**
-     * Given sites
-     * When asking for main addresses by site BPNs
-     * Then main addresses of sites returned
-     */
-    @Test
-    fun `find main addresses by BPNS`() {
-        val givenStructure = testHelpers.createBusinessPartnerStructure(
-            listOf(
-                LegalEntityStructureRequest(
-                    legalEntity = BusinessPartnerNonVerboseValues.legalEntityCreate1,
-                    siteStructures = listOf(SiteStructureRequest(BusinessPartnerNonVerboseValues.siteCreate1))
-                ),
-                LegalEntityStructureRequest(
-                    legalEntity = BusinessPartnerNonVerboseValues.legalEntityCreate2,
-                    siteStructures = listOf(SiteStructureRequest(BusinessPartnerNonVerboseValues.siteCreate2), SiteStructureRequest(BusinessPartnerNonVerboseValues.siteCreate3))
-                )
-            )
-        )
-
-        val expected = givenStructure.flatMap { it.siteStructures }.map { it.site.mainAddress }
-
-        val toSearch = expected.map { it.bpnSite!! }
-
-        val response = poolClient.sites.searchMainAddresses(toSearch)
-        assertHelpers.assertRecursively(response).isEqualTo(expected)
-    }
-
-    /**
-     * Given sites
-     * When asking for main addresses with non-existent BPNs
-     * Then only main addresses of sites with existing BPNs returned
-     */
-    @Test
-    fun `find main address, ignore invalid BPNS`() {
-        val givenStructure = testHelpers.createBusinessPartnerStructure(
-            listOf(
-                LegalEntityStructureRequest(
-                    legalEntity = BusinessPartnerNonVerboseValues.legalEntityCreate1,
-                    siteStructures = listOf(SiteStructureRequest(BusinessPartnerNonVerboseValues.siteCreate1))
-                ),
-                LegalEntityStructureRequest(
-                    legalEntity = BusinessPartnerNonVerboseValues.legalEntityCreate2,
-                    siteStructures = listOf(SiteStructureRequest(BusinessPartnerNonVerboseValues.siteCreate2), SiteStructureRequest(BusinessPartnerNonVerboseValues.siteCreate3))
-                )
-            )
-        )
-
-        val expected = givenStructure.flatMap { it.siteStructures }.map { it.site.mainAddress }
-
-        val toSearch = expected.map { it.bpnSite!! }.plus("NON-EXISTENT")
-
-        val response = poolClient.sites.searchMainAddresses(toSearch)
-        assertHelpers.assertRecursively(response).isEqualTo(expected)
     }
 
     @Test

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/TestHelpers.kt
@@ -135,15 +135,6 @@ class TestHelpers(
         }
     }
 
-    fun `set business partner currentness using nonexistent bpn`(bpn: String) {
-        try {
-            val result = poolClient.legalEntities.setLegalEntityCurrentness(bpn)
-            assertThrows<WebClientResponseException> { result }
-        } catch (e: WebClientResponseException) {
-            Assert.assertEquals(HttpStatus.NOT_FOUND, e.statusCode)
-        }
-    }
-
     fun `get site by bpn-s, not found`(bpn: String) {
         try {
             val result = poolClient.sites.getSite(bpn)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description


This pull request removes endpoints from the BPDM Pool API that are not part of the standard and are not needed anymore.

Endpoints include:

- Search endpoints for legal and site-main addresses
- region endpoints
- documentation endpoints

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
