### PR TITLE
fix(MissingOutputStage): Handle upsert output stage based on the sharing state id

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerService.kt
@@ -97,10 +97,10 @@ class BusinessPartnerService(
         logger.debug { "Executing upsertBusinessPartnersOutput() with parameters $requests" }
 
         val existingOutputs = businessPartnerRepository.findBySharingStateInAndStage(requests.map { it.sharingState }, StageType.Output)
-        val existingOutputsByExternalId = existingOutputs.associateBy { it.sharingState.externalId }
+        val existingOutputsBySharingStateId = existingOutputs.associateBy { it.sharingState.id }
 
         val updatedEntities = requests.map { request ->
-            val existingOutput = existingOutputsByExternalId[request.sharingState.externalId]
+            val existingOutput = existingOutputsBySharingStateId[request.sharingState.id]
             val updatedData = outputUpsertMappings.toEntity(request.upsertData, request.sharingState)
 
             upsertFromEntity(existingOutput, updatedData)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Update the upsert output logic to add data based on the sharing state ID instead of the external ID.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Issue: https://github.com/eclipse-tractusx/bpdm/issues/1104

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
