### PR TITLE
Cherry-Pick(release/6.0.x): Fix Gate Sending Alternative Address To Orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: GET endpoint to download the csv file template for business partner upload. (#700)
 - Apps: Tax Jurisdiction Code to the physical address of a business partner (#955)
 
+
+## [6.0.2] - [2024-07-03]
+
+### Changed
+
+- BPDM Gate: Now sends alternative addresses which are NULL correctly to the Orchestrator
+- BPDM Pool: Changed Checksum generation algorithm: Now checksum includes the BPN with prefix
+
+
 ## [6.0.1] - [2024-05-27]
 
 ### Removed

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -134,7 +134,7 @@ class OrchestratorMappings(
                         deliveryServiceNumber
                     )
                 }
-            } ?: AlternativeAddress.empty,
+            },
             hasChanged = null
         )
     }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds fix from the 6.0.2 release for the Gate only sending non-null alternative addresses to the Orchestrator. #983

I also took over the Changelog entries for 6.0.2 into main.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
