### PR TITLE
fix(Pool): strange assert error on address comparison

### DIFF
--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
@@ -250,10 +250,10 @@ class AddressControllerIT @Autowired constructor(
                     it.content, listOf(
                         // site1
                         BusinessPartnerVerboseValues.addressPartner1.copy(addressType = AddressType.SiteMainAddress),
+                        BusinessPartnerVerboseValues.addressPartner2.copy(addressType = AddressType.SiteMainAddress),
                         BusinessPartnerVerboseValues.addressPartner1,
                         BusinessPartnerVerboseValues.addressPartner2,
                         // site2
-                        BusinessPartnerVerboseValues.addressPartner2.copy(addressType = AddressType.SiteMainAddress),
                         BusinessPartnerVerboseValues.addressPartner3,
                     )
                 )
@@ -547,13 +547,14 @@ class AddressControllerIT @Autowired constructor(
     private fun assertAddressesAreEqual(actuals: Collection<LogisticAddressVerboseDto>, expected: Collection<LogisticAddressVerboseDto>) {
         actuals.forEach { assertThat(it.bpna).matches(testHelpers.bpnAPattern) }
 
-        assertHelpers.assertRecursively(actuals)
-            .ignoringFields(
-                LogisticAddressVerboseDto::bpna.name,
-                LogisticAddressVerboseDto::bpnLegalEntity.name,
-                LogisticAddressVerboseDto::bpnSite.name
-            )
-            .isEqualTo(expected)
+            assertHelpers.assertRecursively(actuals)
+                .ignoringFields(
+                    LogisticAddressVerboseDto::bpna.name,
+                    LogisticAddressVerboseDto::bpnLegalEntity.name,
+                    LogisticAddressVerboseDto::bpnSite.name
+                )
+                .isEqualTo(expected)
+
     }
 
     private fun requestAddress(bpnAddress: String) = poolClient.addresses.getAddress(bpnAddress)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes a strange bug when asserting address collections to be equal in the Pool tests. For some reason the collection order seems to matter eben though, it does not other cases.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
