### PR TITLE
fix(gate): Assigning Wrong Task-Ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Changed:
 
 - BPDM Gate: Fix sending business partner data to the golden record service even when they have no changes
+- BPDM Gate: Fix sharing states sometimes taking the wrong task id from the orchestrator
 
 
 ## [6.0.2] - [2024-07-03]

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskCreationService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskCreationService.kt
@@ -58,8 +58,8 @@ class TaskCreationService(
         val orchestratorBusinessPartnersDto = foundPartners.map { orchestratorMappings.toOrchestratorDto(it) }
         val createdTasks = createGoldenRecordTasks(TaskMode.UpdateFromSharingMember, orchestratorBusinessPartnersDto)
 
-        foundStates.zip(createdTasks).forEach { (state, task) ->
-            sharingStateService.setPending(state, task.taskId)
+        foundPartners.zip(createdTasks).forEach { (partner, task) ->
+            sharingStateService.setPending(partner.sharingState, task.taskId)
         }
 
         logger.info { "Created ${createdTasks.size} new golden record tasks from ready business partners" }


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

When the Gate sends business partner data to the Orchestrator, it can happen that it saves the wrong golden record task-ID to the wrong sharing state, by this mixing up the desired results in the output stage. 

This pull request fixes the behaviour making sure that  the task-Ids are assigned to the correct sharing states as long as the Orchestrator returns the tasks in the order in which the requests have been received.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
