### PR TITLE
fix(bpdm): updated double precision data type for Geographic-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Orchestrator: Fix possible out-of-memory exception during the execution of large volumes of tasks ([#1029](https://github.com/eclipse-tractusx/bpdm/pull/1029))
 - BPDM Cleaning Service Dummy: Add whitespaces between name parts when creating legal name from them
 - BPDM Cleaning Service Dummy: Improve duplication check to better distinguish between incoming business partners
+- Apps: Updated double precision data type for Geographic-data([#978](https://github.com/eclipse-tractusx/bpdm/issues/978))
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
@@ -33,7 +33,7 @@ object BusinessPartnerGenericCommonValues {
         hasChanged = true,
         addressName = "Address Name",
         physicalAddress = PhysicalAddress(
-            geographicCoordinates = GeoCoordinate(0.5f, 0.5f, 0.5f),
+            geographicCoordinates = GeoCoordinate(0.5, 0.5, 0.5),
             country = CountryCode.PT.alpha2,
             administrativeAreaLevel1 = "PT-PT",
             administrativeAreaLevel2 = "pt-admin-level-2-cleaned",
@@ -61,7 +61,7 @@ object BusinessPartnerGenericCommonValues {
             taxJurisdictionCode = "123"
         ),
         alternativeAddress = AlternativeAddress(
-            geographicCoordinates = GeoCoordinate(0.6f, 0.6f, 0.6f),
+            geographicCoordinates = GeoCoordinate(0.6, 0.6, 0.6),
             country = CountryCode.PT.alpha2,
             administrativeAreaLevel1 = "PT-PT",
             postalCode = "postal-code-cleaned",

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
@@ -234,13 +234,13 @@ object BusinessPartnerVerboseValues {
         deliveryServiceType = DeliveryServiceType.PO_BOX,
         deliveryServiceQualifier = "DHL",
         deliveryServiceNumber = "1234",
-        geographicCoordinates = GeoCoordinateDto(7.619f, 45.976f, 4478f),
+        geographicCoordinates = GeoCoordinateDto(7.619, 45.976, 4478.0),
         postalCode = "70547",
         administrativeAreaLevel1 = "adminAreaLevel1RegionCode_2",
     )
 
     val postalAddress1 = PhysicalPostalAddressDto(
-        geographicCoordinates = GeoCoordinateDto(13.178f, 48.946f),
+        geographicCoordinates = GeoCoordinateDto(13.178, 48.946),
         country = CountryCode.DE,
         postalCode = "70546 ",
         city = "Stuttgart",
@@ -257,7 +257,7 @@ object BusinessPartnerVerboseValues {
     )
 
     val postalAddress2 = PhysicalPostalAddressDto(
-        geographicCoordinates = GeoCoordinateDto(7.619f, 45.976f, 4478f),
+        geographicCoordinates = GeoCoordinateDto(7.619, 45.976, 4478.0),
         country = CountryCode.US,
         postalCode = "70547",
         city = "Atlanta",
@@ -274,7 +274,7 @@ object BusinessPartnerVerboseValues {
     )
 
     val postalAddress3 = PhysicalPostalAddressDto(
-        geographicCoordinates = GeoCoordinateDto(13.178f, 48.946f),
+        geographicCoordinates = GeoCoordinateDto(13.178, 48.946),
         country = CountryCode.DE,
         postalCode = "70546 ",
         city = "Stuttgart",
@@ -337,7 +337,7 @@ object BusinessPartnerVerboseValues {
 
     //New Values for Logistic Addresses Tests
     val postalAddressLogisticAddress1 = PhysicalPostalAddressDto(
-        geographicCoordinates = GeoCoordinateDto(13.178f, 48.946f),
+        geographicCoordinates = GeoCoordinateDto(13.178, 48.946),
         country = CountryCode.DE,
         postalCode = "70546 ",
         city = "Stuttgart",
@@ -354,7 +354,7 @@ object BusinessPartnerVerboseValues {
     )
 
     val postalAddressLogisticAddress2 = PhysicalPostalAddressDto(
-        geographicCoordinates = GeoCoordinateDto(7.619f, 45.976f, 4478f),
+        geographicCoordinates = GeoCoordinateDto(7.619, 45.976, 4478.0),
         country = CountryCode.US,
         postalCode = "70547",
         city = "Atlanta",
@@ -752,7 +752,7 @@ object BusinessPartnerVerboseValues {
             name = "Address Name",
             addressType = AddressType.AdditionalAddress,
             physicalPostalAddress = PhysicalPostalAddressDto(
-                geographicCoordinates = GeoCoordinateDto(0.5f, 0.5f, 0.5f),
+                geographicCoordinates = GeoCoordinateDto(0.5, 0.5, 0.5),
                 country = CountryCode.PT,
                 administrativeAreaLevel1 = "PT-PT",
                 administrativeAreaLevel2 = "pt-admin-level-2-cleaned",
@@ -779,7 +779,7 @@ object BusinessPartnerVerboseValues {
                 door = "door"
             ),
             alternativePostalAddress = AlternativePostalAddressDto(
-                geographicCoordinates = GeoCoordinateDto(0.6f, 0.6f, 0.6f),
+                geographicCoordinates = GeoCoordinateDto(0.6, 0.6, 0.6),
                 country = CountryCode.PT,
                 administrativeAreaLevel1 = "PT-PT",
                 postalCode = "postal-code-cleaned",

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/orchestrator/BusinessPartnerTestDataFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/orchestrator/BusinessPartnerTestDataFactory.kt
@@ -109,7 +109,7 @@ class BusinessPartnerTestDataFactory(
             states = createStates(seed, 5, random),
             confidenceCriteria = createConfidenceCriteria(random),
             physicalAddress = PhysicalAddress(
-                geographicCoordinates = GeoCoordinate(longitude = random.nextFloat(), latitude = random.nextFloat(), altitude = random.nextFloat()),
+                geographicCoordinates = GeoCoordinate(longitude = random.nextDouble(), latitude = random.nextDouble(), altitude = random.nextDouble()),
                 country = CountryCode.entries.toTypedArray().random(random).alpha2,
                 administrativeAreaLevel1 = metadata?.adminAreas?.random(random) ?: "Admin Level 1 $seed",
                 administrativeAreaLevel2 = "Admin Level 2 $seed",
@@ -136,7 +136,7 @@ class BusinessPartnerTestDataFactory(
                 taxJurisdictionCode = "123"
             ),
             alternativeAddress = AlternativeAddress(
-                geographicCoordinates = GeoCoordinate(longitude = random.nextFloat(), latitude = random.nextFloat(), altitude = random.nextFloat()),
+                geographicCoordinates = GeoCoordinate(longitude = random.nextDouble(), latitude = random.nextDouble(), altitude = random.nextDouble()),
                 country = CountryCode.entries.toTypedArray().random(random).alpha2,
                 administrativeAreaLevel1 =  metadata?.adminAreas?.random(random) ?: "Alt Admin Level 1 $seed",
                 postalCode = "Alt Postal Code $seed",

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerRequestFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerRequestFactory.kt
@@ -178,7 +178,7 @@ class BusinessPartnerRequestFactory(
                 .mapNotNull { it }
                 .mapIndexed { index, idKey -> AddressIdentifierDto("$idKey Value $seed $index", idKey) },
             physicalPostalAddress = PhysicalPostalAddressDto(
-                geographicCoordinates = GeoCoordinateDto(longitude = random.nextFloat(), latitude = random.nextFloat(), altitude = random.nextFloat()),
+                geographicCoordinates = GeoCoordinateDto(longitude = random.nextDouble(), latitude = random.nextDouble(), altitude = random.nextDouble()),
                 country = CountryCode.entries.random(random),
                 administrativeAreaLevel1 = availableAdminAreas.randomOrNull(random),
                 administrativeAreaLevel2 = "Admin Level 2 $seed",
@@ -205,7 +205,7 @@ class BusinessPartnerRequestFactory(
                 taxJurisdictionCode = "Tax Jurisdiction Code $seed"
             ),
             alternativePostalAddress = AlternativePostalAddressDto(
-                geographicCoordinates = GeoCoordinateDto(longitude = random.nextFloat(), latitude = random.nextFloat(), altitude = random.nextFloat()),
+                geographicCoordinates = GeoCoordinateDto(longitude = random.nextDouble(), latitude = random.nextDouble(), altitude = random.nextDouble()),
                 country = CountryCode.entries.random(random),
                 administrativeAreaLevel1 = availableAdminAreas.randomOrNull(random),
                 postalCode = "Postal Code $seed",

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/GeoCoordinateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/GeoCoordinateDto.kt
@@ -26,11 +26,11 @@ import org.eclipse.tractusx.bpdm.common.dto.openapidescription.PostalAddressDesc
 data class GeoCoordinateDto(
 
     @get:Schema(description = "Longitude coordinate")
-    val longitude: Float,
+    val longitude: Double,
 
     @get:Schema(description = "Latitude coordinate")
-    val latitude: Float,
+    val latitude: Double,
     
     @get:Schema(description = "Altitude, if applicable")
-    val altitude: Float? = null
+    val altitude: Double? = null
 )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/GeographicCoordinateDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/GeographicCoordinateDb.kt
@@ -44,9 +44,9 @@ import jakarta.persistence.Embeddable
 @Embeddable
 data class GeographicCoordinateDb(
     @Column(name = "latitude")
-    val latitude: Float,
+    val latitude: Double,
     @Column(name = "longitude")
-    val longitude: Float,
+    val longitude: Double,
     @Column(name = "altitude")
-    val altitude: Float?,
+    val altitude: Double?,
 )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/model/upsert/output/GeoCoordinate.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/model/upsert/output/GeoCoordinate.kt
@@ -20,7 +20,7 @@
 package org.eclipse.tractusx.bpdm.gate.model.upsert.output
 
 data class GeoCoordinate(
-    val longitude: Float,
-    val latitude: Float,
-    val altitude: Float?
+    val longitude: Double,
+    val latitude: Double,
+    val altitude: Double?
 )

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/PartnerFileUtil.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/PartnerFileUtil.kt
@@ -211,9 +211,9 @@ object PartnerFileUtil {
             addressType = addressType?.let { parseEnum(it, AddressType::valueOf, errors, rowIndex + 1, PartnerUploadFileHeader.ADDRESS_TYPE) },
             physicalPostalAddress = PhysicalPostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(
-                    longitude = physicalPostalAddressLongitude?.toFloatOrNull() ?: 0f,
-                    latitude = physicalPostalAddressLatitude?.toFloatOrNull() ?: 0f,
-                    altitude = physicalPostalAddressAltitude?.toFloatOrNull() ?: 0f
+                    longitude = physicalPostalAddressLongitude?.toDoubleOrNull() ?: 0.0,
+                    latitude = physicalPostalAddressLatitude?.toDoubleOrNull() ?: 0.0,
+                    altitude = physicalPostalAddressAltitude?.toDoubleOrNull() ?: 0.0
                 ),
                 country = physicalPostalAddressCountry?.let { parseEnum(it, CountryCode::valueOf, errors, rowIndex + 1, PartnerUploadFileHeader.PHYSICAL_POSTAL_ADDRESS_COUNTRY) },
                 administrativeAreaLevel1 = physicalPostalAddressAdminArea1?.takeIf { it.isNotEmpty() },
@@ -241,9 +241,9 @@ object PartnerFileUtil {
             ),
             alternativePostalAddress = AlternativePostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(
-                    longitude = alternativePostalAddressLongitude?.toFloatOrNull() ?: 0f,
-                    latitude = alternativePostalAddressLatitude?.toFloatOrNull() ?: 0f,
-                    altitude = alternativePostalAddressAltitude?.toFloatOrNull() ?: 0f
+                    longitude = alternativePostalAddressLongitude?.toDoubleOrNull() ?: 0.0,
+                    latitude = alternativePostalAddressLatitude?.toDoubleOrNull() ?: 0.0,
+                    altitude = alternativePostalAddressAltitude?.toDoubleOrNull() ?: 0.0
                 ),
                 country = alternativePostalAddressCountry?.let { parseEnum(it, CountryCode::valueOf, errors, rowIndex + 1, PartnerUploadFileHeader.ALTERNATIVE_POSTAL_ADDRESS_COUNTRY) },
                 administrativeAreaLevel1 = alternativePostalAddressAdminArea1?.takeIf { it.isNotEmpty() },

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/entity/generic/BusinessPartnerIT.kt
@@ -132,8 +132,8 @@ internal class BusinessPartnerIT @Autowired constructor(
         assertEquals(savedAddress.id, foundAddress.id)
         assertEquals(AddressType.LegalAddress, foundAddress.addressType)
 
-        assertEquals(10.0f, foundPhysicalPostalAddress?.geographicCoordinates?.altitude)
-        assertEquals(52.0f, foundPhysicalPostalAddress?.geographicCoordinates?.latitude)
+        assertEquals(10.0, foundPhysicalPostalAddress?.geographicCoordinates?.altitude)
+        assertEquals(52.0, foundPhysicalPostalAddress?.geographicCoordinates?.latitude)
         assertEquals("Berlin", foundPhysicalPostalAddress?.city)
     }
 
@@ -152,8 +152,8 @@ internal class BusinessPartnerIT @Autowired constructor(
         assertEquals(savedAddress.id, foundAddress.id)
         assertEquals(AddressType.LegalAddress, foundAddress.addressType)
 
-        assertEquals(15.0f, foundAlternativePostalAddress?.geographicCoordinates?.altitude)
-        assertEquals(52.5f, foundAlternativePostalAddress?.geographicCoordinates?.latitude)
+        assertEquals(15.0, foundAlternativePostalAddress?.geographicCoordinates?.altitude)
+        assertEquals(52.5, foundAlternativePostalAddress?.geographicCoordinates?.latitude)
         assertEquals("Berlin", foundAlternativePostalAddress?.city)
     }
 
@@ -205,9 +205,9 @@ internal class BusinessPartnerIT @Autowired constructor(
     private fun createPhysicalPostalAddress() =
         PhysicalPostalAddressDb(
             geographicCoordinates = GeographicCoordinateDb(
-                altitude = 10.0f,
-                latitude = 52.0f,
-                longitude = 13.0f
+                altitude = 10.0,
+                latitude = 52.0,
+                longitude = 13.0
             ),
             country = CountryCode.DE,
             administrativeAreaLevel1 = "adminlevel1",
@@ -233,9 +233,9 @@ internal class BusinessPartnerIT @Autowired constructor(
     private fun createAlternativePostalAddress() =
         AlternativePostalAddressDb(
             geographicCoordinates = GeographicCoordinateDb(
-                altitude = 15.0f,
-                latitude = 52.5f,
-                longitude = 13.5f
+                altitude = 15.0,
+                latitude = 52.5,
+                longitude = 13.5
             ),
             country = CountryCode.DE,
             administrativeAreaLevel1 = "level1",

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartner.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartner.kt
@@ -219,9 +219,9 @@ data class AlternativeAddress(
 
 @Schema(description = PostalAddressDescription.headerGeoCoordinates)
 data class GeoCoordinate(
-    val longitude: Float?,
-    val latitude: Float?,
-    val altitude: Float?
+    val longitude: Double?,
+    val latitude: Double?,
+    val altitude: Double?
 ){
     companion object{
         val empty: GeoCoordinate = GeoCoordinate(null, null, null)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/PostalAddressDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/PostalAddressDb.kt
@@ -132,11 +132,11 @@ data class PostalAddressDb(
     @Embeddable
     data class GeoCoordinate(
         @Column(name = "longitude")
-        val longitude: Float?,
+        val longitude: Double?,
         @Column(name = "latitude")
-        val latitude: Float?,
+        val latitude: Double?,
         @Column(name = "altitude")
-        val altitude: Float?
+        val altitude: Double?
     )
 
     @Embeddable

--- a/bpdm-orchestrator/src/main/resources/db/migration/V6_2_0_2__update_geographical_coordinates_type.sql
+++ b/bpdm-orchestrator/src/main/resources/db/migration/V6_2_0_2__update_geographical_coordinates_type.sql
@@ -1,0 +1,17 @@
+ALTER TABLE business_partner_addresses
+ALTER COLUMN alt_latitude SET DATA TYPE double precision;
+
+ALTER TABLE business_partner_addresses
+ALTER COLUMN alt_longitude SET DATA TYPE double precision;
+
+ALTER TABLE business_partner_addresses
+ALTER COLUMN alt_altitude SET DATA TYPE double precision;
+
+ALTER TABLE business_partner_addresses
+ALTER COLUMN phy_latitude SET DATA TYPE double precision;
+
+ALTER TABLE business_partner_addresses
+ALTER COLUMN phy_longitude SET DATA TYPE double precision;
+
+ALTER TABLE business_partner_addresses
+ALTER COLUMN phy_altitude SET DATA TYPE double precision;

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/GeographicCoordinateDb.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/GeographicCoordinateDb.kt
@@ -25,9 +25,9 @@ import jakarta.persistence.Embeddable
 @Embeddable
 data class GeographicCoordinateDb(
     @Column(name = "latitude")
-    val latitude: Float,
+    val latitude: Double,
     @Column(name = "longitude")
-    val longitude: Float,
+    val longitude: Double,
     @Column(name = "altitude")
-    val altitude: Float?,
+    val altitude: Double?,
 )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

In this pull request, updated double precision data type for geographical coordinate  attributes like longitude, latitude and altitude in all bpdm services. 

Reason  to choose Double as data type - 
-  FLOAT and float4: Essentially the same in most cases, providing 32-bit floating-point precision (~6-7 decimal digits). But rounding issue still persisted with Float data type.
-  String: Using Strings could lead to performance overheads, particularly when performing calculations or comparisons between coordinates. 
- Double: This will give you higher precision and help avoid rounding issues.

Fixes #978 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
