### PR TITLE
chore(workflows): Pre-release docker tags

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -67,7 +67,7 @@ jobs:
         id: dockerTags
         run: |
           FULL_IMAGE_NAME="${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}"
-          SUFFIX="${{ steps.semVer.outputs.prerelease == 'SNAPSHOT' && '-SNAPSHOT' || '' }}"
+          SUFFIX="${{ steps.semVer.outputs.prerelease &&  '-' || '' }}${{ steps.semVer.outputs.prerelease }}"
           MAJOR="${{ steps.semVer.outputs.major }}"
           MINOR="${MAJOR}.${{ steps.semVer.outputs.minor }}"
           PATCH="${MINOR}.${{ steps.semVer.outputs.patch }}"
@@ -75,7 +75,17 @@ jobs:
           MAJOR_TAG="${FULL_IMAGE_NAME}:${MAJOR}${SUFFIX}"
           MINOR_TAG="${FULL_IMAGE_NAME}:${MINOR}${SUFFIX}"
           PATCH_TAG="${FULL_IMAGE_NAME}:${PATCH}${SUFFIX}"
-          echo "tags=${LATEST_TAG},${MAJOR_TAG},${MINOR_TAG},${PATCH_TAG}" >> $GITHUB_OUTPUT
+          if ${{ steps.semVer.outputs.prerelease == 'SNAPSHOT' &&  true || false }}; then 
+            ALL_TAGS="${LATEST_TAG},${PATCH_TAG}" 
+          else 
+             if ${{ steps.semVer.outputs.prerelease &&  true || false }}; then
+               ALL_TAGS="${PATCH_TAG}" 
+             else
+               ALL_TAGS="${LATEST_TAG},${MAJOR_TAG},${MINOR_TAG},${PATCH_TAG}"
+             fi
+          fi
+          echo "tags=${ALL_TAGS}" >> $GITHUB_OUTPUT
+          echo "tags=${ALL_TAGS}"
 
       - name: DockerHub login
         uses: docker/login-action@v3


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

chore(workflows): allow for deploying any kind of non-snapshot pre-release deployment

Now distinguished between 3 cases:

- RELEASE: no pre-release suffix, make full list of version tags
- SNAPSHOT: SNAPSHOT pre-release suffix, create latest and patch version tag
- PRE-RELEASE: any other pre-release suffix, only create patch version tag (intended for release candidate versions with numbered 'rc' as suffix)

### Why is this needed?

Currently, we can only deploy full releases or SNAPSHOT releases. However, the behaviour of our SNAPSHOT releases is to override tags always to the newest version. This works for SNAPSHOTs but it is still nice to use fixed pre-release tags that stay long term and are not overwritten.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
