### PR TITLE
cicd: create docker image tags based on maven versioning

### DIFF
--- a/.github/workflows/deploy-docker-all.yaml
+++ b/.github/workflows/deploy-docker-all.yaml
@@ -17,55 +17,40 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-name: Build All - Docker images (SemVer)
+name: Deploy - All Docker Images
 on:
+  workflow_dispatch:
   push:
-    # only execute when source specific files or workflows change
     paths:
-      - pom.xml
-      - bpdm-pool/**
-      - bpdm-gate/**
-      - bpdm-common/**
-      - bpdm-gate-api/**
-      - bpdm-bridge-dummy/**
-      - bpdm-cleaning-service-dummy/**
-      - bpdm-orchestrator/**
-      - .github/workflows/**
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+      - 'pom.xml'
+      - 'bpdm-**'
     branches:
       - main
-      - rc/**
 jobs:
   build-docker-pool:
-    uses: ./.github/workflows/build-docker.yaml
+    uses: ./.github/workflows/deploy-docker.yaml
     secrets: inherit
     with:
       imageName: bpdm-pool
       dockerfilePath: ./docker/pool
-      push: ${{ github.event_name != 'pull_request' }}
 
   build-docker-gate:
-    uses: ./.github/workflows/build-docker.yaml
+    uses: ./.github/workflows/deploy-docker.yaml
     secrets: inherit
     with:
       imageName: bpdm-gate
       dockerfilePath: ./docker/gate
-      push: ${{ github.event_name != 'pull_request' }}
 
   build-docker-cleaning-service:
-    uses: ./.github/workflows/build-docker.yaml
+    uses: ./.github/workflows/deploy-docker.yaml
     secrets: inherit
     with:
       imageName: bpdm-cleaning-service-dummy
       dockerfilePath: ./docker/cleaning-service-dummy
-      push: ${{ github.event_name != 'pull_request' }}
 
   build-docker-orchestrator:
-    uses: ./.github/workflows/build-docker.yaml
+    uses: ./.github/workflows/deploy-docker.yaml
     secrets: inherit
     with:
       imageName: bpdm-orchestrator
       dockerfilePath: ./docker/orchestrator
-      push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -17,9 +17,18 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-name: Build - Docker image (SemVer)
-
+name: Deploy - Docker Image
 on:
+  workflow_dispatch:
+    inputs:
+      imageName:
+        required: true
+        type: string
+        description: Name the built image should get
+      dockerfilePath:
+        required: true
+        type: string
+        description: Path to where the Dockerfile to build is
   workflow_call:
     inputs:
       imageName:
@@ -30,11 +39,6 @@ on:
         required: true
         type: string
         description: Path to where the Dockerfile to build is
-      push:
-        required: true
-        type: boolean
-        description: Whether to also push created image or just build it
-
 
 env:
   IMAGE_NAMESPACE: "tractusx"
@@ -43,56 +47,64 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Create SemVer or ref tags dependent of trigger event
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
+      - uses: dorny/paths-filter@v3
+        id: changes
         with:
-          images: |
-            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          # Automatically prepare image tags; See action docs for more examples.
-          # semver patter will generate tags like these for example :1 :1.2 :1.2.3
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest-alpha,enable={{is_default_branch}}
+          filters: |
+            apps:
+              - 'pom.xml'
+              - 'bpdm-**'
+
+      - name: Extract Maven Project Version
+        if: steps.changes.outputs.apps == 'true'
+        id: pomVersion
+        run: |
+          POM_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' -B --non-recursive exec:exec)
+          echo "version=$POM_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Parse semantic version from string
+        if: steps.changes.outputs.apps == 'true'
+        id: semVer
+        uses: release-kit/semver@v2
+        with:
+          string: 'v${{ steps.pomVersion.outputs.version }}'
+
+      - name: Create Docker Tags
+        id: dockerTags
+        run: |
+          SUFFIX="${{ steps.semVer.outputs.prerelease == 'SNAPSHOT' && '-SNAPSHOT' || '' }}"
+          LATEST="latest$SUFFIX"
+          MAJOR="${{ steps.semVer.outputs.major }}"
+          MINOR="${MAJOR}.${{ steps.semVer.outputs.minor }}"
+          PATCH="${MINOR}.${{ steps.semVer.outputs.patch }}"
+          MAJOR_VER="${MAJOR}${SUFFIX}"
+          MINOR_VER="${MINOR}${SUFFIX}"
+          PATCH_VER="${PATCH}${SUFFIX}"
+          echo "tags=${LATEST},${MAJOR_VER},${MINOR_VER},${PATCH_VER}" >> $GITHUB_OUTPUT
 
       - name: DockerHub login
-        if:  inputs.push
         uses: docker/login-action@v3
         with:
-          # Use existing DockerHub credentials present as secrets
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
+        if: steps.changes.outputs.apps == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
-          # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ inputs.push }}
+          push: true
           file: ${{ inputs.dockerfilePath }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.dockerTags.outputs.tags }}
 
-      # https://github.com/peter-evans/dockerhub-description
-      # Important step to push image description to DockerHub
       - name: Update Docker Hub description
-        if: inputs.push
+        if: steps.changes.outputs.apps == 'true'
         uses: peter-evans/dockerhub-description@v4
         with:
-        # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'
-        # readme-filepath: path/to/dedicated/notice-for-docker-image.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -40,42 +40,64 @@ Check the [Eclipse Dash License Tool documentation](https://github.com/eclipse/d
 
 ```mermaid
 ---
-title: BPDM Branching Strategy
+title: BPDM Branching Strategy (App Tags)
 ---
-gitGraph
+gitGraph TB:
+    commit tag: "v1.0.0-alpha.0"
+    branch "app-feature A"
+    branch "app-feature B"
+    checkout "app-feature A"
     commit
     commit
-    branch "release/1.0.x"
-    checkout "release/1.0.x"
-    commit id: "ver(1.0.0)" tag: "1.0.0"
+    checkout "main"
+    merge "app-feature A" tag:  "v1.0.0-alpha.1"
+    checkout "app-feature B"
+    commit
+    checkout "main"
+    merge "app-feature B" tag: "v1.0.0"
+    branch "chart-feature C"
+    commit
+    checkout "main"
+    merge "chart-feature C"
+    branch "app-feature D"
+    commit
+    checkout "main"
+    merge "app-feature D" tag: "v1.0.1-alpha.0"
+    branch "app-feature E"
+    commit
+    checkout "main"
+    merge "app-feature E" tag: "v1.1.0-alpha.0"
+```
 
-    checkout main
-    commit id: "ver(0.1.0-SNAPSHOT)"
-    commit id: "fix(A)"
-    commit
-    checkout "release/1.0.x"
-    branch "fix/1.0.x/A"
-    cherry-pick id: "fix(A)"
-    checkout "release/1.0.x"
-    merge "fix/1.0.x/A"
-
-    checkout "release/1.0.x"
-    commit id: "ver(1.0.1)" tag: "1.0.1"
-    checkout main
+```mermaid
+---
+title: BPDM Branching Strategy (Chart Tags)
+---
+gitGraph TB:
+    commit tag: "bpdm-1.0.0-alpha.0"
+    branch "app-feature A"
+    branch "app-feature B"
+    checkout "app-feature A"
     commit
     commit
-    branch "release/1.1.x"
-    checkout "release/1.1.x"
-    commit id: "ver(1.1.0)" tag: "1.1.0"
-    checkout main
-    commit id: "ver(1.2.0-SNAPSHOT)"
+    checkout "main"
+    merge "app-feature A" tag:  "bpdm-1.0.0-alpha.1"
+    checkout "app-feature B"
     commit
-    commit id: "ver(2.0.0-SNAPSHOT)"
-    branch "feat(B)"
-    commit id: "feat(B)"
-    checkout main
-    branch "fix/C"
-    commit id: "fix(C)"
+    checkout "main"
+    merge "app-feature B" tag: "bpdm-1.0.0"
+    branch "chart-feature C"
+    commit
+    checkout "main"
+    merge "chart-feature C" tag: "bpdm-1.0.1"
+    branch "app-feature D"
+    commit
+    checkout "main"
+    merge "app-feature D" tag: "bpdm-1.0.1-alpha.0"
+    branch "app-feature E"
+    commit
+    checkout "main"
+    merge "app-feature E" tag: "bpdm-1.1.0-alpha.0"
 ```
 
 ## NOTICE


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request createsdocker image tags based on maven versioning

- now only deploy docker images when the apps have been changed
- deploy snapshot or release version based on maven version

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
