### PR TITLE
fix(docker): remove wget and health check from docker images

### DIFF
--- a/docker/cleaning-service-dummy/Dockerfile
+++ b/docker/cleaning-service-dummy/Dockerfile
@@ -23,8 +23,6 @@ WORKDIR /home/app
 RUN mvn -B -U clean package -pl bpdm-cleaning-service-dummy -am -DskipTests
 
 FROM eclipse-temurin:21-jre-alpine
-# Adding wget for the health check
-RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-cleaning-service-dummy/target/bpdm-cleaning-service-dummy.jar /usr/local/lib/bpdm/app.jar
 ARG USERNAME=bpdm
 ARG USERID=10001
@@ -34,7 +32,4 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-# Health check instruction
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8084/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/docker/gate/Dockerfile
+++ b/docker/gate/Dockerfile
@@ -24,8 +24,6 @@ WORKDIR  $HOME
 RUN --mount=type=cache,target=/root/.m2 mvn -B -U clean package -pl bpdm-gate -am -DskipTests
 
 FROM eclipse-temurin:21-jre-alpine
-# Adding wget for the health check
-RUN apk --no-cache add wget
 ENV HOME=/home/app
 COPY --from=build $HOME/bpdm-gate/target/bpdm-gate.jar /usr/local/lib/bpdm/app.jar
 ARG USERNAME=bpdm
@@ -36,7 +34,4 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-# Health check instruction
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8081/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/docker/orchestrator/Dockerfile
+++ b/docker/orchestrator/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /home/app
 RUN mvn -B -U clean package -pl bpdm-orchestrator -am -DskipTests
 
 FROM eclipse-temurin:21-jre-alpine
-# Adding wget for the health check
-RUN apk --no-cache add wget
 COPY --from=build /home/app/bpdm-orchestrator/target/bpdm-orchestrator.jar /usr/local/lib/bpdm/app.jar
 ARG USERNAME=bpdm
 ARG USERID=10001
@@ -15,7 +13,4 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-# Health check instruction
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8085/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/docker/pool/Dockerfile
+++ b/docker/pool/Dockerfile
@@ -5,8 +5,6 @@ WORKDIR $HOME
 RUN --mount=type=cache,target=/root/.m2 mvn -B -U clean package -pl bpdm-pool -am -DskipTests
 
 FROM eclipse-temurin:21-jre-alpine
-# Adding wget for the health check
-RUN apk --no-cache add wget
 ENV HOME=/home/app
 COPY --from=build $HOME/bpdm-pool/target/bpdm-pool.jar /usr/local/lib/bpdm/app.jar
 ARG USERNAME=bpdm
@@ -17,7 +15,4 @@ RUN adduser -u $USERID -S $USERNAME $USERNAME
 USER $USERNAME
 WORKDIR /usr/local/lib/bpdm
 EXPOSE 8080
-# Health check instruction
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1
 ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Removes modifiying the base image by installing wget. Removed also the healtcheck that was only possible by adding this package to the alpine base image.

fixes #924

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
