### PR TITLE
fix(chart): faulty default configuration in subcharts

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [5.0.3] -  2024-07-16
+
+### Changed
+
+- Fixed faulty configuration of subcharts that comes into effect when deploying the subchart directly or using the BPDM chart as a dependency in another chart.
+  For anyone using the BPDM chart directly this will have no impact.
+
 ## [5.0.2] -  2024-07-03
 
 ### Changed

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 5.0.2
+version: 5.0.3
 appVersion: "6.0.2"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
@@ -33,17 +33,17 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 6.0.2
+    version: 6.0.3
     alias: bpdm-gate
     condition: bpdm-gate.enabled
     repository: "file://./charts/bpdm-gate"
   - name: bpdm-pool
-    version: 7.0.2
+    version: 7.0.3
     alias: bpdm-pool
     condition: bpdm-pool.enabled
     repository: "file://./charts/bpdm-pool"
   - name: bpdm-cleaning-service-dummy
-    version: 3.0.2
+    version: 3.0.3
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
     repository: "file://./charts/bpdm-cleaning-service-dummy"

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [3.0.3] - 2024-07-16
+
+### Changed
+
+- Fix faulty default applicationConfig
+
 ## [3.0.2] - 2024-07-03
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
 appVersion: "6.0.2"
-version: 3.0.2
+version: 3.0.3
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
@@ -114,11 +114,6 @@ startupProbe:
 
 # Used to overwrite the default property values of the application configuration
 applicationConfig:
-  bpdm:
-    client:
-      orchestrator:
-        # If empty sets kubernetes BPDM Orchestrator service with same release name
-        base-url:
 
 # Used to overwrite the secret property values of the application configuration
 applicationSecrets:

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [6.0.3] - 2024-07-16
+
+### Changed
+
+- Fix faulty default applicationConfig
+
 ## [6.0.2] - 2024-07-03
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-gate
 appVersion: "6.0.2"
-version: 6.0.2
+version: 6.0.3
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -118,17 +118,6 @@ startupProbe:
 
 # Used to overwrite the default property values of the application configuration
 applicationConfig:
-  bpdm:
-    datasource:
-      # If empty sets kubernetes postgres service with same release name
-      host:
-    client:
-      pool:
-        # If empty sets kubernetes BPDM Pool service with same release name
-        base-url:
-      orchestrator:
-        # If empty sets kubernetes BPDM Orchestrator service with same release name
-        base-url:
 
 # Used to overwrite the secret property values of the application configuration
 applicationSecrets:

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [7.0.3] - 2024-07-16
+
+### Changed
+
+- Fix faulty default applicationConfig
+
 ## [7.0.2] - 2024-07-03
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 type: application
 name: bpdm-pool
 appVersion: "6.0.2"
-version: 7.0.2
+version: 7.0.3
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -118,14 +118,6 @@ startupProbe:
   successThreshold: 1
 
 applicationConfig:
-  bpdm:
-    datasource:
-      # If empty sets kubernetes postgres service with same release name
-      host:
-    client:
-      orchestrator:
-        # If empty sets kubernetes BPDM Orchestrator service with same release name
-        base-url:
 
 applicationSecrets:
   spring:


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Fixed faulty configuration of subcharts that comes into effect when deploying the subchart directly or using the BPDM chart as a dependency in another chart. For anyone using the BPDM chart directly this will have no impact.


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
