### PR TITLE
feat(Member): set isCatenaXMemberData based on ownership information

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/GenericBusinessPartnerMappings.kt
@@ -44,6 +44,7 @@ fun BusinessPartnerGenericDto.toLegalEntityDto(bpnReferenceDto: BpnReferenceDto,
         legalForm = legalEntity.legalForm,
         states = states.mapNotNull { it.toLegalEntityState() },
         legalAddress = legalAddress,
+        isCatenaXMemberData = ownerBpnL != null,
         confidenceCriteria = dummyConfidenceCriteria
     )
 }

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/testdata/CommonValues.kt
@@ -183,6 +183,7 @@ object CommonValues {
         identifiers = identifiers.mapNotNull { it.toLegalEntityIdentifierDto() },
         legalForm = legalForm,
         states = states.mapNotNull { it.toLegalEntityState() },
+        isCatenaXMemberData = true,
         confidenceCriteria = dummyConfidenceCriteria
     )
 

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
@@ -422,7 +422,8 @@ object BusinessPartnerGenericCommonValues {
             lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
             confidenceLevel = 3
-        )
+        ),
+        isCatenaXMemberData = false
     )
 
     val legalEntity2 = LegalEntityDto(
@@ -456,7 +457,8 @@ object BusinessPartnerGenericCommonValues {
             lastConfidenceCheckAt = LocalDateTime.of(2023, 5, 6, 7, 8),
             nextConfidenceCheckAt = LocalDateTime.of(2026, 5, 6, 7, 8),
             confidenceLevel = 4
-        )
+        ),
+        isCatenaXMemberData = false
     )
 
     val site1 = SiteDto(

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
@@ -195,6 +195,7 @@ object BusinessPartnerVerboseValues {
         legalShortName = "short1",
         legalForm = "LF1",
         states = listOf(legalEntityBusinessStatus1),
+        isCatenaXMemberData = false
     )
 
     val legalEntity2 = LegalEntityDto(
@@ -202,6 +203,7 @@ object BusinessPartnerVerboseValues {
         legalShortName = "short3",
         legalForm = "LF2",
         states = listOf(legalEntityBusinessStatus2),
+        isCatenaXMemberData = false
     )
 
     val legalEntity3 = LegalEntityDto(
@@ -209,6 +211,7 @@ object BusinessPartnerVerboseValues {
         legalShortName = "short1",
         legalForm = "LF1",
         states = listOf(legalEntityBusinessStatus1),
+        isCatenaXMemberData = false
     )
 
     val siteBusinessStatus1 = SiteStateDto(

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
@@ -215,7 +215,8 @@ object BusinessPartnerVerboseValues {
         confidenceCriteria = confidenceCriteria1,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
-        addressType = AddressType.AdditionalAddress
+        addressType = AddressType.AdditionalAddress,
+        isCatenaXMemberData = false
     )
 
     val addressPartner2 = LogisticAddressVerboseDto(
@@ -226,7 +227,8 @@ object BusinessPartnerVerboseValues {
         confidenceCriteria = confidenceCriteria2,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
-        addressType = AddressType.AdditionalAddress
+        addressType = AddressType.AdditionalAddress,
+        isCatenaXMemberData = false
     )
 
     val addressPartner3 = LogisticAddressVerboseDto(
@@ -237,7 +239,8 @@ object BusinessPartnerVerboseValues {
         confidenceCriteria = confidenceCriteria3,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
-        addressType = AddressType.AdditionalAddress
+        addressType = AddressType.AdditionalAddress,
+        isCatenaXMemberData = false
     )
 
     val addressPartnerCreate1 = AddressPartnerCreateVerboseDto(
@@ -261,6 +264,7 @@ object BusinessPartnerVerboseValues {
         states = listOf(siteStatus1),
         bpnLegalEntity = "BPNL000000000001",
         confidenceCriteria = confidenceCriteria1,
+        isCatenaXMemberData = false,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -271,6 +275,7 @@ object BusinessPartnerVerboseValues {
         states = listOf(siteStatus2),
         bpnLegalEntity = "BPNL0000000001YN",
         confidenceCriteria = confidenceCriteria2,
+        isCatenaXMemberData = false,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -281,6 +286,7 @@ object BusinessPartnerVerboseValues {
         states = listOf(siteStatus3),
         bpnLegalEntity = "BPNL0000000002XY",
         confidenceCriteria = confidenceCriteria3,
+        isCatenaXMemberData = false,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -322,6 +328,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria1,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -346,6 +353,7 @@ object BusinessPartnerVerboseValues {
             bpnLegalEntity = null,
             bpnSite = null,
             confidenceCriteria = confidenceCriteria1,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -360,6 +368,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria2,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -384,6 +393,7 @@ object BusinessPartnerVerboseValues {
             bpnLegalEntity = null,
             bpnSite = null,
             confidenceCriteria = confidenceCriteria2,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -398,6 +408,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus3),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria3,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -422,6 +433,7 @@ object BusinessPartnerVerboseValues {
             bpnLegalEntity = null,
             bpnSite = null,
             confidenceCriteria = confidenceCriteria3,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -436,6 +448,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria1,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -455,6 +468,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria2,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -474,6 +488,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus3),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria3,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -496,6 +511,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria1,
+            isCatenaXMemberData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
@@ -39,4 +39,7 @@ interface IBaseLegalEntityDto {
     val states: Collection<ILegalEntityStateDto>
 
     val confidenceCriteria: IConfidenceCriteriaDto?
+
+    @get:Schema(description = "Indicates whether the legal entity is owned and thus provided by a Catena-X Member.")
+    val isCatenaXMemberData: Boolean
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
@@ -40,6 +40,8 @@ data class LegalEntityDto(
     @get:ArraySchema(arraySchema = Schema(description = CommonDescription.roles))
     val roles: Collection<BusinessPartnerRole> = emptyList(),
 
-    override val confidenceCriteria: ConfidenceCriteriaDto? = null
+    override val confidenceCriteria: ConfidenceCriteriaDto? = null,
+
+    override val isCatenaXMemberData: Boolean
 
 ) : IBaseLegalEntityDto

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ResponseMappings.kt
@@ -360,6 +360,7 @@ fun LegalEntityDb.toLegalEntityDto(): LegalEntityDto {
         legalShortName = shortName,
         states = mapToLegalEntityStateDto(states),
         identifiers = mapToLegalEntityIdentifiersDto(identifiers),
+        isCatenaXMemberData = false,
         roles = roles.map { it.roleName },
     )
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/LegalEntityDto.kt
@@ -44,6 +44,8 @@ data class LegalEntityDto(
 
     val legalAddress: LogisticAddressDto? = null,
 
-    override val confidenceCriteria: ConfidenceCriteriaDto? = null
+    override val confidenceCriteria: ConfidenceCriteriaDto? = null,
+
+    override val isCatenaXMemberData: Boolean
 
 ) : IBaseLegalEntityDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
@@ -33,6 +33,7 @@ data class LegalEntityDto(
     override val legalForm: String? = null,
     override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
     override val states: Collection<LegalEntityStateDto> = emptyList(),
-    override val confidenceCriteria: ConfidenceCriteriaDto
+    override val confidenceCriteria: ConfidenceCriteriaDto,
+    override val isCatenaXMemberData: Boolean = false
 
 ) : IBaseLegalEntityDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
@@ -54,7 +54,7 @@ data class LegalEntityVerboseDto(
 
     override val confidenceCriteria: ConfidenceCriteriaDto,
 
-    val isCatenaXMemberData: Boolean = false,
+    override val isCatenaXMemberData: Boolean,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressDto.kt
@@ -41,5 +41,4 @@ data class LogisticAddressDto(
     override val alternativePostalAddress: AlternativePostalAddressDto? = null,
 
     override val confidenceCriteria: ConfidenceCriteriaDto
-
 ) : IBaseLogisticAddressDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
@@ -46,7 +46,8 @@ data class LogisticAddressVerboseDto(
     @get:Schema(description = LogisticAddressDescription.bpnSite)
     val bpnSite: String?,
 
-    val isCatenaXMemberData: Boolean = false,
+    @get:Schema(description = "Indicates whether the address is owned and thus provided by a Catena-X Member.")
+    val isCatenaXMemberData: Boolean,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteDto.kt
@@ -32,5 +32,4 @@ data class SiteDto(
     val mainAddress: LogisticAddressDto,
 
     override val confidenceCriteria: ConfidenceCriteriaDto
-
 ) : IBaseSiteDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
@@ -34,7 +34,8 @@ data class SiteVerboseDto(
     override val name: String,
     override val states: Collection<SiteStateVerboseDto> = emptyList(),
 
-    val isCatenaXMemberData: Boolean = false,
+    @get:Schema(description = "Indicates whether the site is owned and thus provided by a Catena-X Member.")
+    val isCatenaXMemberData: Boolean,
 
     @get:Schema(description = SiteDescription.bpnLegalEntity)
     val bpnLegalEntity: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -85,7 +85,7 @@ class LegalEntityController(
         bpnl: String,
         paginationRequest: PaginationRequest
     ): PageDto<SiteVerboseDto> {
-        return siteService.findByPartnerBpn(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
+        return siteService.findByParentBpn(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntityDb.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/LegalEntityDb.kt
@@ -43,7 +43,10 @@ class LegalEntityDb(
     var currentness: Instant,
 
     @Embedded
-    var confidenceCriteria: ConfidenceCriteriaDb
+    var confidenceCriteria: ConfidenceCriteriaDb,
+
+    @Column(name = "is_catena_member", nullable = false)
+    var isCatenaXMemberData: Boolean
 
 ) : BaseEntity() {
     @OneToMany(mappedBy = "legalEntity", cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
@@ -34,8 +34,7 @@ interface SiteRepository : PagingAndSortingRepository<SiteDb, Long>, CrudReposit
     @Query("SELECT DISTINCT p FROM SiteDb p LEFT JOIN FETCH p.states WHERE p IN :partners")
     fun joinStates(partners: Set<SiteDb>): Set<SiteDb>
 
-    @Query("SELECT s FROM SiteDb s join s.legalEntity p where p.bpn=:bpn")
-    fun findByLegalEntityBpn(bpn: String, pageable: Pageable): Page<SiteDb>
+    fun findByLegalEntity(legalEntity: LegalEntityDb, pageable: Pageable): Page<SiteDb>
 
     fun findByLegalEntityInOrBpnIn(partners: Collection<LegalEntityDb>, bpns: Collection<String>, pageable: Pageable): Page<SiteDb>
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -587,7 +587,8 @@ class BusinessPartnerBuildService(
                 legalName = legalName,
                 legalForm = legalForm,
                 currentness = Instant.now().truncatedTo(ChronoUnit.MICROS),
-                confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria)
+                confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria),
+                isCatenaXMemberData = legalEntityDto.isCatenaXMemberData
             )
             updateLegalEntity(newLegalEntity, legalEntityDto, metadataMap)
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
@@ -45,6 +45,7 @@ class BusinessPartnerEquivalenceMapper {
                 identifiers = identifiers.map { IdentifierEquivalenceDto(it.value, it.type.technicalKey) }.toSortedSet(compareBy { it.value }),
                 states = states.map { StateEquivalenceDto(it.validFrom, it.validTo, it.type) }.toSortedSet(compareBy { it.validFrom }),
                 confidenceCriteria = toEquivalenceDto(confidenceCriteria),
+                isCatenaXMemberData = isCatenaXMemberData,
                 legalAddress = toEquivalenceDto(legalEntity.legalAddress)
             )
         }
@@ -144,7 +145,8 @@ class BusinessPartnerEquivalenceMapper {
         override val identifiers: SortedSet<IdentifierEquivalenceDto>,
         override val states: SortedSet<StateEquivalenceDto>,
         override val confidenceCriteria: ConfidenceCriteriaEquivalenceDto?,
-        val legalAddress: LogisticAddressEquivalenceDto?
+        val legalAddress: LogisticAddressEquivalenceDto?,
+        override val isCatenaXMemberData: Boolean
     ) : IBaseLegalEntityDto
 
     data class SiteEquivalenceDto(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -68,6 +68,7 @@ fun LegalEntityDb.toDto(): LegalEntityVerboseDto {
         relations = startNodeRelations.plus(endNodeRelations).map { it.toDto() },
         currentness = currentness,
         confidenceCriteria = confidenceCriteria.toDto(),
+        isCatenaXMemberData = isCatenaXMemberData,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )
@@ -119,6 +120,7 @@ fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
         physicalPostalAddress = physicalPostalAddress.toDto(),
         alternativePostalAddress = alternativePostalAddress?.toDto(),
         confidenceCriteria = confidenceCriteria.toDto(),
+        isCatenaXMemberData = legalEntity?.isCatenaXMemberData ?: site?.legalEntity?.isCatenaXMemberData ?: false,
         addressType = getAddressType(this)
     )
 }
@@ -222,6 +224,7 @@ fun SiteDb.toDto(): SiteVerboseDto {
         states = states.map { it.toDto() },
         bpnLegalEntity = legalEntity.bpn,
         confidenceCriteria = confidenceCriteria.toDto(),
+        isCatenaXMemberData = legalEntity.isCatenaXMemberData,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )
@@ -236,6 +239,7 @@ fun SiteDb.toPoolDto(): SiteWithMainAddressVerboseDto {
             states = states.map { it.toDto() },
             bpnLegalEntity = legalEntity.bpn,
             confidenceCriteria = confidenceCriteria.toDto(),
+            isCatenaXMemberData = legalEntity.isCatenaXMemberData,
             createdAt = createdAt,
             updatedAt = updatedAt,
         ),

--- a/bpdm-pool/src/main/resources/db/migration/V6_0_0_0__add_is_catena_member.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V6_0_0_0__add_is_catena_member.sql
@@ -1,0 +1,10 @@
+ALTER TABLE legal_entities
+    ADD is_catena_member boolean;
+
+UPDATE  legal_entities
+    SET is_catena_member = case when shared_by_owner is NULL then false else true end
+WHERE
+    is_catena_member is NULL;
+
+
+ALTER TABLE legal_entities ALTER COLUMN is_catena_member SET NOT NULL;

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerCreator.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerCreator.kt
@@ -37,7 +37,7 @@ fun minFullBusinessPartner(): BusinessPartnerFullDto {
 
 fun emptyLegalEntity(): LegalEntityDto {
 
-    return LegalEntityDto()
+    return LegalEntityDto(isCatenaXMemberData = false)
 }
 
 fun minValidLegalEntity(bpnLReference: BpnReferenceDto, bpnAReference: BpnReferenceDto): LegalEntityDto {
@@ -45,6 +45,7 @@ fun minValidLegalEntity(bpnLReference: BpnReferenceDto, bpnAReference: BpnRefere
     return LegalEntityDto(
         bpnLReference = bpnLReference,
         legalName = "legalName_" + bpnLReference.referenceValue,
+        isCatenaXMemberData = false,
         legalAddress = minLogisticAddress(bpnAReference = bpnAReference)
     )
 }
@@ -64,6 +65,7 @@ fun fullValidLegalEntity(bpnLReference: BpnReferenceDto, bpnAReference: BpnRefer
             legalEntityState(bpnLReference.referenceValue, 1L, BusinessStateType.ACTIVE),
             legalEntityState(bpnLReference.referenceValue, 2L, BusinessStateType.INACTIVE)
         ),
+        isCatenaXMemberData = false,
         legalAddress = fullLogisticAddressDto(bpnAReference)
     )
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -1258,7 +1258,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
 
     fun emptyLegalEntity(): LegalEntityDto {
 
-        return LegalEntityDto()
+        return LegalEntityDto(isCatenaXMemberData = false)
     }
 
     fun minValidLegalEntity(bpnLReference: BpnReferenceDto, bpnAReference: BpnReferenceDto): LegalEntityDto {
@@ -1267,6 +1267,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
             bpnLReference = bpnLReference,
             legalName = "legalName_" + bpnLReference.referenceValue,
             legalAddress = minLogisticAddress(bpnAReference = bpnAReference),
+            isCatenaXMemberData = false,
             confidenceCriteria = fullConfidenceCriteria()
         )
     }
@@ -1287,6 +1288,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
                 legalEntityState(bpnLReference.referenceValue, 2L, BusinessStateType.INACTIVE)
             ),
             legalAddress = fullLogisticAddressDto(bpnAReference),
+            isCatenaXMemberData = false,
             confidenceCriteria = fullConfidenceCriteria()
         )
     }


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

This pull request implements the logic to set the isCatenaXMemberData field of the business partners based on the confidence criteria sharedByOwner flag.

- Cleaning Service Dummy know sets the isCatenaXMemberData field based on whether a owner BPNL has been provided
- isCatenaXMemberData is now part of the legal entity database table and is initialized with the same value as the confidence criteria sharedByOwner
- added correct mappings in the Pool
- isCatenaXMemberData now also appears in the Orchestrator API model where it is set by the cleaning service dummy
- adjusted tests accordingly

Contributes to #793 

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
