### PR TITLE
feat(bpdm-common): SwaggerUiConfigProperties optional in Landing Page

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/LandingPageConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/LandingPageConfig.kt
@@ -28,13 +28,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class LandingPageConfig(
-    val swaggerProperties: SwaggerUiConfigProperties
+    val swaggerProperties: SwaggerUiConfigProperties?
 ) : WebMvcConfigurer{
 
     private val logger = KotlinLogging.logger { }
 
     override fun addViewControllers(registry: ViewControllerRegistry) {
-        val redirectUri = swaggerProperties.path
+        if(swaggerProperties == null) return
+        val redirectUri = swaggerProperties!!.path
         logger.info { "Set landing page to path '$redirectUri'" }
         registry.addRedirectViewController("/", redirectUri)
     }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

In this pull request, made SwaggerUiConfigProperties optional in LandingPageConfig.
- Updated LandingPageConfig to accept a nullable SwaggerUiConfigProperties dependency
- Added null check in addViewControllers to handle cases where SwaggerUiConfigProperties is not available
- Ensures application can start without requiring SwaggerUiConfigProperties, improving flexibility in test and non-Swagger environments

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
