### PR TITLE
test(Pool): fix possible null exception in Pool tests

### DIFF
--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerComparator.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerComparator.kt
@@ -149,8 +149,12 @@ fun compareStates(statesVerbose: Collection<LegalEntityStateVerboseDto>,  states
 
 fun isEqualToIgnoringMilliseconds(): BiPredicate<LocalDateTime?, Instant?> {
     return BiPredicate<LocalDateTime?, Instant?> { d1, d2 ->
-        (d1 == null && d2 == null)
-                || d1.toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).equals(d2.truncatedTo(ChronoUnit.SECONDS))
+         (d1 == null && d2 == null)
+                 || d1?.let { notNullD1 ->
+                     d2?.let { notNullD2 ->
+                         notNullD1.toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).equals(notNullD2.truncatedTo(ChronoUnit.SECONDS))
+                     }
+                 } ?: false
     }
 }
 


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes a possible null exception in Pool tests when comparing dates of expected and actual business partnert data. If one of those dates is null and the other is not (currently not happening during tests) a null-Exception would be thrown.

This potential Null Exception leads to a comilation error in #948 
It seems like the new kotlin compiler is able to detect this potentional null-expection where the old one did not.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
