### PR TITLE
fix(bpdm-cleaning): Removed assignment of uncategorized identifier while performing cleaning task process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: Fixed logic for identifiers to retrieve only generic type on output business partner
 - BPDM Gate: Fixed construction logic for states and identifiers by enabling business partner type 
 - BPDM Pool: When processing golden record tasks the Pool now ignores isCatenaXMemberData field if it is set to null. ([#1069](https://github.com/eclipse-tractusx/bpdm/issues/1069))
-- BPDM Gate: Fixed gate output logic to provide states based on business partner type.  
+- BPDM Gate: Fixed gate output logic to provide states based on business partner type.
+- BPDM Cleaning Service Dummy: Removed assignment of uncategorized identifier while performing cleaning task process.  
 
 ## [6.1.0] - [2024-07-15]
 

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -86,7 +86,8 @@ class CleaningServiceDummy(
 
         val cleanedBusinessPartner = BusinessPartner(
             nameParts = businessPartner.nameParts,
-            uncategorized = businessPartner.uncategorized,
+            // Identifiers are taken as legal identifiers and should be removed from uncategorized collection
+            uncategorized = businessPartner.uncategorized.copy(identifiers = emptyList()),
             owningCompany = businessPartner.owningCompany,
             legalEntity = cleanLegalEntity(businessPartner, sharedByOwner),
             site = cleanSite(businessPartner, sharedByOwner),

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
@@ -102,6 +102,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
             .copyWithBpnReferences(BpnReference.empty)
             .copyWithLegalAddress(PostalAddress.empty)
             .copyWithSiteMainAddress(PostalAddress.empty)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -130,6 +135,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
         val mockedBusinessPartner = businessPartnerFactory.createFullBusinessPartner("test")
             .copyWithLegalAddress(PostalAddress.empty)
             .copyWithSiteMainAddress(PostalAddress.empty)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -158,6 +168,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
             .copyWithBpnReferences(BpnReference.empty)
             .copyWithLegalAddress(PostalAddress.empty)
             .copy(site = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -185,6 +200,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
         val mockedBusinessPartner = businessPartnerFactory.createFullBusinessPartner("test")
             .copyWithLegalAddress(PostalAddress.empty)
             .copy(site = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -212,6 +232,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
             .copyWithBpnReferences(BpnReference.empty)
             .copyWithLegalAddress(PostalAddress.empty)
             .copy(additionalAddress = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList()
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -239,6 +264,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
         val mockedBusinessPartner = businessPartnerFactory.createFullBusinessPartner("test")
             .copyWithLegalAddress(PostalAddress.empty)
             .copy(additionalAddress = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -266,6 +296,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
             .copyWithBpnReferences(BpnReference.empty)
             .copyWithSiteMainAddress(null)
             .copy(additionalAddress = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -292,6 +327,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
         val mockedBusinessPartner = businessPartnerFactory.createFullBusinessPartner("test")
             .copyWithSiteMainAddress(null)
             .copy(additionalAddress = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -318,6 +358,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
             .copyWithBpnReferences(BpnReference.empty)
             .copyWithLegalAddress(PostalAddress.empty)
             .copy(site = null, additionalAddress = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)
@@ -345,6 +390,11 @@ class CleaningServiceApiCallsTest @Autowired constructor(
         val mockedBusinessPartner = businessPartnerFactory.createFullBusinessPartner("test")
             .copyWithLegalAddress(PostalAddress.empty)
             .copy(site = null, additionalAddress = null)
+            .copy(
+                uncategorized = businessPartnerFactory.createFullBusinessPartner("test").uncategorized.copy(
+                    identifiers = emptyList() // Assign empty list to uncategorized identifiers
+                )
+            )
 
         val resolveMapping = mockOrchestratorResolveApi()
         mockOrchestratorReserveApi(mockedBusinessPartner)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

In this pull request, we have assigned emptylist to the uncategorized collection while performing cleaning task process.
Ideally in cleaning process, Identifiers are being taken as legal identifiers and should be removed from uncategorized collection.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
