### PR TITLE
docs(bpdm):updated legal docs for cleaning and orchestrator service with snapshot version

### DIFF
--- a/bpdm-cleaning-service-dummy/pom.xml
+++ b/bpdm-cleaning-service-dummy/pom.xml
@@ -155,6 +155,8 @@
                 <directory>${project.basedir}/src/main/resources</directory>
                 <includes>
                     <include>*.properties</include>
+                    <include>application.yml</include>
+                    <include>application-*.yml</include>
                 </includes>
             </resource>
             <resource>
@@ -162,7 +164,18 @@
                 <directory>${project.basedir}/src/main/resources</directory>
                 <excludes>
                     <exclude>*.properties</exclude>
+                    <exclude>application.yml</exclude>
+                    <exclude>application-*.yml</exclude>
                 </excludes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES</include>
+                </includes>
+                <targetPath>META-INF/</targetPath>
             </resource>
         </resources>
 

--- a/bpdm-orchestrator/pom.xml
+++ b/bpdm-orchestrator/pom.xml
@@ -172,6 +172,15 @@
                     <exclude>application-*.yml</exclude>
                 </excludes>
             </resource>
+            <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES</include>
+                </includes>
+                <targetPath>META-INF/</targetPath>
+            </resource>
         </resources>
 
         <plugins>

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -23,7 +23,7 @@ name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
 version: 5.2.0-SNAPSHOT
-appVersion: "6.2.0-rc5"
+appVersion: "6.2.0-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "6.2.0-rc5"
+appVersion: "6.2.0-SNAPSHOT"
 version: 3.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "6.2.0-rc5"
+appVersion: "6.2.0-SNAPSHOT"
 version: 6.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "6.2.0-rc5"
+appVersion: "6.2.0-SNAPSHOT"
 version: 3.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "6.2.0-rc5"
+appVersion: "6.2.0-SNAPSHOT"
 version: 7.2.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </modules>
 
     <properties>
-        <revision>6.2.0-rc5</revision>
+        <revision>6.2.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

In this pull request, we have updated legal docs for orchestrator and cleaning service dummy to include license, notice and dependency details while building resource. 
Also, we have made change for application version.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
