### PR TITLE
fix(bpdm-gate): Add Tax Jurisdiction code to save it to the Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Cleaning Service Dummy: Improve duplication check to better distinguish between incoming business partners
 - Apps: Updated double precision data type for Geographic-data([#978](https://github.com/eclipse-tractusx/bpdm/issues/978))
 - BPDM Gate: Improved error response by adding external id details and reduced csv columns by removing support for uncategorized fields in csv file for partner upload process([#700](https://github.com/eclipse-tractusx/sig-release/issues/700))
+- BPDM Gate: Enabled Tax Jurisdiction code to save it to the Output.
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
@@ -802,7 +802,8 @@ object BusinessPartnerVerboseValues {
                 industrialZone = "industrial-zone",
                 building = "building",
                 floor = "floor",
-                door = "door"
+                door = "door",
+                taxJurisdictionCode = "123"
             ),
             alternativePostalAddress = AlternativePostalAddressDto(
                 geographicCoordinates = GeoCoordinateDto(0.6, 0.6, 0.6),

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OutputUpsertMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OutputUpsertMappings.kt
@@ -79,7 +79,8 @@ class OutputUpsertMappings {
             industrialZone = industrialZone,
             building = building,
             floor = floor,
-            door = door
+            door = door,
+            taxJurisdictionCode = taxJurisdictionCode
         )
 
     private fun AlternativeAddress.toEntity() =


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
In previous implementation, the value for Tax Jurisdiction code was appearing as null due to missing mapping for output.
In this pull request, we have enabled Tax Jurisdiction code to save it to the Output on BPDM Gate service.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
