### PR TITLE
fix(Gate): Always Sending Owner BPNL on Owned Gate

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -184,15 +184,15 @@ class OrchestratorMappings(
         } ?: BpnReference.empty
 
     private fun getOwnerBpnL(entity: BusinessPartnerDb): String? {
-        return if (entity.sharingState.tenantBpnl != null) {
-            entity.sharingState.tenantBpnl
-        }else if (entity.isOwnCompanyData) {
-            bpnConfigProperties.ownerBpnL
-        }
-        else {
-            logger.warn { "Owner BPNL property is not configured" }
-            null
-        }
+        //only determine owner BPNL if it is own company data
+        if(!entity.isOwnCompanyData) return null
+
+        return entity.sharingState.tenantBpnl
+                ?: bpnConfigProperties.ownerBpnL.takeIf { it.isNotBlank() }
+                ?: run {
+                    logger.warn { "Owner BPNL can't be determined for owned company data" }
+                    null
+                }
     }
 
 


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes a bug in which a Gate which has a owner BPNL assigned will always send that owner's BPNL to the golden record process. Now the Gate will only assign the owner BPNL if it the data is marked as owned company data; even if the Gate has a fixed owner assigned.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
