### PR TITLE
feat(Charts):  Delay Container Startup

### DIFF
--- a/.github/workflows/app-test-charts.yaml
+++ b/.github/workflows/app-test-charts.yaml
@@ -59,6 +59,7 @@ on:
     paths:
       - 'pom.xml'
       - 'bpdm-**'
+      - 'charts/**'
   push:
     branches:
       - main

--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [5.1.0] -  tbd
+
+### Changed
+
+- Increase appversion to 6.1.0
+- update BPDM Pool Chart to version 7.1.0
+- update BPDM Gate Chart to version 6.1.0
+- update BPDM Orchestrator Chart to version 3.1.0
+- update BPDM Cleaning Service Dummy Chart to version 3.1.0
+- update BPDM Bridge Chart to version 3.1.0
+
 ## [5.0.1] -  2024-05-27
 
 ### Changed

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -36,25 +36,20 @@ dependencies:
     version: 6.1.0-SNAPSHOT
     alias: bpdm-gate
     condition: bpdm-gate.enabled
-    repository: "file://./charts/bpdm-gate"
   - name: bpdm-pool
     version: 7.1.0-SNAPSHOT
     alias: bpdm-pool
     condition: bpdm-pool.enabled
-    repository: "file://./charts/bpdm-pool"
   - name: bpdm-cleaning-service-dummy
     version: 3.1.0-SNAPSHOT
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
-    repository: "file://./charts/bpdm-cleaning-service-dummy"
   - name: bpdm-orchestrator
     version: 3.1.0-SNAPSHOT
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
-    repository: "file://./charts/bpdm-orchestrator"
   - name: bpdm-common
     version: 1.0.1
-    repository: "file://./charts/bpdm-common"
   - name: postgresql
     version: 12.12.10
     repository: https://charts.bitnami.com/bitnami

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [3.1.0] - tbd
+
+### Changed
+
+- Increase appversion to 6.1.0
+- Increased range of CPU request and limit
+- Reduced initial delay of startup probe
+- Value for delaying startup of application container.
+  This decreases crashes when waiting for Keycloak and Postgres dependencies to be up.
+
 ## [3.0.1] - 2024-05-27
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
@@ -59,7 +59,7 @@ autoscaling:
 
 resources:
   limits:
-    cpu: 500m
+    cpu: 1000m
     memory: 1Gi
   requests:
     cpu: 100m
@@ -80,12 +80,14 @@ affinity:
                 operator: DoesNotExist
           topologyKey: kubernetes.io/hostname
 
+startupDelaySeconds: 90
+
 livenessProbe:
   httpGet:
     path: "/actuator/health/liveness"
     port: 8084
     scheme: HTTP
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
@@ -95,7 +97,7 @@ readinessProbe:
     path: "/actuator/health/readiness"
     port: 8084
     scheme: HTTP
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
@@ -105,9 +107,9 @@ startupProbe:
     path: "/actuator/health/readiness"
     port: 8084
     scheme: HTTP
-  initialDelaySeconds: 60
+  initialDelaySeconds: 30
   failureThreshold: 40
-  periodSeconds: 30
+  periodSeconds: 5
   timeoutSeconds: 1
   successThreshold: 1
 

--- a/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
@@ -80,6 +80,10 @@ spec:
               readOnly: true
             - mountPath: /tmp
               name: cache
+      initContainers:
+        - name: startup-delay
+          image: busybox:1.28
+          command: ['sh', '-c', "sleep {{ $.Values.startupDelaySeconds }}"]
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [6.1.0] - tbd
+
+### Changed
+
+- Increase appversion to 6.1.0
+- Increased range of CPU request and limit
+- Reduced initial delay of startup probe
+- Value for delaying startup of application container.
+  This decreases crashes when waiting for Keycloak and Postgres dependencies to be up.
+
 ## [6.0.1] - 2024-05-27
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -66,7 +66,7 @@ resources:
     cpu: 1000m
     memory: 1Gi
   requests:
-    cpu: 200m
+    cpu: 100m
     memory: 1Gi
 
 nodeSelector: {}
@@ -84,12 +84,14 @@ affinity:
                 operator: DoesNotExist
           topologyKey: kubernetes.io/hostname
 
+startupDelaySeconds: 90
+
 livenessProbe:
   httpGet:
     path: "/actuator/health/liveness"
     port: 8081
     scheme: HTTP
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
@@ -99,7 +101,7 @@ readinessProbe:
     path: "/actuator/health/readiness"
     port: 8081
     scheme: HTTP
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
@@ -109,9 +111,9 @@ startupProbe:
     path: "/actuator/health/readiness"
     port: 8081
     scheme: HTTP
-  initialDelaySeconds: 60
+  initialDelaySeconds: 30
   failureThreshold: 40
-  periodSeconds: 30
+  periodSeconds: 5
   timeoutSeconds: 1
   successThreshold: 1
 

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [3.1.0] - tbd
+
+### Changed
+
+- Increase appversion to 6.1.0
+- Increased range of CPU request and limit
+- Reduced initial delay of startup probe
+- Value for delaying startup of application container.
+  This decreases crashes when waiting for Keycloak and Postgres dependencies to be up.
+
 ## [3.0.1] - 2024-05-27
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-orchestrator/values.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/values.yaml
@@ -65,7 +65,7 @@ ingress:
 
 resources:
   limits:
-    cpu: 500m
+    cpu: 1000m
     memory: 1Gi
   requests:
     cpu: 100m
@@ -86,12 +86,14 @@ affinity:
                 operator: DoesNotExist
           topologyKey: kubernetes.io/hostname
 
+startupDelaySeconds: 90
+
 livenessProbe:
   httpGet:
     path: "/actuator/health/liveness"
     port: 8085
     scheme: HTTP
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
@@ -101,7 +103,7 @@ readinessProbe:
     path: "/actuator/health/readiness"
     port: 8085
     scheme: HTTP
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 5
   periodSeconds: 5
   successThreshold: 1
@@ -111,9 +113,9 @@ startupProbe:
     path: "/actuator/health/readiness"
     port: 8085
     scheme: HTTP
-  initialDelaySeconds: 60
+  initialDelaySeconds: 30
   failureThreshold: 40
-  periodSeconds: 30
+  periodSeconds: 5
   timeoutSeconds: 1
   successThreshold: 1
 

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [7.1.0] - tbd
+
+### Changed
+
+- Increase appversion to 6.1.0
+- Increased range of CPU request and limit
+- Reduced initial delay of startup probe
+- Value for delaying startup of application container.
+  This decreases crashes when waiting for Keycloak and Postgres dependencies to be up.
+
 ## [7.0.1] - 2024-05-27
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -66,7 +66,7 @@ resources:
     cpu: 1000m
     memory: 1Gi
   requests:
-    cpu: 300m
+    cpu: 100m
     memory: 1Gi
 
 nodeSelector: {}
@@ -84,13 +84,15 @@ affinity:
                 operator: DoesNotExist
           topologyKey: kubernetes.io/hostname
 
+startupDelaySeconds: 90
+
 livenessProbe:
   httpGet:
     path: "/actuator/health/liveness"
     port: 8080
     scheme: HTTP
   failureThreshold: 5
-  initialDelaySeconds: 120
+  initialDelaySeconds: 5
   periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
@@ -100,9 +102,9 @@ readinessProbe:
     path: "/actuator/health/readiness"
     port: 8080
     scheme: HTTP
-  failureThreshold: 3
+  failureThreshold: 5
   initialDelaySeconds: 5
-  periodSeconds: 5
+  periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
 
@@ -111,9 +113,9 @@ startupProbe:
     path: "/actuator/health/readiness"
     port: 8080
     scheme: HTTP
-  initialDelaySeconds: 60
+  initialDelaySeconds: 30
   failureThreshold: 40
-  periodSeconds: 30
+  periodSeconds: 5
   timeoutSeconds: 1
   successThreshold: 1
 


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request introduces a new value to delay the startup of the BPDM application containers.

This feature is helpful for environments which have limited resources like the Kind cluster setup in the Github workflows where we discovered that the install may take more than 10 minutes due to repeated crash loop backs.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
