### PR TITLE
Feat: Add Record ID to Golden Record Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: GET endpoint to download the csv file template for business partner upload. (#700)
 - Apps: Tax Jurisdiction Code to the physical address of a business partner (#955)
 - BPDM Orchestrator: Tasks will now be persisted
+- BPDM Orchestrator: Tasks now come with a gate record identifier. This makes it possible for cleaning services to match tasks for the same Gate record 
 
 ### Changed:
 

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
@@ -42,6 +42,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import java.time.Instant
+import java.util.*
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -373,7 +374,7 @@ class CleaningServiceApiCallsTest @Autowired constructor(
 
     // Helper method to create a sample TaskStepReservationResponse
     private fun createSampleTaskStepReservationResponse(businessPartner: BusinessPartner): TaskStepReservationResponse {
-        return TaskStepReservationResponse(listOf(TaskStepReservationEntryDto(fixedTaskId, businessPartner)), Instant.MIN)
+        return TaskStepReservationResponse(listOf(TaskStepReservationEntryDto(fixedTaskId, UUID.randomUUID().toString(), businessPartner)), Instant.MIN)
     }
 
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/SharingStateDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/SharingStateDb.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import org.eclipse.tractusx.bpdm.gate.api.exception.BusinessPartnerSharingError
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
 import java.time.LocalDateTime
+import java.util.*
 
 
 @Entity
@@ -35,6 +36,9 @@ class SharingStateDb(
 
     @Column(name = "tenant_bpnl", nullable = true)
     var tenantBpnl: String? = null,
+
+    @Column(name = "orchestrator_record_id", nullable = true, unique = true)
+    var orchestratorRecordId: UUID?,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "sharing_state_type", nullable = false)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -43,6 +43,13 @@ class OrchestratorMappings(
 ) {
     private val logger = KotlinLogging.logger { }
 
+    fun toCreateRequest(entity: BusinessPartnerDb): TaskCreateRequestEntry{
+        return TaskCreateRequestEntry(
+            recordId = entity.sharingState.orchestratorRecordId?.toString(),
+            businessPartner = toOrchestratorDto(entity)
+        )
+    }
+
     fun toOrchestratorDto(entity: BusinessPartnerDb): BusinessPartner {
         val postalAddress = toPostalAddress(entity)
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SharingStateService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SharingStateService.kt
@@ -167,6 +167,7 @@ class SharingStateService(
                     SharingStateDb(
                         externalId,
                         sharingStateType = SharingStateType.Ready,
+                        orchestratorRecordId = null,
                         sharingErrorCode = null,
                         sharingErrorMessage = null,
                         sharingProcessStarted = null,

--- a/bpdm-gate/src/main/resources/db/migration/V6_1_0_4__add_orchestrator_record_id.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V6_1_0_4__add_orchestrator_record_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sharing_states
+ADD COLUMN orchestrator_record_id UUID unique;

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -161,6 +161,7 @@ internal class BusinessPartnerIT @Autowired constructor(
         return SharingStateDb(
             externalId = "testExternalId",
             sharingErrorCode = null,
+            orchestratorRecordId = null,
             sharingStateType = SharingStateType.Initial
         )
     }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -64,6 +64,7 @@ class MockAndAssertUtils @Autowired constructor(
                     TaskClientStateDto(
                         taskId = "0",
                         businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                        recordId = "e3a05ebc-ff59-4d09-bd58-da31d6245701",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
                             step = TaskStep.CleanAndSync,
@@ -77,6 +78,7 @@ class MockAndAssertUtils @Autowired constructor(
                     TaskClientStateDto(
                         taskId = "1",
                         businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                        recordId = "f05574ff-4ddd-4360-821a-923203711f85",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
                             step = TaskStep.CleanAndSync,
@@ -90,6 +92,7 @@ class MockAndAssertUtils @Autowired constructor(
                     TaskClientStateDto(
                         taskId = "2",
                         businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                        recordId = "8c03850d-d772-4a2e-9845-65211231b38c",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
                             step = TaskStep.CleanAndSync,
@@ -103,6 +106,7 @@ class MockAndAssertUtils @Autowired constructor(
                     TaskClientStateDto(
                         taskId = "3",
                         businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                        recordId = "6bebb1aa-935d-467a-afd4-7e8623420a18",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
                             step = TaskStep.CleanAndSync,
@@ -132,6 +136,7 @@ class MockAndAssertUtils @Autowired constructor(
                     TaskClientStateDto(
                         taskId = "0",
                         businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                        recordId = "e3a05ebc-ff59-4d09-bd58-da31d6245701",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Success,
                             step = TaskStep.CleanAndSync,
@@ -145,6 +150,7 @@ class MockAndAssertUtils @Autowired constructor(
                     TaskClientStateDto(
                         taskId = "1",
                         businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                        recordId = "f05574ff-4ddd-4360-821a-923203711f85",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Error,
                             step = TaskStep.CleanAndSync,
@@ -172,7 +178,10 @@ class MockAndAssertUtils @Autowired constructor(
         val taskStateResponse = TaskStateResponse(
             listOf(
                 TaskClientStateDto(
-                    taskId = "0", businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1, processingState = TaskProcessingStateDto(
+                    taskId = "0",
+                    businessPartnerResult = BusinessPartnerGenericCommonValues.businessPartner1,
+                    recordId = "e3a05ebc-ff59-4d09-bd58-da31d6245701",
+                    processingState = TaskProcessingStateDto(
                         resultState = ResultState.Success,
                         step = TaskStep.CleanAndSync,
                         stepState = StepState.Queued,

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskClientStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskClientStateDto.kt
@@ -28,6 +28,9 @@ data class TaskClientStateDto(
     @get:Schema(required = true)
     val taskId: String,
 
+    @get:Schema(required = true, description = "The identifier of the gate record for which this task has been created")
+    val recordId: String,
+
     val businessPartnerResult: BusinessPartner,
 
     @get:Schema(required = true)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateRequestEntry.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskCreateRequestEntry.kt
@@ -19,15 +19,11 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request object to specify for which business partner data tasks should be created and in which mode")
-data class TaskCreateRequest(
-
-    @get:Schema(required = true, description = "The mode affecting which processing steps the business partner goes through")
-    val mode: TaskMode,
-
-    @get:ArraySchema(arraySchema = Schema(description = "The list of tasks to create"))
-    val requests: List<TaskCreateRequestEntry>
+data class TaskCreateRequestEntry(
+    @get:Schema(description = "The unique identifier for this record which was previously issued by the Orchestrator")
+    val recordId: String?,
+    @get:Schema(description = "The business partner data to be processed")
+    val businessPartner: BusinessPartner
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationEntryDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStepReservationEntryDto.kt
@@ -28,6 +28,9 @@ data class TaskStepReservationEntryDto(
     @get:Schema(description = "The identifier of the reserved task")
     val taskId: String,
 
+    @get:Schema(description = "The identifier of the gate record for which this task has been created")
+    val recordId: String,
+
     @get:Schema(description = "The business partner data to process")
     val businessPartner: BusinessPartner
 ) : RequestWithKey {

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
@@ -38,8 +38,8 @@ class GoldenRecordTaskController(
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.CREATE_TASK})")
     override fun createTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
-        if (createRequest.businessPartners.size > apiConfigProperties.upsertLimit)
-            throw BpdmUpsertLimitException(createRequest.businessPartners.size, apiConfigProperties.upsertLimit)
+        if (createRequest.requests.size > apiConfigProperties.upsertLimit)
+            throw BpdmUpsertLimitException(createRequest.requests.size, apiConfigProperties.upsertLimit)
 
         return goldenRecordTaskService.createTasks(createRequest)
     }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/DbTimestampConverter.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/DbTimestampConverter.kt
@@ -30,7 +30,6 @@ class DbTimestampConverter: AttributeConverter<DbTimestamp, Timestamp> {
     }
 
     override fun convertToEntityAttribute(p0: Timestamp?): DbTimestamp? {
-      return p0?.let { DbTimestamp(p0.toInstant()) }
+        return p0?.let { DbTimestamp(p0.toInstant()) }
     }
-
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/GateRecordDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/GateRecordDb.kt
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.Instant
+import java.util.*
+
+@Entity
+@Table(
+    name = "gate_records",
+    indexes = [
+        Index(name = "index_gate_records_private_uuid", columnList = "private_uuid")
+    ]
+)
+class GateRecordDb (
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "bpdm_sequence")
+    @SequenceGenerator(name = "bpdm_sequence", sequenceName = "bpdm_sequence", allocationSize = 1)
+    @Column(name = "id", nullable = false, updatable = false, insertable = false)
+    val id: Long = 0,
+
+    @Column(updatable = false, nullable = false, name = "CREATED_AT")
+    @CreationTimestamp
+    var createdAt: Instant = Instant.now(),
+
+    @Column(nullable = false, name = "UPDATED_AT")
+    @UpdateTimestamp
+    var updatedAt: Instant = Instant.now(),
+
+    @Column(name = "public_id", columnDefinition = "UUID", nullable = false, unique = true)
+    var publicId: UUID,
+
+    @Column(name = "private_id", columnDefinition = "UUID", nullable = false, unique = true)
+    var privateId: UUID
+)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/GoldenRecordTaskDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/GoldenRecordTaskDb.kt
@@ -52,6 +52,10 @@ class GoldenRecordTaskDb(
     @Column(nullable = false, name = "UPDATED_AT")
     @Convert(converter = DbTimestampConverter::class)
     var updatedAt: DbTimestamp = createdAt,
+    @ManyToOne
+    @JoinColumn(name = "gate_record_id", nullable = false, foreignKey = ForeignKey(name = "fk_tasks_gate_records"))
+    var gateRecord: GateRecordDb,
+
     @Embedded
     val processingState: ProcessingState,
     @Embedded

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/exception/BpdmRecordNotFoundException.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/exception/BpdmRecordNotFoundException.kt
@@ -17,17 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
+package org.eclipse.tractusx.bpdm.orchestrator.exception
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.util.*
 
-@Schema(description = "Request object to specify for which business partner data tasks should be created and in which mode")
-data class TaskCreateRequest(
-
-    @get:Schema(required = true, description = "The mode affecting which processing steps the business partner goes through")
-    val mode: TaskMode,
-
-    @get:ArraySchema(arraySchema = Schema(description = "The list of tasks to create"))
-    val requests: List<TaskCreateRequestEntry>
-)
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class BpdmRecordNotFoundException (
+    recordIds: List<UUID>
+): RuntimeException("The following gate records are not registered: ${recordIds.joinToString()}")

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GateRecordRepository.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GateRecordRepository.kt
@@ -17,17 +17,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.orchestrator.api.model
 
-import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.Schema
+package org.eclipse.tractusx.bpdm.orchestrator.repository
 
-@Schema(description = "Request object to specify for which business partner data tasks should be created and in which mode")
-data class TaskCreateRequest(
+import org.eclipse.tractusx.bpdm.orchestrator.entity.GateRecordDb
+import org.springframework.data.repository.CrudRepository
+import java.util.*
 
-    @get:Schema(required = true, description = "The mode affecting which processing steps the business partner goes through")
-    val mode: TaskMode,
+interface GateRecordRepository: CrudRepository<GateRecordDb, Long> {
 
-    @get:ArraySchema(arraySchema = Schema(description = "The list of tasks to create"))
-    val requests: List<TaskCreateRequestEntry>
-)
+    fun findByPrivateIdIn(privateUuids: Set<UUID>): Set<GateRecordDb>
+}

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachine.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachine.kt
@@ -22,10 +22,7 @@ package org.eclipse.tractusx.bpdm.orchestrator.service
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.util.replace
 import org.eclipse.tractusx.bpdm.orchestrator.config.TaskConfigProperties
-import org.eclipse.tractusx.bpdm.orchestrator.entity.DbTimestamp
-import org.eclipse.tractusx.bpdm.orchestrator.entity.GoldenRecordTaskDb
-import org.eclipse.tractusx.bpdm.orchestrator.entity.TaskErrorDb
-import org.eclipse.tractusx.bpdm.orchestrator.entity.toTimestamp
+import org.eclipse.tractusx.bpdm.orchestrator.entity.*
 import org.eclipse.tractusx.bpdm.orchestrator.exception.BpdmIllegalStateException
 import org.eclipse.tractusx.bpdm.orchestrator.repository.GoldenRecordTaskRepository
 import org.eclipse.tractusx.orchestrator.api.model.*
@@ -41,7 +38,7 @@ class GoldenRecordTaskStateMachine(
 
     private val logger = KotlinLogging.logger { }
 
-    fun initTask(mode: TaskMode, initBusinessPartner: BusinessPartner): GoldenRecordTaskDb {
+    fun initTask(mode: TaskMode, initBusinessPartner: BusinessPartner, record: GateRecordDb): GoldenRecordTaskDb {
         logger.debug { "Executing initProcessingState() with parameters mode: $mode and business partner data: $initBusinessPartner" }
 
         val initialStep = getInitialStep(mode)
@@ -56,6 +53,7 @@ class GoldenRecordTaskStateMachine(
         )
 
         val initialTask = GoldenRecordTaskDb(
+            gateRecord = record,
             processingState = initProcessingState,
             businessPartner = requestMapper.toBusinessPartner(initBusinessPartner)
         )

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/ResponseMapper.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/ResponseMapper.kt
@@ -32,6 +32,7 @@ class ResponseMapper {
         with(task) {
             TaskClientStateDto(
                 taskId = task.uuid.toString(),
+                recordId = task.gateRecord.privateId.toString(),
                 businessPartnerResult = toBusinessPartnerResult(businessPartner),
                 processingState = toProcessingState(task, timeout)
             )

--- a/bpdm-orchestrator/src/main/resources/db/migration/V6_1_0_0__create_tables.sql
+++ b/bpdm-orchestrator/src/main/resources/db/migration/V6_1_0_0__create_tables.sql
@@ -146,6 +146,7 @@ create table business_partner_states (
 );
 
 create table golden_record_tasks (
+  gate_record_id bigint not null,
   is_cx_member boolean,
   legal_entity_has_changed boolean,
   site_exists boolean not null,
@@ -180,6 +181,16 @@ create table task_errors (
   type varchar(255) not null check (type in ('Timeout', 'Unspecified'))
 );
 
+create table gate_records (
+    id bigint not null,
+    created_at TIMESTAMP not null,
+    updated_at TIMESTAMP not null,
+    private_id uuid not null unique,
+    public_id uuid not null unique,
+    primary key(id)
+);
+
+
 create index index_tasks_uuid on golden_record_tasks (uuid);
 
 create index index_tasks_step_step_state on golden_record_tasks (task_step, task_step_state);
@@ -187,6 +198,11 @@ create index index_tasks_step_step_state on golden_record_tasks (task_step, task
 create index index_tasks_pending_timeout on golden_record_tasks (task_pending_timeout);
 
 create index index_tasks_retention_timeout on golden_record_tasks (task_retention_timeout);
+
+alter table
+  if exists golden_record_tasks
+add
+  constraint fk_tasks_gate_records foreign key (gate_record_id) references gate_records;
 
 alter table
   if exists business_partner_addresses

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepFetchAndReserveServiceTest.kt
@@ -21,13 +21,16 @@ package org.eclipse.tractusx.bpdm.pool.service
 
 import com.neovisionaries.i18n.CountryCode
 import org.assertj.core.api.Assertions.assertThat
-import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
 import org.eclipse.tractusx.bpdm.pool.repository.BpnRequestIdentifierRepository
 import org.eclipse.tractusx.bpdm.pool.service.TaskStepBuildService.CleaningError
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.*
+import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.BusinessPartnerTestDataFactory
+import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.copyWithBpnRequests
+import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.copyWithLegalEntityIdentifiers
+import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.copyWithSiteMainAddress
 import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
 import org.eclipse.tractusx.bpdm.test.testdata.pool.TestDataEnvironment
 import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
@@ -42,6 +45,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.*
 
 
 @SpringBootTest(
@@ -744,6 +748,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         return listOf(
             TaskStepReservationEntryDto(
                 taskId = taskId,
+                recordId = UUID.randomUUID().toString(),
                 businessPartner = businessPartner
             )
         )
@@ -754,6 +759,7 @@ class TaskStepFetchAndReserveServiceTest @Autowired constructor(
         return businessPartners.map {
             TaskStepReservationEntryDto(
                 taskId = it.legalEntity.bpnReference.referenceValue!!,
+                recordId = UUID.randomUUID().toString(),
                 businessPartner = it
             )
         }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds a gate record ID to the Orchestrator tasks. By this, tasks belonging to the same gate record can be identified by the cleaning services.


Implements eclipse-tractusx/sig-release#711

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
