### PR TITLE
docs: update copyright notice in the BPDM documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -305,8 +305,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/001-multitenancy_approach.md
+++ b/docs/decision-records/001-multitenancy_approach.md
@@ -86,8 +86,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/002-edc_for_pool_api.md
+++ b/docs/decision-records/002-edc_for_pool_api.md
@@ -34,8 +34,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/003-orchestrator_serviceApi_vs_messagebus_approach.md
+++ b/docs/decision-records/003-orchestrator_serviceApi_vs_messagebus_approach.md
@@ -129,8 +129,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/004-openapi_descriptions.md
+++ b/docs/decision-records/004-openapi_descriptions.md
@@ -84,8 +84,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/decision-records/005-edc-usage-for-third-party-services.md
+++ b/docs/decision-records/005-edc-usage-for-third-party-services.md
@@ -85,16 +85,16 @@ In this scenario the operating environment itself operates a backend service or 
 ![Internal web application/service that provides enriched data based on gate data and/or pool data](assets/edc_usage_2_2.drawio.svg)
 
 
-## More Information
-
 ## NOTICE
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -62,3 +62,17 @@ gitGraph
     branch "fix/C"
     commit id: "fix(C)"
 ```
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
+- SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
+- SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/security-assessment/README.md
+++ b/docs/security-assessment/README.md
@@ -174,3 +174,17 @@ Primary controls implemented on product (or on specific aspect of product):
 | Before Mitigation | Impact: High, Likelihood: Low, Risk: Medium |
 | After Mitigation | Impact: Low, Likelihood: Low, Risk: Low |
 | Mitigation | Implementation of integrity controls. Implemented solution should be allowing the application to confirm the integrity (authenticity and confirmation that information was not changed by unauthorized party) of the stored data, especially golden records, that are further used and consumed by other entities. Rollback of manipulated data must be possible. |
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
+- SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
+- SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
+- SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -34,8 +34,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/templates/decision-record.md
+++ b/docs/templates/decision-record.md
@@ -87,8 +87,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm

--- a/docs/templates/use-case.md
+++ b/docs/templates/use-case.md
@@ -35,8 +35,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 - SPDX-License-Identifier: Apache-2.0
 - SPDX-FileCopyrightText: 2023,2024 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023,2024 SAP SE
 - SPDX-FileCopyrightText: 2023,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 - SPDX-FileCopyrightText: 2023,2024 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023,2024 Robert Bosch GmbH
 - SPDX-FileCopyrightText: 2023,2024 Schaeffler AG
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/bpdm


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request updates the copyright notice information for the BPDM documentation by adding SAP and Bosch to the notice.

Also added the copyright where it was missing previously.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
