### PR TITLE
fix(bpdm-orchestrator): introduced pagination for handling pending and retention timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 - BPDM Gate: Fixed Gate not resending business partner data to the golden record process on error sharing state when member sends the exact same business partner again
 
-### Changed
-
 - BPDM Pool & Gate: Reduce standard batch size for golden record task processing ([#1032](https://github.com/eclipse-tractusx/bpdm/pull/1032))
+
+- BPDM Orchestrator: Fix possible out-of-memory exception during the execution of large volumes of tasks ([#1029](https://github.com/eclipse-tractusx/bpdm/pull/1029))
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GoldenRecordTaskRepository.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GoldenRecordTaskRepository.kt
@@ -39,7 +39,7 @@ interface GoldenRecordTaskRepository : CrudRepository<GoldenRecordTaskDb, Long>,
     @Query("SELECT task from GoldenRecordTaskDb task WHERE task.processingState.step = :step AND task.processingState.stepState = :stepState")
     fun findByStepAndStepState(step: TaskStep, stepState: StepState, pageable: Pageable): Page<GoldenRecordTaskDb>
 
-    fun findByProcessingStatePendingTimeoutBefore(time: DbTimestamp): Set<GoldenRecordTaskDb>
+    fun findByProcessingStatePendingTimeoutBefore(time: DbTimestamp, pageable: Pageable): Page<GoldenRecordTaskDb>
 
-    fun findByProcessingStateRetentionTimeoutBefore(time: DbTimestamp): Set<GoldenRecordTaskDb>
+    fun findByProcessingStateRetentionTimeoutBefore(time: DbTimestamp, pageable: Pageable): Page<GoldenRecordTaskDb>
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/TimeoutProcessBatchService.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/TimeoutProcessBatchService.kt
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.service
+
+import jakarta.persistence.EntityManager
+import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class TimeoutProcessBatchService(
+    private val goldenRecordTaskService: GoldenRecordTaskService,
+    private val entityManager: EntityManager
+) {
+    private val logger = KotlinLogging.logger { }
+
+    @Scheduled(cron = "\${bpdm.task.timeoutCheckCron}")
+    fun processForTimeouts() {
+        try {
+            // Track the total number of processed tasks
+            var totalProcessedTasks = 0
+            logger.debug { "Checking for timeouts" }
+            // Process pending timeouts
+            totalProcessedTasks += processTimeouts(goldenRecordTaskService::processPendingTimeouts)
+            // Process retention timeouts
+            totalProcessedTasks += processTimeouts(goldenRecordTaskService::processRetentionTimeouts)
+            logger.info { "Finished processing timeouts. Total processed tasks: $totalProcessedTasks" }
+        } catch (err: RuntimeException) {
+            logger.error(err) { "Error checking for timeouts" }
+        }
+    }
+
+
+    private fun processTimeouts(processFunction: (Int) -> PaginationInfo): Int {
+        val pageSize = 1000  // Adjust the page size based on memory constraints
+        var processedTasks = 0
+        do {
+            val paginationInfo = processFunction(pageSize)
+            processedTasks += paginationInfo.countProcessedTasks()
+            entityManager.clear() // Clear the persistence context to free memory
+        } while (paginationInfo.hasNextPage)
+        return processedTasks
+    }
+}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request introduces pagination for handling pending and retention timeouts in the orchestrator. By processing tasks in manageable batches, the changes prevent out-of-memory errors during the execution of large volumes of tasks, improving the system's stability and efficiency.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
