### PR TITLE
fix(gate): remove unused business partner type filter from sharing state

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GateSharingStateApi.kt
@@ -52,7 +52,6 @@ interface GateSharingStateApi {
     @GetMapping
     fun getSharingStates(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
-        @Parameter(description = "Business partner type") @RequestParam(required = false) businessPartnerType: BusinessPartnerType?,
         @Parameter(description = "External IDs") @RequestParam(required = false) externalIds: Collection<String>?
     ): PageDto<SharingStateDto>
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/SharingStateApiClient.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/SharingStateApiClient.kt
@@ -39,7 +39,6 @@ interface SharingStateApiClient : GateSharingStateApi {
     @GetExchange
     override fun getSharingStates(
         @ParameterObject @Valid paginationRequest: PaginationRequest,
-        @Parameter(description = "Business partner type") @RequestParam(required = false) businessPartnerType: BusinessPartnerType?,
         @Parameter(description = "External IDs") @RequestParam(required = false) externalIds: Collection<String>?
     ): PageDto<SharingStateDto>
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/SharingStateController.kt
@@ -41,7 +41,6 @@ class SharingStateController(
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_SHARING_STATE})")
     override fun getSharingStates(
         paginationRequest: PaginationRequest,
-        businessPartnerType: BusinessPartnerType?,
         externalIds: Collection<String>?
     ): PageDto<SharingStateDto> {
         return sharingStateService.findSharingStates(paginationRequest, externalIds,  getCurrentUserBpn())

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthTestBase.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthTestBase.kt
@@ -63,7 +63,7 @@ abstract class AuthTestBase(
 
     @Test
     fun `GET Sharing State`() {
-        authAssertions.assert(authExpectations.sharingState.getSharingState) { gateClient.sharingState.getSharingStates(PaginationRequest(), null, null) }
+        authAssertions.assert(authExpectations.sharingState.getSharingState) { gateClient.sharingState.getSharingStates(PaginationRequest(), null) }
     }
 
     @Test

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
@@ -130,7 +130,7 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
             )
         )
 
-        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(externalIds)
 
 
         assertHelpers.assertRecursively(upsertSharingStateResponses).isEqualTo(upsertSharingStatesRequests)
@@ -175,7 +175,7 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         //Firstly verifies if the Sharing States was created for new Business Partners
         val externalIds = listOf(externalId4, externalId5)
-        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers
             .assertRecursively(upsertSharingStateResponses)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
@@ -204,7 +204,7 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
         )
 
         //Check for both Sharing State changes (Error and Success)
-        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers.assertRecursively(readCleanedSharingState)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
             .isEqualTo(cleanedSharingState)
@@ -240,7 +240,7 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         //Firstly verifies if the Sharing States was created for new Business Partner
         val externalIds = listOf(externalId3)
-        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers
             .assertRecursively(upsertSharingStateResponses)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
@@ -261,7 +261,7 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
         )
 
         //Check for Sharing State
-        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers.assertRecursively(readCleanedSharingState)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
             .isEqualTo(cleanedSharingState)

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -153,7 +153,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
             )
         )
 
-        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(externalIds)
 
 
         assertHelpers.assertRecursively(upsertSharingStateResponses).isEqualTo(upsertSharingStatesRequests)
@@ -312,7 +312,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         //Firstly verifies if the Sharing States was created for new Business Partners
         val externalIds = listOf(externalId4, externalId5)
-        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers
             .assertRecursively(upsertSharingStateResponses)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
@@ -341,7 +341,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
         )
 
         //Check for both Sharing State changes (Error and Success)
-        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers.assertRecursively(readCleanedSharingState)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
             .isEqualTo(cleanedSharingState)
@@ -377,7 +377,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
 
         //Firstly verifies if the Sharing States was created for new Business Partner
         val externalIds = listOf(externalId3)
-        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val upsertSharingStateResponses = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers
             .assertRecursively(upsertSharingStateResponses)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
@@ -398,7 +398,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
         )
 
         //Check for Sharing State
-        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(BusinessPartnerType.GENERIC, externalIds)
+        val readCleanedSharingState = this.mockAndAssertUtils.readSharingStates(externalIds)
         assertHelpers.assertRecursively(readCleanedSharingState)
             .ignoringFieldsMatchingRegexes(".*${SharingStateDto::sharingProcessStarted.name}")
             .isEqualTo(cleanedSharingState)

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -229,9 +229,9 @@ class MockAndAssertUtils @Autowired constructor(
         )
     }
 
-    fun readSharingStates(businessPartnerType: BusinessPartnerType?, externalIds: Collection<String>?): Collection<SharingStateDto> {
+    fun readSharingStates(externalIds: Collection<String>?): Collection<SharingStateDto> {
 
-        return gateClient.sharingState.getSharingStates(PaginationRequest(), businessPartnerType, externalIds).content
+        return gateClient.sharingState.getSharingStates(PaginationRequest(), externalIds).content
     }
 
     fun assertUpsertOutputResponsesMatchRequests(responses: Collection<BusinessPartnerOutputDto>, requests: List<BusinessPartnerOutputDto>) {
@@ -281,7 +281,7 @@ class MockAndAssertUtils @Autowired constructor(
         org.junit.jupiter.api.Assertions.assertEquals(upsertedBusinessPartners.size.toLong(), searchResponsePage.totalElements)
         assertHelpers.assertRecursively(searchResponsePage.content).isEqualTo(upsertedBusinessPartners)
 
-        val sharingStateResponse = gateClient.sharingState.getSharingStates(PaginationRequest(), businessPartnerType = null, externalIds = null)
+        val sharingStateResponse = gateClient.sharingState.getSharingStates(PaginationRequest(), externalIds = null)
         org.junit.jupiter.api.Assertions.assertEquals(upsertedBusinessPartners.size.toLong(), sharingStateResponse.totalElements)
         Assertions.assertThat(sharingStateResponse.content).isEqualTo(
             upsertedBusinessPartners.map {


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Removes the unused business partner type filter form the sharing state endpoint - making the OpenAPi documentation clearer.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
