### PR TITLE
fix(Gate): Possible out of memory exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 ### Changed
 
+- BPDM Gate: Fix possible out of memory exception when handling large golden record process requests
+
 - BPDM Pool: Fix not resolving golden record tasks on exceptions
 
 ## [6.1.0] - [2024-07-15]

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskCreationServices.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskCreationServices.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
+import jakarta.persistence.EntityManager
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
@@ -37,7 +38,8 @@ import java.util.*
 
 @Service
 class TaskCreationBatchService(
-    private val taskCreationService: TaskCreationChunkService
+    private val taskCreationService: TaskCreationChunkService,
+    private val entityManager: EntityManager
 ){
     private val logger = KotlinLogging.logger { }
 
@@ -49,6 +51,8 @@ class TaskCreationBatchService(
         do {
             val createdTasks = taskCreationService.createTasksForReadyBusinessPartners()
             totalCreatedTasks += createdTasks
+
+            entityManager.clear()
         }while (createdTasks != 0)
 
         logger.debug { "Total created $totalCreatedTasks new golden record tasks from ready business partners" }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskResolutionServices.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskResolutionServices.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.gate.service
 
+import jakarta.persistence.EntityManager
 import mu.KotlinLogging
 import org.eclipse.tractusx.bpdm.common.model.StageType
 import org.eclipse.tractusx.bpdm.gate.api.exception.BusinessPartnerSharingError
@@ -39,7 +40,8 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TaskResolutionBatchService(
-    private val taskResolutionService: TaskResolutionChunkService
+    private val taskResolutionService: TaskResolutionChunkService,
+    private val entityManager: EntityManager
 ){
     private val logger = KotlinLogging.logger { }
 
@@ -63,6 +65,7 @@ class TaskResolutionBatchService(
             totalErrors += stats.resolvedAsError
             totalUnresolved += stats.unresolved
 
+            entityManager.clear()
         }while (stats.foundTasks != 0)
 
         logger.debug { "Total Resolved $totalSuccesses tasks as successful, $totalErrors as errors and $totalUnresolved still unresolved" }


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes a bug in which the Gate can run out of memory when trying to process a large amount of golden records during scheduling.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
