### PR TITLE
docs(Postman): update EDC provider setup collection

### DIFF
--- a/docs/postman/EDC Provider Setup.postman_collection.json
+++ b/docs/postman/EDC Provider Setup.postman_collection.json
@@ -7,51 +7,8 @@
 	},
 	"item": [
 		{
-			"name": "General Policies",
+			"name": "Purpose Policies",
 			"item": [
-				{
-					"name": "Create Is Active Member",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
-									"    var uuid = require('uuid');",
-									"    pm.collectionVariables.set(\"POLICY_ACTIVE_MEMBER\", uuid.v4())",
-									"}",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": [\n        \"https://w3id.org/tractusx/policy/v1.0.0\",\n        \"http://www.w3.org/ns/odrl.jsonld\",\n        {\n            \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n            \"dct\": \"https://purl.org/dc/terms/\",\n            \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n        }\n    ],\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"{{POLICY_ACTIVE_MEMBER}}\",\n    \"policy\": {\n        \"@type\": \"Set\",\n        \"profile\": \"profile2405\",\n        \"permission\": [\n            {\n                \"action\": \"use\",\n                \"constraint\": {\n                    \"and\": [\n                        {\n                            \"leftOperand\": \"Membership\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"active\"\n                        }\n                    ]\n                }\n            }\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"ActiveMember\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/policydefinitions",
-							"host": [
-								"{{PROVIDER_EDC_MANAGEMENT_API}}"
-							],
-							"path": [
-								"v2",
-								"policydefinitions"
-							]
-						}
-					},
-					"response": []
-				},
 				{
 					"name": "Create Accept Purpose Pool",
 					"event": [
@@ -75,7 +32,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": [\n        \"https://w3id.org/tractusx/policy/v1.0.0\",\n        \"http://www.w3.org/ns/odrl.jsonld\",  \n        {\n             \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n             \"dct\": \"https://purl.org/dc/terms/\",\n             \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n\n        }\n    ],\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"{{POLICY_ACCEPT_PURPOSE_POOL}}\",\n    \"policy\": {\n        \"@type\": \"Set\",\n        \"profile\": \"profile2405\",\n        \"permission\": [\n            {\n                \"action\": \"use\",\n                \"constraint\": {\n                    \"and\": [\n                        {\n                            \"leftOperand\": \"FrameworkAgreement\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"businessPartner:1.0\"\n                        },\n                        {\n                            \"leftOperand\": \"UsagePurpose\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"cx.bpdm.pool:1\"\n                        }\n                    ]\n                }\n            }\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"AcceptPurpose\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
+							"raw": "{\n    \"@context\": [\n        \"https://w3id.org/tractusx/policy/v1.0.0\",\n        \"http://www.w3.org/ns/odrl.jsonld\",  \n        {\n             \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n             \"dct\": \"https://purl.org/dc/terms/\",\n             \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n\n        }\n    ],\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"{{POLICY_ACCEPT_PURPOSE_POOL}}\",\n    \"policy\": {\n        \"@type\": \"Set\",\n        \"profile\": \"profile2405\",\n        \"permission\": [\n            {\n                \"action\": \"use\",\n                \"constraint\": {\n                    \"and\": [\n                        {\n                            \"leftOperand\": \"FrameworkAgreement\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"DataExchangeGovernance:1.0\"\n                        },\n                        {\n                            \"leftOperand\": \"UsagePurpose\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"cx.bpdm.pool:1\"\n                        }\n                    ]\n                }\n            }\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"AcceptPurposePool\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -83,12 +40,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/policydefinitions",
+							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/policydefinitions",
 							"host": [
 								"{{PROVIDER_EDC_MANAGEMENT_API}}"
 							],
 							"path": [
-								"v2",
+								"v3",
 								"policydefinitions"
 							]
 						}
@@ -118,7 +75,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": [\n        \"https://w3id.org/tractusx/policy/v1.0.0\",\n        \"http://www.w3.org/ns/odrl.jsonld\",  \n        {\n             \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n             \"dct\": \"https://purl.org/dc/terms/\",\n             \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n\n        }\n    ],\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"{{POLICY_ACCEPT_PURPOSE_GATE_UPLOAD}}\",\n    \"policy\": {\n        \"@type\": \"Set\",\n        \"profile\": \"profile2405\",\n        \"permission\": [\n            {\n                \"action\": \"use\",\n                \"constraint\": {\n                    \"and\": [\n                        {\n                            \"leftOperand\": \"FrameworkAgreement\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"businessPartner:1.0\"\n                        },\n                        {\n                            \"leftOperand\": \"UsagePurpose\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"cx.bpdm.gate.upload:1\"\n                        }\n                    ]\n                }\n            }\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"AcceptPurpose\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
+							"raw": "{\n    \"@context\": [\n        \"https://w3id.org/tractusx/policy/v1.0.0\",\n        \"http://www.w3.org/ns/odrl.jsonld\",  \n        {\n             \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n             \"dct\": \"https://purl.org/dc/terms/\",\n             \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n\n        }\n    ],\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"{{POLICY_ACCEPT_PURPOSE_GATE_UPLOAD}}\",\n    \"policy\": {\n        \"@type\": \"Set\",\n        \"profile\": \"profile2405\",\n        \"permission\": [\n            {\n                \"action\": \"use\",\n                \"constraint\": {\n                    \"and\": [\n                        {\n                            \"leftOperand\": \"FrameworkAgreement\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"DataExchangeGovernance:1.0\"\n                        },\n                        {\n                            \"leftOperand\": \"UsagePurpose\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"cx.bpdm.gate.upload:1\"\n                        }\n                    ]\n                }\n            }\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"AcceptPurpose\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -126,12 +83,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/policydefinitions",
+							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/policydefinitions",
 							"host": [
 								"{{PROVIDER_EDC_MANAGEMENT_API}}"
 							],
 							"path": [
-								"v2",
+								"v3",
 								"policydefinitions"
 							]
 						}
@@ -161,7 +118,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": [\n        \"https://w3id.org/tractusx/policy/v1.0.0\",\n        \"http://www.w3.org/ns/odrl.jsonld\",  \n        {\n             \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n             \"dct\": \"https://purl.org/dc/terms/\",\n             \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n\n        }\n    ],\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"{{POLICY_ACCEPT_PURPOSE_GATE_DOWNLOAD}}\",\n    \"policy\": {\n        \"@type\": \"Set\",\n        \"profile\": \"profile2405\",\n        \"permission\": [\n            {\n                \"action\": \"use\",\n                \"constraint\": {\n                    \"and\": [\n                        {\n                            \"leftOperand\": \"FrameworkAgreement\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"businessPartner:1.0\"\n                        },\n                        {\n                            \"leftOperand\": \"UsagePurpose\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"cx.bpdm.gate.download:1\"\n                        }\n                    ]\n                }\n            }\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"AcceptPurpose\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
+							"raw": "{\n    \"@context\": [\n        \"https://w3id.org/tractusx/policy/v1.0.0\",\n        \"http://www.w3.org/ns/odrl.jsonld\",  \n        {\n             \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n             \"dct\": \"https://purl.org/dc/terms/\",\n             \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n\n        }\n    ],\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"{{POLICY_ACCEPT_PURPOSE_GATE_DOWNLOAD}}\",\n    \"policy\": {\n        \"@type\": \"Set\",\n        \"profile\": \"profile2405\",\n        \"permission\": [\n            {\n                \"action\": \"use\",\n                \"constraint\": {\n                    \"and\": [\n                        {\n                            \"leftOperand\": \"FrameworkAgreement\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"DataExchangeGovernance:1.0\"\n                        },\n                        {\n                            \"leftOperand\": \"UsagePurpose\",\n                            \"operator\": \"eq\",\n                            \"rightOperand\": \"cx.bpdm.gate.download:1\"\n                        }\n                    ]\n                }\n            }\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"AcceptPurpose\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -169,12 +126,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/policydefinitions",
+							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/policydefinitions",
 							"host": [
 								"{{PROVIDER_EDC_MANAGEMENT_API}}"
 							],
 							"path": [
-								"v2",
+								"v3",
 								"policydefinitions"
 							]
 						}
@@ -184,103 +141,13 @@
 			]
 		},
 		{
-			"name": "Pool Member Read Access",
+			"name": "Sharing Member Offers",
 			"item": [
 				{
-					"name": "Create Asset",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
-									"    var uuid = require('uuid');",
-									"    pm.collectionVariables.set(\"ASSET_POOL_CX_MEMBER_READ\", uuid.v4())",
-									"}"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"https://purl.org/dc/terms/\",\n        \"cx-taxo\": \"https://w3id.org/catenax/taxonomy/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n    },\n    \"@type\": \"Asset\", \n    \"@id\": \"{{ASSET_POOL_CX_MEMBER_READ}}\", \n    \"properties\": { \n        \"dct:type\":  \"cx-taxo:BPDMPool\",\n        \"dct:subject\": \"cx-taxo:ReadAccessPoolForCatenaXMember\",\n        \"dct:description\": \"Grants the Catena-X Member read access to the Pool API. This can be used to read legal entity, site, address, legal form, identifier type and administrative area level 1 data. To that end, it also grants read access to the respective changelog entries and identifier mappings, as well as relational data.\",\n        \"cx-common:version\": \"6.0\"\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"{{POOL_API}}/v6\",\n        \"oauth2:tokenUrl\": \"{{TOKEN_URL}}\",\n        \"oauth2:clientId\": \"{{CLIENT_ID_POOL_CX_MEMBER_READ}}\",\n        \"oauth2:clientSecretKey\": \"{{CLIENT_SECRET_PATH_POOL_CX_MEMBER_READ_CLIENT}}\", \n        \"proxyMethod\": \"true\",\n        \"proxyPath\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/assets",
-							"host": [
-								"{{PROVIDER_EDC_MANAGEMENT_API}}"
-							],
-							"path": [
-								"v3",
-								"assets"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create Contract Definition",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
-									"    var uuid = require('uuid');",
-									"    pm.collectionVariables.set(\"CONTRACT_POOL_CX_MEMBER_READ\", uuid.v4())",
-									"}",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\"\n    },\n    \"@id\": \"{{CONTRACT_POOL_CX_MEMBER_READ}}\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"{{POLICY_ACTIVE_MEMBER}}\",\n    \"contractPolicyId\": \"{{POLICY_ACCEPT_PURPOSE_POOL}}\",\n    \"assetsSelector\": {\n        \"@type\": \"CriterionDto\",\n        \"operandLeft\": \"https://w3id.org/edc/v0.0.1/ns/id\",\n        \"operator\": \"in\",\n        \"operandRight\": [\n            \"{{ASSET_POOL_CX_MEMBER_READ}}\"\n        ]\n    },\n    \"privateProperties\": {\n        \"dct:type\": \"ReadAccessPoolForCatenaXMember\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/contractdefinitions",
-							"host": [
-								"{{PROVIDER_EDC_MANAGEMENT_API}}"
-							],
-							"path": [
-								"v2",
-								"contractdefinitions"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Gate",
-			"item": [
-				{
-					"name": "Policies",
+					"name": "1. Create Access Policy",
 					"item": [
 						{
-							"name": "Create Has BPN",
+							"name": "Create Has BPN Policy",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -310,13 +177,103 @@
 									}
 								},
 								"url": {
-									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/policydefinitions",
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/policydefinitions",
 									"host": [
 										"{{PROVIDER_EDC_MANAGEMENT_API}}"
 									],
 									"path": [
-										"v2",
+										"v3",
 										"policydefinitions"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Pool Member Read Access",
+					"item": [
+						{
+							"name": "Create Asset",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
+											"    var uuid = require('uuid');",
+											"    pm.collectionVariables.set(\"ASSET_POOL_CX_MEMBER_READ\", uuid.v4())",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"https://purl.org/dc/terms/\",\n        \"cx-taxo\": \"https://w3id.org/catenax/taxonomy/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n    },\n    \"@type\": \"Asset\", \n    \"@id\": \"{{ASSET_POOL_CX_MEMBER_READ}}\", \n    \"properties\": { \n        \"dct:type\":  \"cx-taxo:BPDMPool\",\n        \"dct:subject\": \"cx-taxo:ReadAccessPoolForCatenaXMember\",\n        \"dct:description\": \"Grants the Catena-X Member read access to the Pool API. This can be used to read legal entity, site, address, legal form, identifier type and administrative area level 1 data. To that end, it also grants read access to the respective changelog entries and identifier mappings, as well as relational data.\",\n        \"cx-common:version\": \"6.0\"\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"{{POOL_API}}/v6\",\n        \"oauth2:tokenUrl\": \"{{TOKEN_URL}}\",\n        \"oauth2:clientId\": \"{{CLIENT_ID_POOL_CX_MEMBER_READ}}\",\n        \"oauth2:clientSecretKey\": \"{{CLIENT_SECRET_PATH_POOL_CX_MEMBER_READ_CLIENT}}\", \n        \"proxyMethod\": \"true\",\n        \"proxyPath\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/assets",
+									"host": [
+										"{{PROVIDER_EDC_MANAGEMENT_API}}"
+									],
+									"path": [
+										"v3",
+										"assets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create Contract Definition",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
+											"    var uuid = require('uuid');",
+											"    pm.collectionVariables.set(\"CONTRACT_POOL_CX_MEMBER_READ\", uuid.v4())",
+											"}",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"https://purl.org/dc/terms/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n    },\n    \"@id\": \"{{CONTRACT_POOL_CX_MEMBER_READ}}\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"{{POLICY_BUSINESS_PARTNER_NUMBER}}\",\n    \"contractPolicyId\": \"{{POLICY_ACCEPT_PURPOSE_POOL}}\",\n    \"assetsSelector\": {\n        \"@type\": \"CriterionDto\",\n        \"operandLeft\": \"https://w3id.org/edc/v0.0.1/ns/id\",\n        \"operator\": \"in\",\n        \"operandRight\": [\n            \"{{ASSET_POOL_CX_MEMBER_READ}}\"\n        ]\n    },\n    \"privateProperties\": {\n        \"BusinessPartnerNumber\": \"{{CONSUMER_BPNL}}\",\n        \"dct:type\": \"ReadAccessPoolForCatenaXMember\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/contractdefinitions",
+									"host": [
+										"{{PROVIDER_EDC_MANAGEMENT_API}}"
+									],
+									"path": [
+										"v3",
+										"contractdefinitions"
 									]
 								}
 							},
@@ -399,12 +356,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/contractdefinitions",
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/contractdefinitions",
 									"host": [
 										"{{PROVIDER_EDC_MANAGEMENT_API}}"
 									],
 									"path": [
-										"v2",
+										"v3",
 										"contractdefinitions"
 									]
 								}
@@ -488,12 +445,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/contractdefinitions",
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/contractdefinitions",
 									"host": [
 										"{{PROVIDER_EDC_MANAGEMENT_API}}"
 									],
 									"path": [
-										"v2",
+										"v3",
 										"contractdefinitions"
 									]
 								}
@@ -577,12 +534,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v2/contractdefinitions",
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/contractdefinitions",
 									"host": [
 										"{{PROVIDER_EDC_MANAGEMENT_API}}"
 									],
 									"path": [
-										"v2",
+										"v3",
 										"contractdefinitions"
 									]
 								}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request updates the EDC provider setup postman collection to be compatible with the EDC version 0.8.0 and the new DataExchangeGovernance framework credential. The new credential replaces the outdated businesspartner framework credential for release 24/08 and below.

Also changed the access policy for offer Pool member access to be BPN based, replacing the more generic IsMember policy. That way we now create an offer to access the Pool for each sharing member separately instead of having one for all.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes #1044 

Contributes to #1082 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
