### PR TITLE
feat(bpdm-gate): Extend error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Added
 
 - BPDM Pool: Post endpoint to fetch the BPNL/S/A based on the requested identifiers.([#1052](https://github.com/eclipse-tractusx/bpdm/issues/1052))
+- BPDM Gate & Orchestrator: Enhance the error handling mechanism for the orchestrator and gate components by extending the list of available error codes.([#1003](https://github.com/eclipse-tractusx/bpdm/pull/1003#pullrequestreview-2477395867))
 
 ### Changed
 

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/exception/GateErrorCodes.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/exception/GateErrorCodes.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.tractusx.bpdm.gate.api.exception
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 /**
  * For every combination of possible errors a separate enum class is defined extending this marker interface.
  * We need separate enum classes in order to get the correct error codes for each endpoint in the Swagger schema.
@@ -30,6 +32,12 @@ enum class BusinessPartnerSharingError : ErrorCode {
     SharingTimeout,
     BpnNotInPool,
     MissingTaskID,
+    NaturalPersonError,
+    BpnErrorNotFound,
+    BpnErrorTooManyOptions,
+    MandatoryFieldValidationFailed,
+    BlacklistCountryPresent,
+    UnknownSpecialCharacters
 }
 
 enum class ChangeLogOutputError : ErrorCode {

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SharingStateDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/response/SharingStateDto.kt
@@ -27,8 +27,7 @@ import java.time.LocalDateTime
 @Schema(
     description = "A sharing state entry shows the progress in the sharing process and is updated each time the " +
             "progress for a business partner changes. The business partner is identified by a combination " +
-            "of external ID and business partner type."
-)
+            "of external ID and business partner type.\n")
 data class SharingStateDto(
 
     @get:Schema(description = "The external identifier of the business partner for which the sharing state entry was created.")
@@ -37,7 +36,13 @@ data class SharingStateDto(
     @get:Schema(description = "One of the sharing state types of the current sharing state.")
     val sharingStateType: SharingStateType = SharingStateType.Initial,
 
-    @get:Schema(description = "One of the sharing error codes in case the current sharing state type is \"error\".")
+    @get:Schema(description = "One of the sharing error codes in case the current sharing state type is \"error\". \n" +
+            "* `NaturalPersonError`: The provided record contains natural person information.\n" +
+            "* `BpnErrorNotFound`: The provided record can not be matched to a legal entity or an address.\n" +
+            "* `BpnErrorTooManyOptions`: The provided record can not link to a clear legal entity.\n" +
+            "* `MandatoryFieldValidationFailed`: The provided record does not fulfill mandatory validation rules.\n" +
+            "* `BlacklistCountryPresent`: The provided record is part of a country that is not allowed to be processed by the GR process (example: Brazil).\n" +
+            "* `UnknownSpecialCharacters`: The provided record contains unallowed special characters.")
     val sharingErrorCode: BusinessPartnerSharingError? = null,
 
     @get:Schema(description = "The error message in case the current sharing state type is \"error\".")

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
@@ -199,7 +199,7 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
             SharingStateDto(
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Error,
-                sharingErrorCode = BusinessPartnerSharingError.SharingProcessError,
+                sharingErrorCode = BusinessPartnerSharingError.SharingTimeout,
                 sharingErrorMessage = "Major Error // Minor Error",
                 sharingProcessStarted = null,
                 taskId = "1"

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -336,7 +336,7 @@ class BusinessPartnerControllerIT @Autowired constructor(
             SharingStateDto(
                 externalId = externalId5,
                 sharingStateType = SharingStateType.Error,
-                sharingErrorCode = BusinessPartnerSharingError.SharingProcessError,
+                sharingErrorCode = BusinessPartnerSharingError.SharingTimeout,
                 sharingErrorMessage = "Major Error // Minor Error",
                 sharingProcessStarted = null,
                 taskId = "1"

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorDto.kt
@@ -21,10 +21,16 @@ package org.eclipse.tractusx.orchestrator.api.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Describes an error that happened during processing of a task")
+@Schema(description = "Describes an error that happened during processing of a task \n")
 data class TaskErrorDto(
 
-    @get:Schema(description = "The type of error that occurred", required = true)
+    @get:Schema(description = "The type of error that occurred. \n" +
+            "* `NaturalPersonError`: The provided record contains natural person information.\n" +
+            "* `BpnErrorNotFound`: The provided record can not be matched to a legal entity or an address.\n" +
+            "* `BpnErrorTooManyOptions`: The provided record can not link to a clear legal entity.\n" +
+            "* `MandatoryFieldValidationFailed`: The provided record does not fulfill mandatory validation rules.\n" +
+            "* `BlacklistCountryPresent`: The provided record is part of a country that is not allowed to be processed by the GR process (example: Brazil).\n" +
+            "* `UnknownSpecialCharacters`: The provided record contains unallowed special characters.\n" , required = true)
     val type: TaskErrorType,
 
     @get:Schema(description = "The free text, detailed description of the error", required = true)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorType.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskErrorType.kt
@@ -19,7 +19,15 @@
 
 package org.eclipse.tractusx.orchestrator.api.model
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 enum class TaskErrorType {
     Timeout,
-    Unspecified
+    Unspecified,
+    NaturalPersonError,
+    BpnErrorNotFound,
+    BpnErrorTooManyOptions,
+    MandatoryFieldValidationFailed,
+    BlacklistCountryPresent,
+    UnknownSpecialCharacters
 }

--- a/bpdm-orchestrator/src/main/resources/db/migration/V6_3_0_0__add_extend_error_code.sql
+++ b/bpdm-orchestrator/src/main/resources/db/migration/V6_3_0_0__add_extend_error_code.sql
@@ -1,0 +1,11 @@
+ALTER TABLE task_errors DROP CONSTRAINT task_errors_type_check;
+ALTER TABLE task_errors ADD CONSTRAINT task_errors_type_check CHECK (type IN (
+    'Timeout',
+    'Unspecified',
+    'NaturalPersonError',
+    'BpnErrorNotFound',
+    'BpnErrorTooManyOptions',
+    'MandatoryFieldValidationFailed',
+    'BlacklistCountryPresent',
+    'UnknownSpecialCharacters'
+));

--- a/docs/api/gate.yaml
+++ b/docs/api/gate.yaml
@@ -1676,6 +1676,12 @@ components:
             - SharingTimeout
             - BpnNotInPool
             - MissingTaskID
+            - NaturalPersonError
+            - BpnErrorNotFound
+            - BpnErrorTooManyOptions
+            - MandatoryFieldValidationFailed
+            - BlacklistCountryPresent
+            - UnknownSpecialCharacters
         sharingErrorMessage:
           type: string
           description: The error message in case the current sharing state type is "error".

--- a/docs/api/orchestrator.yaml
+++ b/docs/api/orchestrator.yaml
@@ -650,6 +650,12 @@ components:
           enum:
             - Timeout
             - Unspecified
+            - NaturalPersonError
+            - BpnErrorNotFound
+            - BpnErrorTooManyOptions
+            - MandatoryFieldValidationFailed
+            - BlacklistCountryPresent
+            - UnknownSpecialCharacters
         description:
           type: string
           description: The free text, detailed description of the error


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Enhance the error handling mechanism for the orchestrator and gate components by extending the list of available error codes. This will improve the visibility and detail of error information, particularly beneficial for the customer dashboard to understand why a data set could not be processed.

Currently, the orchestrator and gate components have a limited set of error codes. Extending these error codes will provide more granular information on processing failures, aiding in quicker diagnosis and resolution. This feature will update both the orchestrator and gate components to support a more comprehensive list of error codes.

Benefits

- Improved Transparency: Customers can view detailed error reasons on the dashboard, enhancing trust and user experience.

- Enhanced Debugging: Developers and support teams can identify and resolve issues more efficiently with detailed error information.

- Better Monitoring: Allows for more precise monitoring and logging of errors, leading to improved system reliability.

New error types add to the following two classes

- org.eclipse.tractusx.bpdm.gate.api.exception.BusinessPartnerSharingError
- org.eclipse.tractusx.orchestrator.api.model.TaskErrorType

New error types

- NaturalPersonError - The provided record contains natural person information.
- BpnErrorNotFound - The provided record can not be matched to a legal entity or an address.
- BpnErrorTooManyOptions - The provided record can not link to a clear legal entity.
- MandatoryFieldValidationFailed - The provided record does not fulfill mandatory validation rules.
- BlacklistCountryPresent - The provided record is part of a country that is not allowed to be processed by the GR process (for example: Brazil).
- UnknownSpecialCharacters - The provided record contains unallowed special characters.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
