### PR TITLE
chore: add no-auth profile to all BPDM applications

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/resources/application-no-auth.yml
+++ b/bpdm-cleaning-service-dummy/src/main/resources/application-no-auth.yml
@@ -1,0 +1,5 @@
+bpdm:
+  client:
+    orchestrator:
+      # Disable trying to authenticate to an OAuth2 resource server when accessing the Orchestrator
+      security-enabled: false

--- a/bpdm-gate/src/main/resources/application-no-auth.yml
+++ b/bpdm-gate/src/main/resources/application-no-auth.yml
@@ -1,0 +1,11 @@
+bpdm:
+  security:
+    # Disable authentication on the application's own API
+    enabled: false
+  client:
+    orchestrator:
+      # Disable trying to authenticate to an OAuth2 resource server when accessing the Orchestrator
+      security-enabled: false
+    pool:
+      # Disable trying to authenticate to an OAuth2 resource server when accessing the Pool
+      security-enabled: false

--- a/bpdm-orchestrator/src/main/resources/application-no-auth.yml
+++ b/bpdm-orchestrator/src/main/resources/application-no-auth.yml
@@ -1,0 +1,4 @@
+bpdm:
+  security:
+    # Disable authentication on the application's own API
+    enabled: false

--- a/bpdm-pool/src/main/resources/application-no-auth.yml
+++ b/bpdm-pool/src/main/resources/application-no-auth.yml
@@ -1,0 +1,8 @@
+bpdm:
+  security:
+    # Disable authentication on the application's own API
+    enabled: false
+  client:
+    orchestrator:
+      # Disable trying to authenticate to an OAuth2 resource server when accessing the Orchestrator
+      security-enabled: false


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
