### PR TITLE
feat(Auth): add additional permissions to the pool and gate APIs

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/PermissionConfigProperties.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/PermissionConfigProperties.kt
@@ -25,10 +25,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = PREFIX)
 data class PermissionConfigProperties(
-    val readInput: String = "read_input",
-    val writeInput: String = "write_input",
-    val readOutput: String = "read_output",
-    val writeOutput: String = "write_output"
+    val readInputPartner: String = "read_input_partner",
+    val writeInputPartner: String = "write_input_partner",
+    val readOutputPartner: String = "read_output_partner",
+    val readInputChangelog: String = "read_input_changelog",
+    val readOutputChangelog: String = "read_output_changelog",
+    val readSharingState: String = "read_sharing_state",
+    val writeSharingState: String = "write_sharing_state",
+    val readStats: String = "read_stats"
 ) {
     companion object {
         const val PREFIX = "bpdm.security.permissions"
@@ -37,9 +41,13 @@ data class PermissionConfigProperties(
         private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.gate.config.PermissionConfigProperties"
         private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
 
-        const val READ_INPUT_AUTHORITY = "@$BEAN_QUALIFIER.getReadInput()"
-        const val WRITE_INPUT_AUTHORITY = "@$BEAN_QUALIFIER.getWriteInput()"
-        const val READ_OUTPUT_AUTHORITY = "@$BEAN_QUALIFIER.getReadOutput()"
-        const val WRITE_OUTPUT_AUTHORITY = "@$BEAN_QUALIFIER.getWriteOutput()"
+        const val READ_INPUT_PARTNER = "@$BEAN_QUALIFIER.getReadInputPartner()"
+        const val WRITE_INPUT_PARTNER = "@$BEAN_QUALIFIER.getWriteInputPartner()"
+        const val READ_OUTPUT_PARTNER = "@$BEAN_QUALIFIER.getReadOutputPartner()"
+        const val READ_INPUT_CHANGELOG = "@$BEAN_QUALIFIER.getReadInputChangelog()"
+        const val READ_OUTPUT_CHANGELOG = "@$BEAN_QUALIFIER.getReadOutputChangelog()"
+        const val READ_SHARING_STATE = "@$BEAN_QUALIFIER.getReadSharingState()"
+        const val WRITE_SHARING_STATE = "@$BEAN_QUALIFIER.getWriteSharingState()"
+        const val READ_STATS = "@$BEAN_QUALIFIER.getReadStats()"
     }
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerController.kt
@@ -41,7 +41,7 @@ class BusinessPartnerController(
     val apiConfigProperties: ApiConfigProperties
 ) : GateBusinessPartnerApi {
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_INPUT_PARTNER})")
     override fun upsertBusinessPartnersInput(businessPartners: Collection<BusinessPartnerInputRequest>): ResponseEntity<Collection<BusinessPartnerInputDto>> {
         if (businessPartners.size > apiConfigProperties.upsertLimit || businessPartners.map { it.externalId }.containsDuplicates()) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)
@@ -50,7 +50,7 @@ class BusinessPartnerController(
         return ResponseEntity.ok(result)
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_PARTNER})")
     override fun getBusinessPartnersInput(
         externalIds: Collection<String>?,
         paginationRequest: PaginationRequest
@@ -58,7 +58,7 @@ class BusinessPartnerController(
         return businessPartnerService.getBusinessPartnersInput(paginationRequest.toPageRequest(), externalIds)
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_OUTPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_OUTPUT_PARTNER})")
     override fun getBusinessPartnersOutput(
         externalIds: Collection<String>?,
         paginationRequest: PaginationRequest

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/ChangelogController.kt
@@ -37,7 +37,7 @@ class ChangelogController(
     private val changelogService: ChangelogService
 ) : GateChangelogApi {
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_CHANGELOG})")
     override fun getInputChangelog(
         paginationRequest: PaginationRequest, searchRequest: ChangelogSearchRequest
     ): PageChangeLogDto<ChangelogGateDto> {
@@ -50,7 +50,7 @@ class ChangelogController(
         )
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_OUTPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_OUTPUT_CHANGELOG})")
     override fun getOutputChangelog(
         paginationRequest: PaginationRequest,
         searchRequest: ChangelogSearchRequest

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
@@ -37,7 +37,7 @@ class SharingStateController(
 ) : GateSharingStateApi {
     private val logger = KotlinLogging.logger { }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_SHARING_STATE})")
     override fun getSharingStates(
         paginationRequest: PaginationRequest,
         businessPartnerType: BusinessPartnerType?,
@@ -47,7 +47,7 @@ class SharingStateController(
     }
 
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_SHARING_STATE})")
     override fun postSharingStateReady(request: PostSharingStateReadyRequest) {
         sharingStateService.setReady(request.externalIds)
     }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/StatsController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/StatsController.kt
@@ -35,22 +35,22 @@ class StatsController(
     private val statsService: StatsService
 ) : StatsApi {
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_STATS})")
     override fun countPartnersBySharingState(): StatsSharingStatesResponse {
         return statsService.countSharingStates()
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_STATS})")
     override fun countPartnersPerStage(): StatsStagesResponse {
         return statsService.countBusinessPartnersPerStage()
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_STATS})")
     override fun countAddressTypes(stage: StageType): StatsAddressTypesResponse {
         return statsService.countAddressTypes(stage)
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_INPUT_AUTHORITY})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_STATS})")
     override fun getConfidenceCriteriaStats(): StatsConfidenceCriteriaResponse {
         return statsService.getConfidenceCriteriaStats()
     }

--- a/bpdm-gate/src/main/resources/application-auth.yml
+++ b/bpdm-gate/src/main/resources/application-auth.yml
@@ -28,22 +28,30 @@ bpdm:
     # URL to the auth endpoint of the Keycloak server
     auth-url: ${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}/protocol/openid-connect/auth
     # This application's resource or client. Used for finding permissions in the given Bearer token
-    client-id: BPDM_GATE
+    client-id: BPDM-GATE
     # The keycloak realm to consider
-    realm: master
+    realm: CX-Central
     # URL to the token refresh endpoint of the Keycloak server
     refresh-url: ${bpdm.security.token-url}
     # URL to the token validation endpoint of the Keycloak server
     token-url: ${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}/protocol/openid-connect/token
     permissions:
       # Name of the permission to read business partner input data
-      readInput: read_input
+      readInputPartner: read_input_partner
       # Name of the permission to upsert input business partner input data
-      writeInput: write_input
+      writeInputPartner: write_input_partner
       # Name of the permission to read business partner output data
-      readOutput: read_output
-      # Name of the permission to upsert business partner output data
-      writeOutput: write_input
+      readOutputPartner: read_output_partner
+      # Name of the permission to read changelog entries for business partner input data
+      readInputChangelog: read_input_changelog
+      # Name of the permission to read changelog entries for business partner output data
+      readOutputChangelog: read_output_changelog
+      # Name of the permission to read business partner sharing states
+      readSharingState: read_sharing_state
+      # Name of the permission to change business partner sharing states
+      writeSharingState: write_sharing_state
+      # Name of the permission to read business partner statistics
+      read_stats: read_stats
 #
 # From here on are framework and dependency configuration
 # More information about those properties can be taken from the respective documentation of Spring or the dependency

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PermissionConfigProperties.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PermissionConfigProperties.kt
@@ -27,14 +27,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class PermissionConfigProperties(
     val readPartner: String = "read_partner",
     val writePartner: String = "write_partner",
-    val readMetaData: String = "read_meta_data",
-    val writeMetaData: String = "write_meta_data",
-    val readMemberPartner: String = "read_member_partner"
+    val readMetaData: String = "read_metadata",
+    val writeMetaData: String = "write_metadata",
+    val readMemberPartner: String = "read_partner_member",
+    val readChangelog: String = "read_changelog",
+    val readMemberChangelog: String = "read_changelog_member"
 ) {
     companion object {
         const val PREFIX = "bpdm.security.permissions"
 
-        //Keep the fully qualified name up to data here
+        //Keep the fully qualified name up to date here
         private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties"
         private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
 
@@ -43,6 +45,8 @@ data class PermissionConfigProperties(
         const val READ_METADATA = "@${BEAN_QUALIFIER}.getReadMetaData()"
         const val WRITE_METADATA = "@${BEAN_QUALIFIER}.getWriteMetaData()"
         const val READ_MEMBER_PARTNER = "@${BEAN_QUALIFIER}.getReadMemberPartner()"
+        const val READ_CHANGELOG = "@${BEAN_QUALIFIER}.getReadChangelog()"
+        const val READ_MEMBER_CHANGELOG = "@${BEAN_QUALIFIER}.getReadMemberChangelog()"
     }
 }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogController.kt
@@ -37,7 +37,7 @@ class ChangelogController(
     private val controllerConfigProperties: ControllerConfigProperties
 ) : PoolChangelogApi {
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_CHANGELOG})")
     override fun getChangelogEntries(
         changelogSearchRequest: ChangelogSearchRequest,
         paginationRequest: PaginationRequest

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MemberController.kt
@@ -92,7 +92,7 @@ class MemberController(
         )
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_CHANGELOG})")
     override fun searchChangelogEntries(
         changelogSearchRequest: ChangelogSearchRequest,
         paginationRequest: PaginationRequest

--- a/bpdm-pool/src/main/resources/application-auth.yml
+++ b/bpdm-pool/src/main/resources/application-auth.yml
@@ -28,9 +28,9 @@ bpdm:
     # URL to the auth endpoint of the Keycloak server
     auth-url: ${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}/protocol/openid-connect/auth
     # This application's resource or client. Used for finding permissions in the given Bearer token
-    client-id: BPDM_POOL
+    client-id: BPDM-POOL
     # The keycloak realm to consider
-    realm: master
+    realm: CX-Central
     # URL to the token refresh endpoint of the Keycloak server
     refresh-url: ${bpdm.security.token-url}
     # URL to the token validation endpoint of the Keycloak server
@@ -41,11 +41,15 @@ bpdm:
       # Name of the permission to upsert business partners
       writePartner: write_partner
       # Name of the permission to read business partners that belong to a Catena-X member
-      readMemberPartner: read_member_partner
+      readMemberPartner: read_partner_member
       # Name of the permission to read metadata
-      readMetaData: read_meta_data
+      readMetaData: read_metadata
       # Name of the permission to create new metadata
-      writeMetaData: write_meta_data
+      writeMetaData: write_metadata
+      # Name of the permission to read changelog entries from business partners
+      readChangelog: read_changelog
+      # Name of the permission to read changelog entries from Catena-X member business partners
+      readMemberChangelog: read_changelog_member
 
 #
 # From here on are framework and dependency configuration


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This pool request adds new, more fine-granular - permissions to the BPDM Gate and Pool API. This way we can better fine tune the access logic to the existing resources.

Contributes to implementing eclipse-tractusx/sig-release#565

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
