### PR TITLE
build(version): increase BPDM app version to 6.1.0 (RELEASE)

### DIFF
--- a/.github/workflows/chart-test-lint.yaml
+++ b/.github/workflows/chart-test-lint.yaml
@@ -49,11 +49,15 @@ jobs:
         id: checkRelease
         run: |
           CHART_VERSION=$(grep 'version:' ./charts/bpdm/Chart.yaml | head -n1 | awk '{ print $2}')
-          SNAPSHOT=$(echo $CHART_VERSION | grep 'SNAPSHOT')
+          echo "CHART_VERSION: $CHART_VERSION"
+          SNAPSHOT=$(echo "$CHART_VERSION" | grep 'SNAPSHOT' || echo "" )
+          echo "SNAPSHOT: $SNAPSHOT"
           if [[ -z "$SNAPSHOT" ]]; then 
-            IS_RELEASE=true; else 
+            IS_RELEASE=true 
+          else 
             IS_RELEASE=false 
           fi
+          echo "IS_RELEASE: $IS_RELEASE"
           echo "isRelease=$IS_RELEASE" >> $GITHUB_OUTPUT
 
       - name: Set up Helm

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -41,11 +41,15 @@ jobs:
         id: checkRelease
         run: |
           CHART_VERSION=$(grep 'version:' ./charts/bpdm/Chart.yaml | head -n1 | awk '{ print $2}')
-          SNAPSHOT=$(echo $CHART_VERSION | grep 'SNAPSHOT')
+          echo "CHART_VERSION: $CHART_VERSION"
+          SNAPSHOT=$(echo "$CHART_VERSION" | grep 'SNAPSHOT' || echo "" )
+          echo "SNAPSHOT: $SNAPSHOT"
           if [[ -z "$SNAPSHOT" ]]; then 
-          IS_RELEASE=true; else 
-          IS_RELEASE=false 
+            IS_RELEASE=true 
+          else 
+            IS_RELEASE=false 
           fi
+          echo "IS_RELEASE: $IS_RELEASE"
           echo "isRelease=$IS_RELEASE" >> $GITHUB_OUTPUT
 
       - name: Configure Git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/CHANGELOG.md) of the charts directly.
 
-## [6.1.0] - [tbd]
+## [6.1.0] - [2024-07-15]
 
 ### Added
 

--- a/bpdm-cleaning-service-dummy/pom.xml
+++ b/bpdm-cleaning-service-dummy/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <dependencies>

--- a/bpdm-common-test/pom.xml
+++ b/bpdm-common-test/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <dependencies>

--- a/bpdm-common/pom.xml
+++ b/bpdm-common/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <dependencies>

--- a/bpdm-gate-api/pom.xml
+++ b/bpdm-gate-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <artifactId>bpdm-parent</artifactId>
         <groupId>org.eclipse.tractusx</groupId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <properties>

--- a/bpdm-gate/pom.xml
+++ b/bpdm-gate/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <dependencies>

--- a/bpdm-orchestrator-api/pom.xml
+++ b/bpdm-orchestrator-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <properties>

--- a/bpdm-orchestrator/pom.xml
+++ b/bpdm-orchestrator/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <dependencies>

--- a/bpdm-pool-api/pom.xml
+++ b/bpdm-pool-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <properties>

--- a/bpdm-pool/pom.xml
+++ b/bpdm-pool/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>bpdm-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <dependencies>

--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [5.1.0] -  tbd
+## [5.1.0] -  2024-07-15
 
 ### Changed
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 5.1.0-SNAPSHOT
-appVersion: "6.1.0-SNAPSHOT"
+version: 5.1.0
+appVersion: "6.1.0"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,19 +33,19 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 6.1.0-SNAPSHOT
+    version: 6.1.0
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 7.1.0-SNAPSHOT
+    version: 7.1.0
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 3.1.0-SNAPSHOT
+    version: 3.1.0
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 3.1.0-SNAPSHOT
+    version: 3.1.0
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [3.1.0] - tbd
+## [3.1.0] - 2024-07-15
 
 ### Changed
 

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "6.1.0-SNAPSHOT"
-version: 3.1.0-SNAPSHOT
+appVersion: "6.1.0"
+version: 3.1.0
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [6.1.0] - tbd
+## [6.1.0] - 2024-07-15
 
 ### Changed
 

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "6.1.0-SNAPSHOT"
-version: 6.1.0-SNAPSHOT
+appVersion: "6.1.0"
+version: 6.1.0
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [3.1.0] - tbd
+## [3.1.0] - 2024-07-15
 
 ### Added
 

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "6.1.0-SNAPSHOT"
-version: 3.1.0-SNAPSHOT
+appVersion: "6.1.0"
+version: 3.1.0
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [7.1.0] - tbd
+## [7.1.0] - 2024-07-15
 
 ### Changed
 

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "6.1.0-SNAPSHOT"
-version: 7.1.0-SNAPSHOT
+appVersion: "6.1.0"
+version: 7.1.0
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>bpdm-parent</artifactId>
     <name>Business Partner Data Management Parent</name>
     <description>Parent pom of Business Partner Data Management</description>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request increases the App version to release 6.1.0.

Also the corresponding Chart Version is increases to release version 5.1.0.

Adapted versions of the Maven POM and Chart.yml, also adapted the Changelogs.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
