### PR TITLE
fix(Orchestrator): permission names and structure in the configuration

### DIFF
--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/PermissionConfigProperties.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/PermissionConfigProperties.kt
@@ -28,12 +28,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class PermissionConfigProperties(
     val createTask: String = "create_task",
     val readTask: String = "read_task",
-    val reservations: TaskStepProperties = TaskStepProperties(
+    val reservation: TaskStepProperties = TaskStepProperties(
         clean = "create_reservation_clean",
         cleanAndSync = "create_reservation_cleanAndSync",
         poolSync = "create_reservation_poolSync"
     ),
-    val results: TaskStepProperties = TaskStepProperties(
+    val result: TaskStepProperties = TaskStepProperties(
         clean = "create_result_clean",
         cleanAndSync = "create_result_cleanAndSync",
         poolSync = "create_result_poolSync"
@@ -54,12 +54,12 @@ data class PermissionConfigProperties(
 
     @Suppress("unused")
     fun createReservation(step: TaskStep): String{
-        return fetchStepPermission(step, reservations)
+        return fetchStepPermission(step, reservation)
     }
 
     @Suppress("unused")
     fun createResult(step: TaskStep): String{
-        return fetchStepPermission(step, results)
+        return fetchStepPermission(step, result)
     }
 
 

--- a/bpdm-orchestrator/src/main/resources/application.yml
+++ b/bpdm-orchestrator/src/main/resources/application.yml
@@ -56,31 +56,24 @@ bpdm:
     # URL to the token validation endpoint of the Keycloak server
     token-url: ${bpdm.security.auth-server-url}/realms/${bpdm.security.realm}/protocol/openid-connect/token
     permissions:
-      task:
-        # Name of permission to create golden record tasks
-        create: create_task
-        # Name of permission to read task status and overall results
-        read: read_task
+      # Name of permission to create golden record tasks
+      createTask: create_task
+      # Name of permission to read task status and overall results
+      readTask: read_task
       reservation:
-        clean:
           # Name of permission to create reservations for tasks in step 'Clean'
-          create: create_reservation_clean
-        cleanAndSync:
+          clean: create_reservation_clean
           # Name of permission to create reservations for tasks in step 'CleanAndSync'
-          create: create_reservation_cleanAndSync
-        poolSync:
+          cleanAndSync: create_reservation_cleanAndSync
           # Name of permission to create reservations for tasks in step 'PoolSync'
-          create: create_reservation_poolSync
+          poolSync: create_reservation_poolSync
       result:
-        clean:
           # Name of permission to post results for tasks in step 'Clean'
-          create: create_result_clean
-        cleanAndSync:
+          clean: create_result_clean
           # Name of permission to post results for tasks in step 'CleanAndSync'
-          create: create_result_cleanAndSync
-        poolSync:
+          cleanAndSync: create_result_cleanAndSync
           # Name of permission to post results for tasks in step 'PoolSync'
-          create: create_result_poolSync
+          poolSync: create_result_poolSync
 
 server:
   # Change default port to avoid clash with other BPDM applications

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <kotlinlogging.version>3.0.5</kotlinlogging.version>
         <wiremock.version>2.35.2</wiremock.version>
         <springmockk.version>4.0.2</springmockk.version>
-        <assertj.version>3.25.3</assertj.version>
+        <assertj.version>3.24.2</assertj.version>
         <spring-boot.version>3.0.4</spring-boot.version>
         <sonar.organization>catenax-ng</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->



## Description

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the permission configuration in the application properties

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
