### PR TITLE
ci(Release Chart): fix check for Chart release version

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -42,7 +42,10 @@ jobs:
         run: |
           CHART_VERSION=$(grep 'version:' ./charts/bpdm/Chart.yaml | head -n1 | awk '{ print $2}')
           SNAPSHOT=$(echo $CHART_VERSION | grep 'SNAPSHOT')
-          if test -z $SNAPSHOT; then IS_RELEASE=true; else IS_RELEASE=false fi
+          if [[ -z "$SNAPSHOT" ]]; then 
+          IS_RELEASE=true; else 
+          IS_RELEASE=false 
+          fi
           echo "isRelease=$IS_RELEASE" >> $GITHUB_OUTPUT
 
       - name: Configure Git


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes a bug in our CICD pipeline when checking whether the current Chart is marked as a release version or not.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
