### PR TITLE
feat: Adding extend error states in the gate and orchestrator

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/SharingStateType.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/SharingStateType.kt
@@ -24,5 +24,18 @@ enum class SharingStateType {
     Success,
     Error,
     Initial,
-    Ready
+    Ready,
+    NaturalPersonError,
+    BpnErrorMissingParent,
+    BpnErrorNotFound,
+    BpnErrorTooManyOptions,
+    MandatoryFieldValidationFailed,
+    BlacklistCountryPresent,
+    InvalidSpecialCharacters,
+    MandatoryFieldMissing,
+    BpnlChanged,
+    UnclearEntity,
+    UnknownSpecialCharacters,
+    MatchBasedOnProvidedNameOrIdentifier,
+    None
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ResultState.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/ResultState.kt
@@ -22,5 +22,18 @@ package org.eclipse.tractusx.orchestrator.api.model
 enum class ResultState {
     Pending,
     Success,
-    Error
+    Error,
+    NaturalPersonError,
+    BpnErrorMissingParent,
+    BpnErrorNotFound,
+    BpnErrorTooManyOptions,
+    MandatoryFieldValidationFailed,
+    BlacklistCountryPresent,
+    InvalidSpecialCharacters,
+    MandatoryFieldMissing,
+    BpnlChanged,
+    UnclearEntity,
+    UnknownSpecialCharacters,
+    MatchBasedOnProvidedNameOrIdentifier,
+    None
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Enhance the error-handling mechanism for the orchestrator and gate components by extending the list of available error codes. This will improve the visibility and detail of error information, particularly beneficial for the customer dashboard to understand why a data set could not be processed.

Currently, the orchestrator and gate components have a limited set of error codes. Extending these error codes will provide more granular information on processing failures, aiding in quicker diagnosis and resolution. This feature will update both the orchestrator and gate components to support a more comprehensive list of error codes.

- NaturalPersonError,
- BpnErrorMissingParent,
- BpnErrorNotFound,
- BpnErrorTooManyOptions,
- MandatoryFieldValidationFailed,
- BlacklistCountryPresent,
- InvalidSpecialCharacters,
- MandatoryFieldMissing,
- BpnlChanged
- NnclearEntity,
- NnknownSpecialCharacters,
- MatchBasedOnProvidedNameOrIdentifier,
- None

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
## Reference issue
https://github.com/eclipse-tractusx/sig-release/issues/727

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
