### PR TITLE
feat(Orchestrator): now aborts outdated tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,9 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Changed
 
 - BPDM Gate: Fix possible out of memory exception when handling large golden record process requests
-
 - BPDM Pool: Fix not resolving golden record tasks on exceptions
-
 - BPDM Gate: Fixed Gate not resending business partner data to the golden record process on error sharing state when member sends the exact same business partner again
+- BPDM Orchestrator: Now aborts tasks that are outdated (that is when a Gate will send newer business partner data for the same record to the golden record process)
 
 - BPDM Pool & Gate: Reduce standard batch size for golden record task processing ([#1032](https://github.com/eclipse-tractusx/bpdm/pull/1032))
 

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/GoldenRecordTaskDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/GoldenRecordTaskDb.kt
@@ -180,6 +180,21 @@ class GoldenRecordTaskDb(
         @Column(name = "site_has_changed")
         var siteHasChanged: Boolean?
     )
+
+    enum class ResultState{
+        Pending,
+        Success,
+        Error,
+        Aborted
+    }
+
+    enum class StepState{
+        Queued,
+        Reserved,
+        Success,
+        Error,
+        Aborted
+    }
 }
 
 

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GoldenRecordTaskRepository.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GoldenRecordTaskRepository.kt
@@ -20,8 +20,8 @@
 package org.eclipse.tractusx.bpdm.orchestrator.repository
 
 import org.eclipse.tractusx.bpdm.orchestrator.entity.DbTimestamp
+import org.eclipse.tractusx.bpdm.orchestrator.entity.GateRecordDb
 import org.eclipse.tractusx.bpdm.orchestrator.entity.GoldenRecordTaskDb
-import org.eclipse.tractusx.orchestrator.api.model.StepState
 import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -37,9 +37,11 @@ interface GoldenRecordTaskRepository : CrudRepository<GoldenRecordTaskDb, Long>,
     fun findByUuidIn(uuids: Set<UUID>): Set<GoldenRecordTaskDb>
 
     @Query("SELECT task from GoldenRecordTaskDb task WHERE task.processingState.step = :step AND task.processingState.stepState = :stepState")
-    fun findByStepAndStepState(step: TaskStep, stepState: StepState, pageable: Pageable): Page<GoldenRecordTaskDb>
+    fun findByStepAndStepState(step: TaskStep, stepState: GoldenRecordTaskDb.StepState, pageable: Pageable): Page<GoldenRecordTaskDb>
 
     fun findByProcessingStatePendingTimeoutBefore(time: DbTimestamp, pageable: Pageable): Page<GoldenRecordTaskDb>
 
     fun findByProcessingStateRetentionTimeoutBefore(time: DbTimestamp, pageable: Pageable): Page<GoldenRecordTaskDb>
+
+    fun findTasksByGateRecordAndProcessingStateResultState(record: GateRecordDb, resultState: GoldenRecordTaskDb.ResultState) : Set<GoldenRecordTaskDb>
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/ResponseMapper.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/ResponseMapper.kt
@@ -41,9 +41,9 @@ class ResponseMapper {
     fun toProcessingState(task: GoldenRecordTaskDb, timeout: Instant) =
         with(task.processingState) {
             TaskProcessingStateDto(
-                resultState = resultState,
+                resultState = toResultState(resultState),
                 step = step,
-                stepState = stepState,
+                stepState = toStepState(stepState),
                 errors = errors.map { toTaskError(it) },
                 createdAt = task.createdAt.instant,
                 modifiedAt = task.updatedAt.instant,
@@ -218,6 +218,23 @@ class ResponseMapper {
                 nameSuffix = nameSuffix,
                 additionalNameSuffix = additionalNameSuffix
             )
+        }
+
+    fun toResultState(resultState: GoldenRecordTaskDb.ResultState) =
+        when(resultState){
+            GoldenRecordTaskDb.ResultState.Pending -> ResultState.Pending
+            GoldenRecordTaskDb.ResultState.Success ->  ResultState.Success
+            GoldenRecordTaskDb.ResultState.Error ->  ResultState.Error
+            GoldenRecordTaskDb.ResultState.Aborted ->  ResultState.Error
+        }
+
+    fun toStepState(stepState: GoldenRecordTaskDb.StepState) =
+        when(stepState){
+            GoldenRecordTaskDb.StepState.Queued -> StepState.Queued
+            GoldenRecordTaskDb.StepState.Reserved -> StepState.Reserved
+            GoldenRecordTaskDb.StepState.Success -> StepState.Success
+            GoldenRecordTaskDb.StepState.Error -> StepState.Error
+            GoldenRecordTaskDb.StepState.Aborted -> StepState.Error
         }
 
 }

--- a/bpdm-orchestrator/src/main/resources/db/migration/V6_2_0_0__add_abort_status_check.sql
+++ b/bpdm-orchestrator/src/main/resources/db/migration/V6_2_0_0__add_abort_status_check.sql
@@ -1,0 +1,13 @@
+ALTER TABLE golden_record_tasks
+DROP CONSTRAINT golden_record_tasks_task_step_state_check;
+
+ALTER TABLE golden_record_tasks
+ADD CONSTRAINT golden_record_tasks_task_step_state_check
+check ( task_step_state in ('Queued', 'Reserved', 'Success', 'Error', 'Aborted'));
+
+ALTER TABLE golden_record_tasks
+DROP CONSTRAINT golden_record_tasks_task_result_state_check;
+
+ALTER TABLE golden_record_tasks
+ADD CONSTRAINT golden_record_tasks_task_result_state_check
+check ( task_result_state in ('Pending', 'Success', 'Error', 'Aborted'));


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

In this pull request the Orchestrator now aborts tasks with outdated business partner data information from the sharing members. On creating new tasks the Gate will check for currently pending tasks for the same record and abort them.

An aborted task counts as a finished tasks and will be removed by the retention timeout check.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
