### PR TITLE
docs(docker): add links to notice files in top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Furthermore, apart from the release workflows there also exists code scanning wo
 
 This README is just the gateway to more detailed documentation files that may be found in the [docs](docs) folder
 
+## Docker Notice
+
+Below you can find information to the used Docker images in this application:
+
+* [BPDM Pool](docker/pool/DOCKER_NOTICE.md)
+* [BPDM Gate](docker/gate/DOCKER_NOTICE.md)
+* [BPDM Orchestrator](docker/orchestrator/DOCKER_NOTICE.md)
+* [BPDM Cleaning Service Dummy](docker/cleaning-service-dummy/DOCKER_NOTICE.md)
+
 ## NOTICE
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request satisfies TRG 4.06 by adding links to the Docker notice files in the top-level README.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
