### PR TITLE
Feat: Prune sharing state

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SharingStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SharingStateDto.kt
@@ -20,7 +20,6 @@
 package org.eclipse.tractusx.bpdm.gate.api.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.gate.api.exception.BusinessPartnerSharingError
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import java.time.LocalDateTime
@@ -31,9 +30,6 @@ import java.time.LocalDateTime
             "of external ID and business partner type."
 )
 data class SharingStateDto(
-
-    @get:Schema(description = "One of the types of business partners for which the sharing state entry was created.")
-    val businessPartnerType: BusinessPartnerType,
 
     @get:Schema(description = "The external identifier of the business partner for which the sharing state entry was created.")
     val externalId: String,
@@ -46,12 +42,6 @@ data class SharingStateDto(
 
     @get:Schema(description = "The error message in case the current sharing state type is \"error\".")
     val sharingErrorMessage: String? = null,
-
-    @get:Schema(
-        description = "The business partner number associated to the combination of external identifier and business partner type " +
-                "in case the sharing state type is “success”. Can be either a BPNL, BPNS or BPNA."
-    )
-    val bpn: String? = null,
 
     @get:Schema(description = "The date and time when the sharing process was started.")
     val sharingProcessStarted: LocalDateTime? = null,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
@@ -43,7 +43,7 @@ class SharingStateController(
         businessPartnerType: BusinessPartnerType?,
         externalIds: Collection<String>?
     ): PageDto<SharingStateDto> {
-        return sharingStateService.findSharingStates(paginationRequest, businessPartnerType, externalIds)
+        return sharingStateService.findSharingStates(paginationRequest, externalIds)
     }
 
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/SharingStateDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/SharingStateDb.kt
@@ -20,7 +20,6 @@
 package org.eclipse.tractusx.bpdm.gate.entity
 
 import jakarta.persistence.*
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import org.eclipse.tractusx.bpdm.gate.api.exception.BusinessPartnerSharingError
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
@@ -38,10 +37,6 @@ class SharingStateDb(
     var associatedOwnerBpnl: String? = null,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "business_partner_type", nullable = false)
-    var businessPartnerType: BusinessPartnerType,
-
-    @Enumerated(EnumType.STRING)
     @Column(name = "sharing_state_type", nullable = false)
     var sharingStateType: SharingStateType,
 
@@ -51,9 +46,6 @@ class SharingStateDb(
 
     @Column(name = "sharing_error_message", nullable = true)
     var sharingErrorMessage: String? = null,
-
-    @Column(name = "bpn", nullable = true)
-    var bpn: String? = null,
 
     @Column(name = "sharing_process_started", nullable = true)
     var sharingProcessStarted: LocalDateTime? = null,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/SharingStateRepository.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.tractusx.bpdm.gate.repository
 
-import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import org.eclipse.tractusx.bpdm.gate.entity.SharingStateDb
 import org.springframework.data.domain.Page
@@ -44,16 +43,6 @@ interface SharingStateRepository : PagingAndSortingRepository<SharingStateDb, Lo
                 }
             }
 
-        /**
-         * Restrict to entries with the given businessPartnerType; ignore if null
-         */
-        fun byBusinessPartnerType(businessPartnerType: BusinessPartnerType?) =
-            Specification<SharingStateDb> { root, _, builder ->
-                businessPartnerType?.let {
-                    builder.equal(root.get<BusinessPartnerType>(SharingStateDb::businessPartnerType.name), businessPartnerType)
-                }
-            }
-
 
         fun byAssociatedOwnerBpnl(associatedOwnerBpnl: String?) =
             Specification<SharingStateDb> { root, _, builder ->
@@ -64,9 +53,7 @@ interface SharingStateRepository : PagingAndSortingRepository<SharingStateDb, Lo
 
     }
 
-    fun findByExternalIdInAndBusinessPartnerTypeAndAssociatedOwnerBpnl(externalId: Collection<String>, businessPartnerType: BusinessPartnerType,associatedOwnerBpnl: String?): Collection<SharingStateDb>
-
-    fun findBySharingStateType(sharingStateType: SharingStateType): Set<SharingStateDb>
+    fun findByExternalIdInAndAssociatedOwnerBpnl(externalId: Collection<String>,associatedOwnerBpnl: String?): Collection<SharingStateDb>
 
     fun findBySharingStateType(sharingStateType: SharingStateType, pageable: Pageable): Page<SharingStateDb>
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -89,7 +89,7 @@ class BusinessPartnerService(
         saveChangelog(resolutionResults)
 
         val partners = resolutionResults.map { it.businessPartner }
-        sharingStateService.setInitial(partners.map { SharingStateService.SharingStateIdentifierDto(it.externalId, BusinessPartnerType.GENERIC) })
+        sharingStateService.setInitial(partners.map { it.externalId })
 
         partners.map {
             it.associatedOwnerBpnl = getCurrentUserBpn()
@@ -112,10 +112,7 @@ class BusinessPartnerService(
         val changedPartners = resolutionResults.map { it.businessPartner }
 
         val successRequests = entityCandidates.map {
-            SharingStateService.SuccessRequest(
-                SharingStateService.SharingStateIdentifierDto(it.externalId, BusinessPartnerType.GENERIC),
-                it.bpnA!!
-            )
+            SharingStateService.SuccessRequest(it.externalId)
         }
         sharingStateService.setSuccess(successRequests)
 
@@ -166,7 +163,7 @@ class BusinessPartnerService(
         val externalIds = entities.map { it.externalId }
         val persistedBusinessPartnerMap = businessPartnerRepository.findByStageAndExternalIdIn(stage, externalIds).associateBy { it.externalId }
         val sharingStatesMap =
-            sharingStateRepository.findByExternalIdInAndBusinessPartnerTypeAndAssociatedOwnerBpnl(externalIds, BusinessPartnerType.GENERIC,getCurrentUserBpn()).associateBy { it.externalId }
+            sharingStateRepository.findByExternalIdInAndAssociatedOwnerBpnl(externalIds,getCurrentUserBpn()).associateBy { it.externalId }
 
         return entities.filter { entity ->
             val matchingBusinessPartner = persistedBusinessPartnerMap[entity.externalId]

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordTaskService.kt
@@ -70,10 +70,8 @@ class GoldenRecordTaskService(
         val pendingRequests = partners.zip(createdTasks)
             .map { (partner, task) ->
                 SharingStateService.PendingRequest(
-                    SharingStateService.SharingStateIdentifierDto(
-                        partner.externalId,
-                        BusinessPartnerType.GENERIC
-                    ), task.taskId
+                    partner.externalId,
+                    task.taskId
                 )
             }
 
@@ -107,7 +105,7 @@ class GoldenRecordTaskService(
 
         val errorRequests = (taskStatesByResult[ResultState.Error]?.map { (task, sharingState) ->
             SharingStateService.ErrorRequest(
-                SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
+                sharingState.externalId,
                 BusinessPartnerSharingError.SharingProcessError,
                 if (task.processingState.errors.isNotEmpty()) task.processingState.errors.joinToString(" // ") { it.description }.take(255) else null
             )
@@ -115,7 +113,7 @@ class GoldenRecordTaskService(
 
         errorRequests.addAll(sharingStatesWithoutTasks.map { sharingState ->
             SharingStateService.ErrorRequest(
-                SharingStateService.SharingStateIdentifierDto(sharingState.externalId, sharingState.businessPartnerType),
+                sharingState.externalId,
                 BusinessPartnerSharingError.MissingTaskID,
                 errorMessage = "Missing Task in Orchestrator"
             )
@@ -156,10 +154,8 @@ class GoldenRecordTaskService(
         val pendingRequests = gateOutputEntries.zip(tasks)
             .map { (partner, task) ->
                 SharingStateService.PendingRequest(
-                    SharingStateService.SharingStateIdentifierDto(
-                        partner.externalId,
-                        partner.parentType ?: BusinessPartnerType.GENERIC
-                    ), task.taskId
+                    partner.externalId,
+                    task.taskId
                 )
             }
         sharingStateService.setPending(pendingRequests)

--- a/bpdm-gate/src/main/resources/db/migration/V6_0_0_2__drop_sharing_state_bp_bpn.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V6_0_0_2__drop_sharing_state_bp_bpn.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sharing_states
+DROP COLUMN business_partner_type;
+
+ALTER TABLE sharing_states
+DROP COLUMN bpn;

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
@@ -32,7 +32,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
 import org.eclipse.tractusx.bpdm.gate.service.GoldenRecordTaskService
 import org.eclipse.tractusx.bpdm.gate.util.MockAndAssertUtils
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
-import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerGenericCommonValues
 import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerNonVerboseValues
 import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerVerboseValues
 import org.eclipse.tractusx.bpdm.test.util.AssertHelpers
@@ -106,32 +105,26 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         val upsertSharingStatesRequests = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId1,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId2,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "1"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "2"
             )
@@ -163,22 +156,18 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         val createdSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "1"
             )
@@ -197,22 +186,18 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         val cleanedSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Success,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = BusinessPartnerGenericCommonValues.businessPartner1.address.addressBpn,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Error,
                 sharingErrorCode = BusinessPartnerSharingError.SharingProcessError,
                 sharingErrorMessage = "Major Error // Minor Error",
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "1"
             )
@@ -244,12 +229,10 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         val createdSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "2"
             )
@@ -268,12 +251,10 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         val cleanedSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Error,
                 sharingErrorCode = BusinessPartnerSharingError.MissingTaskID,
                 sharingErrorMessage = "Missing Task in Orchestrator",
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "2"
             )
@@ -309,12 +290,10 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         val upsertSharingStatesRequests = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = "000000123CCC333",
                 sharingProcessStarted = null,
                 taskId = "0"
             )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -31,7 +31,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
 import org.eclipse.tractusx.bpdm.gate.service.GoldenRecordTaskService
 import org.eclipse.tractusx.bpdm.gate.util.MockAndAssertUtils
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
-import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerGenericCommonValues
 import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerNonVerboseValues
 import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerVerboseValues
 import org.eclipse.tractusx.bpdm.test.util.AssertHelpers
@@ -129,32 +128,26 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val upsertSharingStatesRequests = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId1,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId2,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "1"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "2"
             )
@@ -300,22 +293,18 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val createdSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "1"
             )
@@ -334,22 +323,18 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val cleanedSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Success,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = BusinessPartnerGenericCommonValues.businessPartner1.address.addressBpn,
                 sharingProcessStarted = null,
                 taskId = "0"
             ),
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Error,
                 sharingErrorCode = BusinessPartnerSharingError.SharingProcessError,
                 sharingErrorMessage = "Major Error // Minor Error",
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "1"
             )
@@ -381,12 +366,10 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val createdSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "2"
             )
@@ -405,12 +388,10 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val cleanedSharingState = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId3,
                 sharingStateType = SharingStateType.Error,
                 sharingErrorCode = BusinessPartnerSharingError.MissingTaskID,
                 sharingErrorMessage = "Missing Task in Orchestrator",
-                bpn = null,
                 sharingProcessStarted = null,
                 taskId = "2"
             )
@@ -446,12 +427,10 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         val upsertSharingStatesRequests = listOf(
             SharingStateDto(
-                businessPartnerType = BusinessPartnerType.GENERIC,
                 externalId = externalId4,
                 sharingStateType = SharingStateType.Pending,
                 sharingErrorCode = null,
                 sharingErrorMessage = null,
-                bpn = "000000123CCC333",
                 sharingProcessStarted = null,
                 taskId = "0"
             )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -286,7 +286,6 @@ class MockAndAssertUtils @Autowired constructor(
         Assertions.assertThat(sharingStateResponse.content).isEqualTo(
             upsertedBusinessPartners.map {
                 SharingStateDto(
-                    businessPartnerType = BusinessPartnerType.GENERIC,
                     externalId = it.externalId,
                     sharingStateType = SharingStateType.Ready
                 )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request removes the sharing state's business partner type and BPN from the API. Since we now only deal with generic business partners, those fields are not necessary anymore.

Merge only after #833 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
