### PR TITLE
feat(GRP Tester): add golden record process tester application

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -85,7 +85,8 @@ class CleaningServiceDummy(
 
         val cleanedBusinessPartner = BusinessPartner(
             nameParts = businessPartner.nameParts,
-            uncategorized = businessPartner.uncategorized,
+            // ToDo: Identifiers are taken as legal identifiers and should be removed from uncategorized collection
+            uncategorized = businessPartner.uncategorized.copy(identifiers = emptyList()),
             owningCompany = businessPartner.owningCompany,
             legalEntity = cleanLegalEntity(businessPartner, sharedByOwner),
             site = cleanSite(businessPartner, sharedByOwner),

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -56,7 +56,8 @@ class BusinessPartnerMappings {
             externalId = entity.sharingState.externalId,
             nameParts = entity.nameParts,
             identifiers = entity.identifiers.map(::toIdentifierDto),
-            states = entity.states.map(::toStateDto),
+            // ToDo: States need to be filtered to Generic only
+            states = toStateDtos(entity.states, BusinessPartnerType.GENERIC),
             roles = entity.roles,
             isOwnCompanyData = entity.isOwnCompanyData,
             legalEntity = toLegalEntityComponentOutputDto(entity),

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OutputUpsertMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OutputUpsertMappings.kt
@@ -79,7 +79,9 @@ class OutputUpsertMappings {
             industrialZone = industrialZone,
             building = building,
             floor = floor,
-            door = door
+            door = door,
+            // ToDo: Add Tax Jurisdiction code to save it to the Output
+            taxJurisdictionCode = taxJurisdictionCode
         )
 
     private fun AlternativeAddress.toEntity() =

--- a/bpdm-system-tester/pom.xml
+++ b/bpdm-system-tester/pom.xml
@@ -1,0 +1,105 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.tractusx</groupId>
+        <artifactId>bpdm-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>bpdm-system-tester</artifactId>
+    <name>Business Partner Data Management System Tester</name>
+    <description>Application to perform system tests for the BPDM system and golden record process</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>21</java.version>
+        <kotlin.version>1.9.24</kotlin.version>
+        <kotlinlogging.version>3.0.5</kotlinlogging.version>
+        <cucumber.version>7.18.1</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>1.8.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bpdm-pool-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bpdm-gate-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microutils</groupId>
+            <artifactId>kotlin-logging-jvm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>7.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>7.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+            <version>7.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bpdm-common-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <!-- in kotlin, use mockk instead of mockito -->
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/Application.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/Application.kt
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.system
+
+import io.cucumber.junit.Cucumber
+import io.cucumber.junit.CucumberOptions
+import io.cucumber.spring.CucumberContextConfiguration
+import org.junit.internal.TextListener
+import org.junit.runner.JUnitCore
+import org.junit.runner.RunWith
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+
+
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+@RunWith(Cucumber::class)
+@CucumberOptions(features = ["bpdm-system-tester/src/main/resources"])
+class CucumberTestRunConfiguration
+
+@CucumberContextConfiguration
+@SpringBootTest
+class SpringTestRunConfiguration
+
+@SpringBootApplication(exclude=[DataSourceAutoConfiguration::class])
+@ConfigurationPropertiesScan
+class SpringApplicationConfiguration
+
+fun main(args: Array<String>) {
+    val engine = JUnitCore()
+    engine.addListener(TextListener(System.out))
+    engine.run(CucumberTestRunConfiguration::class.java)
+}

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/GateClientConfig.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/GateClientConfig.kt
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.system
+
+import org.eclipse.tractusx.bpdm.common.util.BpdmClientProperties
+import org.eclipse.tractusx.bpdm.common.util.BpdmWebClientProvider
+import org.eclipse.tractusx.bpdm.common.util.ClientConfigurationProperties
+import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
+import org.eclipse.tractusx.bpdm.gate.api.client.GateClientImpl
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@ConfigurationProperties(prefix = PoolClientConfigurationProperties.PREFIX)
+data class GateClientConfigProperties(
+    override val baseUrl: String = "http://localhost:8081",
+    val searchChangelogPageSize: Int = 100,
+    override val securityEnabled: Boolean = false,
+    override val registration: OAuth2ClientProperties.Registration,
+    override val provider: OAuth2ClientProperties.Provider
+) : BpdmClientProperties {
+    companion object {
+        const val PREFIX = "${ClientConfigurationProperties.PREFIX}.gate"
+    }
+
+    override fun getId() = PREFIX
+}
+
+@Configuration
+class GateClientConfig{
+
+    @Bean
+    fun gateClient(webClientProvider: BpdmWebClientProvider, properties: GateClientConfigProperties): GateClient {
+        return GateClientImpl { webClientProvider.builder(properties).build() }
+    }
+}

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/GateInputFactory.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/GateInputFactory.kt
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.system
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerRole
+import org.eclipse.tractusx.bpdm.common.dto.GeoCoordinateDto
+import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import org.eclipse.tractusx.bpdm.common.model.DeliveryServiceType
+import org.eclipse.tractusx.bpdm.gate.api.model.*
+import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressRepresentationInputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.LegalEntityRepresentationInputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.SiteRepresentationInputDto
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.random.Random
+
+class GateInputFactory(
+    private val testMetadata: TestMetadata,
+    private val testRunData: TestRunData
+) {
+
+    val genericFullValidWithSiteWithoutAnyBpn = createAllFieldsFilled("genericFullValidWithSiteWithoutAnyBpn")
+        { it.withoutAnyBpn().withAddressType(null) }
+
+    fun createAllFieldsFilled(seed: String, transform: (BusinessPartnerInputRequest) -> BusinessPartnerInputRequest = {it}): InputTestData{
+        return InputTestData(seed, transform(SeededTestDataCreator(seed).createAllFieldsFilled()))
+    }
+
+    inner class SeededTestDataCreator(
+        private val seed: String,
+    ){
+        private val longSeed = seed.hashCode().toLong()
+        private val random = Random(longSeed)
+        private val listRange = 1 .. 3
+
+
+        fun createAllFieldsFilled(): BusinessPartnerInputRequest{
+
+            return BusinessPartnerInputRequest(
+                externalId = "${seed}_${testRunData.testTime}",
+                nameParts = listRange.map { "Name Part $seed $it" },
+                identifiers = createIdentifiers(),
+                roles = BusinessPartnerRole.entries,
+                isOwnCompanyData = random.nextBoolean(),
+                states = createStates(),
+                legalEntity = LegalEntityRepresentationInputDto(
+                    legalEntityBpn = "BPNL $seed",
+                    legalName = "Legal Name $seed",
+                    shortName = "Short Name $seed",
+                    legalForm = testMetadata.legalForms.random(random),
+                    states = createStates()
+                ),
+                site = SiteRepresentationInputDto(
+                    siteBpn = "BPNS $seed",
+                    name = "Site Name $seed",
+                    states = createStates()
+                ),
+                address = AddressRepresentationInputDto(
+                    addressBpn = "BPNA $seed",
+                    name = "Address Name $seed",
+                    addressType = AddressType.AdditionalAddress,
+                    physicalPostalAddress = createPhysicalAddress(),
+                    alternativePostalAddress = createAlternativeAddress(),
+                    states = createStates()
+                )
+            )
+        }
+
+
+        private fun createIdentifiers(): List<BusinessPartnerIdentifierDto>{
+            return listRange.map { testMetadata.identifierTypes.random(random) }
+                .mapIndexed{ index, type -> BusinessPartnerIdentifierDto(type = type, value = "Identifier Value $seed $index", issuingBody = "Issuing Body $seed $index") }
+        }
+
+        private fun createStates(): List<BusinessPartnerStateDto>{
+            return random.nextTime().let {
+                listRange.runningFold(Pair(it, it.plus(random.nextDuration()))){ current, _ -> Pair(current.second, current.second.plus(random.nextDuration())) }
+            }.map { (validFrom, validTo) -> BusinessPartnerStateDto(validFrom = validFrom, validTo = validTo, BusinessStateType.entries.random(random)) }
+        }
+
+        private fun createPhysicalAddress(): PhysicalPostalAddressDto{
+            return PhysicalPostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(longitude = random.nextFloat(), latitude = random.nextFloat(), altitude = random.nextFloat()),
+                country = CountryCode.entries.random(random),
+                administrativeAreaLevel1 = testMetadata.adminAreas.random(random),
+                administrativeAreaLevel2 = "Admin Level 2 $seed",
+                administrativeAreaLevel3 = "Admin Level 3 $seed",
+                postalCode = "Postal Code $seed",
+                city = "City $seed",
+                district = "District $seed",
+                street = StreetDto(
+                    name = "Street Name $seed",
+                    houseNumber = "House Number $seed",
+                    houseNumberSupplement = "House Number Supplement $seed",
+                    milestone = "Milestone $seed",
+                    direction = "Direction $seed",
+                    namePrefix = "Name Prefix $seed",
+                    nameSuffix = "Name Suffix $seed",
+                    additionalNamePrefix = "Additional Name Prefix $seed",
+                    additionalNameSuffix = "Additional Name Suffix $seed"
+                ),
+                companyPostalCode = "Company Postal Code $seed",
+                industrialZone = "Industrial Zone $seed",
+                building = "Building $seed",
+                floor = "Floor $seed",
+                door = "Door $seed",
+                taxJurisdictionCode = "123"
+            )
+        }
+
+        private fun createAlternativeAddress(): AlternativePostalAddressDto{
+            return AlternativePostalAddressDto(
+                geographicCoordinates = GeoCoordinateDto(longitude = random.nextFloat(), latitude = random.nextFloat(), altitude = random.nextFloat()),
+                country = CountryCode.entries.random(random),
+                administrativeAreaLevel1 =  testMetadata.adminAreas.random(random),
+                postalCode = "Alt Postal Code $seed",
+                city = "Alt City $seed",
+                deliveryServiceNumber = "Delivery Service Number $seed",
+                deliveryServiceType = DeliveryServiceType.entries.random(random),
+                deliveryServiceQualifier = "Delivery Service Qualifier $seed"
+            )
+        }
+
+        private fun Random.nextInstant() = Instant.ofEpochSecond(nextLong(0, 365241780471))
+        private fun Random.nextTime() = nextInstant().atOffset(ZoneOffset.UTC).toLocalDateTime()
+        private fun Random.nextDuration() = Duration.ofHours(nextLong(0, 10000))
+
+    }
+}
+
+data class InputTestData(
+    val seed: String,
+    val request: BusinessPartnerInputRequest
+)
+
+data class TestMetadata(
+    val identifierTypes: List<String>,
+    val legalForms: List<String>,
+    val adminAreas: List<String>
+)
+
+fun BusinessPartnerInputRequest.withoutAnyBpn() = withoutLegalEntityBpn().withoutSiteBpn().withoutAddressBpn()
+fun BusinessPartnerInputRequest.withAddressType(addressType: AddressType?) = copy(address = address.copy(addressType = addressType))
+fun BusinessPartnerInputRequest.withoutLegalEntityBpn() = copy(legalEntity = legalEntity.copy(legalEntityBpn = null))
+fun BusinessPartnerInputRequest.withoutSiteBpn() = copy(site = site.copy(siteBpn = null))
+fun BusinessPartnerInputRequest.withoutAddressBpn() = copy(address = address.copy(addressBpn = null))

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/GateOutputFactory.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/GateOutputFactory.kt
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.system
+
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.gate.api.model.ConfidenceCriteriaDto
+import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressComponentOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.LegalEntityRepresentationOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.SiteRepresentationOutputDto
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class GateOutputFactory(
+    private val gateInputTestDataFactory: GateInputFactory
+) {
+
+    private val dummyConfidence = ConfidenceCriteriaDto(
+        sharedByOwner = false,
+        numberOfSharingMembers = 1,
+        checkedByExternalDataSource = false,
+        lastConfidenceCheckAt = LocalDateTime.now(),
+        nextConfidenceCheckAt = LocalDateTime.now().plus (5, ChronoUnit.DAYS),
+        confidenceLevel = 0
+    )
+
+    val legalAndSiteMainAddressFullValid = createOutput(gateInputTestDataFactory.genericFullValidWithSiteWithoutAnyBpn)
+        .withAddressType(AddressType.LegalAndSiteMainAddress)
+
+
+    fun createOutput(inputTestData: InputTestData): BusinessPartnerOutputDto{
+        return createOutput(gateInputTestDataFactory.createAllFieldsFilled(inputTestData.seed).request)
+    }
+
+    fun createOutput(
+        fromInput: BusinessPartnerInputRequest
+    ): BusinessPartnerOutputDto{
+        return BusinessPartnerOutputDto(
+            externalId = fromInput.externalId,
+            nameParts = fromInput.nameParts,
+            identifiers = fromInput.identifiers,
+            states = fromInput.states,
+            roles = fromInput.roles,
+            isOwnCompanyData = fromInput.isOwnCompanyData,
+            legalEntity = with(fromInput.legalEntity){
+                LegalEntityRepresentationOutputDto(
+                    legalEntityBpn = legalEntityBpn ?: "INVALID",
+                    legalName = legalName,
+                    shortName = shortName,
+                    legalForm = legalForm,
+                    confidenceCriteria = dummyConfidence,
+                    states = states
+                )
+            },
+            site = with(fromInput.site){
+                SiteRepresentationOutputDto(
+                    siteBpn = siteBpn ?: "INVALID",
+                    name = name,
+                    confidenceCriteria = dummyConfidence,
+                    states = states
+                )
+            },
+            address = with(fromInput.address){
+                AddressComponentOutputDto(
+                    addressBpn = addressBpn ?: "INVALID",
+                    name = name,
+                    addressType = addressType,
+                    physicalPostalAddress = physicalPostalAddress,
+                    alternativePostalAddress = alternativePostalAddress,
+                    confidenceCriteria = dummyConfidence,
+                    states = states
+                )
+            },
+            createdAt = Instant.now(),
+            updatedAt = Instant.now()
+        )
+    }
+}
+
+fun BusinessPartnerOutputDto.withAddressType(addressType: AddressType) = copy(address = address.copy(addressType = addressType))

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/PoolClientConfig.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/PoolClientConfig.kt
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.system
+
+import org.eclipse.tractusx.bpdm.common.util.BpdmClientProperties
+import org.eclipse.tractusx.bpdm.common.util.BpdmWebClientProvider
+import org.eclipse.tractusx.bpdm.common.util.ClientConfigurationProperties
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@ConfigurationProperties(prefix = PoolClientConfigurationProperties.PREFIX)
+data class PoolClientConfigurationProperties(
+    override val baseUrl: String = "http://localhost:8080",
+    val searchChangelogPageSize: Int = 100,
+    override val securityEnabled: Boolean = false,
+    override val registration: OAuth2ClientProperties.Registration,
+    override val provider: OAuth2ClientProperties.Provider
+) : BpdmClientProperties {
+    companion object {
+        const val PREFIX = "${ClientConfigurationProperties.PREFIX}.pool"
+    }
+
+    override fun getId() = PREFIX
+}
+
+@Configuration
+class PoolClientConfiguration{
+
+    @Bean
+    fun poolClient(webClientProvider: BpdmWebClientProvider, properties: PoolClientConfigurationProperties): PoolApiClient{
+     return PoolClientImpl { webClientProvider.builder(properties).build() }
+    }
+}
+

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/StepDefs.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/StepDefs.kt
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.system
+
+import io.cucumber.java.en.Then
+import io.cucumber.java.en.When
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.time.delay
+import kotlinx.coroutines.time.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
+import org.eclipse.tractusx.bpdm.gate.api.model.ConfidenceCriteriaDto
+import org.eclipse.tractusx.bpdm.gate.api.model.SharingStateType
+import org.eclipse.tractusx.bpdm.gate.api.model.response.AddressComponentOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.LegalEntityRepresentationOutputDto
+import org.eclipse.tractusx.bpdm.gate.api.model.response.SiteRepresentationOutputDto
+import java.time.Duration
+
+class StepDefs(
+    private val gateInputDataFactory: GateInputFactory,
+    private val gateOutputFactory: GateOutputFactory,
+    private val gateClient: GateClient
+): SpringTestRunConfiguration() {
+
+    @When("^the sharing member shares business partner$")
+    fun `the sharing member shares business partner`() {
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(gateInputDataFactory.genericFullValidWithSiteWithoutAnyBpn.request))
+    }
+
+    @Then("^the sharing member receives legal and site main address output$")
+    fun `the sharing member receives legal and site main address output`() {
+        val expectedOutput = gateOutputFactory.legalAndSiteMainAddressFullValid
+
+        val result = waitForResult(expectedOutput.externalId)
+        assertThat(result).isEqualTo(SharingStateType.Success)
+
+        val actualOutput = gateClient.businessParters.getBusinessPartnersOutput(listOf(expectedOutput.externalId), PaginationRequest()).content.single()
+
+        assertThat(actualOutput)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .ignoringAllOverriddenEquals()
+            .ignoringFields(
+                BusinessPartnerOutputDto::createdAt.name,
+                BusinessPartnerOutputDto::updatedAt.name,
+                "${BusinessPartnerOutputDto::legalEntity.name}.${LegalEntityRepresentationOutputDto::legalEntityBpn.name}",
+                "${BusinessPartnerOutputDto::site.name}.${SiteRepresentationOutputDto::siteBpn.name}",
+                "${BusinessPartnerOutputDto::address.name}.${AddressComponentOutputDto::addressBpn.name}",
+                // ToDo: Cleaning service dummy should have fixed confidence criteria dummy times otherwise we need to keep ignoring these fields
+                "${BusinessPartnerOutputDto::legalEntity.name}.${AddressComponentOutputDto::confidenceCriteria.name}.${ConfidenceCriteriaDto::lastConfidenceCheckAt.name}",
+                "${BusinessPartnerOutputDto::legalEntity.name}.${AddressComponentOutputDto::confidenceCriteria.name}.${ConfidenceCriteriaDto::nextConfidenceCheckAt.name}",
+                "${BusinessPartnerOutputDto::site.name}.${AddressComponentOutputDto::confidenceCriteria.name}.${ConfidenceCriteriaDto::lastConfidenceCheckAt.name}",
+                "${BusinessPartnerOutputDto::site.name}.${AddressComponentOutputDto::confidenceCriteria.name}.${ConfidenceCriteriaDto::nextConfidenceCheckAt.name}",
+                "${BusinessPartnerOutputDto::address.name}.${AddressComponentOutputDto::confidenceCriteria.name}.${ConfidenceCriteriaDto::lastConfidenceCheckAt.name}",
+                "${BusinessPartnerOutputDto::address.name}.${AddressComponentOutputDto::confidenceCriteria.name}.${ConfidenceCriteriaDto::nextConfidenceCheckAt.name}",
+            )
+            .isEqualTo(expectedOutput)
+    }
+
+    fun waitForResult(externalId: String): SharingStateType {
+        println("Waiting for result for $externalId ...")
+        return runBlocking {
+            withTimeout(Duration.ofMinutes(2)){
+                var result: SharingStateType = SharingStateType.Error
+                do{
+                    val sharingState = gateClient.sharingState.getSharingStates(PaginationRequest(), listOf(externalId)).content.single()
+                    val isFinished = sharingState.sharingStateType == SharingStateType.Success || sharingState.sharingStateType == SharingStateType.Error
+                    if(isFinished) result = sharingState.sharingStateType
+                    delay(Duration.ofSeconds(10))
+                }while (!isFinished )
+                result
+            }
+        }
+    }
+}

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/TestDataConfiguration.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/TestDataConfiguration.kt
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.system
+
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Instant
+
+@Configuration
+class TestDataConfiguration {
+
+    @Bean
+    fun testMetadata(poolClient: PoolApiClient): TestMetadata{
+        val testMetadata = TestMetadata(
+            listOf("id1", "id2"),
+            listOf("legalform1", "legalform2"),
+            listOf("DE-BW", "DE-BY")
+        )
+
+        testMetadata.identifierTypes.forEach { technicalKey ->
+            try{
+                poolClient.metadata.createIdentifierType(
+                    IdentifierTypeDto(
+                        technicalKey,
+                        IdentifierBusinessPartnerType.LEGAL_ENTITY,
+                        technicalKey,
+                        null,
+                        null,
+                        null
+                    )
+                )
+            }catch (_: Throwable){}
+
+            try{
+                poolClient.metadata.createIdentifierType(
+                    IdentifierTypeDto(
+                        technicalKey,
+                        IdentifierBusinessPartnerType.ADDRESS,
+                        technicalKey,
+                        null,
+                        null,
+                        null
+                    )
+                )
+            }catch (_: Throwable) {}
+        }
+
+        testMetadata.legalForms.forEach { technicalKey ->
+            try{
+                poolClient.metadata.createLegalForm(LegalFormRequest(technicalKey, technicalKey, null))
+            }catch (_: Throwable){}
+        }
+
+        return testMetadata
+    }
+
+    @Bean
+    fun gateTestDataFactory(testMetadata: TestMetadata, testRunData: TestRunData): GateInputFactory{
+        return GateInputFactory(testMetadata, testRunData)
+    }
+
+    @Bean
+    fun gateOutputFactory(gateInputDataFactory: GateInputFactory): GateOutputFactory{
+        return GateOutputFactory(gateInputDataFactory)
+    }
+
+    @Bean
+    fun testRunData(): TestRunData{
+        return TestRunData(Instant.now())
+    }
+}

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/TestRunData.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/TestRunData.kt
@@ -17,26 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.common.config
+package org.eclipse.tractusx.bpdm.test.system
 
-import mu.KotlinLogging
-import org.springdoc.core.properties.SwaggerUiConfigProperties
-import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import java.time.Instant
 
-
-@Configuration
-class LandingPageConfig(
-    val swaggerProperties: SwaggerUiConfigProperties?
-) : WebMvcConfigurer{
-
-    private val logger = KotlinLogging.logger { }
-
-    override fun addViewControllers(registry: ViewControllerRegistry) {
-        if(swaggerProperties == null) return
-        val redirectUri = swaggerProperties!!.path
-        logger.info { "Set landing page to path '$redirectUri'" }
-        registry.addRedirectViewController("/", redirectUri)
-    }
-}
+data class TestRunData (
+    val testTime: Instant
+)

--- a/bpdm-system-tester/src/main/resources/application.yml
+++ b/bpdm-system-tester/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+bpdm:
+  client:
+    pool:
+      enabled: false
+      provider:
+        issuer-uri: ${bpdm.security.auth-server-url:http://localhost:8180}/realms/${bpdm.security.realm:master}
+      registration:
+        authorization-grant-type: client_credentials
+        # Use a default client id for the client credentials request
+        client-id: BPDM-POOL
+        # Please provide a secret here

--- a/bpdm-system-tester/src/main/resources/cucumber/test.feature
+++ b/bpdm-system-tester/src/main/resources/cucumber/test.feature
@@ -1,0 +1,4 @@
+Feature: Share Valid Generic Business Partner With Site
+  Scenario: Without any BPNs
+    When the sharing member shares business partner
+    Then the sharing member receives legal and site main address output

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <module>bpdm-cleaning-service-dummy</module>
         <module>bpdm-orchestrator</module>
         <module>bpdm-orchestrator-api</module>
+        <module>bpdm-system-tester</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

First draft of the golden record process tester application. This still needs heavy refinement but it should give a start on how we can system test the golden record process.

I discovered some bugs during setting up the showcase. They best should be fixed in separate pull requests. That's why I adapted the code but also added ToDos on top.

The application can be executed and also packaged as a JAR as usual. Please bear in mind that Cucumber at the moment searches for feature files in the subpath bpdm-system-tester/src/main/resources when being executed. Therefore, the context should be in the project root when running the application. We will make this more flexible later.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
