### PR TITLE
Feat: Create V6 versioned OpenAPI Document

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/AppInfoProperties.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/AppInfoProperties.kt
@@ -25,5 +25,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class AppInfoProperties(
     val name: String = "BPDM",
     val description: String = "",
-    val version: String = ""
+    val version: String = "",
+    val url: String = ""
 )

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/OpenApiCustomizerFactory.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/OpenApiCustomizerFactory.kt
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.util
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Paths
+import org.springdoc.core.customizers.OpenApiCustomizer
+
+class OpenApiCustomizerFactory {
+
+    fun sortSchemaCustomiser(): OpenApiCustomizer {
+        return OpenApiCustomizer { openApi: OpenAPI ->
+            openApi.components(with(openApi.components) { schemas(schemas?.values?.sortedBy { it.name }?.associateBy { it.name }) })
+        }
+    }
+
+    fun versionApiCustomizer(versionString: String): OpenApiCustomizer {
+        return OpenApiCustomizer { openApi: OpenAPI ->
+            val newPaths = Paths()
+            openApi.paths.forEach{
+                newPaths.addPathItem(it.key.removePrefix("/$versionString"), it.value)
+            }
+
+            openApi.paths = newPaths
+            openApi.servers.forEach { server -> server.url = "${server.url}/$versionString" }
+        }
+    }
+}

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -25,6 +25,11 @@ bpdm:
     version: '@project.version@'
   # Description of this application (shown in Swagger) (on default set by maven resource filtering)
     description: '@project.description@'
+  # The url from which this API is reachable
+  # Will appear as server item in the OpenAPI document
+  # Will also be used by Swagger as base-url to perform requests against
+  # If empty Swagger will generate the OpenAPI server url when accessing the Swagger page
+    url:
     bpn:
       # Specify the BPNL of the owner of this Gate here
       # If set, the BPNL will be attached to business partner data a sharing member claim as their own

--- a/bpdm-orchestrator/src/main/resources/application.yml
+++ b/bpdm-orchestrator/src/main/resources/application.yml
@@ -24,6 +24,11 @@ bpdm:
   version: '@project.version@'
   # Description of this application (shown in Swagger) (on default set by maven resource filtering)
   description: '@project.description@'
+  # The url from which this API is reachable
+  # Will appear as server item in the OpenAPI document
+  # Will also be used by Swagger as base-url to perform requests against
+  # If empty Swagger will generate the OpenAPI server url when accessing the Swagger page
+  url:
   security:
     # API will not be secured per default
     enabled: false

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -24,6 +24,11 @@ bpdm:
   version: '@project.version@'
   # Description of this application (shown in Swagger) (on default set by maven resource filtering)
   description: '@project.description@'
+  # The url from which this API is reachable
+  # Will appear as server item in the OpenAPI document
+  # Will also be used by Swagger as base-url to perform requests against
+  # If empty Swagger will generate the OpenAPI server url when accessing the Swagger page
+  url:
   bpn:
     # The characters that can make up a BPN
     alphabet: 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request creates additionally to the normal OpenAPI documents, special versioned OpenAPI documents that have the API's URL + version as base-url. This serves the following purpose: 

When we support multiple API versions at the same time we can generate separate OpenAPI documents based on each version

This is useful to create versioned Postman collections from these documents as well as publish the different api versions separately.

Only merge after #830

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
