### PR TITLE
feat(Pool): remove isLegalAddress and isMainSiteAddress flags

### DIFF
--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
@@ -289,7 +289,6 @@ object BusinessPartnerVerboseValues {
         site = site1,
         mainAddress = addressPartner1.copy(
             bpnSite = site1.bpns,
-            isMainAddress = true,
             addressType = AddressType.SiteMainAddress
         ),
         index = "1"
@@ -299,7 +298,6 @@ object BusinessPartnerVerboseValues {
         site = site2,
         mainAddress = addressPartner2.copy(
             bpnSite = site2.bpns,
-            isMainAddress = true,
             addressType = AddressType.SiteMainAddress
         ),
         index = "2"
@@ -309,7 +307,6 @@ object BusinessPartnerVerboseValues {
         site = site3,
         mainAddress = addressPartner3.copy(
             bpnSite = site3.bpns,
-            isMainAddress = true,
             addressType = AddressType.SiteMainAddress
         ),
         index = "3"
@@ -444,7 +441,6 @@ object BusinessPartnerVerboseValues {
         ),
         legalAddress = addressPartner1.copy(
             bpnLegalEntity = legalEntity1.legalEntity.bpnl,
-            isLegalAddress = true,
             addressType = AddressType.LegalAddress
         ),
         index = "1"
@@ -464,7 +460,6 @@ object BusinessPartnerVerboseValues {
         ),
         legalAddress = addressPartner2.copy(
             bpnLegalEntity = legalEntity2.legalEntity.bpnl,
-            isLegalAddress = true,
             addressType = AddressType.LegalAddress
         ),
         index = "2"
@@ -484,7 +479,6 @@ object BusinessPartnerVerboseValues {
         ),
         legalAddress = addressPartner3.copy(
             bpnLegalEntity = legalEntity3.legalEntity.bpnl,
-            isLegalAddress = true,
             addressType = AddressType.LegalAddress
         ),
         index = "3"
@@ -507,7 +501,6 @@ object BusinessPartnerVerboseValues {
         ),
         legalAddress = addressPartner1.copy(
             bpnLegalEntity = legalEntity1.legalEntity.bpnl,
-            isLegalAddress = true
         ),
         index = "1"
     )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
@@ -43,14 +43,8 @@ data class LogisticAddressVerboseDto(
     @get:Schema(description = LogisticAddressDescription.bpnLegalEntity)
     val bpnLegalEntity: String?,
 
-    @get:Schema(name = "isLegalAddress", description = LogisticAddressDescription.isLegalAddress)
-    val isLegalAddress: Boolean = false,
-
     @get:Schema(description = LogisticAddressDescription.bpnSite)
     val bpnSite: String?,
-
-    @get:Schema(name = "isMainAddress", description = LogisticAddressDescription.isMainAddress)
-    val isMainAddress: Boolean = false,
 
     val isCatenaXMemberData: Boolean = false,
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -110,9 +110,7 @@ fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
     return LogisticAddressVerboseDto(
         bpna = bpn,
         bpnLegalEntity = legalEntity?.bpn,
-        isLegalAddress = legalEntity?.legalAddress == this,
         bpnSite = site?.bpn,
-        isMainAddress = site?.mainAddress == this,
         createdAt = createdAt,
         updatedAt = updatedAt,
         name = name,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
@@ -88,7 +88,7 @@ class AddressControllerIT @Autowired constructor(
             .let { bpnL -> requestAddressesOfLegalEntity(bpnL).content }
         // 1 legal address, 1 regular address
         assertThat(addressesByBpnL.size).isEqualTo(2)
-        assertThat(addressesByBpnL.count { it.isLegalAddress }).isEqualTo(1)
+        assertThat(addressesByBpnL.count { it.addressType == AddressType.LegalAddress || it.addressType == AddressType.LegalAndSiteMainAddress }).isEqualTo(1)
 
         // Same address if we use the address-by-BPNA method
         addressesByBpnL
@@ -177,7 +177,7 @@ class AddressControllerIT @Autowired constructor(
         val searchResult = poolClient.addresses.searchAddresses(searchRequest, PaginationRequest())
 
         val expected = listOf(
-            BusinessPartnerVerboseValues.addressPartner2.copy(isLegalAddress = true, addressType = AddressType.LegalAddress),
+            BusinessPartnerVerboseValues.addressPartner2.copy(addressType = AddressType.LegalAddress),
             BusinessPartnerVerboseValues.addressPartner3
         )
 
@@ -223,7 +223,7 @@ class AddressControllerIT @Autowired constructor(
             .let {
                 assertAddressesAreEqual(
                     it.content, listOf(
-                        BusinessPartnerVerboseValues.addressPartner1.copy(isMainAddress = true, addressType = AddressType.SiteMainAddress),
+                        BusinessPartnerVerboseValues.addressPartner1.copy(addressType = AddressType.SiteMainAddress),
                         BusinessPartnerVerboseValues.addressPartner1,
                         BusinessPartnerVerboseValues.addressPartner2,
                     )
@@ -236,7 +236,7 @@ class AddressControllerIT @Autowired constructor(
             .let {
                 assertAddressesAreEqual(
                     it.content, listOf(
-                        BusinessPartnerVerboseValues.addressPartner2.copy(isMainAddress = true, addressType = AddressType.SiteMainAddress),
+                        BusinessPartnerVerboseValues.addressPartner2.copy(addressType = AddressType.SiteMainAddress),
                         BusinessPartnerVerboseValues.addressPartner3,
                     )
                 )
@@ -249,11 +249,11 @@ class AddressControllerIT @Autowired constructor(
                 assertAddressesAreEqual(
                     it.content, listOf(
                         // site1
-                        BusinessPartnerVerboseValues.addressPartner1.copy(isMainAddress = true, addressType = AddressType.SiteMainAddress),
+                        BusinessPartnerVerboseValues.addressPartner1.copy(addressType = AddressType.SiteMainAddress),
                         BusinessPartnerVerboseValues.addressPartner1,
                         BusinessPartnerVerboseValues.addressPartner2,
                         // site2
-                        BusinessPartnerVerboseValues.addressPartner2.copy(isMainAddress = true, addressType = AddressType.SiteMainAddress),
+                        BusinessPartnerVerboseValues.addressPartner2.copy(addressType = AddressType.SiteMainAddress),
                         BusinessPartnerVerboseValues.addressPartner3,
                     )
                 )

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -123,7 +123,6 @@ class SiteControllerIT @Autowired constructor(
         val expectedSiteWithReference1 = SiteWithMainAddressVerboseDto(
             site = BusinessPartnerVerboseValues.site1.copy(bpnLegalEntity = bpnL),
             mainAddress = BusinessPartnerVerboseValues.addressPartner1.copy(
-                isMainAddress = true,
                 addressType = AddressType.SiteMainAddress,
                 bpnSite = BusinessPartnerVerboseValues.site1.bpns
             )
@@ -131,7 +130,6 @@ class SiteControllerIT @Autowired constructor(
         val expectedSiteWithReference2 = SiteWithMainAddressVerboseDto(
             site = BusinessPartnerVerboseValues.site2.copy(bpnLegalEntity = bpnL),
             mainAddress = BusinessPartnerVerboseValues.addressPartner2.copy(
-                isMainAddress = true,
                 addressType = AddressType.SiteMainAddress,
                 bpnSite = BusinessPartnerVerboseValues.site2.bpns
             )
@@ -178,7 +176,6 @@ class SiteControllerIT @Autowired constructor(
             SiteWithMainAddressVerboseDto(
                 site = BusinessPartnerVerboseValues.site1.copy(bpnLegalEntity = bpnL1),
                 mainAddress = BusinessPartnerVerboseValues.addressPartner1.copy(
-                    isMainAddress = true,
                     addressType = AddressType.SiteMainAddress,
                     bpnSite = BusinessPartnerVerboseValues.site1.bpns
                 )
@@ -187,7 +184,6 @@ class SiteControllerIT @Autowired constructor(
             SiteWithMainAddressVerboseDto(
                 site = BusinessPartnerVerboseValues.site2.copy(bpnLegalEntity = bpnL1),
                 mainAddress = BusinessPartnerVerboseValues.addressPartner2.copy(
-                    isMainAddress = true,
                     addressType = AddressType.SiteMainAddress,
                     bpnSite = BusinessPartnerVerboseValues.site2.bpns
                 )
@@ -196,7 +192,6 @@ class SiteControllerIT @Autowired constructor(
             SiteWithMainAddressVerboseDto(
                 site = BusinessPartnerVerboseValues.site3.copy(bpnLegalEntity = bpnL2),
                 mainAddress = BusinessPartnerVerboseValues.addressPartner3.copy(
-                    isMainAddress = true,
                     addressType = AddressType.SiteMainAddress,
                     bpnSite = BusinessPartnerVerboseValues.site3.bpns
                 )
@@ -495,7 +490,6 @@ class SiteControllerIT @Autowired constructor(
 
         val legalAddress1: LogisticAddressVerboseDto =
             BusinessPartnerVerboseValues.addressPartner1.copy(
-                isMainAddress = true,
                 addressType = AddressType.SiteMainAddress,
                 bpnSite = BusinessPartnerVerboseValues.site1.bpns,
                 bpna = "BPNA0000000001YN"
@@ -504,7 +498,6 @@ class SiteControllerIT @Autowired constructor(
 
         val legalAddress2: LogisticAddressVerboseDto =
             BusinessPartnerVerboseValues.addressPartner2.copy(
-                isMainAddress = true,
                 addressType = AddressType.SiteMainAddress,
                 bpnSite = BusinessPartnerVerboseValues.site2.bpns,
                 bpna = "BPNA0000000002XY"

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerComparator.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerComparator.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdm.pool.service
 
 import org.assertj.core.api.Assertions
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
 import org.eclipse.tractusx.bpdm.common.dto.ISiteStateDto
 import org.eclipse.tractusx.bpdm.pool.api.model.*
@@ -47,7 +48,7 @@ fun compareLegalEntity(verboseRequest: LegalEntityWithLegalAddressVerboseDto, le
 
     val verboseLegalAddress = verboseRequest.legalAddress
     Assertions.assertThat(verboseLegalAddress.bpnLegalEntity).isEqualTo(legalEntity?.bpnLReference?.referenceValue)
-    Assertions.assertThat(verboseLegalAddress.isLegalAddress).isTrue()
+    Assertions.assertThat(verboseLegalAddress.addressType == AddressType.LegalAddress || verboseLegalAddress.addressType == AddressType.LegalAndSiteMainAddress ).isTrue()
     compareLogisticAddress(verboseLegalAddress, legalEntity?.legalAddress)
 }
 
@@ -62,7 +63,7 @@ fun compareSite(verboseRequest: SiteWithMainAddressVerboseDto, site: SiteDto?) {
     val verboseMainAddress = verboseRequest.mainAddress
     Assertions.assertThat(verboseMainAddress.bpnSite).isEqualTo(site?.bpnSReference?.referenceValue)
     val mainAddress = site?.mainAddress
-    Assertions.assertThat(verboseMainAddress.isMainAddress).isTrue()
+    Assertions.assertThat(verboseMainAddress.addressType == AddressType.SiteMainAddress || verboseMainAddress.addressType == AddressType.LegalAndSiteMainAddress).isTrue()
     compareLogisticAddress(verboseMainAddress, mainAddress)
 }
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -21,10 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.service
 
 import com.neovisionaries.i18n.CountryCode
 import org.assertj.core.api.Assertions.assertThat
-import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
-import org.eclipse.tractusx.bpdm.common.dto.ILegalEntityStateDto
-import org.eclipse.tractusx.bpdm.common.dto.ISiteStateDto
-import org.eclipse.tractusx.bpdm.common.dto.TypeKeyNameVerboseDto
+import org.eclipse.tractusx.bpdm.common.dto.*
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
@@ -35,7 +32,6 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAdd
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.repository.BpnRequestIdentifierRepository
 import org.eclipse.tractusx.bpdm.pool.service.TaskStepBuildService.CleaningError
-
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues.addressIdentifierTypeDto1
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues.addressIdentifierTypeDto2
@@ -187,14 +183,12 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val createdLegalEntity = poolClient.legalEntities.getLegalEntity(createResult[0].businessPartner?.legalEntity?.bpnLReference?.referenceValue!!)
         assertThat(createdLegalEntity.legalAddress.bpnLegalEntity).isEqualTo(createdLegalEntity.legalEntity.bpnl)
-        assertThat(createdLegalEntity.legalAddress.isLegalAddress).isTrue()
-        assertThat(createdLegalEntity.legalAddress.isMainAddress).isFalse()
+        assertThat(createdLegalEntity.legalAddress.addressType == AddressType.LegalAddress).isTrue()
         assertThat(createResult[0].businessPartner?.generic?.legalEntity?.legalEntityBpn).isEqualTo(createdLegalEntity.legalEntity.bpnl)
         compareLegalEntity(createdLegalEntity, createResult[0].businessPartner?.legalEntity)
         val createdAdditionalAddress = poolClient.addresses.getAddress(createResult[0].businessPartner?.address?.bpnAReference?.referenceValue!!)
         assertThat(createdAdditionalAddress.bpnLegalEntity).isEqualTo(createdLegalEntity.legalEntity.bpnl)
-        assertThat(createdAdditionalAddress.isLegalAddress).isFalse()
-        assertThat(createdAdditionalAddress.isMainAddress).isFalse()
+        assertThat(createdAdditionalAddress.addressType == AddressType.AdditionalAddress).isTrue()
     }
 
     @Test
@@ -738,8 +732,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         compareLogisticAddress(createdAdditionalAddress, createResult[0].businessPartner?.address)
         assertThat(createdAdditionalAddress.bpnLegalEntity).isNull()
         assertThat(createdAdditionalAddress.bpnSite).isEqualTo(createResult[0].businessPartner?.site?.bpnSReference?.referenceValue)
-        assertThat(createdAdditionalAddress.isLegalAddress).isFalse()
-        assertThat(createdAdditionalAddress.isMainAddress).isFalse()
+        assertThat(createdAdditionalAddress.addressType == AddressType.AdditionalAddress).isTrue()
     }
 
 
@@ -1080,9 +1073,8 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val createdAdditionalAddress = poolClient.addresses.getAddress(createResult[0].businessPartner?.address?.bpnAReference?.referenceValue!!)
         assertThat(createResult[0].taskId).isEqualTo("TASK_1")
         assertThat(createResult[0].errors).hasSize(0)
-        assertThat(createdLeAddress.isLegalAddress).isTrue()
-        assertThat(createdAdditionalAddress.isMainAddress).isFalse()
-        assertThat(createdAdditionalAddress.isLegalAddress).isFalse()
+        assertThat(createdLeAddress.addressType == AddressType.LegalAddress).isTrue()
+        assertThat(createdAdditionalAddress.addressType == AddressType.AdditionalAddress).isTrue()
         compareLogisticAddress(createdAdditionalAddress, createResult[0].businessPartner?.address)
     }
 
@@ -1472,7 +1464,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
         val verboseLegalAddress = verboseRequest.legalAddress
         assertThat(verboseLegalAddress.bpnLegalEntity).isEqualTo(legalEntity?.bpnLReference?.referenceValue)
-        assertThat(verboseLegalAddress.isLegalAddress).isTrue()
+        assertThat(verboseLegalAddress.addressType == AddressType.LegalAddress).isTrue()
         compareLogisticAddress(verboseLegalAddress, legalEntity?.legalAddress)
     }
 
@@ -1487,7 +1479,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         val verboseMainAddress = verboseRequest.mainAddress
         assertThat(verboseMainAddress.bpnSite).isEqualTo(site?.bpnSReference?.referenceValue)
         val mainAddress = site?.mainAddress
-        assertThat(verboseMainAddress.isMainAddress).isTrue()
+        assertThat(verboseMainAddress.addressType == AddressType.SiteMainAddress).isTrue()
         compareLogisticAddress(verboseMainAddress, mainAddress)
     }
 


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

This pull request removes the flags "isLegalAddress" and "isSiteMainAddress" from the Pool's address model.

The flags are not needed anymore since the information is already stored in the address type enumeration.

Adjusted tests accordingly.

Solves #680 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
