### PR TITLE
fix(bpdm-gate): fetched and attached legal name of entity while performing partner upload process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 ## [6.3.0] - tbd
 
+### Added
+
+
+### Changed
+
+- BPDM Gate: Fetched and updated legal name of legal entity from pool while performing partner upload process via CSV([#1141](https://github.com/eclipse-tractusx/bpdm/issues/1141))
+
 
 ## [6.2.0] - 2024-11-28
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/PartnerFileUtil.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/PartnerFileUtil.kt
@@ -67,7 +67,7 @@ object PartnerFileUtil {
      * @return A list of BusinessPartnerInputRequest objects derived from the valid CSV rows.
      * @throws BpdmInvalidPartnerUploadException if any validation errors are encountered during processing.
      */
-    fun validateAndMapToBusinessPartnerInputRequests(csvData: List<PartnerUploadFileRow>, tenantBpnl: String?): List<BusinessPartnerInputRequest> {
+    fun validateAndMapToBusinessPartnerInputRequests(csvData: List<PartnerUploadFileRow>, tenantBpnl: String?, legalName: String): List<BusinessPartnerInputRequest> {
         val formatter = DateTimeFormatter.ISO_DATE_TIME
         val validator: Validator = Validation.buildDefaultValidatorFactory().validator
         val errors = mutableListOf<String>()
@@ -85,8 +85,10 @@ object PartnerFileUtil {
                     states = emptyList(),
                     roles = emptyList(),
                     isOwnCompanyData = true,
-                    // Legal entity's business partner number is nothing but tenant's partner number who is performing business partner upload action
-                    legalEntity = LegalEntityRepresentationInputDto(legalEntityBpn = tenantBpnl?.takeIf { it.isNotEmpty() }),
+                    legalEntity = LegalEntityRepresentationInputDto(
+                        legalEntityBpn = tenantBpnl?.takeIf { it.isNotEmpty() },
+                        legalName = legalName
+                    ),
                     site = row.toSiteRepresentationInputDto(formatter, errors, index, row.externalId.orEmpty()),
                     address = row.toAddressRepresentationInputDto(formatter, errors, index, row.externalId.orEmpty())
                 )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
In this pull request, we have added functionality for getting Legal Name from Pool service while performing partner upload process via CSV file. As per the standards, we should have legal name attached and now we are fetching legal name for particular legal entity based on tenantBpnl(User BPNL).

Fixes #1141 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
