### PR TITLE
fix(bpdm-gate): refactored construction logic for states in business partner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Cleaning Service Dummy: Added a null check for name parts to ensure proper whitespace handling when constructing the legal name from them.
 - BPDM Gate: Enabled Tax Jurisdiction code to save it to the Output.
 - BPDM Cleaning Service Dummy: Removed assignment of uncategorized states while performing cleaning legal entity process.
+- BPDM Gate: Fixed construction logic for states and identifiers by enabling business partner type 
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerCopyUtil.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/BusinessPartnerCopyUtil.kt
@@ -59,6 +59,7 @@ class BusinessPartnerCopyUtil {
             validFrom = fromState.validFrom
             validTo = fromState.validTo
             type = fromState.type
+            businessPartnerTyp = fromState.businessPartnerTyp
         }
 
     private fun copyValues(fromClassification: ClassificationDb, toClassification: ClassificationDb) =
@@ -73,6 +74,7 @@ class BusinessPartnerCopyUtil {
             type = fromIdentifier.type
             value = fromIdentifier.value
             issuingBody = fromIdentifier.issuingBody
+            businessPartnerType = fromIdentifier.businessPartnerType
         }
 
     private fun copyValues(fromPostalAddress: PostalAddressDb, toPostalAddress: PostalAddressDb) =


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
In this pull request, we are adding business partner type while constructing state and identifiers for business partner input. 
With this changes, states and identifiers will be maintained correctly even after update on business partner data.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
