### PR TITLE
chore: Updated trufflehog secret scanning workflow

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,12 +1,33 @@
+#
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 name: "TruffleHog"
 
 on:
   push:
-    branches: [ main ]
+    branches: ["main"]
   pull_request:
-  
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
   schedule:
     - cron: "0 0 * * *" # Once a day
+  workflow_dispatch:
 
 permissions:
   actions: read
@@ -24,7 +45,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
-          ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
 
       - name: TruffleHog OSS
         id: trufflehog


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

This PR updated the copyright header and provide minor fix on scan for new pull requests.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
