### PR TITLE
fix(charts): error on disabling subcharts

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 5.2.0-rc2
-appVersion: "6.2.0-rc2"
+version: 5.2.0-rc3
+appVersion: "6.2.0-rc3"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 6.2.0-rc2
+    version: 6.2.0-rc3
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 7.2.0-rc2
+    version: 7.2.0-rc3
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 3.2.0-rc2
+    version: 3.2.0-rc3
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 3.2.0-rc2
+    version: 3.2.0-rc3
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
   - name: postgresql
     version: 12.12.10
     repository: https://charts.bitnami.com/bitnami

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,15 +21,15 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "6.2.0-rc2"
-version: 3.2.0-rc2
+appVersion: "6.2.0-rc3"
+version: 3.2.0-rc3
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 3.0.1

--- a/charts/bpdm/charts/bpdm-common/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-common/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: library
 name: bpdm-common
-version: 1.0.1
+version: 1.0.2
 description: A library Helm Chart for other BPDM Charts
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
@@ -83,6 +83,15 @@ spec:
       initContainers:
         - name: startup-delay
           image: busybox:1.28
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities:
+              drop:
+                - ALL
           command: ['sh', '-c', "sleep {{ $.Values.startupDelaySeconds }}"]
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/bpdm/charts/bpdm-common/templates/_helpers.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_helpers.tpl
@@ -89,35 +89,21 @@ Create name of application secret
 Determine postgres service/host name to connect to
 */}}
 {{- define "bpdm.postgresDependency" -}}
-        {{- include "includeWithPostgresContext" (list $ "postgresql.v1.primary.fullname") }}
+    {{- if .Subcharts.postgres }}
+        .Values.postgres.nameOverride
+        {{- include "postgresql.v1.primary.fullname" .Subcharts.postgres }}
+    {{- end}}
 {{- end }}}
-
-{{/*
-Invoke include on given definition with postgresql dependency context
-Usage: include "includeWithPostgresContext" (list $ "your_include_function_here")
-*/}}
-{{- define "includeWithPostgresContext" -}}
-{{- $ := index . 0 }}
-{{- $function := index . 1 }}
-{{- include $function (dict "Values" $.Values.postgres "Chart" (dict "Name" "postgres") "Release" $.Release "global" $.global) }}
-{{- end }}
 
 {/*
 Determine centralidp service/host name to connect to
 */}}
 {{- define "bpdm.centralidpDependency" -}}
-        {{- include "includeWithCentralidpContext" (list $ "centralidp.fullname") }}
+    {{- if .Subcharts.centralidp }}
+        {{- include "centralidp.fullname" .Subcharts.centralidp }}
+    {{- end}}
 {{- end }}}
 
-{{/*
-Invoke include on given definition with centralidp dependency context
-Usage: include "includeWithCentralidpContext" (list $ "your_include_function_here")
-*/}}
-{{- define "includeWithCentralidpContext" -}}
-{{- $ := index . 0 }}
-{{- $function := index . 1 }}
-{{- include $function (dict "Values" $.Values.centralidp "Chart" (dict "Name" "centralidp") "Release" $.Release "global" $.global) }}
-{{- end }}
 
 {{- /*
 Merges three templates one after another in the following order:

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "6.2.0-rc2"
-version: 6.2.0-rc2
+appVersion: "6.2.0-rc3"
+version: 6.2.0-rc3
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 3.0.1

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,15 +21,15 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "6.2.0-rc2"
-version: 3.2.0-rc2
+appVersion: "6.2.0-rc3"
+version: 3.2.0-rc3
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: postgresql
     version: 12.12.10

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "6.2.0-rc2"
-version: 7.2.0-rc2
+appVersion: "6.2.0-rc3"
+version: 7.2.0-rc3
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 3.0.1

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -128,7 +128,7 @@ applicationSecrets:
       password: &postgresPass  bpdm
 
 postgres:
-  enabled: true
+  enabled: false
   auth:
     database: bpdm
     username: bpdm

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -20,40 +20,53 @@
 
 bpdm-gate:
   enabled: true
+  applicationConfig:
+    bpdm:
+      datasource:
+        host: bpdm-postgres
+      security:
+        auth-server-url: "http://bpdm-centralidp/auth"
   postgres:
     enabled: false
-    fullnameOverride: bpdm-postgres
   centralidp:
     enabled: false
-    keycloak:
-      nameOverride: bpdm-centralidp
 
 bpdm-pool:
   enabled: true
+  applicationConfig:
+    bpdm:
+      datasource:
+        host: bpdm-postgres
+      security:
+        auth-server-url: "http://bpdm-centralidp/auth"
   postgres:
     enabled: false
-    fullnameOverride: bpdm-postgres
   centralidp:
     enabled: false
-    keycloak:
-      nameOverride: bpdm-centralidp
 
 bpdm-cleaning-service-dummy:
   enabled: true
+  applicationConfig:
+    bpdm:
+      client:
+        orchestrator:
+          provider:
+            issuer-uri: "http://bpdm-centralidp/auth/realms/CX-Central"
   centralidp:
     enabled: false
-    keycloak:
-      nameOverride: bpdm-centralidp
 
 bpdm-orchestrator:
   enabled: true
+  applicationConfig:
+    bpdm:
+      datasource:
+        host: bpdm-postgres
+      security:
+        auth-server-url: "http://bpdm-centralidp/auth"
   postgres:
     enabled: false
-    fullnameOverride: bpdm-postgres
   centralidp:
     enabled: false
-    keycloak:
-      nameOverride: bpdm-centralidp
 
 postgres:
   enabled: true
@@ -67,7 +80,7 @@ postgres:
 centralidp:
   enabled: true
   keycloak:
-    nameOverride: bpdm-centralidp
+    fullnameOverride: bpdm-centralidp
     initContainers:
       - name: import
         image: docker.io/tractusx/portal-iam:3018805f77913926061af13bb5b35cbb98835c6e

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </modules>
 
     <properties>
-        <revision>6.2.0-rc2</revision>
+        <revision>6.2.0-rc3</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request makes it possible to disable the postgres and the central-idp subcharts in the BPDM charts by fixing the default configuration. Now BPDM Charts can be deployed without having to deploy to its own postgres and central-idp next to it. If these subcharts are disabled it is necessary to specify an external postgres and central-idp in the Charts application configurations.

In order to work this fix now makes subcharts referenced by fullnameOverrides instead of just nameOverrides

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Solves #1086

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
