### PR TITLE
fix(api-clients): base url path for endpoints

### DIFF
--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
@@ -49,8 +49,8 @@ class CleaningServiceApiCallsTest @Autowired constructor(
 ) {
 
     companion object {
-        const val ORCHESTRATOR_RESERVE_TASKS_URL = "/${GoldenRecordTaskApi.TASKS_PATH}/step-reservations"
-        const val ORCHESTRATOR_RESOLVE_TASKS_URL = "/${GoldenRecordTaskApi.TASKS_PATH}/step-results"
+        const val ORCHESTRATOR_RESERVE_TASKS_URL = "${GoldenRecordTaskApi.TASKS_PATH}/step-reservations"
+        const val ORCHESTRATOR_RESOLVE_TASKS_URL = "${GoldenRecordTaskApi.TASKS_PATH}/step-results"
 
         @JvmField
         @RegisterExtension

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/ApiCommons.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/ApiCommons.kt
@@ -20,5 +20,5 @@
 package org.eclipse.tractusx.bpdm.gate.api
 
 object ApiCommons {
-    const val BASE_PATH = "v6"
+    const val BASE_PATH = "/v6"
 }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -53,9 +53,9 @@ class MockAndAssertUtils @Autowired constructor(
     val assertHelpers: AssertHelpers
 ) {
 
-    val ORCHESTRATOR_CREATE_TASKS_URL = "/${GoldenRecordTaskApi.TASKS_PATH}"
-    val ORCHESTRATOR_SEARCH_TASK_STATES_URL = "/${GoldenRecordTaskApi.TASKS_PATH}/state/search"
-    val POOL_API_SEARCH_CHANGE_LOG_URL = "/${PoolChangelogApi.CHANGELOG_PATH}/search"
+    val ORCHESTRATOR_CREATE_TASKS_URL = GoldenRecordTaskApi.TASKS_PATH
+    val ORCHESTRATOR_SEARCH_TASK_STATES_URL = "${GoldenRecordTaskApi.TASKS_PATH}/state/search"
+    val POOL_API_SEARCH_CHANGE_LOG_URL = "${PoolChangelogApi.CHANGELOG_PATH}/search"
 
     fun mockOrchestratorApi(gateWireMockServer: WireMockExtension) {
         val taskCreateResponse =

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
@@ -38,7 +38,7 @@ const val TagWorker = "Task Worker"
 interface GoldenRecordTaskApi {
 
     companion object{
-        const val TASKS_PATH = "v6/golden-record-tasks"
+        const val TASKS_PATH = "/v6/golden-record-tasks"
     }
 
     @Operation(

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/ApiCommons.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/ApiCommons.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.api
 
 object ApiCommons {
 
-    const val BASE_PATH = "v6"
+    const val BASE_PATH = "/v6"
 
     const val LEGAL_ENTITIES_NAME = "Legal Entity Controller"
     const val LEGAL_ENTITIES_DESCRIPTION = "Read, create and update business partner of type legal entity"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the BPDM API clients not correctly assembling the base url path of endpoints.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
