### PR TITLE
ci(trivy): let trivy regularly check latest containers

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.22.0
         with:
           scan-type: "config"
           # ignore-unfixed: true
@@ -78,7 +78,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-pool:latest-alpha"
+          image-ref: "docker.io/tractusx/bpdm-pool:latest"
           format: "sarif"
           output: "trivy-results2.sarif"
           exit-code: "0"
@@ -108,10 +108,10 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.22.0
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-gate:latest-alpha"
+          image-ref: "docker.io/tractusx/bpdm-gate:latest"
           format: "sarif"
           output: "trivy-results3.sarif"
           exit-code: "0"
@@ -141,10 +141,10 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.22.0
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-cleaning-service-dummy:latest-alpha"
+          image-ref: "docker.io/tractusx/bpdm-cleaning-service-dummy:latest"
           format: "sarif"
           output: "trivy-results4.sarif"
           exit-code: "0"
@@ -174,10 +174,10 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.22.0
         with:
           # Path to Docker image
-          image-ref: "docker.io/tractusx/bpdm-orchestrator:latest-alpha"
+          image-ref: "docker.io/tractusx/bpdm-orchestrator:latest"
           format: "sarif"
           output: "trivy-results4.sarif"
           exit-code: "0"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Currently, the scheduled trivy job analyzes tags which are not updated anymore. Also, since we already perform trivy scans on the pull requests we already find vulnerabilities early for snapshot versions. That is why I think the scheduled trivy job should rather work on the latest released version, making sure that in the current release are no critical vulnerabilties.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
