### PR TITLE
fix(bpdm-gate): refactored logic for identifiers on output business partners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Cleaning Service Dummy: Added a null check for name parts to ensure proper whitespace handling when constructing the legal name from them.
 - BPDM Gate: Enabled Tax Jurisdiction code to save it to the Output.
 - BPDM Cleaning Service Dummy: Removed assignment of uncategorized states while performing cleaning legal entity process.
-- BPDM Gate: Fixed construction logic for states and identifiers by enabling business partner type 
+- BPDM Gate: Fixed construction logic for states and identifiers by enabling business partner type
+- BPDM Gate: Fixed logic for identifiers to retrieve only generic type on output business partner
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
@@ -143,8 +143,9 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
     fun `insert one business partners and finalize cleaning task without error`() {
         this.mockAndAssertUtils.mockOrchestratorApiCleaned(gateWireMockServer)
 
+        // Expect outputBusinessPartner without identifiers as there are not Address identifier provided.
         val outputBusinessPartners = listOf(
-            BusinessPartnerVerboseValues.bpOutputDtoCleaned
+            BusinessPartnerVerboseValues.bpOutputDtoCleaned.copy(identifiers = emptyList())
         )
 
         val upsertRequests = listOf(

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -280,8 +280,9 @@ class BusinessPartnerControllerIT @Autowired constructor(
     fun `insert one business partners and finalize cleaning task without error`() {
         this.mockAndAssertUtils.mockOrchestratorApiCleaned(gateWireMockServer)
 
+        // Expect outputBusinessPartner without identifiers as there are not Address identifier provided.
         val outputBusinessPartners = listOf(
-            BusinessPartnerVerboseValues.bpOutputDtoCleaned
+            BusinessPartnerVerboseValues.bpOutputDtoCleaned.copy(identifiers = emptyList())
         )
 
         val upsertRequests = listOf(


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

In this pull request, we have fixed issue where we were retrieving identifiers for all categorise of business partner in output stage.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
