### PR TITLE
feat(Orchestrator): ignore resolutions for already resolved steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Changed
 
 - BPDM Gate: Fetched and updated legal name of legal entity from pool while performing partner upload process via CSV([#1141](https://github.com/eclipse-tractusx/bpdm/issues/1141))
+- BPDM Orchestrator: When trying to resolve tasks for a step that have has been resolved before, the request is ignored. A HTTP OK instead of a BadRequest will be returned ([#1092](https://github.com/eclipse-tractusx/bpdm/issues/1092))
 
 
 ## [6.2.0] - 2024-11-28

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachineIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskStateMachineIT.kt
@@ -105,8 +105,6 @@ class GoldenRecordTaskStateMachineIT @Autowired constructor(
      * GIVEN a task with initial TaskProcessingState
      * WHEN reserving and resolving
      *  THEN expect the TaskProcessingState to walk through all the steps/states until final state Success
-     * WHEN trying to reserve or resolve twice
-     *  THEN expect an error
      */
     @ParameterizedTest
     @EnumSource(TaskMode::class)
@@ -134,10 +132,8 @@ class GoldenRecordTaskStateMachineIT @Autowired constructor(
             // resolve
             goldenRecordTaskStateMachine.resolveTaskStepToSuccess(task, step, businessPartnerFull)
 
-            // resolve again!
-            assertThatThrownBy {
-                goldenRecordTaskStateMachine.resolveTaskStepToSuccess(task, step, businessPartnerFull)
-            }.isInstanceOf(BpdmIllegalStateException::class.java)
+            // resolve again ignored
+            goldenRecordTaskStateMachine.resolveTaskStepToSuccess(task, step, businessPartnerFull)
         }
 
         val finalStep = stateMachineConfigProperties.modeSteps[taskMode]!!.last()
@@ -150,14 +146,12 @@ class GoldenRecordTaskStateMachineIT @Autowired constructor(
             WITHIN_ALLOWED_TIME_OFFSET
         )
 
-        // Can't resolve again!
-        assertThatThrownBy {
-            goldenRecordTaskStateMachine.doResolveTaskToError(
-                task,
-                finalStep,
-                listOf(TaskErrorDto(TaskErrorType.Unspecified, "error"))
-            )
-        }.isInstanceOf(BpdmIllegalStateException::class.java)
+        // Second resolve ignored
+        goldenRecordTaskStateMachine.doResolveTaskToError(
+            task,
+            finalStep,
+            listOf(TaskErrorDto(TaskErrorType.Unspecified, "error"))
+        )
     }
 
 
@@ -202,10 +196,8 @@ class GoldenRecordTaskStateMachineIT @Autowired constructor(
             goldenRecordTaskStateMachine.doReserve(task)
         }.isInstanceOf(BpdmIllegalStateException::class.java)
 
-        // Can't resolve now!
-        assertThatThrownBy {
-            goldenRecordTaskStateMachine.resolveTaskStepToSuccess(task, expectedStep, businessPartnerFull)
-        }.isInstanceOf(BpdmIllegalStateException::class.java)
+        // Resolve again ignored
+        goldenRecordTaskStateMachine.resolveTaskStepToSuccess(task, expectedStep, businessPartnerFull)
     }
 
     private fun assertProcessingState(processingState: GoldenRecordTaskDb.ProcessingState,


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request changes the Orchestrator's behaviour when receiving resolutions for already resolved steps for a task.

- return 200 status code when posting resolution already resolved steps ignoring the content
- adapted tests

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

# Solves #1092

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
