### PR TITLE
fix(bpdm-clearing): refactored legal name construction logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Cleaning Service Dummy: Improve duplication check to better distinguish between incoming business partners
 - Apps: Updated double precision data type for Geographic-data([#978](https://github.com/eclipse-tractusx/bpdm/issues/978))
 - BPDM Gate: Improved error response by adding external id details and reduced csv columns by removing support for uncategorized fields in csv file for partner upload process([#700](https://github.com/eclipse-tractusx/sig-release/issues/700))
+- BPDM Cleaning Service Dummy: Added a null check for name parts to ensure proper whitespace handling when constructing the legal name from them.
 - BPDM Gate: Enabled Tax Jurisdiction code to save it to the Output.
 
 ## [6.1.0] - [2024-07-15]

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -108,7 +108,7 @@ class CleaningServiceDummy(
         return with(businessPartner.legalEntity){
                 copy(
                     bpnReference = bpnReference.toRequestIfNotBpn(businessPartner.legalEntityReference()),
-                    legalName = legalName ?: businessPartner.uncategorized.nameParts.joinToString(" "),
+                    legalName = legalName ?: businessPartner.uncategorized.nameParts.takeIf { it.isNotEmpty() }?.joinToString(" "),
                     identifiers = identifiers.takeIf { it.isNotEmpty() } ?: businessPartner.uncategorized.identifiers,
                     states = states.takeIf { it.isNotEmpty() } ?: businessPartner.uncategorized.states,
                     confidenceCriteria = dummyConfidenceCriteria.copy(sharedByOwner = sharedByOwner),


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
In this pull request, we have refactored the logic while constructing legal name for business partner.
This change will avoid setting empty value for legal name in clearning process so eventually, this will not allow sharing member to provide business partner data for their legal entity without nameparts or legal entity name(either of both must be shared while performing GR process). 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
