### PR TITLE
docs(user): move user guide to docs/user

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,6 @@
 This folder contains supporting documentation for the BPDM applications.
 A good entrypoint are the `views` providing guidance for different interest groups:
 
-- [Adoption view](ADOPTION_VIEW.md): You want to integrate BPDM APIs
+- [Adoption view](user/ADOPTION_VIEW.md): You want to integrate BPDM APIs
 - [Operator view](OPERATOR_VIEW.md): You want to operate BPDM applications
 - [Developer view](DEVELOPER_VIEW.md): You want to contribute to the development of BPDM

--- a/docs/user/ADOPTION_VIEW.md
+++ b/docs/user/ADOPTION_VIEW.md
@@ -4,7 +4,7 @@ Here you can find documentation on how to access and integrate BPDM APIs.
 The main user groups for BPDM are sharing members, cleaning service providers and VAS providers.
 
 This document contains explanations for different use cases for these user groups.
-Accompanied by these explanations is a [Postman collection](postman/BPDM%20Tests.postman_collection.json) showcasing these use cases.
+Accompanied by these explanations is a [Postman collection](../postman/BPDM%20Tests.postman_collection.json) showcasing these use cases.
 Please mind that the requests in this Postman collection are not meant to be executed for automated tests but rather serve as documentation.
 
 ## Sharing Member View
@@ -104,7 +104,7 @@ A VAS provider uses golden records to provide an value-added service to the Cate
 ## Access BPDM over EDC
 
 This section details how a sharing member EDC can access an EDC exposing the BPDM API as assets. Before you can access the assets make sure that the BPDM EDC
-has been configured to provide assets for your company's BPN (see [Operator View](OPERATOR_VIEW.md)).
+has been configured to provide assets for your company's BPN (see [Operator View](../OPERATOR_VIEW.md)).
 This [POSTMAN collection](postman/EDC_BPDM_Usage.postman_collection.json) gives example requests for communicating with a deployed BPDM EDC over a sharing
 member EDC.
 In general, in order to access API endpoints you need to accept the contract of the corresponding asset first, then require a temporary access token for the


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request satisfies TRG 1.07 by moving the user guide (adoption view) to the docs/user folder.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
