### PR TITLE
Change State to Ready on BPDM Create

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessConfigProperties.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessConfigProperties.kt
@@ -37,7 +37,7 @@ data class GoldenRecordTaskConfigProperties(
     )
 
     data class CreationTaskProperties(
-        val startsAsReady: Boolean = false,
+        val startsAsReady: Boolean = true,
         val batchSize: Int = 100,
         val cron: String = "-",
     )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SharingStateService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SharingStateService.kt
@@ -240,7 +240,7 @@ class SharingStateService(
                 ?: SharingStateDb(
                     externalId,
                     businessPartnerType = businessPartnerType,
-                    sharingStateType = SharingStateType.Initial,
+                    sharingStateType = SharingStateType.Ready,
                     sharingErrorCode = null,
                     sharingErrorMessage = null,
                     bpn = null,

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -39,7 +39,7 @@ bpdm:
             fromSharingMember:
                 # If true, new business partner input data will be directly ready to be shared
                 # If false, new business partner input data need to be manually set to ready
-                starts-as-ready: false
+                starts-as-ready: true
                 # When and how often the Gate checks for new business partner data to be shared
                 cron: '-'
                 # Up to how many golden record tasks can be created when checking

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -1,0 +1,294 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import org.assertj.core.api.Assertions
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerIdentifierDto
+import org.eclipse.tractusx.bpdm.gate.api.model.BusinessPartnerStateDto
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
+import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDto
+import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerGenericCommonValues
+import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerVerboseValues
+import org.eclipse.tractusx.bpdm.test.util.AssertHelpers
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class MockAndAssertUtils @Autowired constructor(
+    val gateClient: GateClient,
+    val objectMapper: ObjectMapper,
+    val assertHelpers: AssertHelpers
+) {
+
+    val ORCHESTRATOR_CREATE_TASKS_URL = "/golden-record-tasks"
+    val ORCHESTRATOR_SEARCH_TASK_STATES_URL = "/golden-record-tasks/state/search"
+    val POOL_API_SEARCH_CHANGE_LOG_URL = "/business-partners/changelog/search"
+
+    fun mockOrchestratorApi(gateWireMockServer: WireMockExtension) {
+        val taskCreateResponse =
+            TaskCreateResponse(
+                listOf(
+                    TaskClientStateDto(
+                        taskId = "0",
+                        businessPartnerResult = null,
+                        processingState = TaskProcessingStateDto(
+                            resultState = ResultState.Pending,
+                            step = TaskStep.CleanAndSync,
+                            stepState = StepState.Queued,
+                            errors = emptyList(),
+                            createdAt = Instant.now(),
+                            modifiedAt = Instant.now(),
+                            timeout = Instant.now()
+                        )
+                    ),
+                    TaskClientStateDto(
+                        taskId = "1",
+                        businessPartnerResult = null,
+                        processingState = TaskProcessingStateDto(
+                            resultState = ResultState.Pending,
+                            step = TaskStep.CleanAndSync,
+                            stepState = StepState.Queued,
+                            errors = emptyList(),
+                            createdAt = Instant.now(),
+                            modifiedAt = Instant.now(),
+                            timeout = Instant.now()
+                        )
+                    ),
+                    TaskClientStateDto(
+                        taskId = "2",
+                        businessPartnerResult = null,
+                        processingState = TaskProcessingStateDto(
+                            resultState = ResultState.Pending,
+                            step = TaskStep.CleanAndSync,
+                            stepState = StepState.Queued,
+                            errors = emptyList(),
+                            createdAt = Instant.now(),
+                            modifiedAt = Instant.now(),
+                            timeout = Instant.now()
+                        )
+                    ),
+                    TaskClientStateDto(
+                        taskId = "3",
+                        businessPartnerResult = null,
+                        processingState = TaskProcessingStateDto(
+                            resultState = ResultState.Pending,
+                            step = TaskStep.CleanAndSync,
+                            stepState = StepState.Queued,
+                            errors = emptyList(),
+                            createdAt = Instant.now(),
+                            modifiedAt = Instant.now(),
+                            timeout = Instant.now()
+                        )
+                    )
+                )
+            )
+
+        // Orchestrator request new cleaning endpoint
+        gateWireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(ORCHESTRATOR_CREATE_TASKS_URL))
+                .willReturn(
+                    WireMock.okJson(objectMapper.writeValueAsString(taskCreateResponse))
+                )
+        )
+    }
+
+    fun mockOrchestratorApiCleaned(gateWireMockServer: WireMockExtension) {
+        val taskStateResponse =
+            TaskStateResponse(
+                listOf(
+                    TaskClientStateDto(
+                        taskId = "0",
+                        businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                        processingState = TaskProcessingStateDto(
+                            resultState = ResultState.Success,
+                            step = TaskStep.CleanAndSync,
+                            stepState = StepState.Queued,
+                            errors = emptyList(),
+                            createdAt = Instant.now(),
+                            modifiedAt = Instant.now(),
+                            timeout = Instant.now()
+                        )
+                    ),
+                    TaskClientStateDto(
+                        taskId = "1",
+                        businessPartnerResult = null,
+                        processingState = TaskProcessingStateDto(
+                            resultState = ResultState.Error,
+                            step = TaskStep.CleanAndSync,
+                            stepState = StepState.Queued,
+                            errors = listOf(
+                                TaskErrorDto(TaskErrorType.Timeout, "Major Error"),
+                                TaskErrorDto(TaskErrorType.Unspecified, "Minor Error")
+                            ),
+                            createdAt = Instant.now(),
+                            modifiedAt = Instant.now(),
+                            timeout = Instant.now()
+                        )
+                    )
+                )
+            )
+
+        gateWireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(ORCHESTRATOR_SEARCH_TASK_STATES_URL)).willReturn(
+                WireMock.okJson(objectMapper.writeValueAsString(taskStateResponse))
+            )
+        )
+    }
+
+    fun mockOrchestratorApiCleanedResponseSizeOne(gateWireMockServer: WireMockExtension) {
+        val taskStateResponse = TaskStateResponse(
+            listOf(
+                TaskClientStateDto(
+                    taskId = "0", businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1, processingState = TaskProcessingStateDto(
+                        resultState = ResultState.Success,
+                        step = TaskStep.CleanAndSync,
+                        stepState = StepState.Queued,
+                        errors = emptyList(),
+                        createdAt = Instant.now(),
+                        modifiedAt = Instant.now(),
+                        timeout = Instant.now()
+                    )
+                )
+            )
+        )
+        gateWireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(ORCHESTRATOR_SEARCH_TASK_STATES_URL))
+                .willReturn(
+                    WireMock.okJson(objectMapper.writeValueAsString(taskStateResponse))
+                )
+        )
+    }
+
+    fun mockPoolApiGetChangeLogs(poolWireMockServer: WireMockExtension) {
+
+        val poolChangelogEntries = PageDto(
+            totalElements = 3,
+            totalPages = 1,
+            page = 0,
+            contentSize = 3,
+            content = listOf(
+                ChangelogEntryVerboseDto(
+                    bpn = BusinessPartnerVerboseValues.bpOutputDtoCleaned.legalEntity.legalEntityBpn,
+                    businessPartnerType = BusinessPartnerType.LEGAL_ENTITY,
+                    timestamp = Instant.now(),
+                    changelogType = ChangelogType.UPDATE
+                ),
+                ChangelogEntryVerboseDto(
+                    bpn = BusinessPartnerVerboseValues.bpOutputDtoCleaned.address.addressBpn,
+                    businessPartnerType = BusinessPartnerType.ADDRESS,
+                    timestamp = Instant.now(),
+                    changelogType = ChangelogType.UPDATE
+                ),
+                ChangelogEntryVerboseDto(
+                    bpn = BusinessPartnerVerboseValues.bpOutputDtoCleaned.site!!.siteBpn!!,
+                    businessPartnerType = BusinessPartnerType.SITE,
+                    timestamp = Instant.now(),
+                    changelogType = ChangelogType.UPDATE
+                )
+            )
+        )
+        // Pool APi get changelogs endpoint
+        poolWireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(POOL_API_SEARCH_CHANGE_LOG_URL))
+                .willReturn(
+                    WireMock.okJson(objectMapper.writeValueAsString(poolChangelogEntries))
+                )
+        )
+    }
+
+    fun readSharingStates(businessPartnerType: BusinessPartnerType?, externalIds: Collection<String>?): Collection<SharingStateDto> {
+
+        return gateClient.sharingState.getSharingStates(PaginationRequest(), businessPartnerType, externalIds).content
+    }
+
+    fun assertUpsertOutputResponsesMatchRequests(responses: Collection<BusinessPartnerOutputDto>, requests: List<BusinessPartnerOutputDto>) {
+        Assertions.assertThat(responses)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .ignoringFieldsOfTypes(Instant::class.java)
+            .isEqualTo(requests)
+    }
+
+    fun assertUpsertResponsesMatchRequests(responses: Collection<BusinessPartnerInputDto>, requests: List<BusinessPartnerInputRequest>) {
+        Assertions.assertThat(responses)
+            .usingRecursiveComparison()
+            .ignoringFieldsOfTypes(Instant::class.java)
+            .isEqualTo(requests.map(::toExpectedResponse))
+    }
+
+    private fun toExpectedResponse(request: BusinessPartnerInputRequest): BusinessPartnerInputDto {
+        // same sorting order as defined for entity
+        return BusinessPartnerInputDto(
+            externalId = request.externalId,
+            nameParts = request.nameParts,
+            identifiers = request.identifiers.toSortedSet(identifierDtoComparator),
+            states = request.states.toSortedSet(stateDtoComparator),
+            roles = request.roles.toSortedSet(),
+            isOwnCompanyData = request.isOwnCompanyData,
+            legalEntity = request.legalEntity,
+            site = request.site,
+            address = request.address,
+            createdAt = Instant.now(),
+            updatedAt = Instant.now()
+        )
+    }
+
+    val identifierDtoComparator = compareBy(
+        BusinessPartnerIdentifierDto::type,
+        BusinessPartnerIdentifierDto::value,
+        BusinessPartnerIdentifierDto::issuingBody
+    )
+
+    val stateDtoComparator = compareBy(nullsFirst(), BusinessPartnerStateDto::validFrom)       // here null means MIN
+        .thenBy(nullsLast(), BusinessPartnerStateDto::validTo)        // here null means MAX
+        .thenBy(BusinessPartnerStateDto::type)
+
+    fun assertBusinessPartnersUpsertedCorrectly(upsertedBusinessPartners: Collection<BusinessPartnerInputDto>) {
+        val searchResponsePage = gateClient.businessParters.getBusinessPartnersInput(null)
+        org.junit.jupiter.api.Assertions.assertEquals(upsertedBusinessPartners.size.toLong(), searchResponsePage.totalElements)
+        assertHelpers.assertRecursively(searchResponsePage.content).isEqualTo(upsertedBusinessPartners)
+
+        val sharingStateResponse = gateClient.sharingState.getSharingStates(PaginationRequest(), businessPartnerType = null, externalIds = null)
+        org.junit.jupiter.api.Assertions.assertEquals(upsertedBusinessPartners.size.toLong(), sharingStateResponse.totalElements)
+        Assertions.assertThat(sharingStateResponse.content).isEqualTo(
+            upsertedBusinessPartners.map {
+                SharingStateDto(
+                    businessPartnerType = BusinessPartnerType.GENERIC,
+                    externalId = it.externalId,
+                    sharingStateType = SharingStateType.Ready
+                )
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Description
On Bpn creation pass the sharing state to ready by default
Change Unit Test to contemplate both states Initial and Ready
Rework and organize Unit Test

issue: https://github.com/eclipse-tractusx/bpdm/issues/815

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
