### PR TITLE
chore(Docker): add Keycloak container to docker compose file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,13 +20,11 @@
 
 # Can be used to start required services in order to run bpdm with profile `local` for development purposes
 services:
+
   postgres:
-    image: postgres:14.2
+    image: postgres:15.4
     container_name: bpdm-postgres
     environment:
-      POSTGRES_USER: bpdm
-      POSTGRES_PASSWORD:
-      POSTGRES_DB: bpdm
       POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:
       test: [ 'CMD-SHELL', 'pg_isready -U bpdm' ]
@@ -36,7 +34,25 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      - ./postgres/:/docker-entrypoint-initdb.d/:ro
       - bpdm-postgres-data:/var/lib/postgresql/data
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:22.0.5
+    container_name: bpdm-keycloak
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://bpdm-postgres:5432/keycloak
+      KC_DB_USERNAME: keycloak
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    command: start-dev --import-realm
+    ports:
+        - "8180:8080"
+    depends_on:
+      - postgres
+    volumes:
+      - ../bpdm-common-test/src/main/resources/keycloak/CX-Central.json:/opt/keycloak/data/import/CX-Central.json:ro
 
 volumes:
   bpdm-postgres-data:

--- a/docker/postgres/init.sh
+++ b/docker/postgres/init.sh
@@ -1,0 +1,22 @@
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+psql -U postgres -c "CREATE USER bpdm" -c "CREATE DATABASE bpdm" -c "GRANT ALL PRIVILEGES ON DATABASE bpdm TO bpdm"
+psql -U postgres -c "CREATE USER keycloak" -c "CREATE DATABASE keycloak"  -c "GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak"
+psql -U postgres -d keycloak -c "GRANT ALL PRIVILEGES ON SCHEMA public TO keycloak"


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Add Keycloak container to docker compose file for setting up BPDM app dependencies.

The Keycloak container is configured with a default realm which corresponds to the default auth configuration of the BPDM apps. This makes executing BPDM apps locally with authentication profile running much easier.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
