### PR TITLE
feat(bpdm-gate): GET endpoint to download csv file template for business partner upload process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Added
 
 - BPDM Gate: Post endpoint to upload business partner input data using csv file.(#700)
+- BPDM Gate: GET endpoint to download the csv file template for business partner upload. (#700)
 
 ## [6.0.1] - [2024-05-27]
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GatePartnerUploadApi.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/GatePartnerUploadApi.kt
@@ -27,8 +27,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.eclipse.tractusx.bpdm.gate.api.GateBusinessPartnerApi.Companion.BUSINESS_PARTNER_PATH
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.PartnerUploadErrorResponse
+import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
@@ -62,5 +64,18 @@ interface GatePartnerUploadApi {
     fun uploadPartnerCsvFile(
         @RequestPart("file") file: MultipartFile
     ): ResponseEntity<Collection<BusinessPartnerInputDto>>
+
+    @Operation(
+        summary = "Get CSV template with headers in file",
+        description = "Create empty CSV file template including headers." +
+                "Generated CSV file can later be used for uploading business partner data."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "CSV file template generated successfully")
+        ]
+    )
+    @GetMapping("/input/partner-upload-template")
+    fun getPartnerCsvTemplate(): ResponseEntity<ByteArrayResource>
 
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/PartnerUploadApiClient.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/client/PartnerUploadApiClient.kt
@@ -21,10 +21,12 @@ package org.eclipse.tractusx.bpdm.gate.api.client
 
 import org.eclipse.tractusx.bpdm.gate.api.GatePartnerUploadApi
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
+import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
@@ -39,5 +41,10 @@ interface PartnerUploadApiClient : GatePartnerUploadApi {
     override fun uploadPartnerCsvFile(
         @RequestPart("file") file: MultipartFile
     ): ResponseEntity<Collection<BusinessPartnerInputDto>>
+
+    @GetExchange(
+        url = "/input/partner-upload-template",
+    )
+    override fun getPartnerCsvTemplate(): ResponseEntity<ByteArrayResource>
 
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PartnerUploadController.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PartnerUploadController.kt
@@ -26,7 +26,10 @@ import org.eclipse.tractusx.bpdm.gate.config.PermissionConfigProperties
 import org.eclipse.tractusx.bpdm.gate.service.BusinessPartnerService
 import org.eclipse.tractusx.bpdm.gate.service.PartnerUploadService
 import org.eclipse.tractusx.bpdm.gate.util.getCurrentUserBpn
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
@@ -48,6 +51,15 @@ class PartnerUploadController(
             !file.contentType.equals("text/csv", ignoreCase = true) -> ResponseEntity(HttpStatus.BAD_REQUEST)
             else -> partnerUploadService.processFile(file, getCurrentUserBpn())
         }
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.UPLOAD_INPUT_PARTNER})")
+    override fun getPartnerCsvTemplate(): ResponseEntity<ByteArrayResource> {
+        val resource = partnerUploadService.generatePartnerCsvTemplate()
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=partner-upload-template.csv")
+            .contentType(MediaType.parseMediaType("text/csv"))
+            .body(resource)
     }
 
 }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthAdminIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthAdminIT.kt
@@ -63,7 +63,8 @@ class AuthAdminIT @Autowired constructor(
             getConfidenceCriteria = AuthExpectationType.Authorized
         ),
         uploadPartner = UploadPartnerAuthExpections(
-            postInput = AuthExpectationType.Authorized
+            postInput = AuthExpectationType.Authorized,
+            getInputTemplate = AuthExpectationType.Authorized
         )
     )
 ) {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputConsumerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputConsumerIT.kt
@@ -63,7 +63,8 @@ class AuthInputConsumerIT @Autowired constructor(
             getConfidenceCriteria = AuthExpectationType.Authorized
         ),
         uploadPartner = UploadPartnerAuthExpections(
-            postInput = AuthExpectationType.Forbidden
+            postInput = AuthExpectationType.Forbidden,
+            getInputTemplate = AuthExpectationType.Forbidden
         )
     )
 ) {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputManagerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputManagerIT.kt
@@ -63,7 +63,8 @@ class AuthInputManagerIT @Autowired constructor(
             getConfidenceCriteria = AuthExpectationType.Authorized
         ),
         uploadPartner = UploadPartnerAuthExpections(
-            postInput = AuthExpectationType.Authorized
+            postInput = AuthExpectationType.Authorized,
+            getInputTemplate = AuthExpectationType.Authorized
         )
     )
 ) {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthOutputConsumerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthOutputConsumerIT.kt
@@ -63,7 +63,8 @@ class AuthOutputConsumerIT @Autowired constructor(
             getConfidenceCriteria = AuthExpectationType.Authorized
         ),
         uploadPartner = UploadPartnerAuthExpections(
-            postInput = AuthExpectationType.Forbidden
+            postInput = AuthExpectationType.Forbidden,
+            getInputTemplate = AuthExpectationType.Forbidden
         )
     )
 ) {

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthTestBase.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthTestBase.kt
@@ -101,6 +101,11 @@ abstract class AuthTestBase(
         authAssertions.assert(authExpectations.uploadPartner.postInput) { gateClient.partnerUpload.uploadPartnerCsvFile(uploadedFile) }
     }
 
+    @Test
+    fun `GET Partner Upload Template`() {
+        authAssertions.assert(authExpectations.uploadPartner.getInputTemplate) { gateClient.partnerUpload.getPartnerCsvTemplate() }
+    }
+
 }
 
 data class GateAuthExpectations(
@@ -135,5 +140,6 @@ data class StatsAuthExpectations(
 )
 
 data class UploadPartnerAuthExpections(
-    val postInput: AuthExpectationType
+    val postInput: AuthExpectationType,
+    val getInputTemplate: AuthExpectationType
 )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/NoAuthIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/NoAuthIT.kt
@@ -61,7 +61,8 @@ class NoAuthIT @Autowired constructor(
             getConfidenceCriteria = AuthExpectationType.Unauthorized
         ),
         uploadPartner = UploadPartnerAuthExpections(
-            postInput = AuthExpectationType.Unauthorized
+            postInput = AuthExpectationType.Unauthorized,
+            getInputTemplate = AuthExpectationType.Unauthorized
         )
     )
 )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request introduces new REST api endpoint in BPDM Gate. 

**New Feature**
- *GET Endpoint*: Provides the functionality to download a CSV template for business partner uploads, ensuring users have the correct format for data submission.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
