### PR TITLE
cicd: only release chart if it is a release version

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -22,16 +22,12 @@ name: Release Charts
 on:
   workflow_dispatch:
   push:
-    # prevent unnecessary GH action runs for files outside of charts folder
     paths:
       - 'charts/**'
     branches:
       - main
-
 jobs:
   release:
-    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -41,17 +37,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check for Release Version
+        id: checkRelease
+        run: |
+          CHART_VERSION=$(grep 'version:' ./charts/bpdm/Chart.yaml | head -n1 | awk '{ print $2}')
+          SNAPSHOT=$(echo $CHART_VERSION | grep 'SNAPSHOT')
+          if test -z $SNAPSHOT; then IS_RELEASE=true; else IS_RELEASE=false fi
+          echo "isRelease=$IS_RELEASE" >> GITHUB_OUTPUT
+
       - name: Configure Git
+        if: steps.checkRelease.outputs.isRelease == 'true'
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
+        if:  steps.checkRelease.outputs.isRelease == 'true'
         uses: azure/setup-helm@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-releaser
+        if:  steps.checkRelease.outputs.isRelease == 'true'
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This pull request changes the Charts release behaviour by only releasing the chart if it is a release version

- Charts should now have snapshot versions which prevent the chart from being released

For non-release versions we currently have no solution on where to deploy them. A candidate for this could be dockerhub. Alternatively something akin to a 'next' release could be a solution for  Chart SNAPSHOT versions as well.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
