### PR TITLE
feat(pool): add logic for filtering legal entities of Catena-X members

### DIFF
--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerNonVerboseValues.kt
@@ -244,7 +244,8 @@ object BusinessPartnerNonVerboseValues {
             legalForm = BusinessPartnerVerboseValues.legalForm1.technicalKey,
             identifiers = listOf(identifier1),
             states = listOf(leStatus1),
-            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria,
+            isCatenaXMemberData = false
         ),
         legalAddress = logisticAddress1,
         index = BusinessPartnerVerboseValues.legalEntityUpsert1.index
@@ -257,7 +258,8 @@ object BusinessPartnerNonVerboseValues {
             legalForm = BusinessPartnerVerboseValues.legalForm2.technicalKey,
             identifiers = listOf(identifier2),
             states = listOf(leStatus2),
-            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity2.legalEntity.confidenceCriteria
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity2.legalEntity.confidenceCriteria,
+            isCatenaXMemberData = false
         ),
         legalAddress = logisticAddress2,
         index = BusinessPartnerVerboseValues.legalEntityUpsert2.index
@@ -270,7 +272,8 @@ object BusinessPartnerNonVerboseValues {
             legalForm = BusinessPartnerVerboseValues.legalForm3.technicalKey,
             identifiers = listOf(identifier3),
             states = listOf(leStatus3),
-            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity3.legalEntity.confidenceCriteria
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity3.legalEntity.confidenceCriteria,
+            isCatenaXMemberData = false
         ),
         legalAddress = logisticAddress3,
         index = BusinessPartnerVerboseValues.legalEntityUpsert3.index
@@ -283,7 +286,8 @@ object BusinessPartnerNonVerboseValues {
             legalForm = BusinessPartnerVerboseValues.legalForm1.technicalKey,
             identifiers = listOf(identifier1, identifier2),
             states = listOf(leStatus1),
-            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria
+            confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria,
+            isCatenaXMemberData = false
         ),
         legalAddress = logisticAddress1,
         index = BusinessPartnerVerboseValues.legalEntityUpsertMultipleIdentifier.index

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
@@ -30,11 +30,9 @@ import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
 import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi.Companion.ADDRESS_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerUpdateResponseWrapper
 import org.springdoc.core.annotations.ParameterObject
@@ -66,9 +64,9 @@ interface PoolAddressApi {
     @Tag(name = ApiTags.ADDRESS_NAME, description = ApiTags.ADDRESS_DESCRIPTION)
     @GetMapping
     fun getAddresses(
-        @ParameterObject addressSearchRequest: AddressPartnerSearchRequest,
+        @ParameterObject addressSearchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageDto<AddressMatchVerboseDto>
+    ): PageDto<LogisticAddressVerboseDto>
 
     @Operation(
         summary = "Returns an address by its BPNA",
@@ -100,7 +98,7 @@ interface PoolAddressApi {
     @Tag(name = ApiTags.ADDRESS_NAME, description = ApiTags.ADDRESS_DESCRIPTION)
     @PostMapping(CommonApiPathNames.SUBPATH_SEARCH)
     fun searchAddresses(
-        @RequestBody addressSearchRequest: AddressPartnerBpnSearchRequest,
+        @RequestBody searchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -33,14 +33,12 @@ import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RequestMapping("legal-entities", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -49,8 +47,7 @@ interface PoolLegalEntityApi {
     @Operation(
         summary = "Returns legal entities by different search parameters",
         description = "This endpoint tries to find matches among all existing business partners of type legal entity, " +
-                "filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. " +
-                "The match of a partner is better the higher its relevancy score. "
+                "filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. "
     )
     @ApiResponses(
         value = [
@@ -61,9 +58,9 @@ interface PoolLegalEntityApi {
     @Tag(name = ApiTags.LEGAL_ENTITIES_NAME, description = ApiTags.LEGAL_ENTITIES_DESCRIPTION)
     @GetMapping
     fun getLegalEntities(
-        @ParameterObject bpSearchRequest: LegalEntityPropertiesSearchRequest,
+        @ParameterObject searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageDto<LegalEntityMatchVerboseDto>
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
     @Operation(
         summary = "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
@@ -93,7 +90,7 @@ interface PoolLegalEntityApi {
     ): LegalEntityWithLegalAddressVerboseDto
 
     @Operation(
-        summary = "Returns legal entities by an array of BPNL",
+        summary = "Returns legal entities by different search parameters",
         description = "Search legal entity partners by their BPNLs. " +
                 "The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. " +
                 "For a single request, the maximum number of BPNLs to search for is limited to \${bpdm.bpn.search-request-limit} entries."
@@ -110,9 +107,10 @@ interface PoolLegalEntityApi {
     )
     @Tag(name = ApiTags.LEGAL_ENTITIES_NAME, description = ApiTags.LEGAL_ENTITIES_DESCRIPTION)
     @PostMapping("/search")
-    fun searchLegalEntitys(
-        @RequestBody bpnLs: Collection<String>
-    ): ResponseEntity<Collection<LegalEntityWithLegalAddressVerboseDto>>
+    fun postLegalEntitySearch(
+        @RequestBody searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
     @Operation(
         summary = "Returns all sites of a legal entity with a specific BPNL",

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMembersApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMembersApi.kt
@@ -60,7 +60,7 @@ interface PoolMembersApi {
 
     @Tag(name = ApiTags.SITE_NAME, description = ApiTags.SITE_DESCRIPTION)
     @PostMapping(SITES_SEARCH_PATH)
-    fun searchSites(
+    fun postSiteSearch(
         @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -28,10 +28,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
@@ -71,8 +70,8 @@ interface PoolSiteApi {
     )
     @Tag(name = ApiTags.SITE_NAME, description = ApiTags.SITE_DESCRIPTION)
     @PostMapping("/search")
-    fun searchSites(
-        @RequestBody siteSearchRequest: SiteBpnSearchRequest,
+    fun postSiteSearch(
+        @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
 
@@ -125,7 +124,8 @@ interface PoolSiteApi {
     )
     @Tag(name = ApiTags.SITE_NAME, description = ApiTags.SITE_DESCRIPTION)
     @GetMapping
-    fun getSitesPaginated(
+    fun getSites(
+        @ParameterObject searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageDto<SiteMatchVerboseDto>
+    ): PageDto<SiteWithMainAddressVerboseDto>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/AddressApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/AddressApiClient.kt
@@ -19,17 +19,14 @@
 
 package org.eclipse.tractusx.bpdm.pool.api.client
 
-import jakarta.validation.Valid
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
 import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerUpdateResponseWrapper
 import org.springdoc.core.annotations.ParameterObject
@@ -45,17 +42,17 @@ interface AddressApiClient: PoolAddressApi {
 
     @GetExchange
     override fun getAddresses(
-        @ParameterObject addressSearchRequest: AddressPartnerSearchRequest,
-        @ParameterObject @Valid paginationRequest: PaginationRequest
-    ): PageDto<AddressMatchVerboseDto>
+        @ParameterObject addressSearchRequest: AddressSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto>
 
     @GetExchange(PoolAddressApi.SUBPATH_BPNA)
     override fun getAddress(@PathVariable(PoolAddressApi.PATHVAR_BPNA) bpna: String): LogisticAddressVerboseDto
 
     @PostExchange(CommonApiPathNames.SUBPATH_SEARCH)
     override fun searchAddresses(
-        @RequestBody addressSearchRequest: AddressPartnerBpnSearchRequest,
-        @ParameterObject @Valid paginationRequest: PaginationRequest
+        @RequestBody searchRequest: AddressSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
     @PostExchange

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/LegalEntityApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/LegalEntityApiClient.kt
@@ -28,13 +28,11 @@ import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.springdoc.core.annotations.ParameterObject
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -58,9 +56,9 @@ interface LegalEntityApiClient : PoolLegalEntityApi {
 
     @GetExchange
     override fun getLegalEntities(
-        @ParameterObject bpSearchRequest: LegalEntityPropertiesSearchRequest,
+        @ParameterObject searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageDto<LegalEntityMatchVerboseDto>
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
     @GetExchange("/{idValue}")
     override fun getLegalEntity(
@@ -76,9 +74,10 @@ interface LegalEntityApiClient : PoolLegalEntityApi {
     ): PageDto<SiteVerboseDto>
 
     @PostExchange("/search")
-    override fun searchLegalEntitys(
-        @RequestBody bpnLs: Collection<String>
-    ): ResponseEntity<Collection<LegalEntityWithLegalAddressVerboseDto>>
+    override fun postLegalEntitySearch(
+        @RequestBody searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
     @PutExchange
     override fun updateBusinessPartners(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
@@ -22,10 +22,9 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
@@ -50,13 +49,14 @@ interface SiteApiClient : PoolSiteApi {
     ): SiteWithMainAddressVerboseDto
 
     @GetExchange
-    override fun getSitesPaginated(
+    override fun getSites(
+        @ParameterObject searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageDto<SiteMatchVerboseDto>
+    ): PageDto<SiteWithMainAddressVerboseDto>
 
     @PostExchange("/search")
-    override fun searchSites(
-        @RequestBody siteSearchRequest: SiteBpnSearchRequest,
+    override fun postSiteSearch(
+        @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
@@ -34,6 +34,6 @@ data class LegalEntityDto(
     override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
     override val states: Collection<LegalEntityStateDto> = emptyList(),
     override val confidenceCriteria: ConfidenceCriteriaDto,
-    override val isCatenaXMemberData: Boolean = false
+    override val isCatenaXMemberData: Boolean
 
 ) : IBaseLegalEntityDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/AddressSearchRequest.kt
@@ -23,5 +23,5 @@ data class AddressSearchRequest(
     val addressBpns: List<String> = emptyList(),
     val legalEntityBpns: List<String> = emptyList(),
     val siteBpns: List<String> = emptyList(),
-    val name: String?
+    val name: String? = null
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntitySearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalEntitySearchRequest.kt
@@ -21,5 +21,5 @@ package org.eclipse.tractusx.bpdm.pool.api.model.request
 
 data class LegalEntitySearchRequest(
     val bpnLs: List<String> = emptyList(),
-    val legalName: String?
+    val legalName: String? = null
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SiteSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SiteSearchRequest.kt
@@ -22,5 +22,5 @@ package org.eclipse.tractusx.bpdm.pool.api.model.request
 data class SiteSearchRequest(
     val siteBpns: List<String> = emptyList(),
     val legalEntityBpns: List<String> = emptyList(),
-    val name: String?
+    val name: String? = null
 )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PermissionConfigProperties.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PermissionConfigProperties.kt
@@ -28,7 +28,8 @@ data class PermissionConfigProperties(
     val readPartner: String = "read_partner",
     val writePartner: String = "write_partner",
     val readMetaData: String = "read_meta_data",
-    val writeMetaData: String = "write_meta_data"
+    val writeMetaData: String = "write_meta_data",
+    val readMemberPartner: String = "read_member_partner"
 ) {
     companion object {
         const val PREFIX = "bpdm.security.permissions"
@@ -41,6 +42,7 @@ data class PermissionConfigProperties(
         const val WRITE_PARTNER = "@${BEAN_QUALIFIER}.getWritePartner()"
         const val READ_METADATA = "@${BEAN_QUALIFIER}.getReadMetaData()"
         const val WRITE_METADATA = "@${BEAN_QUALIFIER}.getWriteMetaData()"
+        const val READ_MEMBER_PARTNER = "@${BEAN_QUALIFIER}.getReadMemberPartner()"
     }
 }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
@@ -23,34 +23,26 @@ import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
 import org.eclipse.tractusx.bpdm.pool.service.AddressService
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService
-import org.eclipse.tractusx.bpdm.pool.service.SearchService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class AddressController(
     private val addressService: AddressService,
-    private val businessPartnerBuildService: BusinessPartnerBuildService,
-    private val searchService: SearchService
+    private val businessPartnerBuildService: BusinessPartnerBuildService
 ) : PoolAddressApi {
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
-    override fun getAddresses(
-        addressSearchRequest: AddressPartnerSearchRequest,
-        paginationRequest: PaginationRequest
-    ): PageDto<AddressMatchVerboseDto> {
-
-        return searchService.searchAddresses(addressSearchRequest, paginationRequest)
+    override fun getAddresses(addressSearchRequest: AddressSearchRequest, paginationRequest: PaginationRequest): PageDto<LogisticAddressVerboseDto> {
+        return searchAddresses(addressSearchRequest, paginationRequest)
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
@@ -62,10 +54,19 @@ class AddressController(
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
     override fun searchAddresses(
-        addressSearchRequest: AddressPartnerBpnSearchRequest,
+        searchRequest: AddressSearchRequest,
         paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto> {
-        return addressService.findByPartnerAndSiteBpns(addressSearchRequest, paginationRequest)
+        return addressService.searchAddresses(
+            AddressService.AddressSearchRequest(
+                addressBpns = searchRequest.addressBpns,
+                siteBpns = searchRequest.siteBpns,
+                legalEntityBpns = searchRequest.legalEntityBpns,
+                name = searchRequest.name,
+                isCatenaXMemberData = null
+            ),
+            paginationRequest
+        )
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
@@ -50,11 +50,12 @@ class ChangelogController(
         }
 
         return partnerChangelogService.getChangeLogEntries(
-            changelogSearchRequest.bpns,
-            changelogSearchRequest.businessPartnerTypes,
-            changelogSearchRequest.timestampAfter,
-            paginationRequest.page,
-            paginationRequest.size
+            bpns = changelogSearchRequest.bpns,
+            businessPartnerTypes = changelogSearchRequest.businessPartnerTypes,
+            fromTime = changelogSearchRequest.timestampAfter,
+            isCatenaXMemberData = null,
+            pageIndex = paginationRequest.page,
+            pageSize = paginationRequest.size
         )
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -99,7 +99,7 @@ class LegalEntityController(
         bpnl: String,
         paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto> {
-        return addressService.findByPartnerBpn(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
+        return addressService.findNonSiteAddressesOfLegalEntity(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -24,20 +24,19 @@ import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.BusinessPartnerSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerUpdateRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPropertiesSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.config.BpnConfigProperties
-import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
-import org.eclipse.tractusx.bpdm.pool.service.*
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
+import org.eclipse.tractusx.bpdm.pool.service.AddressService
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
+import org.eclipse.tractusx.bpdm.pool.service.SiteService
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
@@ -45,20 +44,22 @@ import org.springframework.web.bind.annotation.RestController
 class LegalEntityController(
     val businessPartnerFetchService: BusinessPartnerFetchService,
     val businessPartnerBuildService: BusinessPartnerBuildService,
-    val searchService: SearchService,
     val bpnConfigProperties: BpnConfigProperties,
-    val controllerConfigProperties: ControllerConfigProperties,
     val siteService: SiteService,
     val addressService: AddressService
 ) : PoolLegalEntityApi {
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
     override fun getLegalEntities(
-        bpSearchRequest: LegalEntityPropertiesSearchRequest,
-        paginationRequest: PaginationRequest
-    ): PageDto<LegalEntityMatchVerboseDto> {
-        return searchService.searchLegalEntities(
-            BusinessPartnerSearchRequest(bpSearchRequest),
+        @ParameterObject searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto> {
+        return businessPartnerFetchService.searchLegalEntities(
+            BusinessPartnerFetchService.LegalEntitySearchRequest(
+                bpnLs = searchRequest.bpnLs,
+                legalName = searchRequest.legalName,
+                isCatenaXMemberData = null
+            ),
             paginationRequest
         )
     }
@@ -71,13 +72,18 @@ class LegalEntityController(
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
-    override fun searchLegalEntitys(
-        bpnLs: Collection<String>
-    ): ResponseEntity<Collection<LegalEntityWithLegalAddressVerboseDto>> {
-        if (bpnLs.size > controllerConfigProperties.searchRequestLimit) {
-            return ResponseEntity(HttpStatus.BAD_REQUEST)
-        }
-        return ResponseEntity(businessPartnerFetchService.fetchDtosByBpns(bpnLs), HttpStatus.OK)
+    override fun postLegalEntitySearch(
+        searchRequest: LegalEntitySearchRequest,
+        paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto> {
+        return businessPartnerFetchService.searchLegalEntities(
+            BusinessPartnerFetchService.LegalEntitySearchRequest(
+                searchRequest.bpnLs,
+                searchRequest.legalName,
+                isCatenaXMemberData = null
+            ),
+            paginationRequest
+        )
     }
 
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
@@ -31,6 +31,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDt
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.eclipse.tractusx.bpdm.pool.service.AddressService
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
 import org.eclipse.tractusx.bpdm.pool.service.SiteService
 import org.springframework.security.access.prepost.PreAuthorize
@@ -39,7 +40,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class MemberController(
     private val businessPartnerFetchService: BusinessPartnerFetchService,
-    private val siteService: SiteService
+    private val siteService: SiteService,
+    private val addressService: AddressService
 ) : PoolMembersApi {
 
 
@@ -73,7 +75,16 @@ class MemberController(
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
     override fun searchAddresses(searchRequest: AddressSearchRequest, paginationRequest: PaginationRequest): PageDto<LogisticAddressVerboseDto> {
-        TODO("Not yet implemented")
+        return addressService.searchAddresses(
+            AddressService.AddressSearchRequest(
+                addressBpns = searchRequest.addressBpns,
+                siteBpns = searchRequest.siteBpns,
+                legalEntityBpns = searchRequest.legalEntityBpns,
+                name = searchRequest.name,
+                isCatenaXMemberData = true
+            ),
+            paginationRequest
+        )
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
@@ -30,25 +30,43 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class MemberController : PoolMembersApi {
+class MemberController(
+    private val businessPartnerFetchService: BusinessPartnerFetchService
+) : PoolMembersApi {
+
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
     override fun searchLegalEntities(
         searchRequest: LegalEntitySearchRequest,
         paginationRequest: PaginationRequest
     ): PageDto<LegalEntityWithLegalAddressVerboseDto> {
-        TODO("Not yet implemented")
+        return businessPartnerFetchService.searchLegalEntities(
+            BusinessPartnerFetchService.LegalEntitySearchRequest(
+                bpnLs = searchRequest.bpnLs,
+                legalName = searchRequest.legalName,
+                isCatenaXMemberData = true
+            ),
+            paginationRequest
+        )
     }
 
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
     override fun searchSites(searchRequest: SiteSearchRequest, paginationRequest: PaginationRequest): PageDto<SiteWithMainAddressVerboseDto> {
         TODO("Not yet implemented")
     }
 
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
     override fun searchAddresses(searchRequest: AddressSearchRequest, paginationRequest: PaginationRequest): PageDto<LogisticAddressVerboseDto> {
         TODO("Not yet implemented")
     }
 
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
     override fun searchChangelogEntries(
         changelogSearchRequest: ChangelogSearchRequest,
         paginationRequest: PaginationRequest

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
@@ -32,12 +32,14 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAdd
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
+import org.eclipse.tractusx.bpdm.pool.service.SiteService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class MemberController(
-    private val businessPartnerFetchService: BusinessPartnerFetchService
+    private val businessPartnerFetchService: BusinessPartnerFetchService,
+    private val siteService: SiteService
 ) : PoolMembersApi {
 
 
@@ -57,8 +59,16 @@ class MemberController(
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
-    override fun searchSites(searchRequest: SiteSearchRequest, paginationRequest: PaginationRequest): PageDto<SiteWithMainAddressVerboseDto> {
-        TODO("Not yet implemented")
+    override fun postSiteSearch(searchRequest: SiteSearchRequest, paginationRequest: PaginationRequest): PageDto<SiteWithMainAddressVerboseDto> {
+        return siteService.searchSites(
+            SiteService.SiteSearchRequest(
+                siteBpns =  searchRequest.siteBpns,
+                legalEntityBpns = searchRequest.legalEntityBpns,
+                name = searchRequest.name,
+                isCatenaXMemberData = true
+            ),
+            paginationRequest
+        )
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
@@ -23,11 +23,43 @@ import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
 import org.eclipse.tractusx.bpdm.pool.entity.SiteDb
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.CrudRepository
-import org.springframework.data.repository.PagingAndSortingRepository
 
-interface SiteRepository : PagingAndSortingRepository<SiteDb, Long>, CrudRepository<SiteDb, Long> {
+interface SiteRepository : JpaRepository<SiteDb, Long>, JpaSpecificationExecutor<SiteDb> {
+
+    companion object {
+        fun byBpns(bpns: Collection<String>?) =
+            Specification<SiteDb> { root, _, _ ->
+                bpns?.filter { it.isNotBlank() }?.takeIf { it.isNotEmpty() }?.let {
+                    root.get<String>(SiteDb::bpn.name).`in`(bpns)
+                }
+            }
+
+        fun byParentBpns(bpns: Collection<String>?) =
+            Specification<SiteDb> { root, _, _ ->
+                bpns?.filter { it.isNotBlank() }?.takeIf { it.isNotEmpty() }?.let {
+                    root.get<LegalEntityDb>(SiteDb::legalEntity.name).get<String>(LegalEntityDb::bpn.name).`in`(bpns)
+                }
+            }
+
+        fun byName(name: String?) =
+            Specification<SiteDb> { root, _, builder ->
+                name?.takeIf { it.isNotBlank() }?.let {
+                    builder.like(root.get(SiteDb::name.name), name)
+                }
+            }
+
+        fun byIsMember(isCatenaXMemberData: Boolean?) =
+            Specification<SiteDb> { root, _, builder ->
+                isCatenaXMemberData?.let {
+                    builder.equal(root.get<LegalEntityDb>(SiteDb::legalEntity.name).get<Boolean>(LegalEntityDb::isCatenaXMemberData.name), isCatenaXMemberData)
+                }
+            }
+    }
+
     @Query("SELECT DISTINCT s FROM SiteDb s LEFT JOIN FETCH s.addresses WHERE s IN :sites")
     fun joinAddresses(sites: Set<SiteDb>): Set<SiteDb>
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -76,7 +76,7 @@ class BusinessPartnerBuildService(
         val requestsByLegalEntities = validRequests
             .mapIndexed { bpnIndex, request ->
                 val legalEntity = createLegalEntity(request.legalEntity, bpnLs[bpnIndex], legalEntityMetadataMap)
-                val legalAddress = createLogisticAddress(request.legalAddress, bpnAs[bpnIndex], legalEntity, addressMetadataMap)
+                val legalAddress = createLogisticAddress(request.legalAddress, bpnAs[bpnIndex], legalEntity, null, addressMetadataMap)
                 legalEntity.legalAddress = legalAddress
                 Pair(legalEntity, request)
             }
@@ -150,7 +150,7 @@ class BusinessPartnerBuildService(
 
         fun createSiteWithMainAddress(bpnIndex: Int, request: SitePartnerCreateRequest) =
             createSite(request.site, bpnSs[bpnIndex], legalEntitiesByBpn[request.bpnlParent]!!)
-                .apply { mainAddress = createLogisticAddress(request.site.mainAddress, bpnAs[bpnIndex], this, addressMetadataMap) }
+                .apply { mainAddress = createLogisticAddress(request.site.mainAddress, bpnAs[bpnIndex], this.legalEntity, this, addressMetadataMap) }
                 .let { site -> Pair(site, request) }
 
         val requestsBySites = validRequests
@@ -352,7 +352,7 @@ class BusinessPartnerBuildService(
         val addressesWithIndex = validRequests
             .mapIndexed { i, request ->
                 val legalEntity = parentLegalEntitiesByBpn[request.bpnParent]!!
-                val address = createLogisticAddress(request.address, bpnAs[i], legalEntity, metadataMap)
+                val address = createLogisticAddress(request.address, bpnAs[i], legalEntity, null, metadataMap)
                 Pair(address, request.index)
             }
 
@@ -373,7 +373,7 @@ class BusinessPartnerBuildService(
         val addressesWithIndex = validRequests
             .mapIndexed { i, request ->
                 val site = siteParentsByBpn[request.bpnParent]!!
-                val address = createLogisticAddress(request.address, bpnAs[i], site, metadataMap)
+                val address = createLogisticAddress(request.address, bpnAs[i], site.legalEntity, site, metadataMap)
                 Pair(address, request.index)
             }
 
@@ -388,17 +388,13 @@ class BusinessPartnerBuildService(
         dto: LogisticAddressDto,
         bpn: String,
         legalEntity: LegalEntityDb,
+        site: SiteDb?,
         metadataMap: AddressMetadataMapping
     ) = createLogisticAddressInternal(dto, bpn, metadataMap)
-        .also { it.legalEntity = legalEntity }
-
-    private fun createLogisticAddress(
-        dto: LogisticAddressDto,
-        bpn: String,
-        site: SiteDb,
-        metadataMap: AddressMetadataMapping
-    ) = createLogisticAddressInternal(dto, bpn, metadataMap)
-        .also { it.site = site }
+        .apply {
+            this.legalEntity = legalEntity
+            this.site = site
+        }
 
     private fun createLogisticAddressInternal(
         dto: LogisticAddressDto,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.bpdm.pool.service
 
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.dto.*
-import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.common.util.replace
 import org.eclipse.tractusx.bpdm.pool.api.model.*
 import org.eclipse.tractusx.bpdm.pool.api.model.request.*
@@ -340,14 +339,6 @@ class BusinessPartnerBuildService(
         return AddressPartnerUpdateResponseWrapper(addressResponses, errors)
     }
 
-    @Transactional
-    fun setBusinessPartnerCurrentness(bpn: String) {
-        logger.info { "Updating currentness of business partner $bpn" }
-        val partner = legalEntityRepository.findByBpn(bpn) ?: throw BpdmNotFoundException("Business Partner", bpn)
-        partner.currentness = createCurrentnessTimestamp()
-        legalEntityRepository.save(partner)
-    }
-
     private fun createAddressesForLegalEntity(
         validRequests: Collection<AddressPartnerCreateRequest>,
         metadataMap: AddressMetadataMapping
@@ -608,6 +599,7 @@ class BusinessPartnerBuildService(
             legalEntity.identifiers.replace(legalEntityDto.identifiers.map { toLegalEntityIdentifier(it, metadataMap.idTypes, legalEntity) })
             legalEntity.states.replace(legalEntityDto.states.map { toLegalEntityState(it, legalEntity) })
             legalEntity.confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria)
+            legalEntity.isCatenaXMemberData = legalEntityDto.isCatenaXMemberData
         }
 
         fun createPhysicalAddress(physicalAddress: IBasePhysicalPostalAddressDto, regions: Map<String, RegionDb>): PhysicalPostalAddressDb {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -34,6 +34,11 @@ fun <S, T> Page<S>.toDto(dtoContent: Collection<T>): PageDto<T> {
     return PageDto(this.totalElements, this.totalPages, this.number, this.numberOfElements, dtoContent)
 }
 
+fun <S, T> Page<S>.toDto(map: (S) -> T): PageDto<T> {
+    return PageDto(totalElements, totalPages, number, numberOfElements, content.map { map(it) })
+}
+
+
 fun LegalEntityDb.toMatchDto(score: Float): LegalEntityMatchVerboseDto {
     return LegalEntityMatchVerboseDto(
         score = score,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -115,7 +115,7 @@ fun AddressStateDb.toDto(): AddressStateVerboseDto {
 fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
     return LogisticAddressVerboseDto(
         bpna = bpn,
-        bpnLegalEntity = legalEntity?.bpn,
+        bpnLegalEntity = legalEntity.takeIf { site == null }?.bpn,
         bpnSite = site?.bpn,
         createdAt = createdAt,
         updatedAt = updatedAt,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
@@ -42,7 +42,7 @@ class SiteService(
 
     fun findByParentBpn(bpn: String, pageIndex: Int, pageSize: Int): PageDto<SiteVerboseDto> {
         logger.debug { "Executing findByPartnerBpn() with parameters $bpn // $pageIndex // $pageSize" }
-        val legalEntity = legalEntityRepository.findByBpn(bpn) ?: throw BpdmNotFoundException("Business Partner", bpn)
+        val legalEntity = legalEntityRepository.findByBpnIgnoreCase(bpn) ?: throw BpdmNotFoundException("Business Partner", bpn)
 
         val page = siteRepository.findByLegalEntity(legalEntity, PageRequest.of(pageIndex, pageSize))
         fetchSiteDependencies(page.toSet())

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
@@ -24,13 +24,14 @@ import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.SiteDb
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
 import org.eclipse.tractusx.bpdm.pool.repository.SiteRepository
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SiteService(
@@ -40,6 +41,26 @@ class SiteService(
 ) {
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * Search sites per page for [searchRequest] and [paginationRequest]
+     */
+    @Transactional
+    fun searchSites(searchRequest: SiteSearchRequest, paginationRequest: PaginationRequest): PageDto<SiteWithMainAddressVerboseDto>{
+        logger.debug { "Executing site search with request: $searchRequest" }
+        val spec = Specification.allOf(
+            SiteRepository.byBpns(searchRequest.siteBpns),
+            SiteRepository.byParentBpns(searchRequest.legalEntityBpns),
+            SiteRepository.byName(searchRequest.name),
+            SiteRepository.byIsMember(searchRequest.isCatenaXMemberData)
+        )
+
+        val sitePage = siteRepository.findAll(spec, PageRequest.of(paginationRequest.page, paginationRequest.size))
+
+        fetchSiteDependencies(sitePage.toSet())
+
+        return sitePage.toDto(SiteDb::toPoolDto)
+    }
+
     fun findByParentBpn(bpn: String, pageIndex: Int, pageSize: Int): PageDto<SiteVerboseDto> {
         logger.debug { "Executing findByPartnerBpn() with parameters $bpn // $pageIndex // $pageSize" }
         val legalEntity = legalEntityRepository.findByBpnIgnoreCase(bpn) ?: throw BpdmNotFoundException("Business Partner", bpn)
@@ -47,17 +68,6 @@ class SiteService(
         val page = siteRepository.findByLegalEntity(legalEntity, PageRequest.of(pageIndex, pageSize))
         fetchSiteDependencies(page.toSet())
         return page.toDto(page.content.map { it.toDto() })
-    }
-
-    fun findByPartnerBpns(siteSearchRequest: SiteBpnSearchRequest, paginationRequest: PaginationRequest): PageDto<SiteWithMainAddressVerboseDto> {
-        logger.debug { "Executing findByPartnerBpns() with parameters $siteSearchRequest // $paginationRequest" }
-        val parents =
-            if (siteSearchRequest.legalEntities.isNotEmpty()) legalEntityRepository.findDistinctByBpnIn(siteSearchRequest.legalEntities) else emptyList()
-        val sitePage =
-            siteRepository.findByLegalEntityInOrBpnIn(parents, siteSearchRequest.sites, PageRequest.of(paginationRequest.page, paginationRequest.size))
-        fetchSiteDependencies(sitePage.toSet())
-
-        return sitePage.toDto(sitePage.content.map { it.toPoolDto() })
     }
 
     fun findByBpn(bpn: String): SiteWithMainAddressVerboseDto {
@@ -81,5 +91,12 @@ class SiteService(
 
         return sites
     }
+
+    data class SiteSearchRequest(
+        val siteBpns: List<String>?,
+        val legalEntityBpns: List<String>?,
+        val name: String?,
+        val isCatenaXMemberData: Boolean?
+    )
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -332,6 +332,7 @@ class TaskStepBuildService(
                 states = states.map { LegalEntityStateDto(it.validFrom, it.validTo, it.type) },
                 confidenceCriteria = confidenceCriteria?.let { toPoolDto(it) }
                     ?: throw BpdmValidationException(CleaningError.LEGAL_ENTITY_CONFIDENCE_CRITERIA_MISSING.message),
+                isCatenaXMemberData = isCatenaXMemberData
             )
         }
 

--- a/bpdm-pool/src/main/resources/application-auth.yml
+++ b/bpdm-pool/src/main/resources/application-auth.yml
@@ -38,12 +38,15 @@ bpdm:
     permissions:
       # Name of the permission to read business partners
       readPartner: read_partner
-      # Name of the permissions to upsert business partners
+      # Name of the permission to upsert business partners
       writePartner: write_partner
+      # Name of the permission to read business partners that belong to a Catena-X member
+      readMemberPartner: read_member_partner
       # Name of the permission to read metadata
       readMetaData: read_meta_data
       # Name of the permission to create new metadata
       writeMetaData: write_meta_data
+
 #
 # From here on are framework and dependency configuration
 # More information about those properties can be taken from the respective documentation of Spring or the dependency

--- a/bpdm-pool/src/main/resources/db/migration/V6_0_0_1__add_address_legal_entity.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V6_0_0_1__add_address_legal_entity.sql
@@ -1,0 +1,4 @@
+UPDATE  logistic_addresses
+    SET legal_entity_id = sites.legal_entity_id
+FROM sites
+WHERE sites.id = logistic_addresses.site_id;

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.pool.controller
 
+
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
@@ -27,12 +28,9 @@ import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
 import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerBpnSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.eclipse.tractusx.bpdm.pool.util.*
-
-
-
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues.addressIdentifier
@@ -42,7 +40,6 @@ import org.eclipse.tractusx.bpdm.test.testdata.pool.SiteStructureRequest
 import org.eclipse.tractusx.bpdm.test.util.AssertHelpers
 import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
 import org.eclipse.tractusx.bpdm.test.util.PoolDataHelpers
-
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -139,7 +136,7 @@ class AddressControllerIT @Autowired constructor(
         val bpnA1 = createdStructures[0].addresses[0].address.bpna
         val bpnA2 = createdStructures[0].addresses[1].address.bpna
 
-        val searchRequest = AddressPartnerBpnSearchRequest(addresses = listOf(bpnA1, bpnA2))
+        val searchRequest = AddressSearchRequest(addressBpns = listOf(bpnA1, bpnA2))
         val searchResult =
             poolClient.addresses.searchAddresses(searchRequest, PaginationRequest())
 
@@ -173,7 +170,7 @@ class AddressControllerIT @Autowired constructor(
 
         val bpnL2 = createdStructures[1].legalEntity.legalEntity.bpnl
 
-        val searchRequest = AddressPartnerBpnSearchRequest(legalEntities = listOf(bpnL2))
+        val searchRequest = AddressSearchRequest(legalEntityBpns = listOf(bpnL2))
         val searchResult = poolClient.addresses.searchAddresses(searchRequest, PaginationRequest())
 
         val expected = listOf(
@@ -218,7 +215,7 @@ class AddressControllerIT @Autowired constructor(
         val bpnS2 = createdStructures[1].siteStructures[0].site.site.bpns
 
         // search for site1 -> main address and 2 regular addresses
-        AddressPartnerBpnSearchRequest(sites = listOf(bpnS1))
+        AddressSearchRequest(siteBpns = listOf(bpnS1))
             .let { poolClient.addresses.searchAddresses(it, PaginationRequest()) }
             .let {
                 assertAddressesAreEqual(
@@ -231,7 +228,7 @@ class AddressControllerIT @Autowired constructor(
             }
 
         // search for site2 -> main address and 1 regular address
-        AddressPartnerBpnSearchRequest(sites = listOf(bpnS2))       // search for site2
+        AddressSearchRequest(siteBpns = listOf(bpnS2))       // search for site2
             .let { poolClient.addresses.searchAddresses(it, PaginationRequest()) }
             .let {
                 assertAddressesAreEqual(
@@ -243,7 +240,7 @@ class AddressControllerIT @Autowired constructor(
             }
 
         // search for site1 and site2 -> 2 main addresses and 3 regular addresses
-        AddressPartnerBpnSearchRequest(sites = listOf(bpnS2, bpnS1))    // search for site1 and site2
+        AddressSearchRequest(siteBpns = listOf(bpnS2, bpnS1))    // search for site1 and site2
             .let { poolClient.addresses.searchAddresses(it, PaginationRequest()) }
             .let {
                 assertAddressesAreEqual(

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
@@ -24,12 +24,10 @@ import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressMatchVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
 import org.eclipse.tractusx.bpdm.pool.util.TestHelpers
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues
-
 import org.eclipse.tractusx.bpdm.test.testdata.pool.LegalEntityStructureRequest
 import org.eclipse.tractusx.bpdm.test.testdata.pool.SiteStructureRequest
 import org.eclipse.tractusx.bpdm.test.util.AssertHelpers
@@ -108,17 +106,15 @@ class AddressControllerSearchIT @Autowired constructor(
     fun `search address via name`() {
         val expected = PageDto(
             1, 1, 0, 1, listOf(
-                AddressMatchVerboseDto(0f, givenAddress1)
+                givenAddress1
             )
         )
 
 
-        val addressSearchRequest = AddressPartnerSearchRequest()
-        addressSearchRequest.name = BusinessPartnerNonVerboseValues.addressPartnerCreate4.address.name
-
+        val addressSearchRequest = AddressSearchRequest(name = BusinessPartnerNonVerboseValues.addressPartnerCreate4.address.name)
         val pageResponse = poolClient.addresses.getAddresses(addressSearchRequest, PaginationRequest())
 
-        assertPageEquals(pageResponse, expected)
+        assertHelpers.assertRecursively(pageResponse).isEqualTo(expected)
     }
 
     /**
@@ -129,22 +125,13 @@ class AddressControllerSearchIT @Autowired constructor(
     @Test
     fun `search address via name not found`() {
         val expected = PageDto(
-            0, 0, 0, 0, emptyList<AddressMatchVerboseDto>()
+            0, 0, 0, 0, emptyList<LogisticAddressVerboseDto>()
         )
 
-
-        val addressSearchRequest = AddressPartnerSearchRequest()
-        addressSearchRequest.name = "NONEXISTENT"
-
+        val addressSearchRequest = AddressSearchRequest(name =  "NONEXISTENT")
         val pageResponse = poolClient.addresses.getAddresses(addressSearchRequest, PaginationRequest())
 
-        assertPageEquals(pageResponse, expected)
+        assertHelpers.assertRecursively(pageResponse).isEqualTo(expected)
     }
 
-
-    private fun assertPageEquals(actual: PageDto<AddressMatchVerboseDto>, expected: PageDto<AddressMatchVerboseDto>) {
-        assertHelpers.assertRecursively(actual)
-            .ignoringFieldsMatchingRegexes(".*${AddressMatchVerboseDto::score.name}")
-            .isEqualTo(expected)
-    }
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -20,12 +20,14 @@
 package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.eclipse.tractusx.bpdm.pool.util.EndpointValues
 import org.eclipse.tractusx.bpdm.pool.util.TestHelpers
@@ -511,8 +513,8 @@ class LegalEntityControllerIT @Autowired constructor(
             .map { it.legalEntity }
             .take(2) // only search for a subset of the existing legal entities
 
-        val bpnsToSearch = expected.map { it.bpnl }
-        val response = poolClient.legalEntities.searchLegalEntitys(bpnsToSearch).body?.map { it.legalEntity }
+        val bpnsToSearch = LegalEntitySearchRequest(bpnLs = expected.map { it.bpnl })
+        val response = poolClient.legalEntities.postLegalEntitySearch(bpnsToSearch, PaginationRequest()).content.map { it.legalEntity }
 
         assertThat(response)
             .usingRecursiveComparison()
@@ -655,8 +657,8 @@ class LegalEntityControllerIT @Autowired constructor(
             .map { it.legalEntity }
             .take(2) // only search for a subset of the existing legal entities
 
-        val bpnsToSearch = expected.map { it.bpnl }.plus("NONEXISTENT") // also search for nonexistent BPN
-        val response = poolClient.legalEntities.searchLegalEntitys(bpnsToSearch).body?.map { it.legalEntity }
+        val bpnsToSearch = LegalEntitySearchRequest(bpnLs = expected.map { it.bpnl }.plus("NONEXISTENT")) // also search for nonexistent BPN
+        val response = poolClient.legalEntities.postLegalEntitySearch(bpnsToSearch, PaginationRequest()).content.map { it.legalEntity }
 
         assertThat(response)
             .usingRecursiveComparison()

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -29,7 +29,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDto
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteBpnSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import org.eclipse.tractusx.bpdm.pool.util.TestHelpers
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
@@ -117,8 +117,8 @@ class SiteControllerIT @Autowired constructor(
         val bpnS2 = createdStructures[0].siteStructures[1].site.site.bpns
         val bpnL = createdStructures[0].legalEntity.legalEntity.bpnl
 
-        val siteSearchRequest = SiteBpnSearchRequest(emptyList(), listOf(bpnS1, bpnS2))
-        val searchResult = poolClient.sites.searchSites(siteSearchRequest, PaginationRequest())
+        val siteSearchRequest = SiteSearchRequest(siteBpns = listOf(bpnS1, bpnS2))
+        val searchResult = poolClient.sites.postSiteSearch(siteSearchRequest, PaginationRequest())
 
         val expectedSiteWithReference1 = SiteWithMainAddressVerboseDto(
             site = BusinessPartnerVerboseValues.site1.copy(bpnLegalEntity = bpnL),
@@ -169,8 +169,8 @@ class SiteControllerIT @Autowired constructor(
         val bpnL1 = createdStructures[0].legalEntity.legalEntity.bpnl
         val bpnL2 = createdStructures[1].legalEntity.legalEntity.bpnl
 
-        val siteSearchRequest = SiteBpnSearchRequest(listOf(bpnL1, bpnL2))
-        val searchResult = poolClient.sites.searchSites(siteSearchRequest, PaginationRequest())
+        val siteSearchRequest = SiteSearchRequest(legalEntityBpns =   listOf(bpnL1, bpnL2))
+        val searchResult = poolClient.sites.postSiteSearch(siteSearchRequest, PaginationRequest())
 
         val expectedSiteWithReference1 =
             SiteWithMainAddressVerboseDto(
@@ -511,7 +511,7 @@ class SiteControllerIT @Autowired constructor(
             )
         )
 
-        val firstPage = poolClient.sites.getSitesPaginated(paginationRequest = PaginationRequest(0, 10))
+        val firstPage = poolClient.sites.getSites(SiteSearchRequest(), PaginationRequest(0, 10))
 
         assertHelpers.assertRecursively(firstPage).ignoringFieldsOfTypes(Instant::class.java).isEqualTo(expectedFirstPage)
 


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

This pull request adds the logic for filtering legal entities, sites and addresses based on Catena-X membership.

- adapted the DTOs and return objects of non-member endpoints to match the one from the member endpoints
- added search logic in service and make search endpoints reuse them where appropriate
- adjusted tests appropriately
- now all logistic address entities have a reference to its legal entity independent of whether they belong to a site or not (DTOs and search behaviour is unchanged in that addresses belonging to sites only appear to be attached to its parent site)

#793


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
