### PR TITLE
fix(config): lower the standard batch sizes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 ### Added
 
--BPDM Pool: Post endpoint to create a site for LegalAndSiteMainAddress addressType.([#739](https://github.com/eclipse-tractusx/sig-release/issues/739))
+- BPDM Pool: Post endpoint to create a site for LegalAndSiteMainAddress addressType.([#739](https://github.com/eclipse-tractusx/sig-release/issues/739))
 
+
+### Changed
+
+- BPDM Pool & Gate: Reduce standard batch size for golden record task processing ([#1032](https://github.com/eclipse-tractusx/bpdm/pull/1032))
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -48,14 +48,14 @@ bpdm:
         # When and how often the Gate checks for new business partner data to be shared
         cron: '*/30 * * * * *'
         # Up to how many golden record tasks can be created when checking
-        batchSize: 100
+        batchSize: 20
       fromPool:
         # Up to how many golden record tasks can be created when checking
-        batchSize: 100
+        batchSize: 20
         # When and how often the Gate checks for golden record updates from the Pool
         cron: '*/30 * * * * *'
     check:
-      batchSize: 100
+      batchSize: 20
       cron: '*/30 * * * * *'
   # Connection to the pool and orchestrator
   client:

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -82,7 +82,7 @@ bpdm:
     # When and how often the Pool should poll for golden record tasks in the orchestrator
     cron: '*/30 * * * * *'
     # Up to how many tasks can be requested at the same time
-    batchSize: 100
+    batchSize: 20
   security:
     # Allowed origins for CORS
     cors-origins: '*'


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Request sizes can be quite big when interacting with the golden record process due to large business partner data. This may lead to exceptions when the used clients do not support such big request sizes. 

Therefore this pull request reduces the standard batch size for golden record task processing in the Gate and Pool.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
