### PR TITLE
fix(gate): Starting Golden Record Process Without Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: GET endpoint to download the csv file template for business partner upload. (#700)
 - Apps: Tax Jurisdiction Code to the physical address of a business partner (#955)
 
+### Changed:
+
+- BPDM Gate: Fix sending business partner data to the golden record service even when they have no changes
+
 
 ## [6.0.2] - [2024-07-03]
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -81,8 +81,11 @@ class BusinessPartnerService(
             val updatedData = businessPartnerMappings.toBusinessPartnerInput(request, sharingState)
             val existingInput = existingInputsByExternalId[request.externalId]
 
-            sharingStateService.setInitial(sharingState)
-            upsertFromEntity(existingInput, updatedData).takeIf { it.hadChanges }?.businessPartner
+
+            upsertFromEntity(existingInput, updatedData)
+                .takeIf { it.hadChanges }
+                ?.also { sharingStateService.setInitial(sharingState) }
+                ?.businessPartner
         }
 
         return updatedEntities.map(businessPartnerMappings::toBusinessPartnerInputDto)


### PR DESCRIPTION



<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

When upserting business partner input to the BPDM Gate that matches the existing business partner input, the Gate would still send the unchanged input data unnecessarily to the Golden Record Process. 

This pull request fixes this behaviour. Now the Gate only sends data to the Golden Record Process if it has been changed.


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
