### PR TITLE
cicd(Chart Test): upgrade the default kubernetes version to 1.31

### DIFF
--- a/.github/workflows/app-test-charts.yaml
+++ b/.github/workflows/app-test-charts.yaml
@@ -23,7 +23,7 @@ on:
     inputs:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
-        default: 'kindest/node:v1.27.3'
+        default: 'kindest/node:v1.31.2'
         required: false
         type: string
       upgrade_from:
@@ -40,7 +40,7 @@ on:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
         # k8s version from 3.1 release as default
-        default: 'kindest/node:v1.27.3'
+        default: 'kindest/node:v1.31.2'
         required: false
         type: string
       upgrade_from:
@@ -79,7 +79,7 @@ jobs:
         uses: container-tools/kind-action@v2
         with:
           version: v0.20.0
-          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.31.2' }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->


This pull request raises the Kubernetes version on which we perform Chart tests to the newest release v1.31 on default.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Contributes to #1082

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
