### PR TITLE
feat(BPDM Bridge): Handle 500 error on create entities from Gate to Pool

### DIFF
--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -22,6 +22,7 @@ package com.catenax.bpdm.bridge.dummy.service
 import com.catenax.bpdm.bridge.dummy.dto.*
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.exception.BpdmNullMappingException
 import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressDto
@@ -40,30 +41,69 @@ class PoolUpdateService(
     private val logger = KotlinLogging.logger { }
 
     fun createLegalEntitiesInPool(entriesToCreate: Collection<GateLegalEntityInfo>): LegalEntityPartnerCreateResponseWrapper {
-        val createRequests = entriesToCreate.map {
-            LegalEntityPartnerCreateRequest(
-                legalEntity = gateToPoolLegalEntity(it.legalEntity),
-                legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
-                index = it.externalId
-            )
+        val errorListException = mutableListOf<ErrorInfo<LegalEntityCreateError>>()
+        val createRequests = mutableListOf<LegalEntityPartnerCreateRequest>()
+
+        entriesToCreate.forEach {
+            try {
+                createRequests.add( LegalEntityPartnerCreateRequest(
+                    legalEntity = gateToPoolLegalEntity(it.legalEntity),
+                    legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
+                    index = it.externalId)
+                )
+            }catch (e: BpdmNullMappingException){
+                val errorMapped = mapError(it, e.message!!,LegalEntityCreateError.LegalEntityErrorMapping)
+                errorListException.add(errorMapped)
+            }
         }
 
-        return poolClient.legalEntities.createBusinessPartners(createRequests)
-            .also { logger.info { "Pool accepted ${it.entityCount} new legal entities, ${it.errorCount} were refused" } }
+        val result = poolClient.legalEntities.createBusinessPartners(createRequests)
+        val createdResult = result.copy(errors = result.errors + errorListException)
+        logger.info { "Pool accepted ${createdResult.entityCount} new legal entities, ${createdResult.errorCount} were refused" }
+
+        return createdResult
     }
 
     fun updateLegalEntitiesInPool(entriesToUpdate: Collection<GateLegalEntityInfo>): LegalEntityPartnerUpdateResponseWrapper {
-        val updateRequests = entriesToUpdate.map {
-            LegalEntityPartnerUpdateRequest(
-                legalEntity = gateToPoolLegalEntity(it.legalEntity),
-                legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
-                bpnl = it.bpn!!
-            )
+        val errorListException = mutableListOf<ErrorInfo<LegalEntityUpdateError>>()
+        val updateRequests = mutableListOf<LegalEntityPartnerUpdateRequest>()
+
+        entriesToUpdate.forEach {
+            try {
+                updateRequests.add(
+                    LegalEntityPartnerUpdateRequest(
+                        legalEntity = gateToPoolLegalEntity(it.legalEntity),
+                        legalAddress = gateToPoolLogisticAddress(it.legalAddress.address),
+                        bpnl = it.bpn!!
+                    )
+                )
+            } catch (e: BpdmNullMappingException) {
+                val errorMapped = mapError(it, e.message!!,LegalEntityUpdateError.LegalEntityErrorMapping)
+                errorListException.add(errorMapped)
+            }
         }
 
-        return poolClient.legalEntities.updateBusinessPartners(updateRequests)
-            .also { logger.info { "Pool accepted ${it.entityCount} updated legal entities, ${it.errorCount} were refused" } }
+        val result = poolClient.legalEntities.updateBusinessPartners(updateRequests)
+        val updatedResult = result.copy(errors = result.errors + errorListException)
+        logger.info { "Pool accepted ${updatedResult.entityCount} updated legal entities, ${updatedResult.errorCount} were refused" }
+
+        return updatedResult
     }
+
+    private fun <T : ErrorCode> mapError(
+        record: GateLegalEntityInfo,
+        message: String,
+        errorCode: T
+    ): ErrorInfo<T> {
+        logger.info { "Error processing ${record.externalId}" }
+        logger.error { "Error message: $message" }
+        return ErrorInfo(
+            errorCode,
+            "Error on mapping '${record.legalEntity}' with bpn ${record.bpn} and externalId ${record.externalId}",
+            record.bpn
+        )
+    }
+
 
     fun createSitesInPool(entriesToCreate: Collection<GateSiteInfo>): SitePartnerCreateResponseWrapper {
         val leParentBpnByExternalId = entriesToCreate

--- a/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
+++ b/bpdm-bridge-dummy/src/main/kotlin/com/catenax/bpdm/bridge/dummy/service/PoolUpdateService.kt
@@ -99,8 +99,8 @@ class PoolUpdateService(
         logger.error { "Error message: $message" }
         return ErrorInfo(
             errorCode,
-            "Error on mapping '${record.legalEntity}' with bpn ${record.bpn} and externalId ${record.externalId}",
-            record.bpn
+            "Error on mapping legal entity with bpn ${record.bpn} and externalId ${record.externalId}: $message".take(250),
+            record.externalId
         )
     }
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/PoolErrorCodes.kt
@@ -35,6 +35,7 @@ enum class LegalEntityCreateError : ErrorCode {
     LegalAddressRegionNotFound,
     LegalAddressIdentifierNotFound,
     LegalAddressDuplicateIdentifier,
+    LegalEntityErrorMapping
 }
 
 @Schema(description = "LegalEntityUpdateError")
@@ -45,7 +46,9 @@ enum class LegalEntityUpdateError : ErrorCode {
     LegalEntityIdentifierNotFound,
     LegalAddressRegionNotFound,
     LegalAddressIdentifierNotFound,
-    LegalAddressDuplicateIdentifier
+    LegalAddressDuplicateIdentifier,
+    LegalEntityErrorMapping
+
 }
 
 @Schema(description = "SiteCreateError")


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

This pull request adds the fix for the BPDM Bridge responding with 500 to the 5.0.x release branch. Context on #790 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
