### PR TITLE
fix(model): wrong name for confidence criteria number of sharing members

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -27,7 +27,7 @@ import java.time.LocalDateTime
 
 val dummyConfidenceCriteria = ConfidenceCriteriaDto(
     sharedByOwner = false,
-    numberOfBusinessPartners = 1,
+    numberOfSharingMembers = 1,
     checkedByExternalDataSource = false,
     lastConfidenceCheckAt = LocalDateTime.now(),
     nextConfidenceCheckAt = LocalDateTime.now().plusDays(5),

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
@@ -70,7 +70,7 @@ object BusinessPartnerGenericCommonValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = true,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 7,
+                numberOfSharingMembers = 7,
                 lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
                 confidenceLevel = 1
@@ -82,7 +82,7 @@ object BusinessPartnerGenericCommonValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = false,
                 checkedByExternalDataSource = false,
-                numberOfBusinessPartners = 8,
+                numberOfSharingMembers = 8,
                 lastConfidenceCheckAt = LocalDateTime.of(2023, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2024, 4, 3, 2, 1),
                 confidenceLevel = 2
@@ -132,7 +132,7 @@ object BusinessPartnerGenericCommonValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = false,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 4,
+                numberOfSharingMembers = 4,
                 lastConfidenceCheckAt = LocalDateTime.of(2020, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2028, 4, 3, 2, 1),
                 confidenceLevel = 5
@@ -168,7 +168,7 @@ object BusinessPartnerGenericCommonValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = true,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 7,
+                numberOfSharingMembers = 7,
                 lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
                 confidenceLevel = 1
@@ -180,7 +180,7 @@ object BusinessPartnerGenericCommonValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = true,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 7,
+                numberOfSharingMembers = 7,
                 lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
                 confidenceLevel = 1
@@ -230,7 +230,7 @@ object BusinessPartnerGenericCommonValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = true,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 7,
+                numberOfSharingMembers = 7,
                 lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
                 confidenceLevel = 1
@@ -308,7 +308,7 @@ object BusinessPartnerGenericCommonValues {
         confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = true,
             checkedByExternalDataSource = true,
-            numberOfBusinessPartners = 7,
+            numberOfSharingMembers = 7,
             lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
             confidenceLevel = 1
@@ -374,7 +374,7 @@ object BusinessPartnerGenericCommonValues {
         confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
-            numberOfBusinessPartners = 2,
+            numberOfSharingMembers = 2,
             lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
             confidenceLevel = 2
@@ -418,7 +418,7 @@ object BusinessPartnerGenericCommonValues {
         confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
-            numberOfBusinessPartners = 2,
+            numberOfSharingMembers = 2,
             lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
             confidenceLevel = 3
@@ -452,7 +452,7 @@ object BusinessPartnerGenericCommonValues {
         confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
-            numberOfBusinessPartners = 2,
+            numberOfSharingMembers = 2,
             lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
             confidenceLevel = 4
@@ -482,7 +482,7 @@ object BusinessPartnerGenericCommonValues {
         confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
-            numberOfBusinessPartners = 2,
+            numberOfSharingMembers = 2,
             lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
             confidenceLevel = 5
@@ -507,7 +507,7 @@ object BusinessPartnerGenericCommonValues {
         confidenceCriteria = ConfidenceCriteriaDto(
             sharedByOwner = false,
             checkedByExternalDataSource = false,
-            numberOfBusinessPartners = 2,
+            numberOfSharingMembers = 2,
             lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
             confidenceLevel = 6

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
@@ -726,7 +726,7 @@ object BusinessPartnerVerboseValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = true,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 7,
+                numberOfSharingMembers = 7,
                 lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
                 confidenceLevel = 1
@@ -738,7 +738,7 @@ object BusinessPartnerVerboseValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = false,
                 checkedByExternalDataSource = false,
-                numberOfBusinessPartners = 8,
+                numberOfSharingMembers = 8,
                 lastConfidenceCheckAt = LocalDateTime.of(2023, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2024, 4, 3, 2, 1),
                 confidenceLevel = 2
@@ -788,7 +788,7 @@ object BusinessPartnerVerboseValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = false,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 4,
+                numberOfSharingMembers = 4,
                 lastConfidenceCheckAt = LocalDateTime.of(2020, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2028, 4, 3, 2, 1),
                 confidenceLevel = 5

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
@@ -102,7 +102,7 @@ object BusinessPartnerVerboseValues {
     private val confidenceCriteria1 = ConfidenceCriteriaDto(
         sharedByOwner = true,
         checkedByExternalDataSource = true,
-        numberOfBusinessPartners = 1,
+        numberOfSharingMembers = 1,
         lastConfidenceCheckAt = LocalDateTime.of(2023, 10, 10, 10, 10, 10),
         nextConfidenceCheckAt = LocalDateTime.of(2024, 10, 10, 10, 10, 10),
         confidenceLevel = 10
@@ -111,7 +111,7 @@ object BusinessPartnerVerboseValues {
     private val confidenceCriteria2 = ConfidenceCriteriaDto(
         sharedByOwner = false,
         checkedByExternalDataSource = false,
-        numberOfBusinessPartners = 3,
+        numberOfSharingMembers = 3,
         lastConfidenceCheckAt = LocalDateTime.of(2022, 10, 10, 10, 10, 10),
         nextConfidenceCheckAt = LocalDateTime.of(2025, 10, 10, 10, 10, 10),
         confidenceLevel = 6
@@ -120,7 +120,7 @@ object BusinessPartnerVerboseValues {
     private val confidenceCriteria3 = ConfidenceCriteriaDto(
         sharedByOwner = true,
         checkedByExternalDataSource = false,
-        numberOfBusinessPartners = 10,
+        numberOfSharingMembers = 10,
         lastConfidenceCheckAt = LocalDateTime.of(2021, 10, 10, 10, 10, 10),
         nextConfidenceCheckAt = LocalDateTime.of(2026, 10, 10, 10, 10, 10),
         confidenceLevel = 3

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IConfidenceCriteriaDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IConfidenceCriteriaDto.kt
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 interface IConfidenceCriteriaDto {
     val sharedByOwner: Boolean?
     val checkedByExternalDataSource: Boolean?
-    val numberOfBusinessPartners: Int?
+    val numberOfSharingMembers: Int?
     val lastConfidenceCheckAt: LocalDateTime?
     val nextConfidenceCheckAt: LocalDateTime?
     val confidenceLevel: Int?

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/ConfidenceCriteriaDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/ConfidenceCriteriaDto.kt
@@ -25,7 +25,7 @@ import java.time.LocalDateTime
 data class ConfidenceCriteriaDto(
     override val sharedByOwner: Boolean,
     override val checkedByExternalDataSource: Boolean,
-    override val numberOfBusinessPartners: Int,
+    override val numberOfSharingMembers: Int,
     override val lastConfidenceCheckAt: LocalDateTime,
     override val nextConfidenceCheckAt: LocalDateTime,
     override val confidenceLevel: Int

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -175,7 +175,7 @@ class BusinessPartnerMappings {
         ConfidenceCriteriaDto(
             sharedByOwner = entity.sharedByOwner,
             checkedByExternalDataSource = entity.checkedByExternalDataSource,
-            numberOfBusinessPartners = entity.numberOfBusinessPartners,
+            numberOfSharingMembers = entity.numberOfBusinessPartners,
             lastConfidenceCheckAt = entity.lastConfidenceCheckAt,
             nextConfidenceCheckAt = entity.nextConfidenceCheckAt,
             confidenceLevel = entity.confidenceLevel

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -146,7 +146,7 @@ class OrchestratorMappings(
         ConfidenceCriteriaDto(
             sharedByOwner = entity.sharedByOwner,
             checkedByExternalDataSource = entity.checkedByExternalDataSource,
-            numberOfBusinessPartners = entity.numberOfBusinessPartners,
+            numberOfSharingMembers = entity.numberOfBusinessPartners,
             lastConfidenceCheckAt = entity.lastConfidenceCheckAt,
             nextConfidenceCheckAt = entity.nextConfidenceCheckAt,
             confidenceLevel = entity.confidenceLevel
@@ -250,7 +250,7 @@ class OrchestratorMappings(
         ConfidenceCriteriaDb(
             sharedByOwner = dto.sharedByOwner,
             checkedByExternalDataSource = dto.checkedByExternalDataSource,
-            numberOfBusinessPartners = dto.numberOfBusinessPartners,
+            numberOfBusinessPartners = dto.numberOfSharingMembers,
             lastConfidenceCheckAt = dto.lastConfidenceCheckAt,
             nextConfidenceCheckAt = dto.nextConfidenceCheckAt,
             confidenceLevel = dto.confidenceLevel

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerGenericValues.kt
@@ -70,7 +70,7 @@ object BusinessPartnerGenericValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = true,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 7,
+                numberOfSharingMembers = 7,
                 lastConfidenceCheckAt = LocalDateTime.of(2022, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2026, 4, 3, 2, 1),
                 confidenceLevel = 1
@@ -82,7 +82,7 @@ object BusinessPartnerGenericValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = false,
                 checkedByExternalDataSource = false,
-                numberOfBusinessPartners = 8,
+                numberOfSharingMembers = 8,
                 lastConfidenceCheckAt = LocalDateTime.of(2023, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2024, 4, 3, 2, 1),
                 confidenceLevel = 2
@@ -132,7 +132,7 @@ object BusinessPartnerGenericValues {
             confidenceCriteria = ConfidenceCriteriaDto(
                 sharedByOwner = false,
                 checkedByExternalDataSource = true,
-                numberOfBusinessPartners = 4,
+                numberOfSharingMembers = 4,
                 lastConfidenceCheckAt = LocalDateTime.of(2020, 4, 3, 2, 1),
                 nextConfidenceCheckAt = LocalDateTime.of(2028, 4, 3, 2, 1),
                 confidenceLevel = 5

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ConfidenceCriteriaDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ConfidenceCriteriaDto.kt
@@ -25,7 +25,7 @@ import java.time.LocalDateTime
 data class ConfidenceCriteriaDto(
     override val sharedByOwner: Boolean,
     override val checkedByExternalDataSource: Boolean,
-    override val numberOfBusinessPartners: Int,
+    override val numberOfSharingMembers: Int,
     override val lastConfidenceCheckAt: LocalDateTime,
     override val nextConfidenceCheckAt: LocalDateTime,
     override val confidenceLevel: Int

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/ConfidenceCriteriaDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/ConfidenceCriteriaDto.kt
@@ -25,7 +25,7 @@ import java.time.LocalDateTime
 data class ConfidenceCriteriaDto(
     override val sharedByOwner: Boolean,
     override val checkedByExternalDataSource: Boolean,
-    override val numberOfBusinessPartners: Int,
+    override val numberOfSharingMembers: Int,
     override val lastConfidenceCheckAt: LocalDateTime,
     override val nextConfidenceCheckAt: LocalDateTime,
     override val confidenceLevel: Int

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -670,7 +670,7 @@ class BusinessPartnerBuildService(
             ConfidenceCriteriaDb(
                 sharedByOwner = confidenceCriteria.sharedByOwner!!,
                 checkedByExternalDataSource = confidenceCriteria.checkedByExternalDataSource!!,
-                numberOfBusinessPartners = confidenceCriteria.numberOfBusinessPartners!!,
+                numberOfBusinessPartners = confidenceCriteria.numberOfSharingMembers!!,
                 lastConfidenceCheckAt = confidenceCriteria.lastConfidenceCheckAt!!,
                 nextConfidenceCheckAt = confidenceCriteria.nextConfidenceCheckAt!!,
                 confidenceLevel = confidenceCriteria.confidenceLevel!!

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
@@ -118,7 +118,7 @@ class BusinessPartnerEquivalenceMapper {
             ConfidenceCriteriaEquivalenceDto(
                 sharedByOwner,
                 checkedByExternalDataSource,
-                numberOfBusinessPartners,
+                numberOfSharingMembers,
                 lastConfidenceCheckAt,
                 nextConfidenceCheckAt,
                 confidenceLevel
@@ -225,7 +225,7 @@ class BusinessPartnerEquivalenceMapper {
     data class ConfidenceCriteriaEquivalenceDto(
         override val sharedByOwner: Boolean?,
         override val checkedByExternalDataSource: Boolean?,
-        override val numberOfBusinessPartners: Int?,
+        override val numberOfSharingMembers: Int?,
         override val lastConfidenceCheckAt: LocalDateTime?,
         override val nextConfidenceCheckAt: LocalDateTime?,
         override val confidenceLevel: Int?

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -361,7 +361,7 @@ class TaskStepBuildService(
                         ConfidenceCriteriaPoolDto(
                             sharedByOwner,
                             checkedByExternalDataSource,
-                            numberOfBusinessPartners,
+                            numberOfSharingMembers,
                             lastConfidenceCheckAt,
                             nextConfidenceCheckAt,
                             confidenceLevel
@@ -426,7 +426,7 @@ class TaskStepBuildService(
             ConfidenceCriteriaPoolDto(
                 sharedByOwner,
                 checkedByExternalDataSource,
-                numberOfBusinessPartners,
+                numberOfSharingMembers,
                 lastConfidenceCheckAt,
                 nextConfidenceCheckAt,
                 confidenceLevel

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1446,7 +1446,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
     fun fullConfidenceCriteria() =
         ConfidenceCriteriaDto(
             sharedByOwner = true,
-            numberOfBusinessPartners = 1,
+            numberOfSharingMembers = 1,
             checkedByExternalDataSource = true,
             lastConfidenceCheckAt = LocalDateTime.now(),
             nextConfidenceCheckAt = LocalDateTime.now().plusDays(1),


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Corrects naming mistake of the field "numberOfBusinessPartners" in the confidence criteria to "numberOfSharingMembers".

Solves #788

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
