### PR TITLE
perf(Orchestrator): increase performance for database access

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/WebClientProvider.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/WebClientProvider.kt
@@ -52,6 +52,7 @@ class BpdmUnauthorizedWebClientProvider: BpdmWebClientProvider{
     override fun builder(properties: BpdmClientProperties): WebClient.Builder{
         return WebClient.builder()
             .baseUrl(properties.baseUrl)
+            .codecs { codecs -> codecs.defaultCodecs().maxInMemorySize(10 * 1024 * 1024) }
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
     }
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/BusinessStateDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/BusinessStateDb.kt
@@ -19,15 +19,19 @@
 
 package org.eclipse.tractusx.bpdm.orchestrator.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
+import org.hibernate.annotations.Type
 
 @Embeddable
 data class BusinessStateDb(
-    @Convert(converter = DbTimestampConverter::class)
+    @Type(value = DbTimestampConverter::class)
     @Column(name = "valid_from")
     val validFrom: DbTimestamp?,
-    @Convert(converter = DbTimestampConverter::class)
+    @Type(value = DbTimestampConverter::class)
     @Column(name = "valid_to")
     val validTo: DbTimestamp?,
     @Enumerated(EnumType.STRING)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/ConfidenceCriteriaDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/ConfidenceCriteriaDb.kt
@@ -20,8 +20,8 @@
 package org.eclipse.tractusx.bpdm.orchestrator.entity
 
 import jakarta.persistence.Column
-import jakarta.persistence.Convert
 import jakarta.persistence.Embeddable
+import org.hibernate.annotations.Type
 
 @Embeddable
 data class ConfidenceCriteriaDb(
@@ -31,10 +31,10 @@ data class ConfidenceCriteriaDb(
     val checkedByExternalDataSource: Boolean?,
     @Column(name = "number_of_sharing_members")
     val numberOfSharingMembers: Int?,
-    @Convert(converter = DbTimestampConverter::class)
+    @Type(value = DbTimestampConverter::class)
     @Column(name = "last_confidence_check")
     val lastConfidenceCheckAt: DbTimestamp?,
-    @Convert(converter = DbTimestampConverter::class)
+    @Type(value = DbTimestampConverter::class)
     @Column(name = "next_confidence_check")
     val nextConfidenceCheckAt: DbTimestamp?,
     @Column(name = "confidence_level")

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/DbTimestamp.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/DbTimestamp.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.orchestrator.entity
 
+import java.io.Serializable
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -27,13 +28,32 @@ import java.time.temporal.ChronoUnit
  *
  * This makes sure that timestamps in entities and database are always equal even before the entity is persisted in the database
  */
-class DbTimestamp(instant: Instant){
+class DbTimestamp(instant: Instant): Serializable{
+
+
     private val truncatedInstant = instant.truncatedTo(ChronoUnit.MICROS)
 
     val instant get(): Instant = truncatedInstant
 
     companion object{
         fun now(): DbTimestamp = Instant.now().toTimestamp()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DbTimestamp
+
+        return truncatedInstant == other.truncatedInstant
+    }
+
+    override fun hashCode(): Int {
+        return truncatedInstant?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "DbTimestamp(truncatedInstant=$truncatedInstant)"
     }
 }
 

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/DbTimestampConverter.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/DbTimestampConverter.kt
@@ -19,17 +19,56 @@
 
 package org.eclipse.tractusx.bpdm.orchestrator.entity
 
-import jakarta.persistence.AttributeConverter
-import jakarta.persistence.Converter
+import org.hibernate.engine.spi.SharedSessionContractImplementor
+import org.hibernate.usertype.UserType
+import java.io.Serializable
+import java.sql.PreparedStatement
+import java.sql.ResultSet
 import java.sql.Timestamp
+import java.sql.Types
 
-@Converter
-class DbTimestampConverter: AttributeConverter<DbTimestamp, Timestamp> {
-    override fun convertToDatabaseColumn(p0: DbTimestamp?): Timestamp? {
-        return p0?.let { Timestamp.from(it.instant) }
+class DbTimestampConverter: UserType<DbTimestamp> {
+
+    override fun equals(p0: DbTimestamp?, p1: DbTimestamp?): Boolean {
+        return p0?.instant == p1?.instant
     }
 
-    override fun convertToEntityAttribute(p0: Timestamp?): DbTimestamp? {
-        return p0?.let { DbTimestamp(p0.toInstant()) }
+    override fun hashCode(p0: DbTimestamp?): Int {
+        return p0?.instant.hashCode()
+    }
+
+    override fun getSqlType(): Int {
+        return Types.TIMESTAMP
+    }
+
+    override fun returnedClass(): Class<DbTimestamp> {
+        return DbTimestamp::class.java
+    }
+
+    override fun nullSafeGet(resultSet: ResultSet, position: Int, p2: SharedSessionContractImplementor?, p3: Any?): DbTimestamp? {
+        return resultSet.getTimestamp(position)?.let { DbTimestamp(it.toInstant()) }
+    }
+
+    override fun isMutable(): Boolean {
+        return false
+    }
+
+    override fun assemble(p0: Serializable?, p1: Any?): DbTimestamp? {
+        return p0?.let { p0 as DbTimestamp  }
+    }
+
+    override fun disassemble(p0: DbTimestamp?): Serializable? {
+        return p0
+    }
+
+    override fun deepCopy(p0: DbTimestamp?): DbTimestamp? {
+       return p0?.let { DbTimestamp(it.instant) }
+    }
+
+    override fun nullSafeSet(preparedStatement: PreparedStatement, timeStamp: DbTimestamp?, index: Int, p3: SharedSessionContractImplementor?) {
+        if(timeStamp == null) preparedStatement.setNull(index, Types.TIMESTAMP)
+        else{
+            preparedStatement.setTimestamp(index, Timestamp.from(timeStamp.instant))
+        }
     }
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GoldenRecordTaskRepository.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/repository/GoldenRecordTaskRepository.kt
@@ -36,6 +36,30 @@ interface GoldenRecordTaskRepository : CrudRepository<GoldenRecordTaskDb, Long>,
 
     fun findByUuidIn(uuids: Set<UUID>): Set<GoldenRecordTaskDb>
 
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.gateRecord WHERE task IN :tasks")
+    fun fetchGateRecords(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.processingState.errors WHERE task IN :tasks")
+    fun fetchProcessingErrors(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.businessPartner.nameParts WHERE task IN :tasks")
+    fun fetchNameParts(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.businessPartner.identifiers WHERE task IN :tasks")
+    fun fetchIdentifiers(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.businessPartner.businessStates WHERE task IN :tasks")
+    fun fetchBusinessStates(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.businessPartner.confidences WHERE task IN :tasks")
+    fun fetchConfidences(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.businessPartner.addresses WHERE task IN :tasks")
+    fun fetchAddresses(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
+    @Query("SELECT DISTINCT task FROM GoldenRecordTaskDb task LEFT JOIN FETCH task.businessPartner.bpnReferences WHERE task IN :tasks")
+    fun fetchBpnReferences(tasks: Set<GoldenRecordTaskDb>): Set<GoldenRecordTaskDb>
+
     @Query("SELECT task from GoldenRecordTaskDb task WHERE task.processingState.step = :step AND task.processingState.stepState = :stepState")
     fun findByStepAndStepState(step: TaskStep, stepState: GoldenRecordTaskDb.StepState, pageable: Pageable): Page<GoldenRecordTaskDb>
 
@@ -45,5 +69,16 @@ interface GoldenRecordTaskRepository : CrudRepository<GoldenRecordTaskDb, Long>,
 
     fun findByProcessingStateRetentionTimeoutBefore(time: DbTimestamp, pageable: Pageable): Page<GoldenRecordTaskDb>
 
-    fun findTasksByGateRecordAndProcessingStateResultState(record: GateRecordDb, resultState: GoldenRecordTaskDb.ResultState) : Set<GoldenRecordTaskDb>
+    fun findTasksByGateRecordInAndProcessingStateResultState(records: Set<GateRecordDb>, resultState: GoldenRecordTaskDb.ResultState) : Set<GoldenRecordTaskDb>
+}
+
+fun GoldenRecordTaskRepository.fetchBusinessPartnerData(tasks: Set<GoldenRecordTaskDb>){
+    fetchGateRecords(tasks)
+    fetchProcessingErrors(tasks)
+    fetchNameParts(tasks)
+    fetchIdentifiers(tasks)
+    fetchBusinessStates(tasks)
+    fetchConfidences(tasks)
+    fetchAddresses(tasks)
+    fetchBpnReferences(tasks)
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachine.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachine.kt
@@ -52,11 +52,15 @@ class GoldenRecordTaskStateMachine(
             retentionTimeout = null
         )
 
-        val initialTask = GoldenRecordTaskDb(
-            gateRecord = record,
-            processingState = initProcessingState,
-            businessPartner = requestMapper.toBusinessPartner(initBusinessPartner)
-        )
+        val initialTask = DbTimestamp.now().let { nowTime ->
+            GoldenRecordTaskDb(
+                gateRecord = record,
+                processingState = initProcessingState,
+                businessPartner = requestMapper.toBusinessPartner(initBusinessPartner),
+                createdAt = nowTime,
+                updatedAt = nowTime
+            )
+        }
 
         return taskRepository.save(initialTask)
     }

--- a/bpdm-orchestrator/src/main/resources/application.yml
+++ b/bpdm-orchestrator/src/main/resources/application.yml
@@ -110,6 +110,11 @@ spring:
       hibernate:
         # Hibernate should assume the default schema of this application on default
         default_schema: ${bpdm.datasource.schema}
+        jdbc:
+          batch_size: 100
+          order_inserts: true
+          order_updates: true
+          batch_versioned_data: true
         create_empty_composites:
           enabled: true
 logging:

--- a/bpdm-orchestrator/src/main/resources/db/migration/V6_2_0_3__add_indexes_on_foreign_keys.sql
+++ b/bpdm-orchestrator/src/main/resources/db/migration/V6_2_0_3__add_indexes_on_foreign_keys.sql
@@ -1,0 +1,13 @@
+create index index_task_errors_task_id on task_errors (task_id);
+
+create index index_name_parts_task_id on business_partner_name_parts (task_id);
+
+create index index_identifiers_task_id on business_partner_identifiers (task_id);
+
+create index index_business_states_task_id on business_partner_states (task_id);
+
+create index index_confidences_task_id on business_partner_confidences (task_id);
+
+create index index_addresses_task_id on business_partner_addresses (task_id);
+
+create index index_bpn_references_task_id on business_partner_bpn_references (task_id);

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/performance/OrchestratorPerformanceIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/performance/OrchestratorPerformanceIT.kt
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.performance
+
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.BusinessPartnerTestDataFactory
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "bpdm.security.enabled=false",
+        "bpdm.task.timeoutCheckCron=-"
+    ]
+)
+@ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
+class OrchestratorPerformanceIT@Autowired constructor(
+    private val orchestratorClient: OrchestrationApiClient
+) {
+
+    private val testDataFactory = BusinessPartnerTestDataFactory()
+
+    @ParameterizedTest
+    @ValueSource(ints = [100])
+    fun `measure insert, search, reserve and update` (totalSize: Int){
+        val batchSize = 100
+        var count = 0
+        var insertNew = 0L
+        var insertUpdate = 0L
+        var search = 0L
+        var reserve = 0L
+        var resolve = 0L
+
+        //make orchestrator access database to initialize connection
+        //do it before measurements
+        orchestratorClient.goldenRecordTasks.searchTaskResultStates(TaskResultStateSearchRequest(listOf(UUID.randomUUID().toString())))
+
+        do {
+            val measurements = measurePerformance(batchSize)
+            insertNew += measurements.insertNew
+            insertUpdate += measurements.insertUpdate
+            search += measurements.search
+            reserve += measurements.reserve
+            resolve += measurements.resolve
+            count += batchSize
+        }while (count < totalSize)
+
+        println("Performance result for $totalSize records: ")
+        println("Insert new tasks: ${Duration.ofNanos(insertNew)}")
+        println("Update existing task record: ${Duration.ofNanos(insertUpdate)}")
+        println("Search tasks: ${Duration.ofNanos(search)}")
+        println("Reserve tasks: ${Duration.ofNanos(reserve)}")
+        println("Resolve tasks: ${Duration.ofNanos(resolve)}")
+    }
+
+    private fun measurePerformance(batchSize: Int): PerformanceResult{
+        val beforeCreate = Instant.now()
+        val createdTasks = createNewRecordTasks(batchSize)
+        val beforeUpdate = Instant.now()
+        val updatedTasks = updateRecords(createdTasks.map { it.recordId })
+        val beforeSearch = Instant.now()
+        searchTasks(updatedTasks)
+        val beforeReserve = Instant.now()
+        val reservedTasks = reserveTasks(batchSize)
+        val beforeResolve = Instant.now()
+        resolveTasks(reservedTasks)
+
+        return PerformanceResult(
+            insertNew = Duration.between(beforeCreate, beforeUpdate).toNanos(),
+            insertUpdate = Duration.between(beforeUpdate, beforeSearch).toNanos(),
+            search = Duration.between(beforeSearch, beforeReserve).toNanos(),
+            reserve = Duration.between(beforeReserve, beforeResolve).toNanos(),
+            resolve = Duration.between(beforeResolve, Instant.now()).toNanos()
+        )
+    }
+
+    private fun createNewRecordTasks(size: Int): List<TaskStateRequest.Entry>{
+        return (1 .. size)
+            .map { TaskCreateRequestEntry(null, testDataFactory.createFullBusinessPartner("BP$it")) }
+            .let { TaskCreateRequest(mode = TaskMode.UpdateFromSharingMember, requests = it) }
+            .let {  orchestratorClient.goldenRecordTasks.createTasks(it).createdTasks }
+            .map { TaskStateRequest.Entry(it.taskId, it.recordId) }
+    }
+
+    private fun updateRecords(recordIds: List<String>): List<TaskStateRequest.Entry>{
+        return recordIds
+            .map { TaskCreateRequestEntry(it, testDataFactory.createFullBusinessPartner(it)) }
+            .let { TaskCreateRequest(mode = TaskMode.UpdateFromSharingMember, requests = it) }
+            .let {  orchestratorClient.goldenRecordTasks.createTasks(it).createdTasks }
+            .map { TaskStateRequest.Entry(it.taskId, it.recordId) }
+    }
+
+    private fun searchTasks(identities: List<TaskStateRequest.Entry>){
+        orchestratorClient.goldenRecordTasks.searchTaskStates(TaskStateRequest(identities))
+    }
+
+    private fun reserveTasks(size: Int): List<String>{
+        return TaskStepReservationRequest(size, TaskStep.CleanAndSync)
+            .let { orchestratorClient.goldenRecordTasks.reserveTasksForStep(it).reservedTasks }
+            .map { it.taskId }
+    }
+
+    private fun resolveTasks(taskIds: List<String>){
+        taskIds
+            .map { TaskStepResultEntryDto(it, testDataFactory.createFullBusinessPartner("Resolved $it")) }
+            .run { orchestratorClient.goldenRecordTasks.resolveStepResults(TaskStepResultRequest(TaskStep.CleanAndSync, this)) }
+    }
+
+    data class PerformanceResult(
+        val insertNew: Long,
+        val insertUpdate: Long,
+        val search: Long,
+        val reserve: Long,
+        val resolve: Long
+    )
+
+}


### PR DESCRIPTION



<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request increases the performance of the Orchestrator's access to the database, improving the speed for querying and inserting tasks:

- Exchanged the attribute converter for entity timestamps to a hibernate type mapper
- introduced hibernate configuration for speeding up inserting and updating
- increased codec size for BPDM webclients to support the Orchestrator's upsert limit
- Made element collection fetching lazy
- Made use of PSQL JOIN FETCH statements for the lazy element collections
- Add indexes for the element collection's join column
- Add a test for measuring the Orchestrator's performance in saving and querying tasks

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
