### PR TITLE
build: BPDM app version 6.2.0 - Helm Chart version 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/CHANGELOG.md) of the charts directly.
 
-## [6.2.0] - tbd
+## [6.2.0] - 2024-11-28
 
 ### Added
 

--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [5.2.0] -  tbd
+## [5.2.0] -  2024-11-28
 
 ### Changed
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 5.2.0-SNAPSHOT
-appVersion: "6.2.0-SNAPSHOT"
+version: 5.2.0
+appVersion: "6.2.0"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,19 +33,19 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 6.2.0-SNAPSHOT
+    version: 6.2.0
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 7.2.0-SNAPSHOT
+    version: 7.2.0
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 3.2.0-SNAPSHOT
+    version: 3.2.0
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 3.2.0-SNAPSHOT
+    version: 3.2.0
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [3.2.0] - tbd
+## [3.2.0] - 2024-11-28
 
 - Increase appversion to 6.2.0
 - Replace Keycloak dependency with Central-IDP dependency [#994](https://github.com/eclipse-tractusx/bpdm/issues/994)

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "6.2.0-SNAPSHOT"
-version: 3.2.0-SNAPSHOT
+appVersion: "6.2.0"
+version: 3.2.0
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [6.2.0] - tbd
+## [6.2.0] - 2024-11-28
 
 - Increase appversion to 6.2.0
 - Replace Keycloak dependency with Central-IDP dependency [#994](https://github.com/eclipse-tractusx/bpdm/issues/994)

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "6.2.0-SNAPSHOT"
-version: 6.2.0-SNAPSHOT
+appVersion: "6.2.0"
+version: 6.2.0
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [3.2.0] - tbd
+## [3.2.0] - 2024-11-28
 
 - Increase appversion to 6.2.0
 - Replace Keycloak dependency with Central-IDP dependency [#994](https://github.com/eclipse-tractusx/bpdm/issues/994)

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "6.2.0-SNAPSHOT"
-version: 3.2.0-SNAPSHOT
+appVersion: "6.2.0"
+version: 3.2.0
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [7.2.0] - tbd
+## [7.2.0] - 2024-11-28
 
 - Increase appversion to 6.2.0
 - Replace Keycloak dependency with Central-IDP dependency [#994](https://github.com/eclipse-tractusx/bpdm/issues/994)

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "6.2.0-SNAPSHOT"
-version: 7.2.0-SNAPSHOT
+appVersion: "6.2.0"
+version: 7.2.0
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/docs/api/gate.json
+++ b/docs/api/gate.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Business Partner Data Management Gate",
     "description": "A gate for a member to share business partner data with CatenaX",
-    "version": "6.2.0-rc5"
+    "version": "6.2.0"
   },
   "servers": [
     {

--- a/docs/api/gate.yaml
+++ b/docs/api/gate.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Business Partner Data Management Gate
   description: A gate for a member to share business partner data with CatenaX
-  version: 6.2.0-rc5
+  version: 6.2.0
 servers:
   - url: http://localhost:8081
     description: Generated server url

--- a/docs/api/orchestrator.json
+++ b/docs/api/orchestrator.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Business Partner Data Management Orchestrator",
     "description": "Orchestrator component acts as a passive component and offers for each processing steps individual endpoints",
-    "version": "6.2.0-rc5"
+    "version": "6.2.0"
   },
   "servers": [
     {

--- a/docs/api/orchestrator.yaml
+++ b/docs/api/orchestrator.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Business Partner Data Management Orchestrator
   description: Orchestrator component acts as a passive component and offers for each processing steps individual endpoints
-  version: 6.2.0-rc5
+  version: 6.2.0
 servers:
   - url: http://localhost:8085
     description: Generated server url

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Business Partner Data Management Pool",
     "description": "Service that manages and shares business partner data with other CatenaX services",
-    "version": "6.2.0-rc5"
+    "version": "6.2.0"
   },
   "servers": [
     {

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Business Partner Data Management Pool
   description: Service that manages and shares business partner data with other CatenaX services
-  version: 6.2.0-rc5
+  version: 6.2.0
 servers:
   - url: http://localhost:8080
     description: Generated server url

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </modules>
 
     <properties>
-        <revision>6.2.0-SNAPSHOT</revision>
+        <revision>6.2.0</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull raises the BPDM apps and Helm Charts from SNAPSHOT to its release versions:

BPDM 6.2.0 and BPDM Charts 5.2.0

Upon merging this also marks the release of these version.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
