### PR TITLE
fix(pool): name search behaviour

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityRepository.kt
@@ -42,7 +42,7 @@ interface LegalEntityRepository : JpaRepository<LegalEntityDb, Long>, JpaSpecifi
         fun byLegalName(legalName: String?) =
             Specification<LegalEntityDb> { root, _, builder ->
                 legalName?.takeIf { it.isNotBlank() }?.let {
-                    builder.like(root.get<NameDb>(LegalEntityDb::legalName.name).get(NameDb::value.name), legalName)
+                    builder.like(builder.lower(root.get<NameDb>(LegalEntityDb::legalName.name).get(NameDb::value.name)), "%${legalName.lowercase()}%")
                 }
             }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LogisticAddressRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LogisticAddressRepository.kt
@@ -56,7 +56,7 @@ interface LogisticAddressRepository : JpaRepository<LogisticAddressDb, Long>, Jp
         fun byName(name: String?) =
             Specification<LogisticAddressDb> { root, _, builder ->
                 name?.takeIf { it.isNotBlank() }?.let {
-                    builder.like(root.get(LogisticAddressDb::name.name), name)
+                    builder.like(builder.lower(root.get(LogisticAddressDb::name.name)), "%${name.lowercase()}%")
                 }
             }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
@@ -48,7 +48,7 @@ interface SiteRepository : JpaRepository<SiteDb, Long>, JpaSpecificationExecutor
         fun byName(name: String?) =
             Specification<SiteDb> { root, _, builder ->
                 name?.takeIf { it.isNotBlank() }?.let {
-                    builder.like(root.get(SiteDb::name.name), name)
+                    builder.like(builder.lower(root.get(SiteDb::name.name)), "%${name.lowercase()}%")
                 }
             }
 


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes limitations in the name search of legal entities, sites and addresses.

Now the search
- is case-insensitive
- matches on parts of words

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
