### PR TITLE
cicd(Trivy): stop trivy workflow from failing on any issues

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           scan-type: "config"
           # ignore-unfixed: true
-          exit-code: "1"
+          exit-code: "0"
           hide-progress: false
           format: "sarif"
           output: "trivy-results1.sarif"
@@ -81,7 +81,7 @@ jobs:
           image-ref: "docker.io/tractusx/bpdm-pool:latest-alpha"
           format: "sarif"
           output: "trivy-results2.sarif"
-          exit-code: "1"
+          exit-code: "0"
           severity: "CRITICAL,HIGH"
           timeout: 15m
         env:
@@ -114,7 +114,7 @@ jobs:
           image-ref: "docker.io/tractusx/bpdm-gate:latest-alpha"
           format: "sarif"
           output: "trivy-results3.sarif"
-          exit-code: "1"
+          exit-code: "0"
           severity: "CRITICAL,HIGH"
           timeout: 15m
         env:
@@ -147,7 +147,7 @@ jobs:
           image-ref: "docker.io/tractusx/bpdm-cleaning-service-dummy:latest-alpha"
           format: "sarif"
           output: "trivy-results4.sarif"
-          exit-code: "1"
+          exit-code: "0"
           severity: "CRITICAL,HIGH"
           timeout: 15m
         env:
@@ -180,7 +180,7 @@ jobs:
           image-ref: "docker.io/tractusx/bpdm-orchestrator:latest-alpha"
           format: "sarif"
           output: "trivy-results4.sarif"
-          exit-code: "1"
+          exit-code: "0"
           severity: "CRITICAL,HIGH"
           timeout: 15m
         env:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request changes the Trivy workflow to not fail on any discovered issues. Failing the workflow on this trigger should indicates that there is something wrong with the workflow itself, which is not the case.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
