### PR TITLE
feat(LegalSiteAPI): New endpoint to create legal site reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/CHANGELOG.md) of the charts directly.
 
+## [6.2.0] - tbd
+
+### Added
+
+-BPDM Pool: Post endpoint to create a site for LegalAndSiteMainAddress addressType.([#739](https://github.com/eclipse-tractusx/sig-release/issues/739))
+
+
 ## [6.1.0] - [2024-07-15]
 
 ### Added

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerNonVerboseValues.kt
@@ -332,6 +332,20 @@ object BusinessPartnerNonVerboseValues {
         bpnlParent = legalEntityUpdate1.bpnl
     )
 
+    val siteLegalReferenceUpsert1=SiteCreateRequestWithLegalAddressAsMain(
+        name = BusinessPartnerVerboseValues.siteUpsert1.site.name,
+        bpnLParent = legalEntityUpdate1.bpnl,
+        confidenceCriteria = BusinessPartnerVerboseValues.site1.confidenceCriteria,
+        states = listOf(siteStatus1)
+    )
+
+    val siteLegalReferenceUpsert2=SiteCreateRequestWithLegalAddressAsMain(
+        name = BusinessPartnerVerboseValues.siteUpsert2.site.name,
+        bpnLParent = legalEntityUpdate2.bpnl,
+        confidenceCriteria = BusinessPartnerVerboseValues.site2.confidenceCriteria,
+        states = listOf(siteStatus2)
+    )
+
     val siteCreate2 = SitePartnerCreateRequest(
         site = SiteDto(
             name = BusinessPartnerVerboseValues.siteUpsert2.site.name,

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerRequestFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerRequestFactory.kt
@@ -130,6 +130,27 @@ class BusinessPartnerRequestFactory(
         )
     }
 
+    fun createSiteWithLegalReference(seed: String, bpnL: String, random: Random = Random(seed.hashCode().toLong())):SiteCreateRequestWithLegalAddressAsMain{
+        val timeStamp = LocalDateTime.ofEpochSecond(random.nextLong(0, 365241780471), random.nextInt(0, 999999999), ZoneOffset.UTC)
+
+        return SiteCreateRequestWithLegalAddressAsMain(
+            name = "Site Name $seed",
+            bpnLParent = bpnL,
+            states = listOf(
+                SiteStateDto(validFrom = timeStamp, validTo = timeStamp.plusDays(10), BusinessStateType.ACTIVE),
+                SiteStateDto(validFrom = timeStamp.plusDays(10), validTo = null, BusinessStateType.INACTIVE),
+            ),
+            confidenceCriteria = ConfidenceCriteriaDto(
+                sharedByOwner = true,
+                checkedByExternalDataSource = false,
+                numberOfSharingMembers = 2,
+                lastConfidenceCheckAt = timeStamp.plusDays(10),
+                nextConfidenceCheckAt = timeStamp.plusDays(20),
+                confidenceLevel = 4
+            )
+        )
+    }
+
     fun createAddressRequest(seed: String, bpnParent: String): AddressPartnerCreateRequest {
         val longSeed = seed.hashCode().toLong()
         val random = Random(longSeed)

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
@@ -315,11 +315,29 @@ object BusinessPartnerVerboseValues {
         index = "1"
     )
 
+    val createSiteLegalReference1 = SitePartnerCreateVerboseDto(
+        site = site1,
+        mainAddress = addressPartner1.copy(
+            bpnSite = site1.bpns,
+            addressType = AddressType.LegalAndSiteMainAddress
+        ),
+        index = "1"
+    )
+
     val siteUpsert2 = SitePartnerCreateVerboseDto(
         site = site2,
         mainAddress = addressPartner2.copy(
             bpnSite = site2.bpns,
             addressType = AddressType.SiteMainAddress
+        ),
+        index = "2"
+    )
+
+    val createSiteLegalReference2 = SitePartnerCreateVerboseDto(
+        site = site2,
+        mainAddress = addressPartner2.copy(
+            bpnSite = site2.bpns,
+            addressType = AddressType.LegalAndSiteMainAddress
         ),
         index = "2"
     )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi.Companion.SITE_PATH
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
@@ -133,4 +134,21 @@ interface PoolSiteApi {
         @ParameterObject searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
+
+    @Operation(
+        summary = "Create a new site with legal entity reference",
+        description = "Create a business partner site with the given legal entity reference. " +
+                "It will designate the address information as both legal and site main address."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New sites request was processed successfully, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @PostMapping("/legal-main-sites")
+    fun createSiteWithLegalReference(
+        @RequestBody request: Collection<SiteCreateRequestWithLegalAddressAsMain>
+    ): SitePartnerCreateResponseWrapper
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
@@ -65,5 +66,9 @@ interface SiteApiClient : PoolSiteApi {
         @RequestBody requests: Collection<SitePartnerUpdateRequest>
     ): SitePartnerUpdateResponseWrapper
 
+    @PostExchange("/legal-main-sites")
+    override fun createSiteWithLegalReference(
+        @RequestBody request: Collection<SiteCreateRequestWithLegalAddressAsMain>
+    ): SitePartnerCreateResponseWrapper
 
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SiteCreateRequestWithLegalAddressAsMain.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/SiteCreateRequestWithLegalAddressAsMain.kt
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.model.request
+
+import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.pool.api.model.ConfidenceCriteriaDto
+import org.eclipse.tractusx.bpdm.pool.api.model.SiteStateDto
+
+data class SiteCreateRequestWithLegalAddressAsMain(
+    override val name: String,
+    override val states: Collection<SiteStateDto>,
+    override val confidenceCriteria: ConfidenceCriteriaDto,
+    val bpnLParent: String
+) : IBaseSiteDto
+

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
@@ -83,5 +84,12 @@ class SiteController(
         paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto> {
         return postSiteSearch(searchRequest, paginationRequest)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun createSiteWithLegalReference(
+        request: Collection<SiteCreateRequestWithLegalAddressAsMain>
+    ): SitePartnerCreateResponseWrapper {
+        return businessPartnerBuildService.createSitesWithLegalAddressAsMain(request)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -123,11 +123,11 @@ class BusinessPartnerBuildService(
                 .apply { mainAddress.site = this }
         }
 
+        siteRepository.saveAll(createdSites)
+
         changelogService.createChangelogEntries(createdSites.map {
             ChangelogEntryCreateRequest(it.bpn, ChangelogType.CREATE, BusinessPartnerType.SITE)
         })
-
-        siteRepository.saveAll(createdSites)
 
         val siteResponse = createdSites.mapIndexed { index, site -> site.toUpsertDto(index.toString()) }
 
@@ -459,13 +459,6 @@ class BusinessPartnerBuildService(
         val idTypes: Map<String, IdentifierTypeDb>,
         val regions: Map<String, RegionDb>
     )
-
-    data class SiteCreateRequestWithLegalAddressAsMain(
-        override val name: String,
-        override val states: Collection<SiteStateDto>,
-        override val confidenceCriteria: ConfidenceCriteriaDto,
-        val bpnLParent: String
-    ) : IBaseSiteDto
 
     companion object {
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -243,7 +243,7 @@ class TaskStepBuildService(
     ): SiteBpns {
 
         val result = if(isSiteMainAndLegalAddress){
-            val createRequest = BusinessPartnerBuildService.SiteCreateRequestWithLegalAddressAsMain(
+            val createRequest = SiteCreateRequestWithLegalAddressAsMain(
                 name = poolSite.name,
                 states = poolSite.states,
                 confidenceCriteria = poolSite.confidenceCriteria,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthTestBase.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthTestBase.kt
@@ -91,6 +91,11 @@ abstract class AuthTestBase(
     }
 
     @Test
+    fun `POST SitesLegalReference`(){
+        authAssertions.assert(siteAuthExpectations.postSites) { poolApiClient.sites.createSiteWithLegalReference(listOf(requestFactory.createSiteWithLegalReference("1", "BPNL"))) }
+    }
+
+    @Test
     fun `PUT Sites`(){
         authAssertions.assert(siteAuthExpectations.putSites) { poolApiClient.sites.updateSite(listOf(requestFactory.createSiteUpdateRequest("1", "BPNS"))) }
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -234,6 +234,27 @@ class SiteControllerIT @Autowired constructor(
         assertThat(response.errorCount).isEqualTo(0)
     }
 
+    @Test
+    fun `create new site with legal entity referece`(){
+        val givenLegalEntities =
+            poolClient.legalEntities.createBusinessPartners(listOf(BusinessPartnerNonVerboseValues.legalEntityCreate1,
+                BusinessPartnerNonVerboseValues.legalEntityCreate2)).entities
+
+        val bpnL1 = givenLegalEntities.first().legalEntity.bpnl
+        val bpnL2 = givenLegalEntities.last().legalEntity.bpnl
+        val expected= listOf(BusinessPartnerVerboseValues.createSiteLegalReference1,
+            BusinessPartnerVerboseValues.createSiteLegalReference2)
+
+        val toCreate = listOf(
+            BusinessPartnerNonVerboseValues.siteLegalReferenceUpsert1.copy(bpnLParent = bpnL1),
+            BusinessPartnerNonVerboseValues.siteLegalReferenceUpsert2.copy(bpnLParent = bpnL2)
+        )
+
+        val response=poolClient.sites.createSiteWithLegalReference(toCreate)
+        assertThatCreatedSitesEqual(response.entities, expected)
+        assertThat(response.errorCount).isEqualTo(0)
+    }
+
 
     /**
      * Given no legal entities

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 5.1.1-SNAPSHOT
-appVersion: "6.1.1-SNAPSHOT"
+version: 5.2.0-SNAPSHOT
+appVersion: "6.2.0-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,19 +33,19 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 6.1.1-SNAPSHOT
+    version: 6.2.0-SNAPSHOT
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 7.1.1-SNAPSHOT
+    version: 7.2.0-SNAPSHOT
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 3.1.1-SNAPSHOT
+    version: 3.2.0-SNAPSHOT
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 3.1.1-SNAPSHOT
+    version: 3.2.0-SNAPSHOT
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "6.1.1-SNAPSHOT"
-version: 3.1.1-SNAPSHOT
+appVersion: "6.2.0-SNAPSHOT"
+version: 3.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "6.1.1-SNAPSHOT"
-version: 6.1.1-SNAPSHOT
+appVersion: "6.2.0-SNAPSHOT"
+version: 6.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "6.1.1-SNAPSHOT"
-version: 3.1.1-SNAPSHOT
+appVersion: "6.2.0-SNAPSHOT"
+version: 3.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "6.1.1-SNAPSHOT"
-version: 7.1.1-SNAPSHOT
+appVersion: "6.2.0-SNAPSHOT"
+version: 7.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </modules>
 
     <properties>
-        <revision>6.1.1-SNAPSHOT</revision>
+        <revision>6.2.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Description
What does this PR introduce? 
- Create an endpoint to create site entity
- Create SiteCreateRequestWithLegalAddressAsMain in bpdm-pool-api module
- Add test cases which cover the new code
- This PR solve the https://github.com/eclipse-tractusx/sig-release/issues/739.

Does it fix a bug? 
- Nope

Does it add a new feature?
- Yes

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
