### PR TITLE
Refactor: Make Task Steps Configuration Easier

### DIFF
--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/CleaningServiceConfigProperties.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/CleaningServiceConfigProperties.kt
@@ -17,23 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.config
+package org.eclipse.tractusx.bpdm.cleaning.config
 
-import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties.Companion.PREFIX
+import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties.Companion.PREFIX
 import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties(PREFIX)
-data class GoldenRecordTaskConfigProperties(
-    val cron: String = "-",
-    val batchSize: Int = 100,
+@ConfigurationProperties(prefix = PREFIX)
+class CleaningServiceConfigProperties (
     val step: TaskStep
-) {
-    companion object {
-        const val PREFIX = "bpdm.tasks"
-        private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties"
-        private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
-
-        const val GET_CRON = "@$BEAN_QUALIFIER.getCron()"
+){
+    companion object{
+        const val PREFIX = "bpdm.golden-record-process"
     }
 }

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.cleaning.service
 
 
 import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties
 import org.eclipse.tractusx.bpdm.cleaning.util.toUUID
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
 import org.eclipse.tractusx.orchestrator.api.model.*
@@ -33,7 +34,7 @@ import java.util.*
 @Service
 class CleaningServiceDummy(
     private val orchestrationApiClient: OrchestrationApiClient,
-
+    private val cleaningServiceConfigProperties: CleaningServiceConfigProperties
     ) {
 
     private val logger = KotlinLogging.logger { }
@@ -49,7 +50,7 @@ class CleaningServiceDummy(
 
     @Scheduled(cron = "\${bpdm.cleaningService.pollingCron:-}", zone = "UTC")
     fun pollForCleanAndSyncTasks() {
-        processPollingTasks(TaskStep.CleanAndSync)
+        processPollingTasks(cleaningServiceConfigProperties.step)
     }
 
 

--- a/bpdm-cleaning-service-dummy/src/main/resources/application.yml
+++ b/bpdm-cleaning-service-dummy/src/main/resources/application.yml
@@ -47,6 +47,8 @@ bpdm:
         client-id: sa-cl25-cx-1
         # Please provide client secret here
         client-secret: "**********"
+  golden-record-process:
+    step: CleanAndSync
 
   cleaningService:
     # When and how often the cleaning service should poll for golden record tasks in the orchestrator

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
@@ -29,6 +29,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties
 import org.eclipse.tractusx.bpdm.cleaning.config.OrchestratorConfigProperties
 import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.*
 import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
@@ -51,8 +52,9 @@ import java.util.*
 )
 @ActiveProfiles("test")
 class CleaningServiceApiCallsTest @Autowired constructor(
-    val cleaningServiceDummy: CleaningServiceDummy,
-    val jacksonObjectMapper: ObjectMapper
+    private val cleaningServiceDummy: CleaningServiceDummy,
+    private val jacksonObjectMapper: ObjectMapper,
+    private val cleaningServiceConfigProperties: CleaningServiceConfigProperties
 ) {
 
     companion object {
@@ -410,7 +412,7 @@ class CleaningServiceApiCallsTest @Autowired constructor(
 
     private fun createResultRequest(expectedBusinessPartner: BusinessPartner): TaskStepResultRequest {
         return TaskStepResultRequest(
-            TaskStep.CleanAndSync, listOf(
+            cleaningServiceConfigProperties.step, listOf(
                 TaskStepResultEntryDto(
                     fixedTaskId,
                     expectedBusinessPartner,

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -59,6 +59,8 @@ class MockAndAssertUtils @Autowired constructor(
     val ORCHESTRATOR_SEARCH_TASK_RESULT_STATES_URL = "${GoldenRecordTaskApi.TASKS_PATH}/result-state/search"
     val POOL_API_SEARCH_CHANGE_LOG_URL = "${PoolChangelogApi.CHANGELOG_PATH}/search"
 
+    val taskStep = TaskStep.entries.first()
+
     fun mockOrchestratorApi(gateWireMockServer: WireMockExtension) {
         val taskCreateResponse =
             TaskCreateResponse(
@@ -69,7 +71,7 @@ class MockAndAssertUtils @Autowired constructor(
                         recordId = "e3a05ebc-ff59-4d09-bd58-da31d6245701",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
-                            step = TaskStep.CleanAndSync,
+                            step = taskStep,
                             stepState = StepState.Queued,
                             errors = emptyList(),
                             createdAt = Instant.now(),
@@ -83,7 +85,7 @@ class MockAndAssertUtils @Autowired constructor(
                         recordId = "f05574ff-4ddd-4360-821a-923203711f85",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
-                            step = TaskStep.CleanAndSync,
+                            step = taskStep,
                             stepState = StepState.Queued,
                             errors = emptyList(),
                             createdAt = Instant.now(),
@@ -97,7 +99,7 @@ class MockAndAssertUtils @Autowired constructor(
                         recordId = "8c03850d-d772-4a2e-9845-65211231b38c",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
-                            step = TaskStep.CleanAndSync,
+                            step = taskStep,
                             stepState = StepState.Queued,
                             errors = emptyList(),
                             createdAt = Instant.now(),
@@ -111,7 +113,7 @@ class MockAndAssertUtils @Autowired constructor(
                         recordId = "6bebb1aa-935d-467a-afd4-7e8623420a18",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Pending,
-                            step = TaskStep.CleanAndSync,
+                            step = taskStep,
                             stepState = StepState.Queued,
                             errors = emptyList(),
                             createdAt = Instant.now(),
@@ -141,7 +143,7 @@ class MockAndAssertUtils @Autowired constructor(
                         recordId = "e3a05ebc-ff59-4d09-bd58-da31d6245701",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Success,
-                            step = TaskStep.CleanAndSync,
+                            step = taskStep,
                             stepState = StepState.Queued,
                             errors = emptyList(),
                             createdAt = Instant.now(),
@@ -155,7 +157,7 @@ class MockAndAssertUtils @Autowired constructor(
                         recordId = "f05574ff-4ddd-4360-821a-923203711f85",
                         processingState = TaskProcessingStateDto(
                             resultState = ResultState.Error,
-                            step = TaskStep.CleanAndSync,
+                            step = taskStep,
                             stepState = StepState.Queued,
                             errors = listOf(
                                 TaskErrorDto(TaskErrorType.Timeout, "Major Error"),
@@ -208,7 +210,7 @@ class MockAndAssertUtils @Autowired constructor(
                     recordId = "e3a05ebc-ff59-4d09-bd58-da31d6245701",
                     processingState = TaskProcessingStateDto(
                         resultState = ResultState.Success,
-                        step = TaskStep.CleanAndSync,
+                        step = taskStep,
                         stepState = StepState.Queued,
                         errors = emptyList(),
                         createdAt = Instant.now(),

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/ApiCommons.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/ApiCommons.kt
@@ -17,23 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.config
+package org.eclipse.tractusx.orchestrator.api
 
-import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties.Companion.PREFIX
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+object ApiCommons {
 
-@ConfigurationProperties(PREFIX)
-data class GoldenRecordTaskConfigProperties(
-    val cron: String = "-",
-    val batchSize: Int = 100,
-    val step: TaskStep
-) {
-    companion object {
-        const val PREFIX = "bpdm.tasks"
-        private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties"
-        private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
-
-        const val GET_CRON = "@$BEAN_QUALIFIER.getCron()"
-    }
+    const val BASE_PATH = "/v6"
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
@@ -38,7 +38,7 @@ const val TagWorker = "Task Worker"
 interface GoldenRecordTaskApi {
 
     companion object{
-        const val TASKS_PATH = "/v6/golden-record-tasks"
+        const val TASKS_PATH = "${ApiCommons.BASE_PATH}/golden-record-tasks"
     }
 
     @Operation(

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/PermissionConfigProperties.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/PermissionConfigProperties.kt
@@ -28,54 +28,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class PermissionConfigProperties(
     val createTask: String = "create_task",
     val readTask: String = "read_task",
-    val reservation: TaskStepProperties = TaskStepProperties(
-        clean = "create_reservation_clean",
-        cleanAndSync = "create_reservation_cleanAndSync",
-        poolSync = "create_reservation_poolSync"
-    ),
-    val result: TaskStepProperties = TaskStepProperties(
-        clean = "create_result_clean",
-        cleanAndSync = "create_result_cleanAndSync",
-        poolSync = "create_result_poolSync"
-    )
+    val reservation:  Map<TaskStep, String> = TaskStep.entries.associateWith { "create_reservation_${it.name}" },
+    val result:  Map<TaskStep, String> = TaskStep.entries.associateWith { "create_result_${it.name}" }
 ) {
     companion object {
         const val PREFIX = "bpdm.security.permissions"
 
-        //Keep the fully qualified name up to data here
+        //Keep the fully qualified name up to date here
         private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.orchestrator.config.PermissionConfigProperties"
         private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
 
         const val CREATE_TASK = "@$BEAN_QUALIFIER.getCreateTask()"
         const val VIEW_TASK = "@$BEAN_QUALIFIER.getReadTask()"
-        const val INVOKE_CREATE_RESERVATION = "@$BEAN_QUALIFIER.createReservation"
-        const val INVOKE_CREATE_RESULT = "@$BEAN_QUALIFIER.createResult"
     }
-
-    @Suppress("unused")
-    fun createReservation(step: TaskStep): String{
-        return fetchStepPermission(step, reservation)
-    }
-
-    @Suppress("unused")
-    fun createResult(step: TaskStep): String{
-        return fetchStepPermission(step, result)
-    }
-
-
-    private fun fetchStepPermission(step: TaskStep, stepProperties: TaskStepProperties): String{
-        return when (step) {
-            TaskStep.CleanAndSync -> stepProperties.cleanAndSync
-            TaskStep.PoolSync -> stepProperties.poolSync
-            TaskStep.Clean -> stepProperties.clean
-        }
-    }
-
-    data class TaskStepProperties(
-        val clean: String,
-        val cleanAndSync: String,
-        val poolSync: String
-    )
 }
 
 

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/StateMachineConfig.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/StateMachineConfig.kt
@@ -17,23 +17,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.config
+package org.eclipse.tractusx.bpdm.orchestrator.config
 
-import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties.Companion.PREFIX
+import org.eclipse.tractusx.orchestrator.api.model.TaskMode
 import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
-@ConfigurationProperties(PREFIX)
-data class GoldenRecordTaskConfigProperties(
-    val cron: String = "-",
-    val batchSize: Int = 100,
-    val step: TaskStep
-) {
-    companion object {
-        const val PREFIX = "bpdm.tasks"
-        private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties"
-        private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
+@Configuration
+class StateMachineConfig {
 
-        const val GET_CRON = "@$BEAN_QUALIFIER.getCron()"
+    @Bean
+    fun stateMachineConfigProperties(): StateMachineConfigProperties{
+        return StateMachineConfigProperties(
+            TaskMode.entries.associate { taskMode ->
+                when (taskMode) {
+                    TaskMode.UpdateFromSharingMember -> listOf(TaskStep.CleanAndSync, TaskStep.PoolSync)
+                    TaskMode.UpdateFromPool -> listOf(TaskStep.Clean)
+                }.let { Pair(taskMode, it) }
+            }
+        )
     }
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/StateMachineConfigProperties.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/StateMachineConfigProperties.kt
@@ -17,23 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.config
+package org.eclipse.tractusx.bpdm.orchestrator.config
 
-import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties.Companion.PREFIX
+import org.eclipse.tractusx.orchestrator.api.model.TaskMode
 import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties(PREFIX)
-data class GoldenRecordTaskConfigProperties(
-    val cron: String = "-",
-    val batchSize: Int = 100,
-    val step: TaskStep
-) {
-    companion object {
-        const val PREFIX = "bpdm.tasks"
-        private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties"
-        private const val BEAN_QUALIFIER = "'$PREFIX-$QUALIFIED_NAME'"
-
-        const val GET_CRON = "@$BEAN_QUALIFIER.getCron()"
-    }
-}
+data class StateMachineConfigProperties(
+    val modeSteps: Map<TaskMode, List<TaskStep>>
+)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/GoldenRecordTaskController.kt
@@ -44,7 +44,7 @@ class GoldenRecordTaskController(
         return goldenRecordTaskService.createTasks(createRequest)
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.INVOKE_CREATE_RESERVATION}(#reservationRequest.step))")
+    @PreAuthorize("@stepSecurityService.assertHasReservationAuthority(authentication, #reservationRequest.step)")
     override fun reserveTasksForStep(reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse {
         if (reservationRequest.amount > apiConfigProperties.upsertLimit)
             throw BpdmUpsertLimitException(reservationRequest.amount, apiConfigProperties.upsertLimit)
@@ -52,7 +52,7 @@ class GoldenRecordTaskController(
         return goldenRecordTaskService.reserveTasksForStep(reservationRequest)
     }
 
-    @PreAuthorize("hasAuthority(${PermissionConfigProperties.INVOKE_CREATE_RESULT}(#resultRequest.step))")
+    @PreAuthorize("@stepSecurityService.assertHasResultAuthority(authentication, #resultRequest.step)")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     override fun resolveStepResults(resultRequest: TaskStepResultRequest) {
         if (resultRequest.results.size > apiConfigProperties.upsertLimit)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/StepSecurityService.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/StepSecurityService.kt
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.service
+
+import org.eclipse.tractusx.bpdm.orchestrator.config.PermissionConfigProperties
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Service
+
+@Service
+class StepSecurityService(
+    private val permissionConfigProperties: PermissionConfigProperties
+) {
+
+    private val defaultPermissions = PermissionConfigProperties()
+
+    fun assertHasReservationAuthority(authentication: Authentication, step: TaskStep){
+        val authorities = authentication.authorities.map { it.authority.uppercase() }
+
+        val expectedAuthority = permissionConfigProperties.reservation[step]
+            ?: defaultPermissions.reservation[step]
+
+        expectedAuthority?.uppercase().takeIf { it in authorities }
+            ?: throw AccessDeniedException("Insufficient permissions")
+    }
+
+    fun assertHasResultAuthority(authentication: Authentication, step: TaskStep){
+        val authorities = authentication.authorities.map { it.authority.uppercase() }
+
+        val expectedAuthority = permissionConfigProperties.result[step]
+            ?: defaultPermissions.result[step]
+
+        expectedAuthority?.uppercase().takeIf { it in authorities }
+            ?: throw AccessDeniedException("Insufficient permissions")
+    }
+}

--- a/bpdm-orchestrator/src/main/resources/application.yml
+++ b/bpdm-orchestrator/src/main/resources/application.yml
@@ -63,8 +63,6 @@ bpdm:
       reservation:
           # Name of permission to create reservations for tasks in step 'Clean'
           clean: create_reservation_clean
-          # Name of permission to create reservations for tasks in step 'CleanAndSync'
-          cleanAndSync: create_reservation_cleanAndSync
           # Name of permission to create reservations for tasks in step 'PoolSync'
           poolSync: create_reservation_poolSync
       result:

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthAdminIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthAdminIT.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -47,18 +48,8 @@ class AuthAdminIT @Autowired constructor(
             postTask = AuthExpectationType.Authorized,
             postStateSearch = AuthExpectationType.Authorized
         ),
-        stepClean = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Authorized,
-            postResult = AuthExpectationType.Authorized
-        ),
-        stepCleanAndSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Authorized,
-            postResult = AuthExpectationType.Authorized
-        ),
-        stepPoolSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Authorized,
-            postResult = AuthExpectationType.Authorized
-        )
+        steps = TaskStep.entries
+            .associateWith { TaskStepAuthExpectations(postReservation = AuthExpectationType.Authorized, postResult = AuthExpectationType.Authorized) }
     )
 ){
 

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthTaskCreatorIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthTaskCreatorIT.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.test.containers.SelfClientInitializer
 import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -47,18 +48,8 @@ class AuthTaskCreatorIT @Autowired constructor(
             postTask = AuthExpectationType.Authorized,
             postStateSearch = AuthExpectationType.Authorized
         ),
-        stepClean = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Forbidden,
-            postResult = AuthExpectationType.Forbidden
-        ),
-        stepCleanAndSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Forbidden,
-            postResult = AuthExpectationType.Forbidden
-        ),
-        stepPoolSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Forbidden,
-            postResult = AuthExpectationType.Forbidden
-        )
+        steps = TaskStep.entries
+            .associateWith { TaskStepAuthExpectations(postReservation = AuthExpectationType.Forbidden, postResult = AuthExpectationType.Forbidden) }
     )
 ){
 

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthTaskProcessorCleanIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthTaskProcessorCleanIT.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.test.containers.SelfClientInitializer
 import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -47,18 +48,13 @@ class AuthTaskProcessorCleanIT @Autowired constructor(
             postTask = AuthExpectationType.Forbidden,
             postStateSearch = AuthExpectationType.Forbidden
         ),
-        stepClean = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Authorized,
-            postResult = AuthExpectationType.Authorized
-        ),
-        stepCleanAndSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Authorized,
-            postResult = AuthExpectationType.Authorized
-        ),
-        stepPoolSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Forbidden,
-            postResult = AuthExpectationType.Forbidden
-        )
+        steps = TaskStep.entries.associateWith { step ->
+            when(step){
+                TaskStep.Clean -> AuthExpectationType.Authorized
+                TaskStep.CleanAndSync -> AuthExpectationType.Authorized
+                else -> AuthExpectationType.Forbidden
+            }
+        }.mapValues {  TaskStepAuthExpectations(postReservation = it.value, postResult = it.value) }
     )
 ){
 

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthTaskProcessorPoolTaskProcessingJobApiSyncIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthTaskProcessorPoolTaskProcessingJobApiSyncIT.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.test.containers.SelfClientInitializer
 import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -47,18 +48,12 @@ class AuthTaskProcessorPoolTaskProcessingJobApiSyncIT @Autowired constructor(
             postTask = AuthExpectationType.Forbidden,
             postStateSearch = AuthExpectationType.Forbidden
         ),
-        stepClean = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Forbidden,
-            postResult = AuthExpectationType.Forbidden
-        ),
-        stepCleanAndSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Forbidden,
-            postResult = AuthExpectationType.Forbidden
-        ),
-        stepPoolSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Authorized,
-            postResult = AuthExpectationType.Authorized
-        )
+        steps = TaskStep.entries.associateWith { step ->
+            when(step){
+                TaskStep.PoolSync -> AuthExpectationType.Authorized
+                else -> AuthExpectationType.Forbidden
+            }
+        }.mapValues {  TaskStepAuthExpectations(postReservation = it.value, postResult = it.value) }
     )
 ){
 

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/NoAuthIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/NoAuthIT.kt
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -45,17 +46,7 @@ class NoAuthIT @Autowired constructor(
             postTask = AuthExpectationType.Unauthorized,
             postStateSearch = AuthExpectationType.Unauthorized
         ),
-        stepClean = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Unauthorized,
-            postResult = AuthExpectationType.Unauthorized
-        ),
-        stepCleanAndSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Unauthorized,
-            postResult = AuthExpectationType.Unauthorized
-        ),
-        stepPoolSync = TaskStepAuthExpectations(
-            postReservation = AuthExpectationType.Unauthorized,
-            postResult = AuthExpectationType.Unauthorized
-        )
+        steps = TaskStep.entries
+            .associateWith { TaskStepAuthExpectations(postReservation = AuthExpectationType.Unauthorized, postResult = AuthExpectationType.Unauthorized) }
     )
 )

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -83,6 +83,7 @@ bpdm:
     cron: '*/30 * * * * *'
     # Up to how many tasks can be requested at the same time
     batchSize: 20
+    step: "PoolSync"
   security:
     # Allowed origins for CORS
     cors-origins: '*'

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -100,6 +100,19 @@ gitGraph TB:
     merge "app-feature E" tag: "bpdm-1.1.0-alpha.0"
 ```
 
+## Adapting Golden Record Process Steps
+
+The golden record process is made of single process steps a business partner record sequentially goes through.
+A golden record process provider might want to adjust these steps like adding more steps to realize their own golden record process.
+In order to do so, the following changes are required:
+
+1. Adapt the available task steps in the [TaskStep Enum](../../bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/TaskStep.kt)
+2. Change the golden record process [state machine configuration](../../bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/config/StateMachineConfig.kt)
+3. Adapt the Central-IDP configuration to include roles for the new steps. This should be done [locally](../../bpdm-common-test/src/main/resources/keycloak/CX-Central.json) as well as [remotely](https://github.com/eclipse-tractusx/portal-iam).
+    Alternatively, you can also override the generated standard permission names with ones that already exist in Central-IDP see next point)
+4. Optionally: Adapt the step permissions in the [application properties](../../bpdm-orchestrator/src/main/resources/application.yml) for documentation purposes or for overriding the generated standard permission names
+5. Optionally: Adapt the [task worker authentication tests](../../bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth) for testing the new step permission configuration
+
 ## NOTICE
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request makes task steps configuration easier to adjust

- Extract the Orchestrator's state machine logic to a configuration
- Remove references to explicit steps in the test cases
- Make the step referenced in the Cleaning Service Dummy configurable
- Make the step referenced in the Pool configurable
- Document how to adjust the golden record process steps in code

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Solves #1078

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
