### PR TITLE
fix(charts): missing security context in BPDM init containers

### DIFF
--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 5.2.0-rc2
-appVersion: "6.2.0-rc2"
+version: 5.2.0-SNAPSHOT
+appVersion: "6.2.0-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 6.2.0-rc2
+    version: 6.2.0-SNAPSHOT
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 7.2.0-rc2
+    version: 7.2.0-SNAPSHOT
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 3.2.0-rc2
+    version: 3.2.0-SNAPSHOT
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 3.2.0-rc2
+    version: 3.2.0-SNAPSHOT
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
   - name: postgresql
     version: 12.12.10
     repository: https://charts.bitnami.com/bitnami

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,15 +21,15 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "6.2.0-rc2"
-version: 3.2.0-rc2
+appVersion: "6.2.0-SNAPSHOT"
+version: 3.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 3.0.1

--- a/charts/bpdm/charts/bpdm-common/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-common/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: library
 name: bpdm-common
-version: 1.0.1
+version: 1.0.2
 description: A library Helm Chart for other BPDM Charts
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
@@ -83,6 +83,15 @@ spec:
       initContainers:
         - name: startup-delay
           image: busybox:1.28
+          securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              readOnlyRootFilesystem: true
+              runAsUser: 10001
+              runAsGroup: 10001
+              capabilities:
+                drop:
+                  - ALL
           command: ['sh', '-c', "sleep {{ $.Values.startupDelaySeconds }}"]
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "6.2.0-rc2"
-version: 6.2.0-rc2
+appVersion: "6.2.0-SNAPSHOT"
+version: 6.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 3.0.1

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,15 +21,15 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "6.2.0-rc2"
-version: 3.2.0-rc2
+appVersion: "6.2.0-SNAPSHOT"
+version: 3.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: postgresql
     version: 12.12.10

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "6.2.0-rc2"
-version: 7.2.0-rc2
+appVersion: "6.2.0-SNAPSHOT"
+version: 7.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 3.0.1

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </modules>
 
     <properties>
-        <revision>6.2.0-rc2</revision>
+        <revision>6.2.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
