### PR TITLE
fix(bpdm-gate): output stage to only provide states based on business partner type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: Fixed logic for identifiers to retrieve only generic type on output business partner
 - BPDM Gate: Fixed construction logic for states and identifiers by enabling business partner type 
 - BPDM Pool: When processing golden record tasks the Pool now ignores isCatenaXMemberData field if it is set to null. ([#1069](https://github.com/eclipse-tractusx/bpdm/issues/1069))
+- BPDM Gate: Fixed gate output logic to provide states based on business partner type.  
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -65,7 +65,15 @@ class BusinessPartnerMappings {
                     } }
                     .map(::toIdentifierDto)
             }?: emptyList(),
-            states = entity.states.map(::toStateDto),
+            states = entity.postalAddress.addressType?.let { addressType ->
+                entity.states
+                    .filter { it.businessPartnerTyp == when (addressType) {
+                        AddressType.LegalAndSiteMainAddress, AddressType.LegalAddress -> BusinessPartnerType.LEGAL_ENTITY
+                        AddressType.AdditionalAddress -> BusinessPartnerType.ADDRESS
+                        AddressType.SiteMainAddress -> BusinessPartnerType.SITE
+                    } }
+                    .map(::toStateDto)
+            }?: emptyList(),
             roles = entity.roles,
             isOwnCompanyData = entity.isOwnCompanyData,
             legalEntity = toLegalEntityComponentOutputDto(entity),

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerAndSharingControllerIT.kt
@@ -145,7 +145,7 @@ class BusinessPartnerControllerAndSharingControllerIT @Autowired constructor(
 
         // Expect outputBusinessPartner without identifiers as there are not Address identifier provided.
         val outputBusinessPartners = listOf(
-            BusinessPartnerVerboseValues.bpOutputDtoCleaned.copy(identifiers = emptyList())
+            BusinessPartnerVerboseValues.bpOutputDtoCleaned.copy(identifiers = emptyList(), states = emptyList()),
         )
 
         val upsertRequests = listOf(

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/BusinessPartnerControllerIT.kt
@@ -280,9 +280,9 @@ class BusinessPartnerControllerIT @Autowired constructor(
     fun `insert one business partners and finalize cleaning task without error`() {
         this.mockAndAssertUtils.mockOrchestratorApiCleaned(gateWireMockServer)
 
-        // Expect outputBusinessPartner without identifiers as there are not Address identifier provided.
+        // Expect outputBusinessPartner without identifiers and states as there are no Address identifier and states provided.
         val outputBusinessPartners = listOf(
-            BusinessPartnerVerboseValues.bpOutputDtoCleaned.copy(identifiers = emptyList())
+            BusinessPartnerVerboseValues.bpOutputDtoCleaned.copy(identifiers = emptyList(), states = emptyList())
         )
 
         val upsertRequests = listOf(


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

In this pull request, we have fixed logic for gate output stage to retrieve states based on business partner type.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
