### PR TITLE
feat(Pool): add endpoints to query member-owned business partner data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 ## [6.3.0] - tbd
 
+### Added
+
+- BPDM Pool: Endpoints for retrieving member-owned business partner data.
+Member-owned business partner data includes business partners from non-member legal entities that are owned by Catena-X members 
+([#1088](https://github.com/eclipse-tractusx/bpdm/issues/1088))
 
 ## [6.2.0] - 2024-11-28
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -335,6 +335,18 @@ This offer does **not** grant access to the uploaded business partner input data
 4. Create a `ReadAccessGateOutputForSharingMember` asset with the created technical user for client credentials
 5. Create a contract definition `ReadAccessGateOutputForSharingMember` referencing the created asset
 
+#### ReadAccessPoolForUseCaseConsumer
+
+This offer allows a company to access the Pool for reading golden record data owned by Catena-X members.
+In contrast to the offer `ReadAccessPoolForCatenaXMember` this also includes business partner data from non-member legal entities which are owned by Catena-X members.
+Since, typically, Catena-X use cases require site information of the whole company including subsidiaries this offer is primarily created for use case providers.
+
+1. Create a policy of type `HasBusinessPartnerNumber` for the company's BPNL (if it not yet exists)
+2. Create a policy of type `AcceptPurpose` with usage purpose for the pool (if not yet exists)
+3. Create a technical user with role `BPDM Pool Use Case Consumer` and the company's BPN identity
+4. Create a `ReadAccessPoolForUseCaseConsumer` asset with the created technical user for client credentials
+5. Create a contract definition `ReadAccessPoolForUseCaseConsumer` referencing the created asset
+
 
 ## Portal Configuration
 

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/PoolAssertHelper.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/PoolAssertHelper.kt
@@ -105,7 +105,7 @@ class PoolAssertHelper(
         creationTimeframe: Timeframe,
         updateTimeframe: Timeframe = creationTimeframe
     ) {
-        Assertions.assertThat(actual.first())
+        Assertions.assertThat(actual)
             .usingRecursiveComparison()
             .ignoringCollectionOrder()
             .ignoringAllOverriddenEquals()
@@ -117,7 +117,7 @@ class PoolAssertHelper(
             .withComparatorForType(instantSecondsComparator, Instant::class.java)
             .withComparatorForType(localDatetimeSecondsComparator, LocalDateTime::class.java)
             .withComparatorForType(stringIgnoreComparator, String::class.java)
-            .isEqualTo(expected.first())
+            .isEqualTo(expected)
 
         actual.forEach { Assertions.assertThat(it.createdAt).isBetween(creationTimeframe.startTime, creationTimeframe.endTime) }
         actual.forEach { Assertions.assertThat(it.updatedAt).isBetween(updateTimeframe.startTime, updateTimeframe.endTime) }

--- a/bpdm-common-test/src/main/resources/keycloak/CX-Central.json
+++ b/bpdm-common-test/src/main/resources/keycloak/CX-Central.json
@@ -27,7 +27,7 @@
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "none",
   "registrationAllowed": false,
   "registrationEmailAsUsername": false,
   "rememberMe": false,
@@ -47,25 +47,7 @@
   "roles": {
     "realm": [
       {
-        "id": "9ed742fe-ac2e-462c-ab1f-09895db556b6",
-        "name": "uma_authorization",
-        "description": "${role_uma_authorization}",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "CX-Central",
-        "attributes": {}
-      },
-      {
-        "id": "fd7248cf-7b65-4dbf-ae84-7a967e8ec7c2",
-        "name": "user",
-        "description": "basic user",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "CX-Central",
-        "attributes": {}
-      },
-      {
-        "id": "4c19f2aa-f9b9-473e-ba5c-46c2f4e52c8b",
+        "id": "4a50b303-b315-4298-9ced-328556345fa0",
         "name": "default-roles-cx-central",
         "description": "${role_default-roles}",
         "composite": true,
@@ -75,12 +57,12 @@
             "uma_authorization"
           ],
           "client": {
-            "Cl23-CX-Policy-Hub": [
-              "view_policy_hub"
-            ],
             "account": [
               "manage-account",
               "view-profile"
+            ],
+            "Cl23-CX-Policy-Hub": [
+              "view_policy_hub"
             ]
           }
         },
@@ -89,9 +71,27 @@
         "attributes": {}
       },
       {
-        "id": "1ec798aa-cd95-43bd-9494-b1883e451fbb",
+        "id": "434ad24a-f4a4-42e8-9e86-7971e6bb9a9f",
         "name": "offline_access",
         "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "CX-Central",
+        "attributes": {}
+      },
+      {
+        "id": "6a7e1912-0dea-4326-94fe-3d446ab8775c",
+        "name": "user",
+        "description": "basic user",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "CX-Central",
+        "attributes": {}
+      },
+      {
+        "id": "840eca9d-41cb-4f73-af62-f6fe4e62e08d",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
         "composite": false,
         "clientRole": false,
         "containerId": "CX-Central",
@@ -111,115 +111,161 @@
       "sa-cl22-01": [],
       "Cl24-CX-SSI-CredentialIssuer": [
         {
-          "id": "244d2705-e543-4594-9242-e66ff906748e",
-          "name": "request_ssicredential",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "60306526-b937-4244-ac89-cc1283c8ed74",
-          "attributes": {}
-        },
-        {
-          "id": "e5909b95-c17b-455d-b995-8d768f271e07",
-          "name": "revoke_credential",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "60306526-b937-4244-ac89-cc1283c8ed74",
-          "attributes": {}
-        },
-        {
-          "id": "b7b8d3ae-8b64-42c4-bcbf-f56f6f2a9293",
-          "name": "revoke_credentials_issuer",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "60306526-b937-4244-ac89-cc1283c8ed74",
-          "attributes": {}
-        },
-        {
-          "id": "1bd890e7-fe5f-4bc0-92ef-ac5f48e621a6",
+          "id": "ee754e05-f5d1-4ec2-91bf-db39341bffa3",
           "name": "view_use_case_participation",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "60306526-b937-4244-ac89-cc1283c8ed74",
+          "containerId": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
           "attributes": {}
         },
         {
-          "id": "f79b9b99-7a31-470a-9827-e07eb20c7c4f",
+          "id": "6b023c6e-3086-4a79-b1ad-1c6200ad7a9a",
+          "name": "revoke_credential",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
+          "attributes": {}
+        },
+        {
+          "id": "9b978360-7a25-4951-97a8-7ad3301e99bd",
           "name": "view_certificates",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "60306526-b937-4244-ac89-cc1283c8ed74",
+          "containerId": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
           "attributes": {}
         },
         {
-          "id": "60db179e-d678-4a51-bc31-6c2e55345824",
-          "name": "view_credential_requests",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "60306526-b937-4244-ac89-cc1283c8ed74",
-          "attributes": {}
-        },
-        {
-          "id": "b23c7037-0635-44c4-915d-0d77d64046a5",
+          "id": "c83db2ed-365d-467f-81da-adcaca946d9a",
           "name": "decision_ssicredential",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "60306526-b937-4244-ac89-cc1283c8ed74",
+          "containerId": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
+          "attributes": {}
+        },
+        {
+          "id": "e302aeb3-4611-4570-a8ac-6f69031d43d2",
+          "name": "revoke_credentials_issuer",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
+          "attributes": {}
+        },
+        {
+          "id": "c8e1149b-de27-4ac2-8f10-7e1e133c2da2",
+          "name": "request_ssicredential",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
+          "attributes": {}
+        },
+        {
+          "id": "b4ad329e-9318-4ac8-b69c-eb8cc84cf23b",
+          "name": "view_credential_requests",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
           "attributes": {}
         }
       ],
       "Cl2-CX-Portal": [
         {
-          "id": "39ff444c-888a-4bf6-b8e1-343b66f8a067",
-          "name": "decline_new_partner",
-          "description": "User can decline a partner application",
+          "id": "23abd6c3-6620-4703-82b3-3582dd4381ea",
+          "name": "delete_own_user_account",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "c51f3a5a-02e0-414f-9c60-c2ec5c53bb09",
-          "name": "update_company_role",
+          "id": "4f73c905-9e5d-4cbb-bbb0-4ba4e4da36f5",
+          "name": "view_tech_user_management",
+          "description": "View technical users",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "46905bb9-8d3b-4666-891f-a67e8f963b3b",
-          "name": "view_documents",
-          "description": "User can view/download documents",
-          "composite": false,
+          "id": "41fd9f3b-8523-4cfd-a1c4-8b5f4a26adef",
+          "name": "CX User",
+          "composite": true,
+          "composites": {
+            "client": {
+              "technical_roles_management": [
+                "BPDM Pool Consumer"
+              ],
+              "Cl5-CX-Custodian": [
+                "view_wallet"
+              ],
+              "Cl1-CX-Registration": [
+                "view_registration"
+              ],
+              "Cl24-CX-SSI-CredentialIssuer": [
+                "view_credential_requests"
+              ],
+              "Cl2-CX-Portal": [
+                "delete_own_user_account",
+                "delete_notifications",
+                "view_subscription",
+                "view_service_subscriptions",
+                "view_own_user_account",
+                "view_certificates",
+                "view_membership",
+                "update_own_user_account",
+                "view_service_marketplace",
+                "view_company_data",
+                "view_service_offering",
+                "view_partner_network",
+                "view_documents",
+                "view_notifications",
+                "view_apps",
+                "view_user_management"
+              ],
+              "Cl3-CX-Semantic": [
+                "view_semantic_model"
+              ]
+            }
+          },
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "0769d6ca-3056-42da-84cd-35f2d535d79e",
-          "name": "delete_connectors",
-          "description": "Delete company connectors",
+          "id": "734af99a-62ad-44a1-870d-2ec1acfc46cc",
+          "name": "unsubscribe_apps",
+          "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "54bd7ad1-0773-4c9e-b1be-5cf41faa1c05",
-          "name": "update_service_offering",
+          "id": "3a7b57e5-5205-4db4-8d15-4af7a5a012f0",
+          "name": "add_tech_user_management",
+          "description": "Create / request technical users for my org",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "d566bb6c-e621-4517-9322-26093231b77c",
+          "id": "a7820378-d198-4f0c-924e-2bf86684707c",
+          "name": "view_connectors",
+          "description": "Look up company connectors and their details",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "319dc1ff-cd0e-49d6-87fe-15c77ec06d90",
           "name": "Service Manager",
           "composite": true,
           "composites": {
@@ -231,643 +277,181 @@
                 "view_wallet"
               ],
               "Cl1-CX-Registration": [
-                "delete_documents",
-                "view_registration"
+                "view_registration",
+                "delete_documents"
               ],
               "Cl24-CX-SSI-CredentialIssuer": [
                 "view_credential_requests"
               ],
               "Cl2-CX-Portal": [
-                "view_license_types",
-                "delete_connectors",
-                "update_service_offering",
-                "view_technical_setup",
                 "view_tech_user_management",
-                "view_service_marketplace",
+                "delete_own_user_account",
+                "delete_notifications",
                 "CX User",
-                "view_service_offering",
-                "view_autosetup_status",
-                "add_connectors",
+                "add_tech_user_management",
+                "view_license_types",
+                "view_connectors",
+                "delete_tech_user_management",
+                "view_subscription",
                 "view_own_user_account",
+                "add_self_descriptions",
+                "view_certificates",
                 "view_use_cases",
+                "view_membership",
+                "view_technical_setup",
+                "view_partner_network",
+                "view_autosetup_status",
+                "technical_roles_management",
                 "service_management",
                 "view_idp",
-                "add_tech_user_management",
-                "view_membership",
-                "update_own_user_account",
                 "add_service_offering",
-                "add_self_descriptions",
                 "view_service_subscriptions",
+                "delete_connectors",
+                "add_connectors",
                 "activate_subscription",
-                "view_notifications",
-                "view_certificates",
-                "technical_roles_management",
-                "delete_tech_user_management",
-                "delete_own_user_account",
-                "view_subscription",
-                "delete_notifications",
-                "view_connectors",
-                "view_partner_network"
-              ],
-              "Cl3-CX-Semantic": [
-                "add_semantic_model",
-                "update_semantic_model",
-                "view_semantic_model",
-                "delete_semantic_model"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "4d1ca50b-8a6e-47ee-9a9b-ed5a919bc0d5",
-          "name": "invite_new_partner",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "34742e28-1497-4222-ad1f-93ab9feac92e",
-          "name": "view_app_subscription",
-          "description": "view app subscriptions in pending, active and inactive",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "d41dd839-6562-4be4-8364-de787c367458",
-          "name": "delete_documents",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "8cceb06a-fa9d-4251-a336-9173d268c6d3",
-          "name": "app_management",
-          "description": "can manage apps",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "1290996a-0229-49b8-8aa4-732f4d27f5fa",
-          "name": "view_company_data",
-          "description": "view_company_data",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "ff9d65f5-dbdf-4971-8042-f36bb23cc52c",
-          "name": "approve_app_release",
-          "description": "User can approve apps to get released on the marketplace",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "27521792-5070-4dd9-93ed-d4fea69877e2",
-          "name": "view_app_language",
-          "description": "View available app language",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "c41486f4-86d3-4b9b-9fb0-ceeaaf718268",
-          "name": "modify_user_account",
-          "description": "Users with this right can modify users related to their company",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "19c0e799-4ffd-4709-8b38-45540c677e50",
-          "name": "view_autosetup_status",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "03490917-fd0d-4893-b901-3a426d3958db",
-          "name": "App Developer",
-          "composite": true,
-          "composites": {
-            "client": {
-              "technical_roles_management": [
-                "BPDM Pool Consumer"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
-              "Cl1-CX-Registration": [
-                "view_registration"
-              ],
-              "Cl24-CX-SSI-CredentialIssuer": [
-                "view_credential_requests"
-              ],
-              "Cl2-CX-Portal": [
-                "view_license_types",
-                "view_technical_setup",
-                "view_tech_user_management",
-                "view_service_subscriptions",
-                "app_management",
-                "view_certificates",
-                "view_app_language",
-                "technical_roles_management",
-                "CX User",
-                "edit_apps",
-                "view_use_cases",
-                "view_apps"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "5c0d11f9-a90d-4960-9917-450b70b419f2",
-          "name": "Business Admin",
-          "composite": true,
-          "composites": {
-            "client": {
-              "technical_roles_management": [
-                "BPDM Pool Consumer"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
-              "Cl1-CX-Registration": [
-                "view_registration"
-              ],
-              "Cl24-CX-SSI-CredentialIssuer": [
-                "view_credential_requests",
-                "revoke_credential",
-                "request_ssicredential",
-                "view_use_case_participation",
-                "view_certificates"
-              ],
-              "Cl2-CX-Portal": [
-                "view_documents",
-                "view_app_subscription",
-                "add_user_account",
-                "view_company_data",
                 "view_service_marketplace",
-                "modify_user_account",
-                "view_service_offering",
-                "view_autosetup_status",
-                "unsubscribe_apps",
-                "upload_certificates",
-                "view_own_user_account",
-                "view_user_management",
-                "subscribe_apps",
-                "subscribe_service",
-                "view_membership",
                 "update_own_user_account",
-                "request_ssicredential",
-                "view_service_subscriptions",
-                "view_notifications",
-                "view_certificates",
-                "delete_certificates",
-                "view_client_roles",
-                "delete_own_user_account",
-                "unsubscribe_services",
-                "view_apps",
-                "view_subscription",
-                "view_use_case_participation",
-                "delete_notifications",
-                "view_partner_network",
-                "view_idp"
+                "view_service_offering",
+                "update_service_offering",
+                "view_notifications"
               ],
               "Cl3-CX-Semantic": [
                 "add_semantic_model",
-                "update_semantic_model",
                 "view_semantic_model",
-                "delete_semantic_model"
+                "delete_semantic_model",
+                "update_semantic_model"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "37dc74e9-9f50-49d2-9b95-402b04aa84ff",
-          "name": "add_connectors",
-          "description": "Add new connector (registration and self-description)",
+          "id": "1d5d0fa8-d207-4086-bfef-ca79591d52b6",
+          "name": "disable_idp",
+          "description": "disable an assigned idp",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "c75a196c-2b82-4cd5-b572-0b70ec38e8fb",
-          "name": "configure_partner_registration",
-          "description": "",
+          "id": "5546af2e-8f02-4707-a31b-1cafca70c620",
+          "name": "delete_tech_user_management",
+          "description": "Delete a technical user",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "c9ccade7-ef44-44d2-9607-dae18ad5d2cd",
-          "name": "service_management",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "9f7a5a51-6a38-4d53-816a-6db01ef52111",
-          "name": "view_own_user_account",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "1d12d087-bcaf-4ad5-b21f-77fdce13b423",
-          "name": "view_user_management",
-          "description": "Users with this right can access the user management in CX",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "bcfd6c59-c999-440a-91ac-396a2b0322d4",
-          "name": "view_idp",
-          "description": "User can view IdP details",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "0cf91728-4ab6-413c-af72-4d8aee959c51",
-          "name": "add_apps",
-          "description": "Users with this role can publish new apps in the Marketplace",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "146c2388-2e26-4505-b85d-6824a4f80a2e",
-          "name": "add_tech_user_management",
-          "description": "Create / request technical users for my org",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "a88b7f46-d6c8-46bf-96e4-ec824e8eaee4",
-          "name": "update_application_bpn_credential",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "66f4b417-25d4-47d7-b3d2-e6eb80bcba5e",
-          "name": "create_partner_registration",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "0d41349d-30a8-42c1-9e1c-2b67d69fba30",
-          "name": "update_own_user_account",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "b584419b-1973-4c80-b5f9-0d5989263bd4",
-          "name": "add_self_descriptions",
-          "description": "add self descriptions",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "03897cfe-32c2-4a94-a554-0685d7de63ba",
-          "name": "request_ssicredential",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "f42c35ab-9a75-4be8-9c7d-3ca39a156eba",
-          "name": "view_user_account",
-          "description": "Users with this role can view the user account of others",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "e5267609-478c-40b6-bf96-6495bba42cd5",
-          "name": "view_service_subscriptions",
-          "description": "User is able to view service subscription under own service",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "065e25ce-29db-41f2-87aa-f4003d62df62",
-          "name": "activate_subscription",
-          "description": "Activation of subscriptions",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "0de2c803-1130-4ebf-9dfb-5016aadb9ca2",
-          "name": "setup_idp",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "26eacd86-808a-4869-ad64-564cda6b3e2f",
-          "name": "delete_certificates",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "6560b255-cbc6-4fb7-8afe-d61732e34ab1",
-          "name": "view_client_roles",
-          "description": "Users with this right can view the client roles of an app",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "9c81a6b2-737b-477c-9836-479605350a5f",
-          "name": "subscribe_service",
-          "description": "subscribe_service",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "3c3c8452-fd50-40bd-b223-9660233dd6af",
-          "name": "delete_user_account",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "c78c4b1f-5578-4b31-8be4-c386fd58c55c",
+          "id": "5f8eba43-3bbd-4a83-aace-28af28308b04",
           "name": "view_subscription",
           "description": "View my company subscriptions",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "f4eca60a-55c3-4b53-b3ee-f93a73d497f1",
-          "name": "delete_notifications",
-          "description": "User can delete notifications",
+          "id": "663faf7d-e060-428b-988a-34d4468d33c4",
+          "name": "add_apps",
+          "description": "Users with this role can publish new apps in the Marketplace",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "2e210651-de0f-4f3d-9701-6736c39dfd36",
-          "name": "submit_connector_sd",
+          "id": "853cc861-110e-4bbf-8e37-ce51f36736c3",
+          "name": "view_own_user_account",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "5c5c64c9-46c8-4876-88d0-91cdba553718",
-          "name": "view_license_types",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "cbf9e4ee-77f1-4310-b461-67995552324e",
+          "id": "99738b16-5f9a-4fb9-955a-b89538f973eb",
           "name": "view_submitted_applications",
           "description": "Users with this right can view submitted applications and the respective application status",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "c6e35f9f-f7c0-4899-9ce6-7cce7ea79304",
-          "name": "approve_new_partner",
-          "description": "User with this right can let new partners access the portal by approving the company registration request inside the admin board",
+          "id": "fc2e1d61-44b3-45b7-b5ff-ed6ab5e8d653",
+          "name": "add_self_descriptions",
+          "description": "add self descriptions",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "67ac93fa-6616-466a-b1db-5293b13c15bb",
+          "id": "c7fd1b1b-bfa1-49e2-b65e-78988d197922",
+          "name": "view_certificates",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "2954131f-4352-473d-8ab7-ed316508e285",
+          "name": "view_use_cases",
+          "description": "Users can view available use cases in the network",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "ab4580b8-27df-4d61-af88-b833d07a1318",
+          "name": "subscribe_service",
+          "description": "subscribe_service",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "5ad43989-2b54-466b-8fac-7febaa709c2e",
+          "name": "view_membership",
+          "description": "view_membership",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "7d04e5d9-d38f-4577-b067-caa0f0b48f2a",
+          "name": "view_company_data",
+          "description": "view_company_data",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "6e675aa5-c3ea-4dee-925d-7867c15c2397",
           "name": "view_technical_setup",
           "description": "Users with this right can setup EDC /IDP/etc.",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "a34170d5-779d-489b-b2bb-e1b99b88b638",
-          "name": "view_tech_user_management",
-          "description": "View technical users",
+          "id": "44a40a71-d1c3-4745-8d9b-ff5c269006a9",
+          "name": "view_autosetup_status",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "5998f67b-b190-443d-ab9b-3e76bbd73cab",
-          "name": "add_user_account",
-          "description": "Users with this right can add user accounts under their CX company",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "5654ef02-0b23-422e-8eb3-7bd95778db8f",
-          "name": "IT Admin",
-          "composite": true,
-          "composites": {
-            "client": {
-              "technical_roles_management": [
-                "BPDM Pool Consumer"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
-              "Cl1-CX-Registration": [
-                "view_registration"
-              ],
-              "Cl24-CX-SSI-CredentialIssuer": [
-                "view_credential_requests",
-                "view_use_case_participation",
-                "revoke_credential",
-                "request_ssicredential",
-                "view_certificates"
-              ],
-              "Cl2-CX-Portal": [
-                "view_documents",
-                "delete_connectors",
-                "view_company_data",
-                "modify_user_account",
-                "add_connectors",
-                "configure_partner_registration",
-                "view_own_user_account",
-                "view_user_management",
-                "view_idp",
-                "add_tech_user_management",
-                "update_own_user_account",
-                "add_self_descriptions",
-                "view_user_account",
-                "request_ssicredential",
-                "view_service_subscriptions",
-                "setup_idp",
-                "view_client_roles",
-                "subscribe_service",
-                "delete_user_account",
-                "view_subscription",
-                "delete_notifications",
-                "view_technical_setup",
-                "view_tech_user_management",
-                "add_user_account",
-                "view_managed_idp",
-                "view_service_marketplace",
-                "view_service_offering",
-                "disable_idp",
-                "add_idp",
-                "delete_idp",
-                "view_membership",
-                "view_notifications",
-                "view_certificates",
-                "technical_roles_management",
-                "delete_tech_user_management",
-                "delete_own_user_account",
-                "view_apps",
-                "modify_connectors",
-                "view_use_case_participation",
-                "view_connectors",
-                "view_partner_network"
-              ],
-              "Cl3-CX-Semantic": [
-                "view_semantic_model"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "f70ac54f-c8fa-4d87-b7a6-e5a8c028cafe",
-          "name": "Sales Manager",
-          "composite": true,
-          "composites": {
-            "client": {
-              "technical_roles_management": [
-                "BPDM Pool Consumer"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
-              "Cl1-CX-Registration": [
-                "view_registration"
-              ],
-              "Cl24-CX-SSI-CredentialIssuer": [
-                "view_credential_requests"
-              ],
-              "Cl2-CX-Portal": [
-                "view_app_subscription",
-                "view_service_subscriptions",
-                "app_management",
-                "activate_subscription",
-                "view_certificates",
-                "subscribe_service",
-                "CX User",
-                "view_service_offering",
-                "unsubscribe_apps",
-                "unsubscribe_services",
-                "service_management",
-                "subscribe_apps"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "4f2b58a5-0ebd-4b91-b354-4fefd40cc811",
-          "name": "delete_apps",
-          "description": "User with this role can delete apps published in the Marketplace",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "5bcbf360-c331-4fbf-b1d2-b16b1a1ec25a",
-          "name": "approve_service_release",
-          "description": "approve_service_release",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "21faf04f-5a8b-478a-ac93-face954ee15d",
-          "name": "view_managed_idp",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "e22b8f21-abf0-4fb1-8b26-f468ed9f86ac",
+          "id": "bb722687-58d6-40f7-9c27-a5150aae3f45",
           "name": "Business Partner Data Manager",
           "description": "",
           "composite": true,
@@ -887,319 +471,169 @@
             }
           },
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "43a0826f-ba1a-44d4-952f-e4b879be353c",
-          "name": "view_service_marketplace",
-          "description": "view_service_marketplace",
+          "id": "1c502a5f-6560-4718-90c3-ecb1186666c7",
+          "name": "technical_roles_management",
+          "description": "technical roles management",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "4581b083-0c1e-42a2-bb4c-85dfd14cfa23",
-          "name": "Company Admin",
-          "composite": true,
-          "composites": {
-            "client": {
-              "technical_roles_management": [
-                "BPDM Pool Consumer"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
-              "Cl1-CX-Registration": [
-                "view_registration"
-              ],
-              "Cl24-CX-SSI-CredentialIssuer": [
-                "view_credential_requests",
-                "view_use_case_participation",
-                "revoke_credential",
-                "request_ssicredential",
-                "view_certificates"
-              ],
-              "Cl2-CX-Portal": [
-                "update_company_role",
-                "view_documents",
-                "delete_connectors",
-                "view_app_subscription",
-                "delete_documents",
-                "view_company_data",
-                "view_app_language",
-                "modify_user_account",
-                "view_autosetup_status",
-                "add_connectors",
-                "configure_partner_registration",
-                "view_own_user_account",
-                "view_user_management",
-                "view_idp",
-                "add_tech_user_management",
-                "update_own_user_account",
-                "add_self_descriptions",
-                "view_user_account",
-                "request_ssicredential",
-                "setup_idp",
-                "delete_certificates",
-                "view_client_roles",
-                "subscribe_service",
-                "delete_user_account",
-                "view_subscription",
-                "delete_notifications",
-                "view_technical_setup",
-                "view_tech_user_management",
-                "add_user_account",
-                "view_managed_idp",
-                "view_service_marketplace",
-                "view_service_offering",
-                "unsubscribe_apps",
-                "disable_idp",
-                "upload_certificates",
-                "view_use_cases",
-                "subscribe_apps",
-                "add_idp",
-                "delete_idp",
-                "view_membership",
-                "view_notifications",
-                "view_certificates",
-                "technical_roles_management",
-                "delete_tech_user_management",
-                "delete_own_user_account",
-                "unsubscribe_services",
-                "view_apps",
-                "modify_connectors",
-                "view_use_case_participation",
-                "view_connectors",
-                "view_partner_network"
-              ],
-              "Cl3-CX-Semantic": [
-                "view_semantic_model",
-                "delete_semantic_model",
-                "add_semantic_model",
-                "update_semantic_model"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "496ae7df-fabd-4977-bb81-d6eb96ad81ed",
-          "name": "CX User",
-          "composite": true,
-          "composites": {
-            "client": {
-              "technical_roles_management": [
-                "BPDM Pool Consumer"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
-              "Cl1-CX-Registration": [
-                "view_registration"
-              ],
-              "Cl24-CX-SSI-CredentialIssuer": [
-                "view_credential_requests"
-              ],
-              "Cl2-CX-Portal": [
-                "view_documents",
-                "view_membership",
-                "update_own_user_account",
-                "view_service_subscriptions",
-                "view_company_data",
-                "view_notifications",
-                "view_certificates",
-                "view_service_marketplace",
-                "view_service_offering",
-                "delete_own_user_account",
-                "view_own_user_account",
-                "view_apps",
-                "view_user_management",
-                "view_subscription",
-                "delete_notifications",
-                "view_partner_network"
-              ],
-              "Cl3-CX-Semantic": [
-                "view_semantic_model"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "a1bc8bb5-03bb-465e-8795-c68e3920c51d",
-          "name": "view_service_offering",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "d4833daf-92a0-4509-9b45-4957ca1933d3",
-          "name": "unsubscribe_apps",
+          "id": "f3eadb0f-7339-4a40-a6a6-95cb5c6ebacc",
+          "name": "service_management",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "d9609443-abd1-462f-8881-3e7d8213d785",
-          "name": "disable_idp",
-          "description": "disable an assigned idp",
+          "id": "c95730d8-58d6-4557-9244-4532313af853",
+          "name": "view_documents",
+          "description": "User can view/download documents",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "a5492307-2072-4c5d-9de3-f507f3d3302e",
-          "name": "App Manager",
-          "composite": true,
-          "composites": {
-            "client": {
-              "technical_roles_management": [
-                "BPDM Pool Consumer"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
-              "Cl1-CX-Registration": [
-                "view_registration"
-              ],
-              "Cl24-CX-SSI-CredentialIssuer": [
-                "view_credential_requests"
-              ],
-              "Cl2-CX-Portal": [
-                "add_apps",
-                "view_license_types",
-                "view_app_subscription",
-                "view_service_subscriptions",
-                "activate_subscription",
-                "delete_apps",
-                "view_certificates",
-                "CX User",
-                "view_autosetup_status",
-                "App Developer",
-                "edit_apps",
-                "view_connectors"
-              ],
-              "Cl3-CX-Semantic": [
-                "add_semantic_model",
-                "update_semantic_model",
-                "view_semantic_model",
-                "delete_semantic_model"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "48c262f0-3f56-4bab-94d5-f3c30fb5d9f9",
-          "name": "upload_certificates",
-          "description": "",
+          "id": "4a53d366-314e-4bcf-91db-6bb1d463d637",
+          "name": "view_user_account",
+          "description": "Users with this role can view the user account of others",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "174783fa-1473-4921-8ac4-8d18703836b3",
-          "name": "send_mail",
-          "description": "",
+          "id": "6bb139c0-6c36-49bb-bfc3-a5835c21317f",
+          "name": "delete_user_account",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "b4bead06-e3c4-4fce-9e06-43d9d9537766",
-          "name": "view_use_cases",
-          "description": "Users can view available use cases in the network",
+          "id": "eae5dc26-bde0-4f8d-b99c-c00719735a63",
+          "name": "approve_app_release",
+          "description": "User can approve apps to get released on the marketplace",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "51e6dede-686f-43d5-925a-693784f8a661",
-          "name": "subscribe_apps",
-          "description": "User is able to start the app subscription process",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "8d3a5c8d-d4dc-4aaa-8941-9cd38cd3906e",
-          "name": "update_application_checklist_value",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "9b440b50-0ddd-4a6f-9a22-24073aea801e",
-          "name": "add_idp",
-          "description": "User can create a new idp under his organisation",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "c190da2a-aad4-4a02-9904-88207ba322a6",
-          "name": "delete_idp",
-          "description": "User can delete company idps",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "8cebb227-d72c-428e-92fd-6b4c01cbb899",
-          "name": "view_membership",
-          "description": "view_membership",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "ee373634-1eb3-4702-a269-774f36f54453",
-          "name": "decline_service_release",
-          "description": "decline_service_release",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "b06c2999-6008-4fb6-a22f-93fdac150656",
+          "id": "4e69e88a-56f9-4088-b3f9-5d91a0585b54",
           "name": "decline_app_release",
           "description": "User can decline apps to not get released on the marketplace",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "3a3af42c-c564-44ca-b83c-6d5c3bbd6087",
+          "id": "1d56de30-4e0d-47d9-9979-644fc4f4fbb7",
+          "name": "view_idp",
+          "description": "User can view IdP details",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "900c01e7-aef9-4ff1-b05c-9347eb4b7c66",
+          "name": "view_use_case_participation",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "c80fc400-be67-4c53-ae42-a1d3cc66db94",
+          "name": "view_user_management",
+          "description": "Users with this right can access the user management in CX",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "f0e1a96d-24e1-4283-9c1c-8bffa882efc8",
+          "name": "add_user_account",
+          "description": "Users with this right can add user accounts under their CX company",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "122a6004-a891-4312-9105-10879652b018",
+          "name": "upload_certificates",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "4745330d-6345-4674-a355-da6727e7cf2d",
+          "name": "approve_service_release",
+          "description": "approve_service_release",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "a28b1610-a663-49e7-adbc-1b954f963d98",
           "name": "add_service_offering",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "765bced5-b422-4f91-b35f-19d648595e6a",
+          "id": "13d8a819-c26c-4ce0-8c4d-02332ea34a76",
+          "name": "delete_apps",
+          "description": "User with this role can delete apps published in the Marketplace",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "c0d8b798-72ce-4630-aade-d070704c0266",
+          "name": "delete_documents",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "e556508c-37e5-4c3b-ad25-6b4d098241a7",
+          "name": "view_managed_idp",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "1f8bfb15-93c3-4981-8f07-e603c498c44b",
+          "name": "add_connectors",
+          "description": "Add new connector (registration and self-description)",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "13bba2f4-3e85-453a-bedf-a68581253e46",
           "name": "Purchaser",
           "composite": true,
           "composites": {
@@ -1217,79 +651,492 @@
                 "view_credential_requests"
               ],
               "Cl2-CX-Portal": [
-                "view_app_subscription",
-                "view_service_subscriptions",
-                "view_certificates",
-                "delete_certificates",
-                "subscribe_service",
                 "CX User",
                 "unsubscribe_apps",
-                "unsubscribe_services",
+                "delete_certificates",
                 "upload_certificates",
+                "unsubscribe_services",
+                "view_service_subscriptions",
+                "view_certificates",
+                "subscribe_service",
+                "view_app_subscription",
                 "subscribe_apps"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "f9ec0166-c20b-4f1f-9f0d-11349fec657c",
-          "name": "view_notifications",
-          "description": "User can view notification details",
+          "id": "f4e7e6af-5107-4aff-aeba-649a4664a88c",
+          "name": "modify_user_account",
+          "description": "Users with this right can modify users related to their company",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "8432f49c-8d6c-4b86-aebc-b259056037db",
-          "name": "update_application_membership_credential",
+          "id": "c15a401b-4ffe-406c-9d52-1c82009cd0dc",
+          "name": "send_mail",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "f1231514-aa65-408a-bf0d-c9d6d210e99a",
-          "name": "view_certificates",
+          "id": "87331d2c-8f61-4464-bfcc-2f3fc05fa757",
+          "name": "activate_subscription",
+          "description": "Activation of subscriptions",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "7b816094-20e7-44fb-a45f-3ecb9d9d7157",
+          "id": "3cc2dbf1-3072-470b-92b1-49ef33ac0dd7",
+          "name": "Company Admin",
+          "composite": true,
+          "composites": {
+            "client": {
+              "technical_roles_management": [
+                "BPDM Pool Consumer"
+              ],
+              "Cl5-CX-Custodian": [
+                "view_wallet"
+              ],
+              "Cl1-CX-Registration": [
+                "view_registration"
+              ],
+              "Cl24-CX-SSI-CredentialIssuer": [
+                "request_ssicredential",
+                "view_credential_requests",
+                "view_use_case_participation",
+                "revoke_credential",
+                "view_certificates"
+              ],
+              "Cl2-CX-Portal": [
+                "view_tech_user_management",
+                "delete_own_user_account",
+                "unsubscribe_apps",
+                "add_tech_user_management",
+                "view_connectors",
+                "disable_idp",
+                "view_subscription",
+                "delete_tech_user_management",
+                "view_own_user_account",
+                "add_self_descriptions",
+                "view_certificates",
+                "view_use_cases",
+                "subscribe_service",
+                "view_membership",
+                "view_company_data",
+                "view_technical_setup",
+                "view_autosetup_status",
+                "technical_roles_management",
+                "view_documents",
+                "view_user_account",
+                "delete_user_account",
+                "view_user_management",
+                "view_idp",
+                "view_use_case_participation",
+                "add_user_account",
+                "upload_certificates",
+                "delete_documents",
+                "view_managed_idp",
+                "add_connectors",
+                "modify_user_account",
+                "update_own_user_account",
+                "modify_connectors",
+                "update_company_role",
+                "delete_notifications",
+                "view_client_roles",
+                "configure_partner_registration",
+                "request_ssicredential",
+                "view_app_subscription",
+                "view_partner_network",
+                "view_apps",
+                "add_idp",
+                "delete_certificates",
+                "setup_idp",
+                "unsubscribe_services",
+                "delete_connectors",
+                "view_service_marketplace",
+                "view_service_offering",
+                "subscribe_apps",
+                "view_app_language",
+                "delete_idp",
+                "view_notifications"
+              ],
+              "Cl3-CX-Semantic": [
+                "add_semantic_model",
+                "view_semantic_model",
+                "delete_semantic_model",
+                "update_semantic_model"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "b89b547a-4b65-4207-a70e-cd4da014a7bd",
+          "name": "update_own_user_account",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "2da040d4-d1b9-44d9-bdcf-e03a9bae8f77",
+          "name": "decline_new_partner",
+          "description": "User can decline a partner application",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "6c546099-edb7-4e08-b9f7-ed63701b7606",
+          "name": "modify_connectors",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "cfa2ed20-e789-4738-9506-cbc1a08f4a6d",
+          "name": "update_company_role",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "69c9f49b-43a2-41f4-b81c-6ad48b5eeb4d",
+          "name": "update_application_checklist_value",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "295dce25-fb38-4395-8603-9b6b67810b1b",
+          "name": "update_service_offering",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "c7d70f8e-828f-4c75-afe9-bf448de54b48",
+          "name": "delete_notifications",
+          "description": "User can delete notifications",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "9070e274-260e-4c6c-b893-e5ea53ff4960",
+          "name": "view_client_roles",
+          "description": "Users with this right can view the client roles of an app",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "794741c2-85b7-4c8f-85dd-10c4d486f492",
+          "name": "configure_partner_registration",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "9828c9a3-8bdb-4651-875f-46bd314c9b6f",
+          "name": "view_license_types",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "c079a9bf-ea92-4b29-87b3-7d054c0631e1",
+          "name": "store_didDocument",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "c44562e5-caf4-4100-8d35-d9ef1477ab3a",
+          "name": "App Manager",
+          "composite": true,
+          "composites": {
+            "client": {
+              "technical_roles_management": [
+                "BPDM Pool Consumer"
+              ],
+              "Cl5-CX-Custodian": [
+                "view_wallet"
+              ],
+              "Cl1-CX-Registration": [
+                "view_registration"
+              ],
+              "Cl24-CX-SSI-CredentialIssuer": [
+                "view_credential_requests"
+              ],
+              "Cl3-CX-Semantic": [
+                "add_semantic_model",
+                "update_semantic_model",
+                "view_semantic_model",
+                "delete_semantic_model"
+              ],
+              "Cl2-CX-Portal": [
+                "CX User",
+                "add_tech_user_management",
+                "view_license_types",
+                "view_connectors",
+                "delete_apps",
+                "delete_tech_user_management",
+                "add_apps",
+                "view_service_subscriptions",
+                "edit_apps",
+                "view_certificates",
+                "activate_subscription",
+                "view_app_subscription",
+                "App Developer",
+                "view_autosetup_status"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "6e3dd610-efb9-4d82-b147-acfc5a33330f",
+          "name": "edit_apps",
+          "description": "Users with this role can edit apps which are published in the marketplace",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "bba412b2-a8e3-419d-bb6a-61fd4fa5cfb5",
+          "name": "request_ssicredential",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "2463d679-8f68-4262-a720-2f53ab6cbfca",
+          "name": "app_management",
+          "description": "can manage apps",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "be37e2f1-bffe-4779-88bf-c353721eed3a",
+          "name": "view_app_subscription",
+          "description": "view app subscriptions in pending, active and inactive",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "019eab18-2a57-477e-aec2-e96a53fa0dcc",
+          "name": "App Developer",
+          "composite": true,
+          "composites": {
+            "client": {
+              "technical_roles_management": [
+                "BPDM Pool Consumer"
+              ],
+              "Cl5-CX-Custodian": [
+                "view_wallet"
+              ],
+              "Cl1-CX-Registration": [
+                "view_registration"
+              ],
+              "Cl24-CX-SSI-CredentialIssuer": [
+                "view_credential_requests"
+              ],
+              "Cl2-CX-Portal": [
+                "view_tech_user_management",
+                "CX User",
+                "view_license_types",
+                "view_service_subscriptions",
+                "edit_apps",
+                "view_certificates",
+                "view_use_cases",
+                "view_technical_setup",
+                "app_management",
+                "view_app_language",
+                "technical_roles_management",
+                "view_apps"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "96f84726-631a-4b2a-9046-66ad9c83c2b8",
+          "name": "view_partner_network",
+          "description": "Partner Network view",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "158d4301-b8ca-46bd-8ddf-5a4ccc04a2b2",
+          "name": "decline_service_release",
+          "description": "decline_service_release",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "ad124f04-a38f-41c8-a47e-93258e747a0e",
+          "name": "Business Admin",
+          "composite": true,
+          "composites": {
+            "client": {
+              "technical_roles_management": [
+                "BPDM Pool Consumer"
+              ],
+              "Cl5-CX-Custodian": [
+                "view_wallet"
+              ],
+              "Cl1-CX-Registration": [
+                "view_registration"
+              ],
+              "Cl24-CX-SSI-CredentialIssuer": [
+                "view_credential_requests",
+                "request_ssicredential",
+                "view_use_case_participation",
+                "revoke_credential",
+                "view_certificates"
+              ],
+              "Cl2-CX-Portal": [
+                "delete_own_user_account",
+                "delete_notifications",
+                "unsubscribe_apps",
+                "view_client_roles",
+                "view_subscription",
+                "view_own_user_account",
+                "request_ssicredential",
+                "view_certificates",
+                "subscribe_service",
+                "view_membership",
+                "view_company_data",
+                "view_app_subscription",
+                "view_partner_network",
+                "view_autosetup_status",
+                "view_documents",
+                "view_apps",
+                "view_user_management",
+                "view_use_case_participation",
+                "view_idp",
+                "add_user_account",
+                "delete_certificates",
+                "upload_certificates",
+                "unsubscribe_services",
+                "view_service_subscriptions",
+                "modify_user_account",
+                "view_service_marketplace",
+                "update_own_user_account",
+                "view_service_offering",
+                "subscribe_apps",
+                "view_notifications"
+              ],
+              "Cl3-CX-Semantic": [
+                "add_semantic_model",
+                "view_semantic_model",
+                "delete_semantic_model",
+                "update_semantic_model"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "ea91e242-9951-4320-91df-051a6274f1ec",
+          "name": "view_apps",
+          "description": "Users with this role can view apps in the App Marketplace",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "86343501-dcd8-46f5-8a1a-0ff906d4504b",
+          "name": "add_idp",
+          "description": "User can create a new idp under his organisation",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "ad046384-7b91-468f-bccc-b35c002a682a",
+          "name": "delete_certificates",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "5052990e-ef14-43f5-adcb-8ff4efb3a425",
           "name": "CX Admin",
           "composite": true,
           "composites": {
             "client": {
               "Cl16-CX-BPDMGate": [
-                "read_input_changelog",
-                "read_output_changelog",
                 "read_output_partner",
                 "read_input_partner",
-                "read_stats",
+                "read_input_changelog",
+                "read_output_changelog",
                 "write_input_partner",
-                "read_sharing_state",
-                "write_sharing_state"
+                "write_sharing_state",
+                "read_stats",
+                "read_sharing_state"
               ],
               "Cl7-CX-BPDM": [
                 "write_metadata",
-                "read_partner_member",
                 "read_partner",
-                "read_changelog",
-                "read_changelog_member",
                 "write_partner",
-                "read_metadata"
+                "read_changelog",
+                "read_partner_member",
+                "read_metadata",
+                "read_changelog_member",
+                "read_partner_member_owned"
               ],
               "Cl5-CX-Custodian": [
                 "add_wallet",
-                "view_wallet",
+                "delete_wallet",
                 "update_wallet",
-                "delete_wallet"
+                "view_wallet"
               ],
               "technical_roles_management": [
                 "BPDM Pool Consumer"
@@ -1299,421 +1146,481 @@
               ],
               "Cl24-CX-SSI-CredentialIssuer": [
                 "revoke_credentials_issuer",
+                "view_credential_requests",
+                "revoke_credential",
+                "decision_ssicredential",
+                "request_ssicredential",
+                "view_use_case_participation",
+                "view_certificates"
+              ],
+              "Cl2-CX-Portal": [
+                "add_tech_user_management",
+                "view_subscription",
+                "add_apps",
+                "add_self_descriptions",
+                "view_use_cases",
+                "subscribe_service",
+                "view_technical_setup",
+                "view_autosetup_status",
+                "view_user_account",
+                "delete_user_account",
+                "approve_app_release",
+                "view_idp",
+                "decline_app_release",
+                "view_use_case_participation",
+                "add_user_account",
+                "approve_service_release",
+                "delete_apps",
+                "view_managed_idp",
+                "delete_documents",
+                "modify_connectors",
+                "decline_new_partner",
+                "update_company_role",
+                "configure_partner_registration",
+                "edit_apps",
+                "view_partner_network",
+                "view_apps",
+                "add_idp",
+                "setup_idp",
+                "unsubscribe_services",
+                "view_service_subscriptions",
+                "delete_connectors",
+                "approve_new_partner",
+                "delete_idp",
+                "view_app_language",
+                "view_notifications",
+                "view_tech_user_management",
+                "delete_own_user_account",
+                "unsubscribe_apps",
+                "view_connectors",
+                "disable_idp",
+                "delete_tech_user_management",
+                "view_own_user_account",
+                "view_submitted_applications",
                 "view_certificates",
+                "view_membership",
+                "view_company_data",
+                "technical_roles_management",
+                "view_documents",
+                "service_management",
+                "view_user_management",
+                "add_service_offering",
+                "add_connectors",
+                "modify_user_account",
+                "activate_subscription",
+                "update_own_user_account",
+                "update_service_offering",
+                "delete_notifications",
+                "view_client_roles",
+                "view_license_types",
+                "request_ssicredential",
+                "view_app_subscription",
+                "app_management",
+                "decline_service_release",
+                "invite_new_partner",
+                "create_ssi_notifications",
+                "view_service_marketplace",
+                "view_service_offering",
+                "subscribe_apps"
+              ],
+              "Cl3-CX-Semantic": [
+                "add_semantic_model",
+                "view_semantic_model",
+                "delete_semantic_model",
+                "update_semantic_model"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "ed9713fb-fa73-4f8c-a3cb-290b9b922fd1",
+          "name": "setup_idp",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "83e72d63-a0d3-4710-b89a-35efaf149335",
+          "name": "unsubscribe_services",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "837a6c2d-41d9-45a8-b988-bddcbc4812ef",
+          "name": "update_application_bpn_credential",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "36caf4ed-fb68-4a5a-93ed-2eac06772dbd",
+          "name": "view_service_subscriptions",
+          "description": "User is able to view service subscription under own service",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "84b817dd-7f24-46fd-a8e2-777cab26be87",
+          "name": "delete_connectors",
+          "description": "Delete company connectors",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "1c5a8953-7b11-4d59-b450-fd94ec9b5014",
+          "name": "invite_new_partner",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "2b7a628f-54b9-48ae-a431-b57362c2c14b",
+          "name": "create_ssi_notifications",
+          "description": "User can create notifications for ssi credentials",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "7bbdddf0-972d-4f0b-a273-907edd8bf405",
+          "name": "approve_new_partner",
+          "description": "User with this right can let new partners access the portal by approving the company registration request inside the admin board",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "63bee7be-cad5-4859-b262-5739d4cb7f35",
+          "name": "submit_connector_sd",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "3f3a519e-a645-4b2a-89b0-e3233753b9ab",
+          "name": "view_service_marketplace",
+          "description": "view_service_marketplace",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "8371107c-8198-493f-a741-ef1a60db7656",
+          "name": "view_service_offering",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "5abf6b13-3e00-4fdc-918b-29ac74f5baab",
+          "name": "subscribe_apps",
+          "description": "User is able to start the app subscription process",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "7c9a2443-0923-495b-89ad-1657090a1d2f",
+          "name": "delete_idp",
+          "description": "User can delete company idps",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "40cc640e-0de7-429b-bafd-fbed102f1aff",
+          "name": "IT Admin",
+          "composite": true,
+          "composites": {
+            "client": {
+              "technical_roles_management": [
+                "BPDM Pool Consumer"
+              ],
+              "Cl5-CX-Custodian": [
+                "view_wallet"
+              ],
+              "Cl1-CX-Registration": [
+                "view_registration"
+              ],
+              "Cl24-CX-SSI-CredentialIssuer": [
+                "request_ssicredential",
                 "view_credential_requests",
                 "view_use_case_participation",
                 "revoke_credential",
-                "decision_ssicredential",
-                "request_ssicredential"
+                "view_certificates"
               ],
               "Cl2-CX-Portal": [
-                "view_documents",
-                "delete_connectors",
-                "update_service_offering",
-                "invite_new_partner",
-                "view_app_subscription",
-                "view_company_data",
-                "approve_app_release",
-                "view_autosetup_status",
-                "view_own_user_account",
-                "view_idp",
-                "add_apps",
-                "update_own_user_account",
-                "setup_idp",
-                "view_subscription",
-                "delete_notifications",
-                "view_license_types",
-                "approve_new_partner",
-                "view_technical_setup",
                 "view_tech_user_management",
-                "approve_service_release",
-                "view_managed_idp",
-                "unsubscribe_apps",
-                "disable_idp",
-                "subscribe_apps",
-                "add_idp",
-                "delete_idp",
-                "view_membership",
-                "decline_service_release",
-                "decline_app_release",
-                "add_service_offering",
-                "view_notifications",
-                "view_certificates",
-                "create_ssi_notifications",
-                "unsubscribe_services",
-                "modify_connectors",
-                "view_use_case_participation",
-                "view_partner_network",
-                "decline_new_partner",
-                "update_company_role",
-                "delete_documents",
-                "app_management",
-                "view_app_language",
-                "modify_user_account",
-                "add_connectors",
-                "service_management",
-                "view_user_management",
+                "delete_own_user_account",
                 "add_tech_user_management",
+                "view_connectors",
+                "disable_idp",
+                "view_subscription",
+                "delete_tech_user_management",
+                "view_own_user_account",
                 "add_self_descriptions",
-                "view_user_account",
-                "request_ssicredential",
-                "view_service_subscriptions",
-                "activate_subscription",
-                "view_client_roles",
+                "view_certificates",
                 "subscribe_service",
+                "view_membership",
+                "view_company_data",
+                "view_technical_setup",
+                "technical_roles_management",
+                "view_documents",
+                "view_user_account",
                 "delete_user_account",
-                "view_submitted_applications",
+                "view_user_management",
+                "view_idp",
+                "view_use_case_participation",
                 "add_user_account",
-                "delete_apps",
+                "view_managed_idp",
+                "add_connectors",
+                "modify_user_account",
+                "update_own_user_account",
+                "modify_connectors",
+                "delete_notifications",
+                "view_client_roles",
+                "configure_partner_registration",
+                "request_ssicredential",
+                "view_partner_network",
+                "view_apps",
+                "add_idp",
+                "setup_idp",
+                "view_service_subscriptions",
+                "delete_connectors",
                 "view_service_marketplace",
                 "view_service_offering",
-                "view_use_cases",
-                "technical_roles_management",
-                "delete_tech_user_management",
-                "delete_own_user_account",
-                "edit_apps",
-                "view_apps",
-                "view_connectors"
+                "delete_idp",
+                "view_notifications"
               ],
               "Cl3-CX-Semantic": [
-                "delete_semantic_model",
-                "add_semantic_model",
-                "update_semantic_model",
                 "view_semantic_model"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         },
         {
-          "id": "dc88f8a9-654c-4a97-8339-d6ad5aae7256",
-          "name": "store_didDocument",
+          "id": "c3e93a9b-aa21-410e-a9d2-ff9e7f5ade48",
+          "name": "view_app_language",
+          "description": "View available app language",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "14d61d19-b246-4e8f-9657-a062bc80fcf2",
+          "name": "Sales Manager",
+          "composite": true,
+          "composites": {
+            "client": {
+              "technical_roles_management": [
+                "BPDM Pool Consumer"
+              ],
+              "Cl5-CX-Custodian": [
+                "view_wallet"
+              ],
+              "Cl1-CX-Registration": [
+                "view_registration"
+              ],
+              "Cl24-CX-SSI-CredentialIssuer": [
+                "view_credential_requests"
+              ],
+              "Cl2-CX-Portal": [
+                "CX User",
+                "unsubscribe_apps",
+                "unsubscribe_services",
+                "view_service_subscriptions",
+                "view_certificates",
+                "activate_subscription",
+                "subscribe_service",
+                "view_service_offering",
+                "view_app_subscription",
+                "app_management",
+                "subscribe_apps",
+                "service_management"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "b575ad54-0bc8-4b5b-90e4-d8a94d81a6d3",
+          "name": "view_notifications",
+          "description": "User can view notification details",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
+          "id": "6eb16651-8e2b-40e8-ae4e-4032ce86593f",
+          "name": "update_application_membership_credential",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "92b5a061-8e54-4562-a86c-94c0bacef12d",
-          "name": "technical_roles_management",
-          "description": "technical roles management",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "4ac0c3dc-1401-4ed6-a5f8-d8e08e2f5c78",
-          "name": "delete_tech_user_management",
-          "description": "Delete a technical user",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "f02debf4-92ff-4b7f-a56c-db7c6321ceda",
-          "name": "delete_own_user_account",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "22b05ced-cd8e-4769-a368-b8266bf967ef",
-          "name": "create_ssi_notifications",
-          "description": "User can create notifications for ssi credentials",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "13fe64aa-6de6-4b94-9e3d-af9b2c7f2917",
-          "name": "edit_apps",
-          "description": "Users with this role can edit apps which are published in the marketplace",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "60832277-251d-47f0-b40b-004f7224d0fc",
-          "name": "unsubscribe_services",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "817fa189-808e-465c-b75d-838336ab7a84",
-          "name": "view_apps",
-          "description": "Users with this role can view apps in the App Marketplace",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "dc2b47a7-8e7e-49a1-b23a-e099168b8229",
-          "name": "modify_connectors",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "42873085-5177-4ff5-88df-0290e568babd",
-          "name": "view_use_case_participation",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "e5ec6a66-8fad-4066-bcdd-92041f894831",
-          "name": "view_connectors",
-          "description": "Look up company connectors and their details",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-          "attributes": {}
-        },
-        {
-          "id": "104c094b-eaf5-4b0e-9758-f14dedf925da",
-          "name": "view_partner_network",
-          "description": "Partner Network view",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
           "attributes": {}
         }
       ],
       "Cl22-CX-BPND": [
         {
-          "id": "798bcaf7-fec5-414f-91ef-352967bfd72a",
-          "name": "add_bpn_discovery",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "48fc6e9e-a736-4b0b-9fea-59ad847b02e0",
-          "attributes": {}
-        },
-        {
-          "id": "07c35188-e159-4f5b-b05e-a393c5b8c115",
-          "name": "delete_bpn_discovery",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "48fc6e9e-a736-4b0b-9fea-59ad847b02e0",
-          "attributes": {}
-        },
-        {
-          "id": "05bc014a-ce02-4965-bdea-34d5b206e0e5",
+          "id": "7c8140b6-8482-4892-9725-336a1e0cd6a7",
           "name": "view_bpn_discovery",
           "composite": false,
           "clientRole": true,
-          "containerId": "48fc6e9e-a736-4b0b-9fea-59ad847b02e0",
+          "containerId": "93a98bea-a0fb-47ff-9ae1-2d987327df3f",
+          "attributes": {}
+        },
+        {
+          "id": "edcdf2ac-ae0d-48a8-8051-61e6454bad9b",
+          "name": "add_bpn_discovery",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "93a98bea-a0fb-47ff-9ae1-2d987327df3f",
+          "attributes": {}
+        },
+        {
+          "id": "a80d0c41-ebcc-4472-84bd-f7f791476ff1",
+          "name": "delete_bpn_discovery",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "93a98bea-a0fb-47ff-9ae1-2d987327df3f",
           "attributes": {}
         }
       ],
       "Cl21-CX-DF": [
         {
-          "id": "44a9692a-6d97-4ce0-9d1c-bcdd273792a9",
+          "id": "13cac913-5511-4fd2-9e91-e434fe36f546",
           "name": "view_discovery_endpoint",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "bf1cfe3e-3950-4fdc-8a58-13b73cec6740",
+          "containerId": "60e1415e-a5c9-44a2-8387-4769fd5b5059",
           "attributes": {}
         },
         {
-          "id": "3bb6b58e-b10b-4705-aef9-56f359e46111",
-          "name": "delete_discovery_endpoint",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "bf1cfe3e-3950-4fdc-8a58-13b73cec6740",
-          "attributes": {}
-        },
-        {
-          "id": "518d41c9-c7c7-4ab4-be2b-2b467977ecc9",
+          "id": "6f69e0ff-dc14-4c63-b786-7df307ff4049",
           "name": "add_discovery_endpoint",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "bf1cfe3e-3950-4fdc-8a58-13b73cec6740",
+          "containerId": "60e1415e-a5c9-44a2-8387-4769fd5b5059",
+          "attributes": {}
+        },
+        {
+          "id": "e625a270-e4ac-4e00-a93c-b2032f4167fd",
+          "name": "delete_discovery_endpoint",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "60e1415e-a5c9-44a2-8387-4769fd5b5059",
           "attributes": {}
         }
       ],
       "sa-cl8-cx-1": [],
       "Cl7-CX-BPDM": [
         {
-          "id": "52df2421-b796-4b47-9b3f-7e0bc1cd785e",
-          "name": "read_metadata",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "04cd6d38-674f-4588-980a-8f120bddcc44",
-          "attributes": {}
-        },
-        {
-          "id": "b6f32a00-39ab-4074-89c2-ae43cb27936f",
-          "name": "read_changelog",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "04cd6d38-674f-4588-980a-8f120bddcc44",
-          "attributes": {}
-        },
-        {
-          "id": "43eaf830-14a0-4935-a4d2-0f0060ca1e65",
-          "name": "read_partner_member",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "04cd6d38-674f-4588-980a-8f120bddcc44",
-          "attributes": {}
-        },
-        {
-          "id": "063fdc97-a010-4b9f-a646-8182a401bb75",
-          "name": "write_metadata",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "04cd6d38-674f-4588-980a-8f120bddcc44",
-          "attributes": {}
-        },
-        {
-          "id": "379d1ca0-7253-4277-82d8-143bacf84d56",
-          "name": "read_changelog_member",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "04cd6d38-674f-4588-980a-8f120bddcc44",
-          "attributes": {}
-        },
-        {
-          "id": "02fc3e0c-91c2-4b3c-acee-1fee157ea2b6",
+          "id": "7bd7d9df-eb03-4511-9984-82e835c2688a",
           "name": "write_partner",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "04cd6d38-674f-4588-980a-8f120bddcc44",
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
           "attributes": {}
         },
         {
-          "id": "682935a7-cd27-4bb3-b369-78d248e6a558",
+          "id": "b82f6737-59bc-464d-a0aa-797b8b78e5f4",
+          "name": "read_changelog",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
+          "attributes": {}
+        },
+        {
+          "id": "d85cedc3-83c2-4822-822f-68b7d7e5c550",
           "name": "read_partner",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "04cd6d38-674f-4588-980a-8f120bddcc44",
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
+          "attributes": {}
+        },
+        {
+          "id": "80d44073-d229-48b5-8135-15fce5b43b0e",
+          "name": "read_partner_member",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
+          "attributes": {}
+        },
+        {
+          "id": "f87acf00-b5c3-45c2-aa41-6b740e9d5563",
+          "name": "read_changelog_member",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
+          "attributes": {}
+        },
+        {
+          "id": "64b0cbff-1f11-417b-9134-7f1adcdeb277",
+          "name": "write_metadata",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
+          "attributes": {}
+        },
+        {
+          "id": "de92a46c-98c7-4b89-bec8-8c73aa354ded",
+          "name": "read_metadata",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
+          "attributes": {}
+        },
+        {
+          "id": "426a1cf1-46a0-484e-b2d6-436bb23a5df8",
+          "name": "read_partner_member_owned",
+          "description": "Allow read access to all business partners that are owned by Catena-X members",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
           "attributes": {}
         }
       ],
-      "Cl25-CX-BPDM-Orchestrator": [
-        {
-          "id": "4b20dc8b-0231-41a0-acef-662ed5353c18",
-          "name": "create_result_poolSync",
-          "description": "Allowed to create results for reserved golden record tasks in the 'PoolSync' queue.",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        },
-        {
-          "id": "0a5befef-6ecf-4bc8-ab94-7f0e3731c858",
-          "name": "read_task",
-          "description": "Allowed to read the processing state and result of golden record tasks.",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        },
-        {
-          "id": "4632b001-25e2-4ef8-bd04-05f7b9e0453d",
-          "name": "create_result_cleanAndSync",
-          "description": "Allowed to create results for reserved golden record tasks in the 'CleanAndSync' queue.",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        },
-        {
-          "id": "d335c39d-d160-40d6-86b1-11a6e1889ddd",
-          "name": "create_task",
-          "description": "Allowed to create new golden record tasks",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        },
-        {
-          "id": "1f15361f-c5ee-40e5-9169-fd32b3d0c8da",
-          "name": "create_reservation_clean",
-          "description": "Allowed to create reservations for golden record tasks inside the 'Clean' queue.",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        },
-        {
-          "id": "90451361-9282-4cee-bb43-96f084a43d7e",
-          "name": "create_reservation_poolSync",
-          "description": "Allowed to create reservations for golden record tasks in the 'PoolSync' queue.",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        },
-        {
-          "id": "f972bf5c-7454-4c3f-882b-0535eacd7dd9",
-          "name": "create_result_clean",
-          "description": "Allowed to create results for reserved golden record tasks in the 'Clean' queue.",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        },
-        {
-          "id": "dbb4cbda-671b-4b8c-8ed8-a9c3e8ad7256",
-          "name": "create_reservation_cleanAndSync",
-          "description": "Allowed to create reservations for golden record tasks in the 'CleanAndSync' queue",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
-          "attributes": {}
-        }
-      ],
-      "sa-cl25-cx-1": [],
-      "sa-cl25-cx-2": [],
-      "sa-cl25-cx-3": [],
-      "sa-cl7-cx-1": [],
       "technical_roles_management": [
         {
-          "id": "1e3bef93-036c-44a8-b37a-04ca9effcfcb",
-          "name": "BPDM Sharing Input Consumer",
-          "description": "",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl16-CX-BPDMGate": [
-                "read_input_changelog",
-                "read_stats",
-                "read_input_partner",
-                "read_sharing_state"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "4776c000-7232-4804-a133-aff0c01966ba",
+          "id": "9ca307cf-cff2-4eef-aef5-3d09b7e9053a",
           "name": "Semantic Model Management",
           "description": "",
           "composite": true,
@@ -1725,135 +1632,19 @@
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         },
         {
-          "id": "dee6cf7a-fb6b-451c-9ef7-87459893e48f",
-          "name": "Registration External",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl2-CX-Portal": [
-                "create_partner_registration",
-                "configure_partner_registration"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "8ce375c0-bab3-4df7-939f-a61cd0fa0ab1",
-          "name": "Offer Management",
-          "description": "",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl2-CX-Portal": [
-                "view_tech_user_management",
-                "add_service_offering",
-                "add_connectors",
-                "app_management",
-                "activate_subscription"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "97ac9e26-5db1-4b16-a7ef-a20473b7472d",
-          "name": "BPDM Sharing Input Manager",
-          "description": "",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl16-CX-BPDMGate": [
-                "read_input_changelog",
-                "read_stats",
-                "write_sharing_state",
-                "write_input_partner",
-                "read_input_partner",
-                "read_sharing_state"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "21afd9a8-aecb-4383-9726-4e19f5ed4ed2",
-          "name": "BPDM Pool Admin",
-          "description": "",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl7-CX-BPDM": [
-                "read_metadata",
-                "read_changelog",
-                "read_partner_member",
-                "write_metadata",
-                "read_changelog_member",
-                "write_partner",
-                "read_partner"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "50e20aeb-1dc7-464e-9a69-e48c34fa2078",
-          "name": "BPDM Sharing Output Consumer",
-          "description": "",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl16-CX-BPDMGate": [
-                "read_output_changelog",
-                "read_stats",
-                "read_output_partner",
-                "read_sharing_state"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "f456f008-49b1-40ea-ad89-61ad5470b5dc",
-          "name": "BPDM Pool Consumer",
-          "description": "",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl7-CX-BPDM": [
-                "read_metadata",
-                "read_changelog_member",
-                "read_partner_member"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "d5781775-3fbd-4f46-84ea-b19164393205",
+          "id": "16eccbd3-58af-4ea1-baea-adade8469ae1",
           "name": "Dataspace Discovery",
           "composite": true,
           "composites": {
             "client": {
               "Cl22-CX-BPND": [
+                "view_bpn_discovery",
                 "add_bpn_discovery",
-                "delete_bpn_discovery",
-                "view_bpn_discovery"
+                "delete_bpn_discovery"
               ],
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
@@ -1864,141 +1655,91 @@
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         },
         {
-          "id": "bb22abe9-7a62-4861-b00e-617298017db9",
-          "name": "BPDM Sharing Admin",
-          "description": "",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl16-CX-BPDMGate": [
-                "read_input_changelog",
-                "read_output_changelog",
-                "read_stats",
-                "write_sharing_state",
-                "read_output_partner",
-                "write_input_partner",
-                "read_input_partner",
-                "read_sharing_state"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "0324b0ed-43c0-4493-ad4b-4f202e288df0",
-          "name": "CX Membership Info",
+          "id": "5597527e-3fc6-4a8b-b763-487d078bc641",
+          "name": "Offer Management",
           "description": "",
           "composite": true,
           "composites": {
             "client": {
               "Cl2-CX-Portal": [
-                "view_membership"
+                "view_tech_user_management",
+                "activate_subscription",
+                "app_management",
+                "add_service_offering",
+                "add_connectors"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         },
         {
-          "id": "6f153999-e1a9-4cc7-b9c0-f53e7c5f7a42",
-          "name": "Identity Wallet Management",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl5-CX-Custodian": [
-                "view_wallet",
-                "update_wallet"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "58bc6143-972c-4bc1-bd07-78618ec20f5f",
-          "name": "BPDM Pool Sharing Consumer",
+          "id": "05be73bb-b186-40da-b3a7-efa03c9d0fa3",
+          "name": "BPDM Pool Admin",
           "description": "",
           "composite": true,
           "composites": {
             "client": {
               "Cl7-CX-BPDM": [
-                "read_metadata",
+                "write_partner",
                 "read_changelog",
-                "read_partner"
+                "read_partner",
+                "read_partner_member",
+                "write_metadata",
+                "read_changelog_member",
+                "read_metadata",
+                "read_partner_member_owned"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         },
         {
-          "id": "3fbeeb23-c281-43a4-b76a-f0805e919905",
-          "name": "BPDM Orchestrator Admin",
-          "description": "Full read and write access to the BPDM Orchestrator component",
+          "id": "19ce2a65-11f9-440f-a78c-186e6db985e9",
+          "name": "BPDM Pool Consumer",
+          "description": "",
           "composite": true,
           "composites": {
             "client": {
-              "Cl25-CX-BPDM-Orchestrator": [
-                "create_result_poolSync",
-                "read_task",
-                "create_result_cleanAndSync",
-                "create_task",
-                "create_reservation_clean",
-                "create_reservation_poolSync",
-                "create_result_clean",
-                "create_reservation_cleanAndSync"
+              "Cl7-CX-BPDM": [
+                "read_partner_member",
+                "read_changelog_member",
+                "read_metadata"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         },
         {
-          "id": "a0dab74a-13d2-4ced-b0af-fa8a3894c2ec",
-          "name": "BPDM Orchestrator Task Creator",
-          "description": "Allowed to create new golden record tasks, monitor the processing state and result.",
+          "id": "2e8f3f6a-60a8-48e6-b0fa-81f27e111a89",
+          "name": "BPDM Sharing Output Consumer",
+          "description": "",
           "composite": true,
           "composites": {
             "client": {
-              "Cl25-CX-BPDM-Orchestrator": [
-                "read_task",
-                "create_task"
+              "Cl16-CX-BPDMGate": [
+                "read_output_changelog",
+                "read_sharing_state",
+                "read_output_partner",
+                "read_stats"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         },
         {
-          "id": "efb560b1-3649-4af9-931e-4799c61504e6",
-          "name": "BPDM Orchestrator Processor Clean",
-          "description": "Allowed to process golden record tasks in the 'Clean' queue",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl25-CX-BPDM-Orchestrator": [
-                "create_reservation_clean",
-                "create_result_clean"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
-          "attributes": {}
-        },
-        {
-          "id": "4444626e-b5dd-4c8d-8897-0b7ad3ccdf21",
+          "id": "24e0133b-fdeb-4b9e-9cd6-c965718f2d00",
           "name": "BPDM Orchestrator Processor CleanAndSync",
           "description": "Allowed to process golden record tasks in the 'CleanAndSync' queue",
           "composite": true,
@@ -2011,67 +1752,349 @@
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         },
         {
-          "id": "a1e82d28-ab78-40ac-aae5-cda1f3615c61",
+          "id": "8529b128-6439-48b7-8c38-7640133fbca3",
+          "name": "BPDM Pool Sharing Consumer",
+          "description": "",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl7-CX-BPDM": [
+                "read_changelog",
+                "read_partner",
+                "read_metadata"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "f024abdd-a80e-49bf-8add-e7a45fb609a4",
+          "name": "BPDM Pool Use Case Consumer",
+          "description": "Role for Catena-X use case providers needing access to extended Cx member data",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl7-CX-BPDM": [
+                "read_partner_member_owned",
+                "read_metadata"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "d5203308-34fd-4357-b72b-5cc617a7c873",
+          "name": "Registration Internal",
+          "description": "Technical user enabling the invitation API to integrate 3rd party software.",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl2-CX-Portal": [
+                "view_submitted_applications",
+                "invite_new_partner"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "a20fd6e3-3a61-4e54-b47f-a0840d6a3c03",
+          "name": "BPDM Orchestrator Admin",
+          "description": "Full read and write access to the BPDM Orchestrator component",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "create_task",
+                "read_task",
+                "create_reservation_poolSync",
+                "create_reservation_clean",
+                "create_result_cleanAndSync",
+                "create_reservation_cleanAndSync",
+                "create_result_clean",
+                "create_result_poolSync"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "bbcf0d08-99d1-4350-8820-aebe67e73f37",
           "name": "BPDM Orchestrator Processor PoolSync",
           "description": "Allowed to process golden record tasks in the 'PoolSync' queue",
           "composite": true,
           "composites": {
             "client": {
               "Cl25-CX-BPDM-Orchestrator": [
-                "create_result_poolSync",
-                "create_reservation_poolSync"
+                "create_reservation_poolSync",
+                "create_result_poolSync"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "2d1909fd-36b6-4d8e-a81c-a9a319cd2f7f",
+          "name": "Registration External",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl2-CX-Portal": [
+                "configure_partner_registration"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "8b9c2f78-8527-4b80-9e0d-2c6dfb693860",
+          "name": "BPDM Sharing Input Consumer",
+          "description": "",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl16-CX-BPDMGate": [
+                "read_sharing_state",
+                "read_input_partner",
+                "read_input_changelog",
+                "read_stats"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "5ee770e3-95d5-4678-9615-2370d65c2d8d",
+          "name": "CX Membership Info",
+          "description": "",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl2-CX-Portal": [
+                "view_membership"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "2a441cfc-2296-4e38-803e-ac9e3cfc6b89",
+          "name": "Identity Wallet Management",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl5-CX-Custodian": [
+                "view_wallet",
+                "update_wallet"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "4fc0a657-085c-4ad3-bf69-02a43196db25",
+          "name": "BPDM Sharing Admin",
+          "description": "",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl16-CX-BPDMGate": [
+                "read_output_changelog",
+                "read_sharing_state",
+                "write_sharing_state",
+                "read_output_partner",
+                "read_input_partner",
+                "read_input_changelog",
+                "read_stats",
+                "write_input_partner"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "0e7b8361-bafa-4a5e-af2d-b8c9fa2459f2",
+          "name": "BPDM Orchestrator Task Creator",
+          "description": "Allowed to create new golden record tasks, monitor the processing state and result.",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "create_task",
+                "read_task"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "f18e0207-1620-47ed-bf0d-bfa865b4d468",
+          "name": "BPDM Sharing Input Manager",
+          "description": "",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl16-CX-BPDMGate": [
+                "read_sharing_state",
+                "write_sharing_state",
+                "read_input_partner",
+                "read_input_changelog",
+                "read_stats",
+                "write_input_partner"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "4645a525-78dd-4a29-9665-a411467d935d",
+          "name": "BPDM Orchestrator Processor Clean",
+          "description": "Allowed to process golden record tasks in the 'Clean' queue",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "create_reservation_clean",
+                "create_result_clean"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
         }
       ],
       "admin-cli": [],
       "realm-management": [
         {
-          "id": "aafa6845-0920-4013-a283-594c9dc7ac32",
+          "id": "1bc613dc-adca-47fb-afdb-fd9bfea1ad6b",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
+          "attributes": {}
+        },
+        {
+          "id": "ac682165-cfca-48b0-8cf5-21b5686068ca",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
+          "attributes": {}
+        },
+        {
+          "id": "2d8a2a59-0bd7-4493-9fa9-c8a8c1e48189",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
+          "attributes": {}
+        },
+        {
+          "id": "11a4ccb3-87d3-44ab-994e-2d3756d4072f",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
+          "attributes": {}
+        },
+        {
+          "id": "6d0bc95f-935d-4e60-a157-d0c03fb25fd3",
           "name": "view-realm",
           "description": "${role_view-realm}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "08811aa8-7a05-489d-9f5e-bd51fd39fbc3",
+          "id": "059e9b39-7f08-4035-a9ac-ac99a476662d",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
+          "attributes": {}
+        },
+        {
+          "id": "11262a8d-3dba-4b8e-b8ec-9fb27d5b0de0",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
+          "attributes": {}
+        },
+        {
+          "id": "c470f16b-6e98-414c-ab83-5252b5e58a3f",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
+          "attributes": {}
+        },
+        {
+          "id": "bdc3838a-be75-475e-a5a3-24f8c870d088",
           "name": "manage-realm",
           "description": "${role_manage-realm}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "172dbf29-cc79-438f-9f56-24d0941f04ea",
-          "name": "impersonation",
-          "description": "${role_impersonation}",
+          "id": "ac32c9fb-19a9-4cdf-b203-3869f96e62db",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "6ecdc37e-e84c-4b2f-b7f8-950ad361b831",
-          "name": "manage-events",
-          "description": "${role_manage-events}",
+          "id": "de7a4458-04c3-4416-80cc-4dff7101297d",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "3bc03769-6258-4202-9f83-2f9f33821ccb",
+          "id": "616ffd03-0734-426f-b191-a76cfacdc37a",
           "name": "view-users",
           "description": "${role_view-users}",
           "composite": true,
@@ -2084,116 +2107,80 @@
             }
           },
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "93db5b47-913a-4c45-a227-33f0b5c90701",
-          "name": "create-client",
-          "description": "${role_create-client}",
+          "id": "22314456-9956-4634-9554-a9267b228bfb",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "8cce49c4-c187-4573-ad0d-fddabc764ab3",
-          "name": "view-events",
-          "description": "${role_view-events}",
+          "id": "250b7497-c1b7-45a2-967e-39991f748678",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "a2621233-2118-44ef-aa5b-c1c75854e395",
-          "name": "query-clients",
-          "description": "${role_query-clients}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
-          "attributes": {}
-        },
-        {
-          "id": "fa001419-f155-4709-af5a-7753fa0d5798",
+          "id": "25643939-8ee8-4a30-ada5-687c02cbe3fa",
           "name": "view-identity-providers",
           "description": "${role_view-identity-providers}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "257abe39-01cd-44d1-96c3-e179d83effb6",
-          "name": "manage-users",
-          "description": "${role_manage-users}",
+          "id": "1b44f1f7-21f9-4252-87c9-d1fc711da051",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "ad4b404c-de7f-4224-bb64-fc132a6c54c1",
+          "id": "c1da3950-6b7e-4480-96d1-a3be3b5a49a0",
           "name": "realm-admin",
           "description": "${role_realm-admin}",
           "composite": true,
           "composites": {
             "client": {
               "realm-management": [
-                "view-realm",
-                "manage-realm",
-                "impersonation",
-                "manage-events",
-                "view-users",
-                "create-client",
-                "view-events",
-                "query-clients",
-                "view-identity-providers",
                 "manage-users",
-                "query-realms",
-                "manage-identity-providers",
-                "view-authorization",
-                "view-clients",
                 "manage-authorization",
                 "query-users",
+                "view-realm",
+                "view-events",
+                "query-clients",
+                "view-authorization",
+                "manage-identity-providers",
+                "manage-realm",
+                "query-realms",
+                "view-users",
                 "manage-clients",
-                "query-groups"
+                "manage-events",
+                "query-groups",
+                "view-identity-providers",
+                "impersonation",
+                "view-clients",
+                "create-client"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "13ba5952-cd79-4aea-9511-0741b2578980",
-          "name": "query-realms",
-          "description": "${role_query-realms}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
-          "attributes": {}
-        },
-        {
-          "id": "9842d196-88db-4df8-9c99-e383fa2e1b95",
-          "name": "manage-identity-providers",
-          "description": "${role_manage-identity-providers}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
-          "attributes": {}
-        },
-        {
-          "id": "14d19c59-046b-4772-8c2d-9dc1ccc82f46",
-          "name": "view-authorization",
-          "description": "${role_view-authorization}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
-          "attributes": {}
-        },
-        {
-          "id": "01feddbc-f742-42a9-ba3c-64f8ac2d5ba3",
+          "id": "525dd709-1e1a-4c21-b711-ca5ceca54d06",
           "name": "view-clients",
           "description": "${role_view-clients}",
           "composite": true,
@@ -2205,452 +2192,486 @@
             }
           },
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         },
         {
-          "id": "f36cf8ec-3f54-4df5-80e6-36b44c0b1803",
-          "name": "manage-authorization",
-          "description": "${role_manage-authorization}",
+          "id": "ece0a58c-d177-4fdb-9b45-e5c6961675cb",
+          "name": "create-client",
+          "description": "${role_create-client}",
           "composite": false,
           "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
-          "attributes": {}
-        },
-        {
-          "id": "b0c29452-6401-4f9d-a808-25b861c19006",
-          "name": "query-users",
-          "description": "${role_query-users}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
-          "attributes": {}
-        },
-        {
-          "id": "acf55e28-5dad-462b-abf5-51f598a7b8e8",
-          "name": "manage-clients",
-          "description": "${role_manage-clients}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
-          "attributes": {}
-        },
-        {
-          "id": "08547466-edfb-4676-9fb5-e4f4a6ee7363",
-          "name": "query-groups",
-          "description": "${role_query-groups}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+          "containerId": "834cf665-f6bc-416c-986b-6aa3c9906290",
           "attributes": {}
         }
       ],
       "Cl16-CX-BPDMGate": [
         {
-          "id": "913fa128-8614-49c9-9214-93958fc69758",
-          "name": "read_input_changelog",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
-          "attributes": {}
-        },
-        {
-          "id": "39b49fc2-e48b-4653-97ce-43229b411691",
+          "id": "c3338f4e-9457-4482-9208-af9657d1ed92",
           "name": "read_output_changelog",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
           "attributes": {}
         },
         {
-          "id": "8512daa5-2a72-49ce-a6e1-e05539a067ae",
-          "name": "read_stats",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
-          "attributes": {}
-        },
-        {
-          "id": "d28cdadc-e85f-432a-bd1f-a4350fa8b11a",
-          "name": "write_sharing_state",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
-          "attributes": {}
-        },
-        {
-          "id": "328fb08e-d257-442b-b8bd-da3b3fca85a0",
-          "name": "read_output_partner",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
-          "attributes": {}
-        },
-        {
-          "id": "88712f3f-d043-4739-9645-e814bcef399f",
-          "name": "write_input_partner",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
-          "attributes": {}
-        },
-        {
-          "id": "2c2dbbc9-3b33-4d40-9fa4-13b745134e43",
-          "name": "read_input_partner",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
-          "attributes": {}
-        },
-        {
-          "id": "88edfd18-e528-4622-9152-8e848db2db7d",
+          "id": "0a259e3d-2085-4a4b-aac9-946ec574d8b8",
           "name": "read_sharing_state",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
+          "attributes": {}
+        },
+        {
+          "id": "f75a27cb-6841-4713-81c1-ee61d7f1d511",
+          "name": "write_sharing_state",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
+          "attributes": {}
+        },
+        {
+          "id": "ad83e09f-2d8e-43c3-9a59-a8411aacae54",
+          "name": "read_input_partner",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
+          "attributes": {}
+        },
+        {
+          "id": "54d865e8-3e37-48d5-acd3-7ec2fb0e2b40",
+          "name": "read_output_partner",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
+          "attributes": {}
+        },
+        {
+          "id": "cfdf8d0f-5e3b-4113-a7f7-85a0837baaf8",
+          "name": "read_input_changelog",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
+          "attributes": {}
+        },
+        {
+          "id": "a90f6429-3366-4ef3-b36a-f211aa8d67d9",
+          "name": "read_stats",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
+          "attributes": {}
+        },
+        {
+          "id": "15431cbc-e6a7-4766-80f8-d5e2aab62fad",
+          "name": "write_input_partner",
+          "description": "",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
           "attributes": {}
         }
       ],
       "Cl5-CX-Custodian": [
         {
-          "id": "11c06d7d-8cab-42e8-b8bb-599940c61f2b",
-          "name": "delete_wallet",
-          "description": "User can delete his wallet",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
-          "attributes": {}
-        },
-        {
-          "id": "7cbf7bf7-be0b-4372-9b5d-56bfcfad4ef7",
-          "name": "add_wallets",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
-          "attributes": {}
-        },
-        {
-          "id": "4e985f0a-4d33-409c-93a2-8d1b1de000e6",
+          "id": "b61aeafb-7691-4a74-a24e-4bdf471bc63c",
           "name": "delete_wallets",
           "composite": false,
           "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
           "attributes": {}
         },
         {
-          "id": "823ef0fd-ad22-4817-b31b-4638139b435c",
+          "id": "d5f95fb6-7b41-4a03-8919-98b44b67e52f",
           "name": "update_wallets",
           "composite": false,
           "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
           "attributes": {}
         },
         {
-          "id": "191ff80d-5525-4dc5-a761-80783a4d8c04",
-          "name": "add_wallet",
-          "description": "Add a new wallet",
+          "id": "96aa42e8-e5eb-431f-990b-218d356f4b3f",
+          "name": "add_wallets",
           "composite": false,
           "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
           "attributes": {}
         },
         {
-          "id": "d6521ed5-9154-49a8-9ac4-c0a12573b201",
+          "id": "758018ba-f303-4b3a-b330-1f94ec73d0fb",
+          "name": "view_wallets",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
+          "attributes": {}
+        },
+        {
+          "id": "79daebe2-8855-4688-9a7c-f78f05e5ef17",
           "name": "view_wallet",
           "description": "Can view own wallet",
           "composite": false,
           "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
           "attributes": {}
         },
         {
-          "id": "dbdb11f0-f21a-4012-9610-43934407c309",
+          "id": "ef20c4ff-e5b9-4adc-839d-24bb531b830f",
+          "name": "delete_wallet",
+          "description": "User can delete his wallet",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
+          "attributes": {}
+        },
+        {
+          "id": "edda346c-3950-462d-bc4c-d781f33eab85",
           "name": "update_wallet",
           "description": "Change existing wallet",
           "composite": false,
           "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
           "attributes": {}
         },
         {
-          "id": "82b61160-ff26-4dd0-abf5-33d6ec57cdc7",
-          "name": "view_wallets",
+          "id": "a6587abc-726c-432b-a4f2-dc8ac7e81cb1",
+          "name": "add_wallet",
+          "description": "Add a new wallet",
           "composite": false,
           "clientRole": true,
-          "containerId": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
+          "containerId": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
           "attributes": {}
         }
       ],
       "Cl1-CX-Registration": [
         {
-          "id": "3c7b8dec-3ef8-4665-82a3-2d8aeed059d8",
-          "name": "view_documents",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "21fce69f-e42a-4f03-a47f-74441f5719c7",
-          "name": "view_company_roles",
-          "description": "View Company Roles and Descriptions",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "9fe7f83e-c5af-408f-9e02-66ca6d318d9b",
-          "name": "delete_documents",
-          "description": "delete_documents",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "009c93b3-8cb7-4961-9492-9d2fc9574583",
-          "name": "upload_documents",
-          "description": "User is able to upload documents in the registration service",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "9607136e-9daf-4057-9274-767d4de473ab",
-          "name": "add_company_data",
-          "description": "User is able to add / edit company data under the registration process",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "b1b1e25d-0e14-4fc0-882a-126f3f6cbbc0",
-          "name": "view_registration",
-          "description": "Permission to access & view the registration process",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "fd523149-5499-412d-82b0-d8aeccbb5c5e",
+          "id": "525c493b-a8b0-43df-9c2b-b1825051478c",
           "name": "Company Admin",
           "composite": true,
           "composites": {
             "client": {
               "Cl7-CX-BPDM": [
-                "read_metadata",
                 "read_partner_member",
-                "read_changelog_member",
-                "read_partner"
+                "read_metadata",
+                "read_partner",
+                "read_changelog_member"
               ],
               "Cl1-CX-Registration": [
-                "view_documents",
+                "view_registration",
                 "view_company_roles",
+                "sign_consent",
+                "add_company_data",
                 "delete_documents",
                 "upload_documents",
-                "add_company_data",
-                "view_registration",
-                "submit_registration",
-                "sign_consent",
-                "invite_user"
+                "view_documents",
+                "invite_user",
+                "submit_registration"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
           "attributes": {}
         },
         {
-          "id": "e5f03bf6-0b3c-4539-8873-d146bd18e504",
-          "name": "CX Admin",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl1-CX-Registration": [
-                "add_company_data",
-                "view_registration",
-                "view_documents",
-                "view_company_roles",
-                "submit_registration",
-                "sign_consent",
-                "delete_documents",
-                "upload_documents",
-                "invite_user"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "086cf0b0-7181-4a8a-89d3-137fd02e0847",
-          "name": "submit_registration",
-          "description": "User is able to submit the registration to Catena-X",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "87ecd7bb-039a-4e0a-a1a8-ca17b32d7891",
-          "name": "Signing Manager",
-          "composite": true,
-          "composites": {
-            "client": {
-              "Cl1-CX-Registration": [
-                "add_company_data",
-                "view_registration",
-                "view_documents",
-                "view_company_roles",
-                "submit_registration",
-                "sign_consent",
-                "delete_documents",
-                "upload_documents",
-                "invite_user"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "e12709ce-c1fc-454a-a095-4088cab26539",
-          "name": "sign_consent",
-          "description": "User is able to confirm Terms & Conditions",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
-          "attributes": {}
-        },
-        {
-          "id": "461ea134-91cd-4482-a0cb-6f8406846807",
+          "id": "274efee6-925d-4f79-b5be-e90dd9547bb1",
           "name": "Legal Manager",
           "composite": true,
           "composites": {
             "client": {
               "Cl1-CX-Registration": [
                 "add_company_data",
-                "view_registration",
-                "view_documents",
-                "view_company_roles",
-                "submit_registration",
-                "sign_consent",
                 "delete_documents",
                 "upload_documents",
-                "invite_user"
+                "view_registration",
+                "view_documents",
+                "invite_user",
+                "view_company_roles",
+                "submit_registration",
+                "sign_consent"
               ]
             }
           },
           "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
           "attributes": {}
         },
         {
-          "id": "44d50090-3343-48d8-9843-7eeb15276869",
+          "id": "2c54ed6f-d761-4396-bc9b-2a5efa64b84c",
+          "name": "view_registration",
+          "description": "Permission to access & view the registration process",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "48ef0cc3-a67f-4087-be63-139395597465",
+          "name": "view_company_roles",
+          "description": "View Company Roles and Descriptions",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "db0fc4b4-f67e-4c8d-809e-48eaf8f74d26",
+          "name": "sign_consent",
+          "description": "User is able to confirm Terms & Conditions",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "bb13a7fb-1d7e-41ad-b93a-50c395ca58eb",
+          "name": "add_company_data",
+          "description": "User is able to add / edit company data under the registration process",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "39267716-1340-40cb-9148-10eafac726ca",
+          "name": "delete_documents",
+          "description": "delete_documents",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "693f74cc-cb56-45fb-aae6-b637eaede089",
+          "name": "upload_documents",
+          "description": "User is able to upload documents in the registration service",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "ead0ff99-4e3b-4683-98e1-6d912fc42132",
+          "name": "Signing Manager",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl1-CX-Registration": [
+                "add_company_data",
+                "delete_documents",
+                "upload_documents",
+                "view_registration",
+                "view_documents",
+                "invite_user",
+                "view_company_roles",
+                "submit_registration",
+                "sign_consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "809d2b85-3ed1-4aee-ab50-72a858203865",
           "name": "invite_user",
           "description": "User is able to add additional users to the registration process",
           "composite": false,
           "clientRole": true,
-          "containerId": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "6a338306-a561-408c-9ae4-7df65ce341cb",
+          "name": "view_documents",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "28fe4b38-aab1-47d8-b35a-8d7b383b7fe9",
+          "name": "submit_registration",
+          "description": "User is able to submit the registration to Catena-X",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
+          "attributes": {}
+        },
+        {
+          "id": "b0d2351b-dd63-4c4e-9d25-54cffc334826",
+          "name": "CX Admin",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl1-CX-Registration": [
+                "add_company_data",
+                "delete_documents",
+                "upload_documents",
+                "view_registration",
+                "view_documents",
+                "invite_user",
+                "view_company_roles",
+                "submit_registration",
+                "sign_consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
           "attributes": {}
         }
       ],
+      "Cl25-CX-BPDM-Orchestrator": [
+        {
+          "id": "cebbaa29-d555-44bc-85d5-f5287efd0dac",
+          "name": "create_task",
+          "description": "Allowed to create new golden record tasks",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        },
+        {
+          "id": "8e4319cf-5035-4390-8ee6-ca225bc5cf86",
+          "name": "read_task",
+          "description": "Allowed to read the processing state and result of golden record tasks.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        },
+        {
+          "id": "df7fb7d5-56e0-4852-bd55-b63968f7c9a5",
+          "name": "create_reservation_poolSync",
+          "description": "Allowed to create reservations for golden record tasks in the 'PoolSync' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        },
+        {
+          "id": "21bbd02a-15a2-495c-b2ad-a3168555c2fe",
+          "name": "create_reservation_clean",
+          "description": "Allowed to create reservations for golden record tasks inside the 'Clean' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        },
+        {
+          "id": "99535c1a-7b14-4baa-9244-b98912335609",
+          "name": "create_reservation_cleanAndSync",
+          "description": "Allowed to create reservations for golden record tasks in the 'CleanAndSync' queue",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        },
+        {
+          "id": "ebe03e32-ca7e-42c3-b78e-940b23e4b109",
+          "name": "create_result_cleanAndSync",
+          "description": "Allowed to create results for reserved golden record tasks in the 'CleanAndSync' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        },
+        {
+          "id": "47f504b2-16f4-494d-8af4-12871e0ccefa",
+          "name": "create_result_clean",
+          "description": "Allowed to create results for reserved golden record tasks in the 'Clean' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        },
+        {
+          "id": "e0711559-ad68-4f51-80f3-61ced1cf70eb",
+          "name": "create_result_poolSync",
+          "description": "Allowed to create results for reserved golden record tasks in the 'PoolSync' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
+          "attributes": {}
+        }
+      ],
+      "sa-cl7-cx-1": [],
       "sa-cl21-01": [],
       "sa-cl7-cx-5": [],
       "broker": [
         {
-          "id": "d1330d07-b783-43ad-b545-85a230060023",
+          "id": "378c139e-458b-4da1-9835-a0b7022a3e5e",
           "name": "read-token",
           "description": "${role_read-token}",
           "composite": false,
           "clientRole": true,
-          "containerId": "03885031-084a-4317-aa51-de9b4acf8fa9",
+          "containerId": "3e5c5d5c-39df-42d2-a67e-61eb22893873",
           "attributes": {}
         }
       ],
       "sa-cl7-cx-7": [],
       "Cl3-CX-Semantic": [
         {
-          "id": "beef62b1-2e1c-4fc2-8813-7f3981ebfde2",
-          "name": "view_semantic_model",
-          "description": "View existing data models",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "36e2745d-f331-4fa5-bbfa-90947d7f1dc4",
-          "attributes": {}
-        },
-        {
-          "id": "fa8261a8-fe09-4867-a558-438737917185",
-          "name": "delete_semantic_model",
-          "description": "User can delete existing semantic models",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "36e2745d-f331-4fa5-bbfa-90947d7f1dc4",
-          "attributes": {}
-        },
-        {
-          "id": "a46242a3-26db-4b86-b836-bf0339168c56",
+          "id": "c0e0ba3a-0a90-4536-a064-b9ee8608334e",
           "name": "add_semantic_model",
           "description": "Add semantic model",
           "composite": false,
           "clientRole": true,
-          "containerId": "36e2745d-f331-4fa5-bbfa-90947d7f1dc4",
+          "containerId": "13583bc5-87ca-48c5-bbeb-4080a9c2b33f",
           "attributes": {}
         },
         {
-          "id": "f7d88948-b75d-4ed0-851d-b4c645ae27ca",
+          "id": "af43927e-762c-44ac-8712-aca597403f05",
+          "name": "view_semantic_model",
+          "description": "View existing data models",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "13583bc5-87ca-48c5-bbeb-4080a9c2b33f",
+          "attributes": {}
+        },
+        {
+          "id": "ed3fb460-e41a-4c42-8b9e-1392b05c893a",
           "name": "update_semantic_model",
           "description": "User can update existing semantic models",
           "composite": false,
           "clientRole": true,
-          "containerId": "36e2745d-f331-4fa5-bbfa-90947d7f1dc4",
+          "containerId": "13583bc5-87ca-48c5-bbeb-4080a9c2b33f",
+          "attributes": {}
+        },
+        {
+          "id": "96e19ab8-aedf-4325-86aa-3fb3aa788bc5",
+          "name": "delete_semantic_model",
+          "description": "User can delete existing semantic models",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "13583bc5-87ca-48c5-bbeb-4080a9c2b33f",
           "attributes": {}
         }
       ],
       "sa-cl1-reg-2": [],
       "sa-cl5-custodian-2": [],
+      "sa-cl25-cx-3": [],
+      "sa-cl25-cx-2": [],
       "account": [
         {
-          "id": "9a1e745f-e0b5-4efc-9336-3ba403a79cb8",
-          "name": "manage-consent",
-          "description": "${role_manage-consent}",
-          "composite": true,
-          "composites": {
-            "client": {
-              "account": [
-                "view-consent"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
-          "attributes": {}
-        },
-        {
-          "id": "93070949-280d-4183-9761-94792722cc1d",
+          "id": "7698b3f6-ccaf-4497-8ed2-aa0ce3029994",
           "name": "delete-account",
           "description": "${role_delete-account}",
           "composite": false,
           "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
           "attributes": {}
         },
         {
-          "id": "20d5e725-3d3b-4bfe-9a62-5e650ae55b53",
+          "id": "f475fc98-2e6f-45cf-9201-e503193193d2",
           "name": "manage-account",
           "description": "${role_manage-account}",
           "composite": true,
@@ -2662,71 +2683,88 @@
             }
           },
           "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
           "attributes": {}
         },
         {
-          "id": "d0312a58-8fba-4fea-9a07-bd5e1515f9d8",
-          "name": "view-profile",
-          "description": "${role_view-profile}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
-          "attributes": {}
-        },
-        {
-          "id": "1bc65f13-4eda-4954-9944-6699ec3913b3",
-          "name": "manage-account-links",
-          "description": "${role_manage-account-links}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
-          "attributes": {}
-        },
-        {
-          "id": "8b60326c-d508-4563-a41f-7973383d7501",
-          "name": "view-applications",
-          "description": "${role_view-applications}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
-          "attributes": {}
-        },
-        {
-          "id": "1cf8486a-4671-452c-bda9-115842957c8e",
+          "id": "c98db63d-e514-4ad8-b83c-4861bbfb85f6",
           "name": "view-groups",
           "description": "${role_view-groups}",
           "composite": false,
           "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
           "attributes": {}
         },
         {
-          "id": "ef74a99a-0297-43c7-ae30-109c08a5aa69",
+          "id": "a0770389-8db4-4470-8d1e-b5b3ba21fe3c",
           "name": "view-consent",
           "description": "${role_view-consent}",
           "composite": false,
           "clientRole": true,
-          "containerId": "60313b78-e131-4358-9817-163ee938cc59",
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
+          "attributes": {}
+        },
+        {
+          "id": "2babaeda-dc33-4501-92e3-b57321b8f598",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
+          "attributes": {}
+        },
+        {
+          "id": "20a77362-9a59-44ef-8d86-d2755452ea84",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
+          "attributes": {}
+        },
+        {
+          "id": "65d0ed57-d130-48f9-a88d-f860590313e6",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
+          "attributes": {}
+        },
+        {
+          "id": "74ba83db-88fc-4e0a-9051-93f245bac054",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f857cec8-cabf-4050-9b29-bede81a79fbc",
           "attributes": {}
         }
       ],
       "Cl23-CX-Policy-Hub": [
         {
-          "id": "c9dd28a0-8abe-428b-88e0-56c9de63758a",
+          "id": "2a5acc39-4f71-407b-9c4a-f431b132ad49",
           "name": "view_policy_hub",
           "description": "",
           "composite": false,
           "clientRole": true,
-          "containerId": "6546aea2-dbb9-4ffb-a034-c8544c4aebe0",
+          "containerId": "42b62ecb-2fc8-4bb4-93a9-3db19d7cd544",
           "attributes": {}
         }
-      ]
+      ],
+      "sa-cl25-cx-1": []
     }
   },
   "groups": [],
   "defaultRole": {
-    "id": "4c19f2aa-f9b9-473e-ba5c-46c2f4e52c8b",
+    "id": "4a50b303-b315-4298-9ced-328556345fa0",
     "name": "default-roles-cx-central",
     "description": "${role_default-roles}",
     "composite": true,
@@ -2748,7 +2786,16 @@
     "totpAppGoogleName",
     "totpAppMicrosoftAuthenticatorName"
   ],
-  "localizationTexts": {},
+  "localizationTexts": {
+    "de": {
+      "profile.attributes.organisation": "Organisation",
+      "profile.attributes.bpn": "BPN"
+    },
+    "en": {
+      "profile.attributes.organisation": "Organisation",
+      "profile.attributes.bpn": "BPN"
+    }
+  },
   "webAuthnPolicyRpEntityName": "keycloak",
   "webAuthnPolicySignatureAlgorithms": [
     "ES256"
@@ -2777,47 +2824,18 @@
   "webAuthnPolicyPasswordlessExtraOrigins": [],
   "users": [
     {
-      "id" : "502dabcf-01c7-47d9-a88e-0be4279097b5",
-      "createdTimestamp" : 1652788086549,
-      "username" : "ac1cf001-7fbc-1f2f-817f-bce058020006",
-      "enabled" : true,
-      "totp" : false,
-      "emailVerified" : false,
-      "firstName" : "Operator",
-      "lastName" : "CX Admin",
-      "email" : "tobeadded@cx.com",
-      "attributes" : {
-        "bpn" : [ "BPNL00000003CRHK" ],
-        "organisation" : [ "CX-Operator" ]
-      },
-      "credentials" : [ ],
-      "disableableCredentialTypes" : [ ],
-      "requiredActions" : [ ],
-      "federatedIdentities" : [ {
-        "identityProvider" : "CX-Operator",
-        "userId" : "656e8a94-188b-4a3e-9eec-b45d8efd8347",
-        "userName" : "cx-operator@cx.com"
-      } ],
-      "realmRoles" : [ "default-roles-cx-central" ],
-      "clientRoles" : {
-        "Cl2-CX-Portal" : [ "CX Admin" ]
-      },
-      "notBefore" : 0,
-      "groups" : [ ]
-    },
-    {
       "id": "e69c1397-eee8-434a-b83b-dc7944bb9bdd",
-      "createdTimestamp": 1651730911692,
       "username": "service-account-sa-cl1-reg-2",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl1-reg-2",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1651730911692,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl1-reg-2",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -2835,17 +2853,17 @@
     },
     {
       "id": "f0c69a64-dfbe-46e4-92db-75f6f4670909",
-      "createdTimestamp": 1676572155414,
       "username": "service-account-sa-cl2-01",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl2-01",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1676572155414,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl2-01",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -2861,17 +2879,17 @@
     },
     {
       "id": "18c3a6b3-ecfe-4572-bbb4-af0c1823f206",
-      "createdTimestamp": 1676572207640,
       "username": "service-account-sa-cl2-02",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl2-02",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1676572207640,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl2-02",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -2888,17 +2906,17 @@
     },
     {
       "id": "a0bbb8fa-cc40-44e3-828d-342e782fd284",
-      "createdTimestamp": 1681380138448,
       "username": "service-account-sa-cl2-03",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl2-03",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1681380138448,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl2-03",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -2909,17 +2927,17 @@
     },
     {
       "id": "b2c10c26-2bd6-4181-bb79-b88aa4b250e7",
-      "createdTimestamp": 1712762229098,
       "username": "service-account-sa-cl2-04",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl2-04",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1712762229098,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl2-04",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -2927,12 +2945,12 @@
       ],
       "clientRoles": {
         "Cl24-CX-SSI-CredentialIssuer": [
-          "request_ssicredential",
-          "revoke_credential",
-          "revoke_credentials_issuer",
           "view_use_case_participation",
+          "revoke_credential",
           "view_certificates",
-          "decision_ssicredential"
+          "decision_ssicredential",
+          "revoke_credentials_issuer",
+          "request_ssicredential"
         ]
       },
       "notBefore": 0,
@@ -2940,17 +2958,17 @@
     },
     {
       "id": "a548bfdc-232e-4cd7-8a66-2eab09e1b302",
-      "createdTimestamp": 1712764151096,
       "username": "service-account-sa-cl2-05",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl2-05",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1712764151096,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl2-05",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -2967,17 +2985,17 @@
     },
     {
       "id": "319d6b7f-bd88-4103-8124-e8ac4c791acf",
-      "createdTimestamp": 1681915810810,
       "username": "service-account-sa-cl21-01",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl21-01",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1681915810810,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl21-01",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -2986,8 +3004,8 @@
       "clientRoles": {
         "Cl21-CX-DF": [
           "view_discovery_endpoint",
-          "delete_discovery_endpoint",
-          "add_discovery_endpoint"
+          "add_discovery_endpoint",
+          "delete_discovery_endpoint"
         ]
       },
       "notBefore": 0,
@@ -2995,17 +3013,17 @@
     },
     {
       "id": "b52bd8e5-98ce-48b4-af43-0b43b45d0358",
-      "createdTimestamp": 1681915925763,
       "username": "service-account-sa-cl22-01",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl22-01",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1681915925763,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl22-01",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -3013,9 +3031,9 @@
       ],
       "clientRoles": {
         "Cl22-CX-BPND": [
+          "view_bpn_discovery",
           "add_bpn_discovery",
-          "delete_bpn_discovery",
-          "view_bpn_discovery"
+          "delete_bpn_discovery"
         ]
       },
       "notBefore": 0,
@@ -3023,17 +3041,17 @@
     },
     {
       "id": "9c771d3f-236e-4319-9046-863b234834ea",
-      "createdTimestamp": 1712762697169,
       "username": "service-account-sa-cl24-01",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl24-01",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1712762697169,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl24-01",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -3042,26 +3060,27 @@
       "clientRoles": {
         "Cl2-CX-Portal": [
           "update_application_bpn_credential",
+          "update_application_membership_credential",
           "send_mail",
-          "update_application_membership_credential"
+          "create_ssi_notifications"
         ]
       },
       "notBefore": 0,
       "groups": []
     },
     {
-      "id": "965ae857-1e91-4e0b-bdb5-4efd1fc7ea9c",
-      "createdTimestamp": 1658347753956,
-      "username": "service-account-sa-cl3-cx-1",
-      "enabled": true,
-      "totp": false,
+      "id": "bbb919dd-b3aa-4ec3-8786-582787886276",
+      "username": "service-account-sa-cl25-cx-1",
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl3-cx-1",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1722276592957,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl25-cx-1",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -3069,73 +3088,8 @@
       ],
       "clientRoles": {
         "technical_roles_management": [
-          "Semantic Model Management"
-        ],
-        "Cl3-CX-Semantic": [
-          "delete_semantic_model",
-          "add_semantic_model",
-          "update_semantic_model"
-        ]
-      },
-      "notBefore": 0,
-      "groups": []
-    },
-    {
-      "id": "ca2657a8-eba9-4cb4-8b66-8cc30911dfa1",
-      "createdTimestamp": 1657558751239,
-      "username": "service-account-sa-cl5-custodian-2",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": false,
-      "serviceAccountClientId": "sa-cl5-custodian-2",
-      "attributes": {
-        "bpn": [
-          "BPNL00000003CRHK"
-        ]
-      },
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "default-roles-cx-central"
-      ],
-      "clientRoles": {
-        "Cl5-CX-Custodian": [
-          "delete_wallet",
-          "add_wallets",
-          "delete_wallets",
-          "update_wallets",
-          "add_wallet",
-          "view_wallet",
-          "update_wallet",
-          "view_wallets"
-        ]
-      },
-      "notBefore": 0,
-      "groups": []
-    },
-    {
-      "id": "f014ed5d-9e05-4f29-a5c0-227c7e7b479e",
-      "createdTimestamp": 1670157703230,
-      "username": "service-account-sa-cl7-cx-5",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": false,
-      "serviceAccountClientId": "sa-cl7-cx-5",
-      "attributes": {
-        "bpn": [
-          "BPNL00000003CRHK"
-        ]
-      },
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "default-roles-cx-central"
-      ],
-      "clientRoles": {
-        "technical_roles_management": [
-          "BPDM Sharing Admin",
-          "BPDM Pool Admin",
-          "BPDM Orchestrator Admin"
+          "BPDM Orchestrator Processor Clean",
+          "BPDM Orchestrator Processor CleanAndSync"
         ]
       },
       "notBefore": 0,
@@ -3143,17 +3097,17 @@
     },
     {
       "id": "e24da044-7290-45f4-a2ea-cb8165393f0a",
-      "createdTimestamp": 1722276592957,
       "username": "service-account-sa-cl25-cx-2",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl25-cx-2",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1722276592957,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl25-cx-2",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -3169,17 +3123,17 @@
     },
     {
       "id": "72351810-a1b4-42e6-9686-8abe6b0d5cb0",
-      "createdTimestamp": 1722276592957,
       "username": "service-account-sa-cl25-cx-3",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl25-cx-3",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1722276592957,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl25-cx-3",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -3194,18 +3148,18 @@
       "groups": []
     },
     {
-      "id": "bbb919dd-b3aa-4ec3-8786-582787886276",
-      "createdTimestamp": 1722276592957,
-      "username": "service-account-sa-cl25-cx-1",
-      "enabled": true,
-      "totp": false,
+      "id": "965ae857-1e91-4e0b-bdb5-4efd1fc7ea9c",
+      "username": "service-account-sa-cl3-cx-1",
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl25-cx-1",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1658347753956,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl3-cx-1",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -3213,62 +3167,45 @@
       ],
       "clientRoles": {
         "technical_roles_management": [
-          "BPDM Orchestrator Processor CleanAndSync",
-          "BPDM Orchestrator Processor Clean"
+          "Semantic Model Management"
+        ],
+        "Cl3-CX-Semantic": [
+          "add_semantic_model",
+          "update_semantic_model",
+          "delete_semantic_model"
         ]
       },
       "notBefore": 0,
       "groups": []
     },
     {
-      "id": "3f9fc7e8-d312-4912-a9a1-4db8849ce8f7",
-      "createdTimestamp": 1722276592957,
-      "username": "service-account-sa-cl7-cx-7",
-      "enabled": true,
-      "totp": false,
+      "id": "ca2657a8-eba9-4cb4-8b66-8cc30911dfa1",
+      "username": "service-account-sa-cl5-custodian-2",
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl7-cx-7",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1657558751239,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl5-custodian-2",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
         "default-roles-cx-central"
       ],
       "clientRoles": {
-        "technical_roles_management": [
-          "BPDM Sharing Admin",
-          "BPDM Pool Admin",
-          "BPDM Orchestrator Admin"
-        ]
-      },
-      "notBefore": 0,
-      "groups": []
-    },
-    {
-      "id": "dcb9a153-e1b4-4fac-bc51-7032023e9db9",
-      "createdTimestamp": 1675867052982,
-      "username": "service-account-sa-cl8-cx-1",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": false,
-      "serviceAccountClientId": "sa-cl8-cx-1",
-      "attributes": {
-        "bpn": [
-          "BPNL00000003CRHK"
-        ]
-      },
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "default-roles-cx-central"
-      ],
-      "clientRoles": {
-        "Cl2-CX-Portal": [
-          "add_self_descriptions"
+        "Cl5-CX-Custodian": [
+          "delete_wallets",
+          "update_wallets",
+          "add_wallets",
+          "view_wallets",
+          "view_wallet",
+          "delete_wallet",
+          "update_wallet",
+          "add_wallet"
         ]
       },
       "notBefore": 0,
@@ -3276,17 +3213,17 @@
     },
     {
       "id": "95796de5-c9c6-46fc-a3f7-7af782ea9024",
-      "createdTimestamp": 1722276592957,
       "username": "service-account-sa-cl7-cx-1",
-      "enabled": true,
-      "totp": false,
       "emailVerified": false,
-      "serviceAccountClientId": "sa-cl7-cx-1",
       "attributes": {
         "bpn": [
           "BPNL00000003CRHK"
         ]
       },
+      "createdTimestamp": 1722276592957,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl7-cx-1",
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
@@ -3295,6 +3232,88 @@
       "clientRoles": {
         "technical_roles_management": [
           "BPDM Pool Sharing Consumer"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "f014ed5d-9e05-4f29-a5c0-227c7e7b479e",
+      "username": "service-account-sa-cl7-cx-5",
+      "emailVerified": false,
+      "attributes": {
+        "bpn": [
+          "BPNL00000003CRHK"
+        ]
+      },
+      "createdTimestamp": 1670157703230,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl7-cx-5",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-cx-central"
+      ],
+      "clientRoles": {
+        "technical_roles_management": [
+          "BPDM Orchestrator Admin",
+          "BPDM Pool Admin",
+          "BPDM Sharing Admin"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "3f9fc7e8-d312-4912-a9a1-4db8849ce8f7",
+      "username": "service-account-sa-cl7-cx-7",
+      "emailVerified": false,
+      "attributes": {
+        "bpn": [
+          "BPNL00000003CRHK"
+        ]
+      },
+      "createdTimestamp": 1722276592957,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl7-cx-7",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-cx-central"
+      ],
+      "clientRoles": {
+        "technical_roles_management": [
+          "BPDM Orchestrator Admin",
+          "BPDM Pool Admin",
+          "BPDM Sharing Admin"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "dcb9a153-e1b4-4fac-bc51-7032023e9db9",
+      "username": "service-account-sa-cl8-cx-1",
+      "emailVerified": false,
+      "attributes": {
+        "bpn": [
+          "BPNL00000003CRHK"
+        ]
+      },
+      "createdTimestamp": 1675867052982,
+      "enabled": true,
+      "totp": false,
+      "serviceAccountClientId": "sa-cl8-cx-1",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-cx-central"
+      ],
+      "clientRoles": {
+        "Cl2-CX-Portal": [
+          "add_self_descriptions"
         ]
       },
       "notBefore": 0,
@@ -3342,30 +3361,6 @@
     ],
     "technical_roles_management": [
       {
-        "client": "sa-cl3-cx-1",
-        "roles": [
-          "Dataspace Discovery",
-          "Semantic Model Management",
-          "Identity Wallet Management"
-        ]
-      },
-      {
-        "client": "sa-cl7-cx-5",
-        "roles": [
-          "BPDM Pool Admin",
-          "BPDM Sharing Admin",
-          "BPDM Orchestrator Admin"
-        ]
-      },
-      {
-        "client": "sa-cl7-cx-7",
-        "roles": [
-          "BPDM Pool Admin",
-          "BPDM Sharing Admin",
-          "BPDM Orchestrator Admin"
-        ]
-      },
-      {
         "client": "sa-cl25-cx-1",
         "roles": [
           "BPDM Orchestrator Processor CleanAndSync",
@@ -3385,9 +3380,33 @@
         ]
       },
       {
+        "client": "sa-cl3-cx-1",
+        "roles": [
+          "Dataspace Discovery",
+          "Semantic Model Management",
+          "Identity Wallet Management"
+        ]
+      },
+      {
         "client": "sa-cl7-cx-1",
         "roles": [
           "BPDM Pool Sharing Consumer"
+        ]
+      },
+      {
+        "client": "sa-cl7-cx-5",
+        "roles": [
+          "BPDM Pool Admin",
+          "BPDM Orchestrator Admin",
+          "BPDM Sharing Admin"
+        ]
+      },
+      {
+        "client": "sa-cl7-cx-7",
+        "roles": [
+          "BPDM Pool Admin",
+          "BPDM Orchestrator Admin",
+          "BPDM Sharing Admin"
         ]
       }
     ],
@@ -3398,9 +3417,9 @@
           "delete_wallet",
           "delete_wallets",
           "update_wallets",
-          "add_wallet",
-          "update_wallet",
           "view_wallets",
+          "update_wallet",
+          "add_wallet",
           "view_wallet",
           "add_wallets"
         ]
@@ -3410,8 +3429,8 @@
       {
         "client": "sa-cl2-04",
         "roles": [
-          "revoke_credentials_issuer",
           "view_use_case_participation",
+          "revoke_credentials_issuer",
           "view_certificates",
           "request_ssicredential",
           "revoke_credential",
@@ -3445,6 +3464,7 @@
       {
         "client": "sa-cl2-05",
         "roles": [
+          "technical_roles_management",
           "store_didDocument"
         ]
       },
@@ -3452,9 +3472,9 @@
         "client": "sa-cl24-01",
         "roles": [
           "send_mail",
-          "create_ssi_notifications",
           "update_application_membership_credential",
-          "update_application_bpn_credential"
+          "update_application_bpn_credential",
+          "create_ssi_notifications"
         ]
       },
       {
@@ -3477,7 +3497,7 @@
   },
   "clients": [
     {
-      "id": "60313b78-e131-4358-9817-163ee938cc59",
+      "id": "f857cec8-cabf-4050-9b29-bede81a79fbc",
       "clientId": "account",
       "name": "${client_account}",
       "rootUrl": "${authBaseUrl}",
@@ -3533,6 +3553,7 @@
       "defaultClientScopes": [
         "web-origins",
         "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -3543,7 +3564,7 @@
       ]
     },
     {
-      "id": "edb1e627-426a-4593-93c0-e9b4bc45c4d6",
+      "id": "94da412e-8196-4530-a489-d68242d07bce",
       "clientId": "account-console",
       "name": "${client_account-console}",
       "rootUrl": "${authBaseUrl}",
@@ -3569,29 +3590,29 @@
       "frontchannelLogout": false,
       "protocol": "openid-connect",
       "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
         "saml.force.post.binding": "false",
         "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
         "post.logout.redirect.uris": "+",
         "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
         "saml.server.signature.keyinfo.ext": "false",
         "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
         "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
         "backchannel.logout.session.required": "false",
         "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
         "require.pushed.authorization.requests": "false",
         "saml.client.signature": "false",
-        "pkce.code.challenge.method": "S256",
-        "id.token.as.detached.signature": "false",
-        "saml.assertion.signature": "false",
-        "saml.encrypt": "false",
-        "saml.server.signature": "false",
-        "exclude.session.state.from.auth.response": "false",
-        "saml.artifact.binding": "false",
-        "saml_force_name_id_format": "false",
         "tls.client.certificate.bound.access.tokens": "false",
         "saml.authnstatement": "false",
         "display.on.consent.screen": "false",
+        "pkce.code.challenge.method": "S256",
         "saml.onetimeuse.condition": "false"
       },
       "authenticationFlowBindingOverrides": {},
@@ -3599,33 +3620,34 @@
       "nodeReRegistrationTimeout": 0,
       "protocolMappers": [
         {
-          "id": "62ea7826-6e5b-4200-8f5b-ff69b672d0a3",
-          "name": "audience resolve",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-resolve-mapper",
-          "consentRequired": false,
-          "config": {}
-        },
-        {
-          "id": "dc24237b-46fa-418b-a806-24d371e4385a",
+          "id": "2b8ed4f5-d5b4-41ff-b210-6b087a8e113c",
           "name": "idp mapper",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
             "user.attribute": "idp",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "tenant",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
+        },
+        {
+          "id": "06e0a213-da8b-475e-ad22-5ee63e81f793",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -3636,7 +3658,7 @@
       ]
     },
     {
-      "id": "38d072af-d85b-4b39-ad55-13ed5ce45791",
+      "id": "59ee799c-7811-4299-bad4-dfa0111ffdc4",
       "clientId": "admin-cli",
       "name": "${client_admin-cli}",
       "surrogateAuthRequired": false,
@@ -3663,8 +3685,9 @@
       "nodeReRegistrationTimeout": 0,
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -3675,7 +3698,7 @@
       ]
     },
     {
-      "id": "03885031-084a-4317-aa51-de9b4acf8fa9",
+      "id": "3e5c5d5c-39df-42d2-a67e-61eb22893873",
       "clientId": "broker",
       "name": "${client_broker}",
       "surrogateAuthRequired": false,
@@ -3702,8 +3725,8 @@
       "nodeReRegistrationTimeout": 0,
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
         "email"
       ],
       "optionalClientScopes": [
@@ -3714,7 +3737,7 @@
       ]
     },
     {
-      "id": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
+      "id": "cfe530fb-da05-417b-bbb1-b66a0910ab25",
       "clientId": "Cl16-CX-BPDMGate",
       "name": "",
       "description": " Portal Gate",
@@ -3727,7 +3750,7 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
-        "https://partners-gate.example.org/*"
+        "http://partners-gate.example.org/*"
       ],
       "webOrigins": [
         "+"
@@ -3772,8 +3795,9 @@
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -3784,7 +3808,7 @@
       ]
     },
     {
-      "id": "fcc06fed-6259-4a49-8e1b-e7eae940145e",
+      "id": "ea027af2-9a4f-4fd7-833c-5841d8409be1",
       "clientId": "Cl1-CX-Registration",
       "rootUrl": "",
       "adminUrl": "",
@@ -3793,7 +3817,8 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "https://portal.example.org/*"
+        "http://portal.example.org*",
+        "http://localhost:3000/*"
       ],
       "webOrigins": [
         "+"
@@ -3838,37 +3863,22 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "71f9d485-62aa-41c2-a491-bcb47c447121",
+          "id": "eb6bdb39-2d51-42b2-ac40-c3f0538a8ba2",
           "name": "idp mapper",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
             "user.attribute": "tenant",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "tenant",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "4c180350-8f09-4eed-88f4-4b003a6b5fd1",
-          "name": "organisation-mapper",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "organisation",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "organisation",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "2b1dfde9-aff2-406b-b258-edbf574fc4dd",
+          "id": "537af27c-2dae-4675-9bc1-7a022939ee16",
           "name": "audience-mapper",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-audience-mapper",
@@ -3879,12 +3889,28 @@
             "access.token.claim": "true",
             "userinfo.token.claim": "true"
           }
+        },
+        {
+          "id": "1ecd77a7-bdd3-49b8-b1bd-3b647e5bb12e",
+          "name": "organisation-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "organisation",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organisation",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -3895,7 +3921,7 @@
       ]
     },
     {
-      "id": "bf1cfe3e-3950-4fdc-8a58-13b73cec6740",
+      "id": "60e1415e-a5c9-44a2-8387-4769fd5b5059",
       "clientId": "Cl21-CX-DF",
       "description": "Client for Asset Discovery Service",
       "surrogateAuthRequired": false,
@@ -3944,8 +3970,8 @@
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
         "email"
       ],
       "optionalClientScopes": [
@@ -3956,7 +3982,7 @@
       ]
     },
     {
-      "id": "48fc6e9e-a736-4b0b-9fea-59ad847b02e0",
+      "id": "93a98bea-a0fb-47ff-9ae1-2d987327df3f",
       "clientId": "Cl22-CX-BPND",
       "description": "Client for Business Partner Discovery Service",
       "surrogateAuthRequired": false,
@@ -4005,8 +4031,8 @@
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
         "email"
       ],
       "optionalClientScopes": [
@@ -4017,7 +4043,7 @@
       ]
     },
     {
-      "id": "6546aea2-dbb9-4ffb-a034-c8544c4aebe0",
+      "id": "42b62ecb-2fc8-4bb4-93a9-3db19d7cd544",
       "clientId": "Cl23-CX-Policy-Hub",
       "name": "",
       "description": "Client for Policy-Hub",
@@ -4048,8 +4074,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
@@ -4057,7 +4083,7 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "a438c97e-80c6-40f5-9a27-05d4fb68ff40",
+          "id": "7f650fab-7a9f-47a0-a15f-5dacc3a12b72",
           "name": "catenax-policy-hub-audience-mapper",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-audience-mapper",
@@ -4065,15 +4091,17 @@
           "config": {
             "included.client.audience": "Cl23-CX-Policy-Hub",
             "id.token.claim": "true",
-            "access.token.claim": "true"
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -4084,7 +4112,7 @@
       ]
     },
     {
-      "id": "60306526-b937-4244-ac89-cc1283c8ed74",
+      "id": "8f0db9fa-8c92-48de-93e6-e7f619fb5ac5",
       "clientId": "Cl24-CX-SSI-CredentialIssuer",
       "name": "",
       "description": "Client for SSI Credential Issuer",
@@ -4113,8 +4141,8 @@
       "protocol": "openid-connect",
       "attributes": {
         "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
@@ -4123,8 +4151,9 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -4135,374 +4164,7 @@
       ]
     },
     {
-      "id": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
-      "clientId": "Cl2-CX-Portal",
-      "name": "",
-      "description": "",
-      "rootUrl": "https://portal.example.org/home",
-      "adminUrl": "",
-      "baseUrl": "",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": [
-        "https://portal.example.org/*"
-      ],
-      "webOrigins": [
-        "+"
-      ],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "id.token.as.detached.signature": "false",
-        "saml.assertion.signature": "false",
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "saml.encrypt": "false",
-        "post.logout.redirect.uris": "+",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false",
-        "saml.server.signature": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "use.refresh.tokens": "true",
-        "exclude.session.state.from.auth.response": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "saml.artifact.binding": "false",
-        "backchannel.logout.session.required": "true",
-        "client_credentials.use_refresh_token": "false",
-        "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
-        "saml.client.signature": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "35d0aa44-dd27-4dbd-8f3a-7047ae461fdd",
-          "name": "catenax-registration audience-mapper",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-mapper",
-          "consentRequired": false,
-          "config": {
-            "included.client.audience": "Cl1-CX-Registration",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "userinfo.token.claim": "true"
-          }
-        },
-        {
-          "id": "e97b646a-3753-4da5-b6f7-3a2860741b20",
-          "name": "catenax-portal audience-mapper",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-mapper",
-          "consentRequired": false,
-          "config": {
-            "included.client.audience": "Cl2-CX-Portal",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "userinfo.token.claim": "true"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "roles",
-        "profile",
-        "catena",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    },
-    {
-      "id": "36e2745d-f331-4fa5-bbfa-90947d7f1dc4",
-      "clientId": "Cl3-CX-Semantic",
-      "rootUrl": "",
-      "adminUrl": "https://portal.example.org/home",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": [
-        "https://portal.example.org/*"
-      ],
-      "webOrigins": [
-        "+"
-      ],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "id.token.as.detached.signature": "false",
-        "saml.assertion.signature": "false",
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "saml.encrypt": "false",
-        "post.logout.redirect.uris": "+",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false",
-        "saml.server.signature": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "use.refresh.tokens": "true",
-        "exclude.session.state.from.auth.response": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "saml.artifact.binding": "false",
-        "backchannel.logout.session.required": "true",
-        "client_credentials.use_refresh_token": "false",
-        "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
-        "saml.client.signature": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "1de1f28c-00d2-42b6-bc74-e57d8e73f7df",
-          "name": "catenax-registration audience-mapper",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-mapper",
-          "consentRequired": false,
-          "config": {
-            "included.client.audience": "catenax-registration",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "userinfo.token.claim": "true"
-          }
-        },
-        {
-          "id": "faf297ed-30d7-4e15-8051-40c540c14604",
-          "name": "catenax-portal audience-mapper",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-mapper",
-          "consentRequired": false,
-          "config": {
-            "included.client.audience": "catenax-portal",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "userinfo.token.claim": "true"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "roles",
-        "profile",
-        "catena",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    },
-    {
-      "id": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
-      "clientId": "Cl5-CX-Custodian",
-      "name": "Cl5-CX-Custodian",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [
-        "https://managed-identity-wallets.example.org/*"
-      ],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "token.endpoint.auth.signing.alg": "RS256",
-        "post.logout.redirect.uris": "+",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "use.refresh.tokens": "true",
-        "oidc.ciba.grant.enabled": "false",
-        "backchannel.logout.session.required": "true",
-        "client_credentials.use_refresh_token": "false",
-        "require.pushed.authorization.requests": "false",
-        "saml.client.signature": "false",
-        "id.token.as.detached.signature": "false",
-        "saml.assertion.signature": "false",
-        "saml.encrypt": "false",
-        "saml.server.signature": "false",
-        "exclude.session.state.from.auth.response": "false",
-        "saml.artifact.binding": "false",
-        "saml_force_name_id_format": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "6f273a17-cf91-43dc-9dac-4ec36250d133",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "7a4001a7-aeaf-419c-ae46-6a190bc5e13f",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "9fd2abb2-445e-4622-a068-e3d48eb97634",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "roles"
-      ],
-      "optionalClientScopes": []
-    },
-    {
-      "id": "04cd6d38-674f-4588-980a-8f120bddcc44",
-      "clientId": "Cl7-CX-BPDM",
-      "name": "",
-      "description": " BPDM Pool",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [
-        "https://partners-pool.example.org/*"
-      ],
-      "webOrigins": [
-        "+"
-      ],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "id.token.as.detached.signature": "false",
-        "saml.assertion.signature": "false",
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "saml.encrypt": "false",
-        "post.logout.redirect.uris": "+",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false",
-        "saml.server.signature": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "use.refresh.tokens": "true",
-        "exclude.session.state.from.auth.response": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "saml.artifact.binding": "false",
-        "backchannel.logout.session.required": "true",
-        "client_credentials.use_refresh_token": "false",
-        "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
-        "saml.client.signature": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "defaultClientScopes": [
-        "web-origins",
-        "roles",
-        "profile",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    },
-    {
-      "id": "983159fa-37f3-4519-9c98-8fe23d8ab8bf",
+      "id": "d4d7cb1e-1361-4b9d-ba5d-8fdab5783377",
       "clientId": "Cl25-CX-BPDM-Orchestrator",
       "name": "BPDM Orchestrator",
       "description": "Roles resource for the BPDM Orchestrator component",
@@ -4528,9 +4190,9 @@
       "protocol": "openid-connect",
       "attributes": {
         "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
         "client.secret.creation.time": "1722276592",
         "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
@@ -4538,37 +4200,22 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "de42377c-8b7a-466c-91d6-c95d8a8533b8",
+          "id": "be8f652d-bd66-4403-98e8-51989ef063b2",
           "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientAddress",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "3f29cf79-e84c-4c1a-bf71-29238f655bfc",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "831b2dfd-0c87-4328-b5ed-49a4efced60e",
+          "id": "160e7b31-2f17-4260-b01d-ea9b89cefec5",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -4584,25 +4231,41 @@
           }
         },
         {
-          "id": "200ce257-7bee-4662-988a-750bf3e03790",
+          "id": "cbe200e9-cb5d-4e94-9ff1-9048565ad503",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "d3ab39f4-f943-4caa-8e49-cd07c40ede74",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -4613,10 +4276,311 @@
       ]
     },
     {
-      "id": "4ebeb21b-055e-403f-8bfa-738bb935395d",
-      "clientId": "sa-cl25-cx-1",
-      "name": "BPDM Dummy Cleaning Task Processor",
-      "description": "Client for the BPDM cleaning service dummy component to process golden record tasks from the Orchestrator",
+      "id": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+      "clientId": "Cl2-CX-Portal",
+      "name": "",
+      "description": "",
+      "rootUrl": "http://portal.example.org/home",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://portal.example.org/*",
+        "http://localhost:3000/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "eeae1a28-2af2-44e6-85fb-c863726ed3fe",
+          "name": "catenax-registration audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "Cl1-CX-Registration",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "43ef2105-97eb-4069-a59f-fa3aff3a7075",
+          "name": "catenax-portal audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "Cl2-CX-Portal",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "basic",
+        "catena",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "13583bc5-87ca-48c5-bbeb-4080a9c2b33f",
+      "clientId": "Cl3-CX-Semantic",
+      "rootUrl": "",
+      "adminUrl": "http://portal.example.org/home",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://portal.example.org/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "0c7a224b-abd1-47c5-afa6-24f0751de824",
+          "name": "catenax-registration audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "catenax-registration",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "72bec416-affe-49ac-b02f-3ce25c3616f5",
+          "name": "catenax-portal audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "catenax-portal",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "basic",
+        "catena",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "2adfe458-adcc-4ff6-a5bb-c000a74a0e1b",
+      "clientId": "Cl5-CX-Custodian",
+      "name": "Cl5-CX-Custodian",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://managed-identity-wallets.example.org/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "token.endpoint.auth.signing.alg": "RS256",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "6763c9ed-8bef-4b84-92f2-ff58ac237a76",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "3810f901-db45-4490-b0de-a4bb251fddd7",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "c502d75b-a02d-4a3c-9aaf-d8ca02eb41ca",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "roles",
+        "basic"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "2ef350bf-f017-4696-9f97-e01db49341d2",
+      "clientId": "Cl7-CX-BPDM",
+      "name": "",
+      "description": " BPDM Pool",
       "rootUrl": "",
       "adminUrl": "",
       "baseUrl": "",
@@ -4626,99 +4590,54 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
-        "/*"
+        "http://partners-pool.example.org/*"
       ],
       "webOrigins": [
-        "/*"
+        "+"
       ],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,
-      "standardFlowEnabled": false,
+      "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
       "publicClient": false,
-      "frontchannelLogout": true,
+      "frontchannelLogout": false,
       "protocol": "openid-connect",
       "attributes": {
-        "oidc.ciba.grant.enabled": "false",
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "post.logout.redirect.uris": "+",
         "oauth2.device.authorization.grant.enabled": "false",
-        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
         "backchannel.logout.session.required": "true",
-        "backchannel.logout.revoke.offline.tokens": "false"
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
+      "fullScopeAllowed": true,
       "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "5386537c-2b62-4675-94aa-38f7f056a50e",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "eb517cbb-1f6c-4862-a230-fecf893df8bf",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "c9d1f428-0ad8-4665-9d40-82cd4eb63109",
-          "name": "BPN",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "introspection.token.claim": "true",
-            "userinfo.token.claim": "true",
-            "user.attribute": "bpn",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "bpn",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "64f17173-6918-444d-9aa7-e97ab6f5d7e0",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        }
-      ],
       "defaultClientScopes": [
         "web-origins",
-        "acr",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -4729,355 +4648,7 @@
       ]
     },
     {
-      "id": "0dffae1b-5a95-4253-857e-b84c6904d012",
-      "clientId": "sa-cl25-cx-2",
-      "name": "BPDM Pool Task Processor",
-      "description": "Client for the BPDM Pool component to process golden record tasks from the Orchestrator",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [
-        "/*"
-      ],
-      "webOrigins": [
-        "/*"
-      ],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": false,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": true,
-      "publicClient": false,
-      "frontchannelLogout": true,
-      "protocol": "openid-connect",
-      "attributes": {
-        "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "client.secret.creation.time": "1722276592",
-        "backchannel.logout.session.required": "true",
-        "backchannel.logout.revoke.offline.tokens": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "33525cbd-2aae-49b9-8fda-ae2d0752ed21",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "061cf481-3df4-4b07-921a-fc574ca2ea75",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "02952ea5-5834-42d4-a16c-519448474085",
-          "name": "BPN",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "introspection.token.claim": "true",
-            "userinfo.token.claim": "true",
-            "user.attribute": "bpn",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "bpn",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "97681229-fdb3-46fa-96a6-f0a18455deeb",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "roles",
-        "profile",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    },
-    {
-      "id": "dfb5e903-2509-4d52-bef5-2c6a85e34d5c",
-      "clientId": "sa-cl25-cx-3",
-      "name": "BPDM Portal Gate Task Creator",
-      "description": "Client for the BPDM Portal Gate to create and monitor golden record tasks inside the Orchestrator",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [
-        "/*"
-      ],
-      "webOrigins": [
-        "/*"
-      ],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": false,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": true,
-      "publicClient": false,
-      "frontchannelLogout": true,
-      "protocol": "openid-connect",
-      "attributes": {
-        "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "client.secret.creation.time": "1722276592",
-        "backchannel.logout.session.required": "true",
-        "backchannel.logout.revoke.offline.tokens": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "cef30c81-427c-496b-a715-289f237a47a8",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "7b517bee-6230-4ab6-ad4b-21e1935ab91f",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "84d26429-8401-4271-a9bf-61c519b2f2d1",
-          "name": "BPN",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "introspection.token.claim": "true",
-            "userinfo.token.claim": "true",
-            "user.attribute": "bpn",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "bpn",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "43488006-09e9-4e43-9223-8a492b955c61",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "roles",
-        "profile",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    },
-    {
-      "id": "fd3c0f0d-40f6-4522-9a87-17ea147e7cfe",
-      "clientId": "sa-cl7-cx-1",
-      "name": "BPDM Portal Gate Pool Consumer",
-      "description": "Client for the BPDM Portal Gate to consume golden record data from the Pool",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [
-        "/*"
-      ],
-      "webOrigins": [
-        "/*"
-      ],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": false,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": true,
-      "publicClient": false,
-      "frontchannelLogout": true,
-      "protocol": "openid-connect",
-      "attributes": {
-        "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "client.secret.creation.time": "1722276592",
-        "backchannel.logout.session.required": "true",
-        "backchannel.logout.revoke.offline.tokens": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [
-        {
-          "id": "a38f5a71-c7e9-47e8-966d-fb6ec3bcf382",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "d28bf27f-b56c-4ccc-b912-f4c58f8f5d0c",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "9d722fd1-f545-434e-b7c9-e519b8e3519c",
-          "name": "BPN",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "introspection.token.claim": "true",
-            "userinfo.token.claim": "true",
-            "user.attribute": "bpn",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "bpn",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "cfd2e1ca-f87e-40b4-9e45-40656fd414a0",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "roles",
-        "profile",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    },
-    {
-      "id": "213ea3ce-b036-405f-8abd-3ee08ff72857",
+      "id": "834cf665-f6bc-416c-986b-6aa3c9906290",
       "clientId": "realm-management",
       "name": "${client_realm-management}",
       "surrogateAuthRequired": false,
@@ -5104,8 +4675,8 @@
       "nodeReRegistrationTimeout": 0,
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
         "email"
       ],
       "optionalClientScopes": [
@@ -5116,7 +4687,7 @@
       ]
     },
     {
-      "id": "cdf11dff-530a-4fd4-97b9-84e4d60ac21e",
+      "id": "bcf9c6d0-849e-44b9-91ae-f660d3da2d60",
       "clientId": "sa-cl1-reg-2",
       "description": "Technical User for Portal-Backend to call Keycloak (portal helm chart: backend.keycloak.central.clientId)",
       "surrogateAuthRequired": false,
@@ -5168,7 +4739,37 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "479039e1-718d-48d1-a2e1-a818c5cb8832",
+          "id": "bd4c3977-c3f1-49c1-8dba-0ecb32cd67d9",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "27d3c964-a95e-4794-95bc-d727dbedf698",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "a52117d9-de75-4d40-978a-0a2f8422fade",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -5184,55 +4785,26 @@
           }
         },
         {
-          "id": "7ef011ab-1e39-4d57-9f23-3b389394b57f",
+          "id": "8dddbbe5-3902-4269-ae43-2f9154b89ede",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "dcd989ce-2636-4d01-ba95-0fa20e02383f",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "9d83df9b-abf7-4504-aac4-e7966f8a877c",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -5243,7 +4815,7 @@
       ]
     },
     {
-      "id": "6bf6f4e5-562c-4382-945f-e5fef59423e2",
+      "id": "18a25559-2609-4a05-8194-5cafaf197452",
       "clientId": "sa-cl2-01",
       "description": "Technical User Clearinghouse update application",
       "surrogateAuthRequired": false,
@@ -5293,7 +4865,22 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "1acda193-a63f-4ec1-aa17-3e15d2b7c3ae",
+          "id": "efad316a-7de1-417b-8b70-4a6215651370",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "c58b2219-b586-415d-8faa-3035ceb9b79c",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -5309,55 +4896,41 @@
           }
         },
         {
-          "id": "9a62e6ee-4e3c-4cb9-81b7-53e8dfbdd210",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "b0d195d1-f5be-4249-ac88-133fcf138f4d",
+          "id": "969f09ef-198d-466f-8426-e967f6c90474",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "6920d343-be3f-4e3b-9330-841521ff4a2c",
-          "name": "Client Host",
+          "id": "7a15e6c4-f4aa-422a-adaa-e382ddccd372",
+          "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
-            "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
+            "user.session.note": "clientAddress",
             "id.token.claim": "true",
             "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
+            "claim.name": "clientAddress",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -5368,7 +4941,7 @@
       ]
     },
     {
-      "id": "2d19b59b-4970-4cc0-a561-a9dac9d49045",
+      "id": "2081fd1e-c3c1-4be8-94c1-e4731fdab7f1",
       "clientId": "sa-cl2-02",
       "description": "Technical User SelfDescription (SD) update application",
       "surrogateAuthRequired": false,
@@ -5418,37 +4991,52 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "89fa847a-3f52-4ea3-a09b-5f3552cabccd",
+          "id": "b01783bf-19b6-4391-b35b-bb0e0515cab2",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "74bc9af7-fc27-4061-800b-d50837669083",
           "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientAddress",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "6c3d92dd-e8db-4ecd-a819-bd2d64f73f6c",
+          "id": "101c1ec4-b266-4171-832c-91a7db154017",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "c57a542f-40fa-401a-9329-ec501da2f8e1",
+          "id": "fe275404-a57d-49d3-a55e-2701c3735f86",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -5462,27 +5050,13 @@
             "claim.name": "bpn",
             "jsonType.label": "String"
           }
-        },
-        {
-          "id": "25202b04-d387-45ae-a285-a40d4eaa5b8c",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -5493,7 +5067,7 @@
       ]
     },
     {
-      "id": "cad1382b-0dd4-4ac7-8183-1c08386c84e8",
+      "id": "34e5154a-e6ae-4d06-9724-99bfed09164f",
       "clientId": "sa-cl2-03",
       "description": "Technical User AutoSetup trigger - Portal to Vendor Autosetup (portal helm chart: backend.processesworker.offerprovider.clientId)",
       "surrogateAuthRequired": false,
@@ -5543,22 +5117,22 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "f57ed439-7c35-4a6c-a097-aa750249c442",
+          "id": "064775e5-aedb-493e-a1b7-7643642830e8",
           "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientAddress",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "7866847b-250a-45ac-979f-741f04330aa4",
+          "id": "2133b3a1-e415-414c-9738-26bdfc7f77e5",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -5574,40 +5148,41 @@
           }
         },
         {
-          "id": "ea42e697-8fa8-4359-b342-715683a67a15",
+          "id": "484b3362-053e-47c2-9a8b-5f34e6d0419b",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "743f3d13-5eb1-4fd7-a092-019c052f5db0",
+          "id": "78a50784-1e9d-4bd8-90d6-244c546c2935",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -5618,7 +5193,7 @@
       ]
     },
     {
-      "id": "aa736d92-8ab7-428a-b9f8-d7ef1c02a36a",
+      "id": "00b5aa80-6c7f-48e6-85c4-73c227460df4",
       "clientId": "sa-cl2-04",
       "name": "",
       "description": "Technical User SSI Credential Issuer - Portal to SSI Credential Issuer (portal helm chart: backend.processesworker.issuerComponent.clientId)",
@@ -5659,22 +5234,7 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "d33b18c2-4848-4883-a2bc-1a24a689b658",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "53adca2a-f30d-46d8-b39e-11b1102641f2",
+          "id": "e2dbed3d-523d-4321-b99a-0bcaf3485109",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
@@ -5682,6 +5242,7 @@
           "config": {
             "user.session.note": "client_id",
             "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
@@ -5689,7 +5250,7 @@
           }
         },
         {
-          "id": "fbaf8306-4b29-45bc-9175-dfc496d9ccd5",
+          "id": "4035a78e-f4ef-45a2-b036-7032d56be99a",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
@@ -5697,6 +5258,7 @@
           "config": {
             "user.session.note": "clientHost",
             "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
@@ -5704,7 +5266,23 @@
           }
         },
         {
-          "id": "7d509f6d-4526-4aeb-b3b7-1885f0d1e66d",
+          "id": "ba742fa9-2b80-496c-9547-fbaa60fa227d",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6850fc6e-443c-4368-99a9-fda01f11ffac",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -5723,8 +5301,9 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -5735,7 +5314,7 @@
       ]
     },
     {
-      "id": "04b94188-8879-4358-b9c0-1337d761dfb1",
+      "id": "4603597b-54c7-4a66-9e30-bc916fb62b2f",
       "clientId": "sa-cl2-05",
       "name": "",
       "description": "Technical User Dim Layer - Dim Layer to Portal (dim helm chart: processesworker.callback.clientId)",
@@ -5765,9 +5344,9 @@
       "protocol": "openid-connect",
       "attributes": {
         "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
         "client.secret.creation.time": "1712764151",
         "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
@@ -5775,22 +5354,7 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "519ad98b-ae9d-461e-8fb1-982d77515c2c",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "5e256bb8-1ffa-42b8-b2fb-41a1e015f732",
+          "id": "741fdb2f-05ac-41a9-805c-55a8305a8597",
           "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
@@ -5798,6 +5362,7 @@
           "config": {
             "user.session.note": "clientAddress",
             "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientAddress",
@@ -5805,7 +5370,7 @@
           }
         },
         {
-          "id": "c03ffe07-024e-45c6-96d0-568a40939f20",
+          "id": "c159046e-614a-4478-aa32-3d9453c0bbb9",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -5821,7 +5386,23 @@
           }
         },
         {
-          "id": "1b16d7c2-8ae2-4899-9c9c-f77e89e1fd18",
+          "id": "184d93d6-dbfc-43a0-9d16-461702a50d32",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "88f001c6-3a05-4b67-bdc2-bf70c3421cd0",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
@@ -5829,6 +5410,7 @@
           "config": {
             "user.session.note": "client_id",
             "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
@@ -5839,8 +5421,9 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -5851,7 +5434,7 @@
       ]
     },
     {
-      "id": "b09392dd-8b0f-4a32-bb0b-d00a4091b890",
+      "id": "4824b073-6765-47ef-bda5-276566a88f60",
       "clientId": "sa-cl21-01",
       "description": "Technical User Discovery Finder",
       "surrogateAuthRequired": false,
@@ -5901,70 +5484,71 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "f61880f7-a1d1-47cf-a3eb-906fa83aabda",
+          "id": "b97f428a-3d8b-46c3-88bd-3ce9bea5e73e",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "3c2deac0-fd68-4c39-933c-27123ff073f9",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "8f318235-669e-4236-b8ea-f596b802f672",
+          "id": "dc2874cd-12d7-4308-b805-72084f0dd7a2",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
             "user.attribute": "bpn",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "bpn",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "b74416e5-2376-4f8e-a49b-8a03a053454a",
+          "id": "fdfded5d-c7f9-4efe-918a-956b6c554b4b",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "19890ff6-52a8-47be-b51c-4779e0d46c5f",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -5975,7 +5559,7 @@
       ]
     },
     {
-      "id": "f1806543-d0ca-41cb-b029-883cdfb11a8e",
+      "id": "4427819f-a247-45ef-976b-dda6a054f566",
       "clientId": "sa-cl22-01",
       "description": "Technical User BPN Discovery",
       "surrogateAuthRequired": false,
@@ -6025,70 +5609,71 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "09824b45-f47e-4213-90d5-7aec6a078314",
-          "name": "BPN",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "bpn",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "bpn",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "0c72334b-238a-4f7b-bda6-3814bcd3b06e",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "5b4c8ff8-6c2d-4ece-a91d-6d3113688f6e",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "36e185ed-3af8-489d-a94b-a280ae205e03",
+          "id": "b5722720-383d-4083-b2ac-1639c5c7234c",
           "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientAddress",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "416523df-0420-4f3b-ad7a-d6e03aac3d9b",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "9a8ec21f-4cd6-46ac-8e35-45acfdc79bc4",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "b8095c37-176c-497b-a7c8-ef6e758b9c03",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -6099,7 +5684,7 @@
       ]
     },
     {
-      "id": "7278c4a3-539b-4ec5-8bdd-ba2eb55c2e83",
+      "id": "7fd354b7-5564-4452-9b77-0d1ae7b89167",
       "clientId": "sa-cl24-01",
       "name": "",
       "description": "Technical User for SSI Credential Issuer (credential issuer helm chart: processesworker.portal.clientId)",
@@ -6140,37 +5725,7 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "452b40a8-0662-4039-8f30-c8b0e5e0e0a7",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "eb60d2ec-5147-4cf3-aa57-74399be1cb2a",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "5c3664df-0b87-4fbd-a8d6-b8cca657d46e",
+          "id": "9fffc3ac-2632-47d2-9bcb-6269e86d771d",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
@@ -6178,6 +5733,7 @@
           "config": {
             "user.session.note": "client_id",
             "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
@@ -6185,7 +5741,279 @@
           }
         },
         {
-          "id": "62fbd871-2e40-4117-bda0-e8ecfae8019e",
+          "id": "a060c924-3e16-4358-8b51-e91237f2e926",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "478ef1fc-d3a8-40cf-9a2b-3935f770a525",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "344a8049-d6e7-4b00-9ca1-2643f5187ffa",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "1ed83a83-be64-4f0c-a512-4a57bd69f712",
+      "clientId": "sa-cl25-cx-1",
+      "name": "BPDM Dummy Cleaning Task Processor",
+      "description": "Technical User for the BPDM cleaning service dummy component to process golden record tasks from the Orchestrator",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "4f75450f-1f64-4822-98fa-5ca47a7dc880",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "22d9b379-09ab-4f00-9c1a-5c7c233603f8",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2009be57-8161-40dc-ad79-f91e0bb15ece",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9db370a5-cd57-44a4-ac99-438ce8845ea4",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "7d0280de-db7f-4f63-ac6f-984f71b22ec2",
+      "clientId": "sa-cl25-cx-2",
+      "name": "BPDM Pool Task Processor",
+      "description": "Technical User for the BPDM Pool component to process golden record tasks from the Orchestrator",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "0682c23e-4a5c-453c-8f90-d673a26249cb",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "1a60719c-cf79-4abf-9832-c0b54fdbadd7",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "67eb9289-f0b5-44ef-b7ab-b06a1f1ff8ce",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2f6416a1-a59c-4fae-9bf8-52c288d86fb8",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -6204,8 +6032,9 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -6216,7 +6045,127 @@
       ]
     },
     {
-      "id": "7beaee76-d447-4531-9433-fd9ce19d1460",
+      "id": "a1d9d140-8934-462a-afb3-64bcc70f1f36",
+      "clientId": "sa-cl25-cx-3",
+      "name": "BPDM Portal Gate Task Creator",
+      "description": "Technical User for the BPDM Portal Gate to create and monitor golden record tasks inside the Orchestrator",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "d1db8b63-a6b4-49b9-92a6-d1a850e0d7ed",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e0fc02e4-fa60-4508-9e67-e39b2fde3c62",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6b7d0924-86e5-4576-8bd8-e2a182880754",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f5dd8f34-faf7-4406-8f12-1a1d4b876786",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "ad373cbd-07c0-41cb-abe3-5b9c05427d3a",
       "clientId": "sa-cl3-cx-1",
       "name": "Technical User CX internal - communication GitHub and Semantic Hub",
       "surrogateAuthRequired": false,
@@ -6268,7 +6217,7 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "702c92a9-9f89-4130-9d37-c1620529ca13",
+          "id": "b56b5ea2-227d-457f-a427-c3fee26cffd6",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -6282,55 +6231,56 @@
           }
         },
         {
-          "id": "b5ba389e-26b0-452f-b784-ea1492cf4a0a",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "ef10553b-3bf7-46fe-910a-1bf8d7c74595",
+          "id": "811f9416-dca2-4c93-a141-94d5ab4e4ca4",
           "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientAddress",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "8e82412f-7088-4562-81f2-35b85f1859f5",
+          "id": "1a478f3a-a758-48c1-9d66-37055ae393bb",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "99c1e7de-117e-42f9-8cf6-76dd88eab410",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -6341,7 +6291,7 @@
       ]
     },
     {
-      "id": "50fa6455-a775-4683-b407-57a33a9b9f3b",
+      "id": "84637579-3b2c-4d20-bd12-532d95199ab9",
       "clientId": "sa-cl5-custodian-2",
       "name": "",
       "description": "Technical User for Portal to call Managed Identity Wallet (portal helm chart: backend.processesworker.custodian.clientId)",
@@ -6397,13 +6347,124 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "3d2518d7-950b-40da-b9d4-ca0fe3c6a328",
+          "id": "62ef1b4a-3d4d-4acb-ba1c-08fb45e61daa",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "37d40167-cf74-4786-b2bd-46f6d0f53202",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "fd75b6e2-ed46-4fcc-8dab-1cb572271124",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "2acf28d2-d4a0-46ae-949a-4b6bb0a3f861",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "basic"
+      ],
+      "optionalClientScopes": [
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3ceff74a-bccd-4569-b73e-620bed70cfa8",
+      "clientId": "sa-cl7-cx-1",
+      "name": "BPDM Portal Gate Pool Consumer",
+      "description": "Technical User for the BPDM Portal Gate to consume golden record data from the Pool",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5871dd70-8db3-44d2-8c03-f207049f0716",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
             "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -6412,13 +6473,14 @@
           }
         },
         {
-          "id": "728abacc-c436-4d67-b699-92957a69b519",
+          "id": "a24bf808-71b5-4818-9690-995963c3d264",
           "name": "Client IP Address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
             "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -6427,12 +6489,13 @@
           }
         },
         {
-          "id": "98c6f360-6714-455a-bc94-4fa0b5072866",
+          "id": "08b8a84e-3adb-4626-875c-e3ac89dc3d38",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "introspection.token.claim": "true",
             "userinfo.token.claim": "true",
             "user.attribute": "bpn",
             "id.token.claim": "true",
@@ -6442,13 +6505,14 @@
           }
         },
         {
-          "id": "a7bf4bbd-2764-46c8-b211-5d9676b1380a",
+          "id": "07499101-fc08-460b-96e8-1d01d4791635",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "client_id",
+            "introspection.token.claim": "true",
             "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -6459,14 +6523,21 @@
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles"
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
       ],
       "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
         "microprofile-jwt"
       ]
     },
     {
-      "id": "183aae87-c9cf-4d70-934b-629aa6974c54",
+      "id": "32592910-c7b8-48c7-a913-b36b8c7b28cc",
       "clientId": "sa-cl7-cx-5",
       "description": "User for Portal to access BPDM for Company Address publishing into the BPDM (portal helm chart: backend.processesworker.bpdm.clientId)",
       "surrogateAuthRequired": false,
@@ -6516,7 +6587,52 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "2413cb54-b0a2-4e08-be68-9288b1b0b617",
+          "id": "e11d6f44-a837-4ebf-adb8-0c81ce2a0012",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "602a3dab-2fe5-47c4-a47f-10e819565b40",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "6788184a-5394-4f5c-b273-681ed6cd8a1e",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "00c2fda1-8ff5-4a1e-8793-005df838015e",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -6530,57 +6646,13 @@
             "claim.name": "bpn",
             "jsonType.label": "String"
           }
-        },
-        {
-          "id": "08dbaf87-e25e-489c-bec9-f062af3de2df",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "2420c9fc-2c5a-4e54-b6c1-3d72e4eb9e85",
-          "name": "Client Host",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientHost",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "fb8aa3d7-44dd-4348-9a43-a48fadb0a858",
-          "name": "Client ID",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "client_id",
-            "jsonType.label": "String"
-          }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
         "roles",
         "profile",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -6591,7 +6663,7 @@
       ]
     },
     {
-      "id": "5ec47b9d-6808-4e11-88b0-a7863d4ebf4f",
+      "id": "91eff831-37f5-4d38-8727-1234bcf1bf8b",
       "clientId": "sa-cl7-cx-7",
       "name": "",
       "description": "Technical User for BPDM services to communicate between each other to realize the golden record process: used by the Portal Gate, Pool and Cleaning Service.",
@@ -6621,9 +6693,9 @@
       "protocol": "openid-connect",
       "attributes": {
         "oidc.ciba.grant.enabled": "false",
-        "oauth2.device.authorization.grant.enabled": "false",
         "client.secret.creation.time": "1722276592",
         "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
@@ -6631,22 +6703,7 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "e883740c-6417-432e-9c0c-a68878e03909",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "introspection.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "4524a57a-d00c-4472-b425-b5337c5ef498",
+          "id": "847701da-5768-40e1-83da-d021990056ba",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
@@ -6654,6 +6711,7 @@
           "config": {
             "user.session.note": "clientHost",
             "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
@@ -6661,7 +6719,7 @@
           }
         },
         {
-          "id": "61fd448d-d12f-4148-b8dd-f084af1cb485",
+          "id": "8b43a06f-1c70-4ea8-98dc-9beddcc2511a",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -6677,7 +6735,23 @@
           }
         },
         {
-          "id": "7e3f9e39-dcba-464e-9797-94e8ad9aef40",
+          "id": "e846a94f-de18-41f9-a604-5fcfb5b70b7e",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d9f531bf-71be-46fb-8667-e5f3e7f8a952",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
@@ -6685,6 +6759,7 @@
           "config": {
             "user.session.note": "client_id",
             "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
@@ -6697,6 +6772,7 @@
         "acr",
         "roles",
         "profile",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -6707,7 +6783,7 @@
       ]
     },
     {
-      "id": "c2bdc736-ca35-43c4-8e18-27e7425df9f0",
+      "id": "4ed85fe4-0efb-46cf-ad17-c7778e0f360b",
       "clientId": "sa-cl8-cx-1",
       "description": "Technical User for Portal to SD (portal helm chart: backend.processesworker.sdfactory.clientId)",
       "surrogateAuthRequired": false,
@@ -6759,7 +6835,22 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "459ecd6f-7d60-490a-9e78-b82bfc5592bc",
+          "id": "896494dc-2f89-4abf-a84b-0dd562edb7d7",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "beefa361-6e50-4f40-be4d-acb98496ce1d",
           "name": "BPN",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
@@ -6775,61 +6866,47 @@
           }
         },
         {
-          "id": "5049595f-673e-4ce2-9ce2-90e11c0fc6e9",
-          "name": "Client IP Address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usersessionmodel-note-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.session.note": "clientAddress",
-            "userinfo.token.claim": "true",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "clientAddress",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "b8086ec0-3da2-4f98-a7fd-19d007709e6f",
+          "id": "117af2b0-ea2d-4800-8c09-c83b1f3e8f14",
           "name": "Client Host",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "clientHost",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "clientHost",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "55da2734-a7e2-4d89-b210-7cb0a24fced4",
+          "id": "1d3c1774-1c4f-40f3-945e-3b3fb6d0bcbf",
           "name": "Client ID",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usersessionmodel-note-mapper",
           "consentRequired": false,
           "config": {
             "user.session.note": "client_id",
-            "userinfo.token.claim": "true",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "client_id",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles"
+        "roles",
+        "basic"
       ],
       "optionalClientScopes": [
         "microprofile-jwt"
       ]
     },
     {
-      "id": "d5265cd8-d128-4dc9-8602-d49d1df0a86c",
+      "id": "78fc514d-b77c-4d04-bb6c-2bd52d578f4b",
       "clientId": "security-admin-console",
       "name": "${client_security-admin-console}",
       "rootUrl": "${authAdminUrl}",
@@ -6863,25 +6940,26 @@
       "nodeReRegistrationTimeout": 0,
       "protocolMappers": [
         {
-          "id": "12d9df9a-241b-4ec2-bafa-3f26ccaa1890",
+          "id": "f1dc2ec5-3256-46ea-b879-45c925df4d3d",
           "name": "locale",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
             "user.attribute": "locale",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "locale",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ],
       "defaultClientScopes": [
         "web-origins",
-        "roles",
         "profile",
+        "roles",
+        "basic",
         "email"
       ],
       "optionalClientScopes": [
@@ -6892,7 +6970,7 @@
       ]
     },
     {
-      "id": "6df310ed-500e-43d5-b510-fa4668e939ee",
+      "id": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
       "clientId": "technical_roles_management",
       "surrogateAuthRequired": false,
       "enabled": true,
@@ -6954,7 +7032,7 @@
   ],
   "clientScopes": [
     {
-      "id": "32795711-2e76-43f9-8138-3ce5b9eae1a2",
+      "id": "e6ce522a-c5af-4be9-9b84-4288d4344783",
       "name": "catena",
       "protocol": "openid-connect",
       "attributes": {
@@ -6969,12 +7047,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
             "user.attribute": "organisation",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "organisation",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
@@ -6984,12 +7062,12 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
             "user.attribute": "username",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "preferred_username",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
@@ -6999,118 +7077,389 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
             "user.attribute": "bpn",
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "bpn",
-            "jsonType.label": "String"
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         }
       ]
     },
     {
-      "id": "13834c57-9211-4e3e-b892-0632a3c15225",
-      "name": "phone",
-      "description": "OpenID Connect built-in scope: phone",
+      "id": "954bae49-cdf9-4463-a8f9-cedc172bcb50",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${phoneScopeConsentText}"
-      },
-      "protocolMappers": [
-        {
-          "id": "6c0bfbc5-e3d7-45f9-a0bc-61e30225e22b",
-          "name": "phone number verified",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "phoneNumberVerified",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "phone_number_verified",
-            "jsonType.label": "boolean"
-          }
-        },
-        {
-          "id": "8868b283-df78-4c9a-b78e-1c29e4b9b61c",
-          "name": "phone number",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "phoneNumber",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "phone_number",
-            "jsonType.label": "String"
-          }
-        }
-      ]
-    },
-    {
-      "id": "23e5acb7-2d8c-4bca-8565-36fb57ee7ee0",
-      "name": "role_list",
-      "description": "SAML role list",
-      "protocol": "saml",
-      "attributes": {
-        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "consent.screen.text": "${emailScopeConsentText}",
         "display.on.consent.screen": "true"
       },
       "protocolMappers": [
         {
-          "id": "0adf14b5-a345-4d20-83cc-2a353c686161",
-          "name": "role list",
-          "protocol": "saml",
-          "protocolMapper": "saml-role-list-mapper",
+          "id": "a4c25827-ae7f-4141-afe4-b13524b3f6e1",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
           "consentRequired": false,
           "config": {
-            "single": "false",
-            "attribute.nameformat": "Basic",
-            "attribute.name": "Role"
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "3f2cafaf-199d-47b0-8d7c-741c0a9fa86e",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean",
+            "userinfo.token.claim": "true"
           }
         }
       ]
     },
     {
-      "id": "fc35a8f5-fedd-4b66-b3fa-9427e3947dc5",
+      "id": "6a635762-74c7-4256-809f-c6606a61e3f3",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "43886c4f-43c1-4071-9e14-7da0ecc66bb6",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "c34356c8-8024-443f-8f6f-3fdaf15bfc89",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "e486c0c0-489e-4d82-99d8-3da02c934ee4",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5499bdf8-9e42-4912-9cf0-8afdd45915c1",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "eb0a1b6f-0c50-42de-827c-87e8e7c1aae6",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "dd78db4b-fe72-4982-8c31-b6757ef03b28",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "69eefa8f-d7eb-4e2d-ade7-601b2774f57f",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "8e955fb2-3dc1-4c07-a85b-1cbd216b1c74",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "d4770741-a6bc-4c54-b44b-c67092d1aedd",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "b73b2460-2caa-4543-80dc-c87adf126236",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "61f01758-a1b3-4787-93e5-9409fb94e664",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "37cb17d3-d52e-4224-bd16-66b39d1191c0",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "c574876a-4baf-4f76-9846-5f367211a5af",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "b6bd8981-aa88-4024-ada2-13696fc48dda",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "8a7bb347-cbfc-4bde-a356-e9188bba9276",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "9d80076b-d6de-4df3-bbb9-4f3ea86ebc71",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "66158ae3-abbe-4647-b666-8c506050217d",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "74969d63-cabe-40d2-b0a1-639af234932a",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "d7700771-1707-41ac-b328-ad9c7daef0cb",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6d555789-7885-4e79-8f76-b79f3e0757ab",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "585e978d-81f7-4a55-a6b9-76162491094f",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "7286d1ec-110a-4d05-a6b9-6a67554070ae",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "60a38dbf-70ee-4875-82f2-165b47758955",
       "name": "roles",
       "description": "OpenID Connect scope for add user roles to the access token",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "false",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${rolesScopeConsentText}"
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
       },
       "protocolMappers": [
         {
-          "id": "73a111cf-271c-4b9f-abca-e4894e29229d",
-          "name": "realm roles",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-realm-role-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.attribute": "foo",
-            "access.token.claim": "true",
-            "claim.name": "realm_access.roles",
-            "jsonType.label": "String",
-            "multivalued": "true"
-          }
-        },
-        {
-          "id": "c06270fe-f203-4c9b-92a8-ff716b81127a",
-          "name": "audience resolve",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-resolve-mapper",
-          "consentRequired": false,
-          "config": {}
-        },
-        {
-          "id": "8e22da0e-f450-444a-80b4-824a69532949",
+          "id": "19276da0-eed8-4e9c-ac40-6a43f6dab43a",
           "name": "client roles",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-client-role-mapper",
@@ -7119,25 +7468,45 @@
             "user.attribute": "foo",
             "access.token.claim": "true",
             "claim.name": "resource_access.${client_id}.roles",
-            "jsonType.label": "String",
-            "multivalued": "true"
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "21314dd4-fd5f-417f-acbb-1a6112ac5a18",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        },
+        {
+          "id": "4ef2ef6e-25c1-4384-9b04-c67e29d6ca50",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
           }
         }
       ]
     },
     {
-      "id": "09dc23a3-1b9f-4b9d-aa87-e875f0f20655",
+      "id": "85db8729-720a-4257-90f0-0d5a7ff5cc98",
       "name": "address",
       "description": "OpenID Connect built-in scope: address",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${addressScopeConsentText}"
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
       },
       "protocolMappers": [
         {
-          "id": "0543fff7-3732-433b-8a24-d2784bba1501",
+          "id": "d8cae4a7-cec7-4878-b389-7f05f8382426",
           "name": "address",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-address-mapper",
@@ -7156,346 +7525,52 @@
       ]
     },
     {
-      "id": "34a2f332-9752-4a7f-9d61-b4dbd40946b4",
-      "name": "microprofile-jwt",
-      "description": "Microprofile - JWT built-in scope",
+      "id": "fe9940f8-a33d-42c2-9b3b-7ebf03804be8",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
-        "display.on.consent.screen": "false"
-      },
-      "protocolMappers": [
-        {
-          "id": "955c2cb6-3abb-44d1-a3eb-9ebec0cf6094",
-          "name": "upn",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "username",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "upn",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "48b4aa99-383c-4178-b966-c0ae710d8c21",
-          "name": "groups",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-realm-role-mapper",
-          "consentRequired": false,
-          "config": {
-            "multivalued": "true",
-            "userinfo.token.claim": "true",
-            "user.attribute": "foo",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "groups",
-            "jsonType.label": "String"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e24a7d06-7406-4b2f-854e-a5653f8b964f",
-      "name": "profile",
-      "description": "OpenID Connect built-in scope: profile",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${profileScopeConsentText}"
-      },
-      "protocolMappers": [
-        {
-          "id": "987e5408-e6ef-4cd2-a51f-451fb7c0dc4e",
-          "name": "locale",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "locale",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "locale",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "1a9bd37a-377a-48ae-9b95-a1c0c5f3fa08",
-          "name": "username",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "username",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "preferred_username",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "dca5ee31-87cb-407b-aba6-d6c846e6a6b4",
-          "name": "zoneinfo",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "zoneinfo",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "zoneinfo",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "6af98429-3234-4f57-95c0-7df4209cb349",
-          "name": "family name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "lastName",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "family_name",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "b7e70ea0-1b54-469b-b818-dcb7d4657d9b",
-          "name": "given name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "firstName",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "given_name",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "02aff4ea-454c-41cf-8bf6-1bea1e933812",
-          "name": "nickname",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "nickname",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "nickname",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "438a5f2c-727b-4ba2-82de-d5cf4b8d4daa",
-          "name": "gender",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "gender",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "gender",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "70bf1855-c34a-4bd3-a06d-f3d62d91693b",
-          "name": "middle name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "middleName",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "middle_name",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "0c9106a1-9c93-47bd-85b3-8607ba8485c2",
-          "name": "full name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-full-name-mapper",
-          "consentRequired": false,
-          "config": {
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "userinfo.token.claim": "true"
-          }
-        },
-        {
-          "id": "4386dc68-8dd3-4439-8c63-eabcdb92fd76",
-          "name": "birthdate",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "birthdate",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "birthdate",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "78be8eb6-ca31-434c-8441-6abbfe553a22",
-          "name": "profile",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "profile",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "profile",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "fb918735-48a7-4f96-8830-606815788dfb",
-          "name": "picture",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "picture",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "picture",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "6e4e8483-7c58-4539-98d1-4b02ff5dc6f5",
-          "name": "updated at",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "updatedAt",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "updated_at",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "58e59849-6457-4c8b-b713-2c5a008461c6",
-          "name": "website",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "website",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "website",
-            "jsonType.label": "String"
-          }
-        }
-      ]
-    },
-    {
-      "id": "99ca536c-58c2-432f-904e-10926bbc207b",
-      "name": "offline_access",
-      "description": "OpenID Connect built-in scope: offline_access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "consent.screen.text": "${phoneScopeConsentText}",
         "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "id": "8a14f08a-0ba9-44ae-83bd-5a65b9d0fe8c",
-      "name": "email",
-      "description": "OpenID Connect built-in scope: email",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${emailScopeConsentText}"
       },
       "protocolMappers": [
         {
-          "id": "2c452702-a301-4cc7-b76c-619b23f44fa0",
-          "name": "email verified",
+          "id": "6a02572c-8eb0-45e8-bbdb-ebd39cd8ea7c",
+          "name": "phone number",
           "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "emailVerified",
+            "user.attribute": "phoneNumber",
             "id.token.claim": "true",
             "access.token.claim": "true",
-            "claim.name": "email_verified",
-            "jsonType.label": "boolean"
+            "claim.name": "phone_number",
+            "jsonType.label": "String",
+            "userinfo.token.claim": "true"
           }
         },
         {
-          "id": "1e6f0566-fc33-4e1f-bf4e-686676fcde70",
-          "name": "email",
+          "id": "2a971b6b-3e7f-4fed-8cc2-95ea8191433a",
+          "name": "phone number verified",
           "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "email",
+            "user.attribute": "phoneNumberVerified",
             "id.token.claim": "true",
             "access.token.claim": "true",
-            "claim.name": "email",
-            "jsonType.label": "String"
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean",
+            "userinfo.token.claim": "true"
           }
         }
       ]
     },
     {
-      "id": "2629904c-d708-4072-9fe4-98e4a30c7dde",
-      "name": "web-origins",
-      "description": "OpenID Connect scope for add allowed web origins to the access token",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "false",
-        "display.on.consent.screen": "false",
-        "consent.screen.text": ""
-      },
-      "protocolMappers": [
-        {
-          "id": "07ab75f1-40a3-4b2c-ae83-94dac6e529e2",
-          "name": "allowed web origins",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-allowed-origins-mapper",
-          "consentRequired": false,
-          "config": {}
-        }
-      ]
-    },
-    {
-      "id": "b0cb460b-b342-4c93-8e43-b4b29dd26d40",
-      "name": "acr",
-      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "id": "ea4972a9-9ca1-4de1-a7f7-a59a1176a138",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "false",
@@ -7503,15 +7578,53 @@
       },
       "protocolMappers": [
         {
-          "id": "a49b8ad7-3e2d-4a04-a2a0-bc0bcce786c9",
-          "name": "acr loa level",
+          "id": "66fc44de-6d98-466b-84e1-171aaa458ce3",
+          "name": "sub",
           "protocol": "openid-connect",
-          "protocolMapper": "oidc-acr-mapper",
+          "protocolMapper": "oidc-sub-mapper",
           "consentRequired": false,
           "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "cb7dd3f0-d146-4529-9679-5898b418ae3f",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
             "id.token.claim": "true",
+            "introspection.token.claim": "true",
             "access.token.claim": "true",
-            "userinfo.token.claim": "true"
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5d07139c-4307-4e8d-809c-437845c53bb2",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "14e2e79f-36f8-44d6-a6d2-ed15c07e4c5b",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
           }
         }
       ]
@@ -7519,11 +7632,12 @@
   ],
   "defaultDefaultClientScopes": [
     "role_list",
+    "profile",
     "email",
     "roles",
     "web-origins",
-    "profile",
-    "acr"
+    "acr",
+    "basic"
   ],
   "defaultOptionalClientScopes": [
     "offline_access",
@@ -7534,7 +7648,6 @@
   "browserSecurityHeaders": {
     "contentSecurityPolicyReportOnly": "",
     "xContentTypeOptions": "nosniff",
-    "referrerPolicy": "no-referrer",
     "xRobotsTag": "none",
     "xFrameOptions": "SAMEORIGIN",
     "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
@@ -7634,7 +7747,7 @@
     {
       "alias": "CX-Operator",
       "displayName": "CX-Operator",
-      "internalId": "fbc571fd-cd44-4cec-a36e-4eba647fe712",
+      "internalId": "c5a8426b-9d7b-497d-80b0-ca2ada92fb2b",
       "providerId": "keycloak-oidc",
       "enabled": true,
       "updateProfileFirstLoginMode": "on",
@@ -7643,16 +7756,15 @@
       "addReadTokenRoleOnCreate": false,
       "authenticateByDefault": false,
       "linkOnly": false,
-      "firstBrokerLoginFlowAlias": "first broker login",
       "config": {
         "hideOnLoginPage": "false",
         "validateSignature": "true",
         "clientId": "central-idp",
-        "tokenUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/token",
-        "jwksUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/certs",
-        "authorizationUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/auth",
+        "tokenUrl": "http://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/token",
+        "jwksUrl": "http://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/certs",
+        "authorizationUrl": "http://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/auth",
         "clientAuthMethod": "private_key_jwt",
-        "logoutUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/logout",
+        "logoutUrl": "http://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/logout",
         "clientAssertionSigningAlg": "RS256",
         "syncMode": "FORCE",
         "useJwksUrl": "true"
@@ -7661,7 +7773,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "05407473-42a0-4630-90ed-ce2d6d70108e",
+      "id": "0aba0869-4849-4834-a2f3-6d8e908ef38b",
       "name": "organisation-mapper",
       "identityProviderAlias": "CX-Operator",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -7675,19 +7787,50 @@
   "components": {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
       {
-        "id": "ab25cbe7-60bc-49ed-aa4a-707f84a70893",
-        "name": "Max Clients Limit",
-        "providerId": "max-clients",
-        "subType": "anonymous",
+        "id": "d8efed13-f59b-4ba8-88fb-e2c4f5c4c42b",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
         "subComponents": {},
         "config": {
-          "max-clients": [
-            "200"
+          "allow-default-scopes": [
+            "true"
           ]
         }
       },
       {
-        "id": "277b586e-0b26-40e9-90d1-e76305d69a10",
+        "id": "b19653bb-2f86-4586-a79b-5025982badb6",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "fbeb0743-ed8b-4d5b-b2f9-ec4a98d9c8fd",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "c0772464-095b-4c45-a7b6-39460a815da6",
         "name": "Consent Required",
         "providerId": "consent-required",
         "subType": "anonymous",
@@ -7695,7 +7838,7 @@
         "config": {}
       },
       {
-        "id": "552bd2e5-c656-4796-8d61-b87c3508aab5",
+        "id": "4434b0b5-bbb8-494a-a0ff-d66893d88d68",
         "name": "Trusted Hosts",
         "providerId": "trusted-hosts",
         "subType": "anonymous",
@@ -7710,26 +7853,7 @@
         }
       },
       {
-        "id": "de1bbb33-9e18-4fc1-9ea3-1fd8ad22eae9",
-        "name": "Allowed Protocol Mapper Types",
-        "providerId": "allowed-protocol-mappers",
-        "subType": "authenticated",
-        "subComponents": {},
-        "config": {
-          "allowed-protocol-mapper-types": [
-            "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
-            "saml-user-attribute-mapper",
-            "saml-role-list-mapper",
-            "oidc-sha256-pairwise-sub-mapper",
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-full-name-mapper"
-          ]
-        }
-      },
-      {
-        "id": "b521525f-30e3-4b93-b42b-8c0dd53fc3af",
+        "id": "a4850d49-9df2-450d-943e-225f02d8aea2",
         "name": "Full Scope Disabled",
         "providerId": "scope",
         "subType": "anonymous",
@@ -7737,74 +7861,52 @@
         "config": {}
       },
       {
-        "id": "a4df1d6a-2c46-44f4-9d06-62eb9b754bab",
+        "id": "e0d17fcf-cb52-4c26-8ab4-11b9e9a270fd",
         "name": "Allowed Protocol Mapper Types",
         "providerId": "allowed-protocol-mappers",
-        "subType": "anonymous",
+        "subType": "authenticated",
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-address-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "saml-user-attribute-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "oidc-usermodel-property-mapper",
-            "saml-role-list-mapper",
             "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-attribute-mapper",
             "oidc-full-name-mapper"
           ]
         }
       },
       {
-        "id": "f7e25fe0-dfe5-451a-8f54-ceea0cf201b4",
-        "name": "Allowed Client Scopes",
-        "providerId": "allowed-client-templates",
+        "id": "aaa639c0-d94c-44f4-95cd-6d0eb8e72cb1",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
         "subType": "anonymous",
         "subComponents": {},
         "config": {
-          "allow-default-scopes": [
-            "true"
-          ]
-        }
-      },
-      {
-        "id": "d15d2dae-9c9c-4c7d-83f3-726f29194489",
-        "name": "Allowed Client Scopes",
-        "providerId": "allowed-client-templates",
-        "subType": "authenticated",
-        "subComponents": {},
-        "config": {
-          "allow-default-scopes": [
-            "true"
+          "max-clients": [
+            "200"
           ]
         }
       }
     ],
     "org.keycloak.userprofile.UserProfileProvider": [
       {
-        "id": "8574d707-4fa1-4cd3-851d-9c5ab5491356",
+        "id": "1dd954ae-97aa-4f35-94f9-6afec01a6e9a",
         "providerId": "declarative-user-profile",
         "subComponents": {},
-        "config": {}
+        "config": {
+          "kc.user.profile.config": [
+            "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]}},{\"name\":\"organisation\",\"displayName\":\"${profile.attributes.organisation}\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[],\"edit\":[\"admin\"]}},{\"name\":\"bpn\",\"displayName\":\"${profile.attributes.bpn}\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[],\"edit\":[\"admin\"]}}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}]}"
+          ]
+        }
       }
     ],
     "org.keycloak.keys.KeyProvider": [
       {
-        "id": "2bd55ad0-2f32-40f3-9749-c2d422fb697d",
-        "name": "hmac-generated",
-        "providerId": "hmac-generated",
-        "subComponents": {},
-        "config": {
-          "priority": [
-            "100"
-          ],
-          "algorithm": [
-            "HS256"
-          ]
-        }
-      },
-      {
-        "id": "676a20ad-a79d-4175-998a-672bf4826e92",
+        "id": "e30e81eb-fa28-4c4b-93ae-ced53fb9fb62",
         "name": "rsa-enc-generated",
         "providerId": "rsa-enc-generated",
         "subComponents": {},
@@ -7818,7 +7920,7 @@
         }
       },
       {
-        "id": "50220023-09bf-443a-a8b3-f306279cbb5b",
+        "id": "bdaabfca-7391-4321-9a28-918f35226f02",
         "name": "rsa-generated",
         "providerId": "rsa-generated",
         "subComponents": {},
@@ -7829,13 +7931,41 @@
         }
       },
       {
-        "id": "a510d16e-c3f7-4a88-b853-625a2cd357b4",
+        "id": "35e6f9f0-3934-49d4-8503-2735998ab314",
         "name": "aes-generated",
         "providerId": "aes-generated",
         "subComponents": {},
         "config": {
           "priority": [
             "100"
+          ]
+        }
+      },
+      {
+        "id": "2dad0067-8462-4b92-ae96-f06f58c4e7ce",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "5836315d-2cb6-4dc7-beec-4f52aa609461",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS256"
           ]
         }
       }
@@ -7849,7 +7979,7 @@
   "defaultLocale": "en",
   "authenticationFlows": [
     {
-      "id": "fff7e51f-802f-4826-b18e-551667d2f5af",
+      "id": "b85acc77-a0fd-492e-841f-051eb40cd92f",
       "alias": "Account verification options",
       "description": "Method with which to verity the existing account",
       "providerId": "basic-flow",
@@ -7875,7 +8005,7 @@
       ]
     },
     {
-      "id": "078aeee3-8e08-4904-9455-10e86293fdc3",
+      "id": "a5422b70-5a80-46e1-882c-edf421ce0c6d",
       "alias": "Browser - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -7901,7 +8031,7 @@
       ]
     },
     {
-      "id": "97a6d2ad-95fe-4a49-ba16-4fe37716f8ca",
+      "id": "d3365b5f-aded-4ca2-adf1-ceb7b9023d69",
       "alias": "Direct Grant - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -7927,7 +8057,7 @@
       ]
     },
     {
-      "id": "43a7d34e-262c-42ef-874a-42a7151ef7fe",
+      "id": "687f5531-3dcd-478f-998b-22207de05099",
       "alias": "First broker login - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -7953,7 +8083,7 @@
       ]
     },
     {
-      "id": "49dbe5c0-a28e-4bc1-a735-01b1d44526f8",
+      "id": "992302c6-cb66-454f-8f55-c03880d66512",
       "alias": "Handle Existing Account",
       "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
       "providerId": "basic-flow",
@@ -7979,7 +8109,7 @@
       ]
     },
     {
-      "id": "8843a182-cb40-40c8-acb8-a96c131820bc",
+      "id": "c5eea5f4-0acf-4263-a390-5c0c98293363",
       "alias": "Login without auto user creation",
       "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
       "providerId": "basic-flow",
@@ -7991,14 +8121,14 @@
           "authenticator": "idp-review-profile",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
         {
           "authenticatorFlow": true,
           "requirement": "REQUIRED",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": true,
           "flowAlias": "Login without auto user creation User creation or linking",
           "userSetupAllowed": false
@@ -8006,7 +8136,7 @@
       ]
     },
     {
-      "id": "bad3c307-e0c7-47b3-8124-3d850c5dbb8f",
+      "id": "04aff745-a5d9-4a3e-9553-79bea685cb4f",
       "alias": "Login without auto user creation Account verification options",
       "description": "Method with which to verity the existing account",
       "providerId": "basic-flow",
@@ -8017,14 +8147,14 @@
           "authenticator": "idp-email-verification",
           "authenticatorFlow": false,
           "requirement": "ALTERNATIVE",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
         {
           "authenticatorFlow": true,
           "requirement": "ALTERNATIVE",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": true,
           "flowAlias": "Login without auto user creation Verify Existing Account by Re-authentication",
           "userSetupAllowed": false
@@ -8032,7 +8162,7 @@
       ]
     },
     {
-      "id": "0875bc85-b5cc-4268-8faf-3706d2d377ad",
+      "id": "0294d6de-01c0-496c-8597-2a509855d779",
       "alias": "Login without auto user creation First broker login - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -8043,7 +8173,7 @@
           "authenticator": "conditional-user-configured",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
@@ -8051,14 +8181,14 @@
           "authenticator": "auth-otp-form",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         }
       ]
     },
     {
-      "id": "a98586a2-cdf9-411d-aea8-48c4cf7b139a",
+      "id": "f111f3b0-bda1-4352-92b2-4881a12d6af8",
       "alias": "Login without auto user creation Handle Existing Account",
       "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
       "providerId": "basic-flow",
@@ -8069,14 +8199,14 @@
           "authenticator": "idp-confirm-link",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
         {
           "authenticatorFlow": true,
           "requirement": "REQUIRED",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": true,
           "flowAlias": "Login without auto user creation Account verification options",
           "userSetupAllowed": false
@@ -8084,7 +8214,7 @@
       ]
     },
     {
-      "id": "5c6cb05b-6984-4884-ada0-302a352cae52",
+      "id": "0eb07b77-6732-4a43-a9f1-d8d9b259dc04",
       "alias": "Login without auto user creation User creation or linking",
       "description": "Flow for the existing/non-existing user alternatives",
       "providerId": "basic-flow",
@@ -8096,14 +8226,14 @@
           "authenticator": "idp-create-user-if-unique",
           "authenticatorFlow": false,
           "requirement": "DISABLED",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
         {
           "authenticatorFlow": true,
           "requirement": "ALTERNATIVE",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": true,
           "flowAlias": "Login without auto user creation Handle Existing Account",
           "userSetupAllowed": false
@@ -8111,7 +8241,7 @@
       ]
     },
     {
-      "id": "87cd4301-f245-4e81-9877-51bea2f77c4f",
+      "id": "3dac707d-500f-431c-8990-fa72012109b8",
       "alias": "Login without auto user creation Verify Existing Account by Re-authentication",
       "description": "Reauthentication of existing account",
       "providerId": "basic-flow",
@@ -8122,14 +8252,14 @@
           "authenticator": "idp-username-password-form",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
         {
           "authenticatorFlow": true,
           "requirement": "CONDITIONAL",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": true,
           "flowAlias": "Login without auto user creation First broker login - Conditional OTP",
           "userSetupAllowed": false
@@ -8137,7 +8267,7 @@
       ]
     },
     {
-      "id": "75deb0f4-5ce1-4daa-ac6a-ad992dee52cc",
+      "id": "03b28db9-25de-474b-9238-1d27b9b33f35",
       "alias": "Reset - Conditional OTP",
       "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
       "providerId": "basic-flow",
@@ -8163,7 +8293,7 @@
       ]
     },
     {
-      "id": "70aac624-4ea6-45b7-a3fc-d8456ef2efdc",
+      "id": "134e7c36-1c17-4391-b8aa-a2363a7f11b7",
       "alias": "User creation or linking",
       "description": "Flow for the existing/non-existing user alternatives",
       "providerId": "basic-flow",
@@ -8190,7 +8320,7 @@
       ]
     },
     {
-      "id": "6913a8ea-93d4-4ff7-a6c4-388b2b88cb60",
+      "id": "22872037-65f9-4d83-b526-4974498be36c",
       "alias": "Verify Existing Account by Re-authentication",
       "description": "Reauthentication of existing account",
       "providerId": "basic-flow",
@@ -8216,7 +8346,7 @@
       ]
     },
     {
-      "id": "ffae9561-c06f-4b23-9748-8120ab8baaa8",
+      "id": "12e95146-d54c-43e7-a34b-1828645a0c8b",
       "alias": "WebAuth Browser",
       "description": "browser based authentication",
       "providerId": "basic-flow",
@@ -8227,7 +8357,7 @@
           "authenticator": "auth-cookie",
           "authenticatorFlow": false,
           "requirement": "ALTERNATIVE",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
@@ -8235,7 +8365,7 @@
           "authenticator": "auth-spnego",
           "authenticatorFlow": false,
           "requirement": "DISABLED",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
@@ -8243,14 +8373,14 @@
           "authenticator": "identity-provider-redirector",
           "authenticatorFlow": false,
           "requirement": "ALTERNATIVE",
-          "priority": 25,
+          "priority": 2,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
         {
           "authenticatorFlow": true,
           "requirement": "ALTERNATIVE",
-          "priority": 30,
+          "priority": 3,
           "autheticatorFlow": true,
           "flowAlias": "WebAuth Browser forms",
           "userSetupAllowed": false
@@ -8258,7 +8388,7 @@
       ]
     },
     {
-      "id": "98520dfb-3e2a-4280-964a-5c6a492fd9e2",
+      "id": "3fcc23ba-4ca6-48a4-9029-7ca28616980f",
       "alias": "WebAuth Browser Browser - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -8269,7 +8399,7 @@
           "authenticator": "conditional-user-configured",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
@@ -8277,7 +8407,7 @@
           "authenticator": "auth-otp-form",
           "authenticatorFlow": false,
           "requirement": "ALTERNATIVE",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
@@ -8285,14 +8415,14 @@
           "authenticator": "webauthn-authenticator",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 21,
+          "priority": 2,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         }
       ]
     },
     {
-      "id": "b6215c1f-1023-4748-9e9e-ae700573c9ea",
+      "id": "ddca21ed-8955-4523-b736-d1d702d8f415",
       "alias": "WebAuth Browser forms",
       "description": "Username, password, otp and other auth forms.",
       "providerId": "basic-flow",
@@ -8303,14 +8433,14 @@
           "authenticator": "auth-username-password-form",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
-          "priority": 10,
+          "priority": 0,
           "autheticatorFlow": false,
           "userSetupAllowed": false
         },
         {
           "authenticatorFlow": true,
           "requirement": "CONDITIONAL",
-          "priority": 20,
+          "priority": 1,
           "autheticatorFlow": true,
           "flowAlias": "WebAuth Browser Browser - Conditional OTP",
           "userSetupAllowed": false
@@ -8318,7 +8448,7 @@
       ]
     },
     {
-      "id": "d6521692-2a35-4fab-99a0-655393e7be1c",
+      "id": "adde4bc0-e2d9-4513-8472-8e2f0f0b0ca9",
       "alias": "browser",
       "description": "browser based authentication",
       "providerId": "basic-flow",
@@ -8360,7 +8490,7 @@
       ]
     },
     {
-      "id": "c8b74991-78e2-4948-9b71-9cd95692244a",
+      "id": "5a58b82e-fd7c-4adc-a787-1dc83d1fb43e",
       "alias": "clients",
       "description": "Base authentication for clients",
       "providerId": "client-flow",
@@ -8402,7 +8532,7 @@
       ]
     },
     {
-      "id": "6fc680e7-1083-4ae3-993c-18793394c1d8",
+      "id": "ad9bf369-03b6-4ffc-ad3b-16275bda1f20",
       "alias": "direct grant",
       "description": "OpenID Connect Resource Owner Grant",
       "providerId": "basic-flow",
@@ -8436,7 +8566,7 @@
       ]
     },
     {
-      "id": "fcc00603-9695-436a-8173-bad95ae06eb7",
+      "id": "30540c6a-8fc4-45e8-9a89-3a7b6ebdef65",
       "alias": "docker auth",
       "description": "Used by Docker clients to authenticate against the IDP",
       "providerId": "basic-flow",
@@ -8454,7 +8584,7 @@
       ]
     },
     {
-      "id": "5ecaed63-22cf-4937-93a1-e4e03c3f84d3",
+      "id": "4b990dc9-ceb7-426d-bdad-cef47fce82b1",
       "alias": "first broker login",
       "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
       "providerId": "basic-flow",
@@ -8481,7 +8611,7 @@
       ]
     },
     {
-      "id": "fc1db14a-88b6-4ffd-92bf-ef2aff4b20e4",
+      "id": "17d1c327-3419-49ce-8cf0-c2b1925da72e",
       "alias": "forms",
       "description": "Username, password, otp and other auth forms.",
       "providerId": "basic-flow",
@@ -8507,7 +8637,7 @@
       ]
     },
     {
-      "id": "4e8828db-1033-4383-988c-8a80f5294c8c",
+      "id": "9739e153-f4cd-4127-8d53-6dd7cb595d9a",
       "alias": "registration",
       "description": "registration flow",
       "providerId": "basic-flow",
@@ -8526,7 +8656,7 @@
       ]
     },
     {
-      "id": "5ba3a31b-4969-4b6a-9ade-6b519fd285cb",
+      "id": "cd4259f7-2b28-4b04-8252-b13dfc00e9dd",
       "alias": "registration form",
       "description": "registration form",
       "providerId": "form-flow",
@@ -8560,7 +8690,7 @@
       ]
     },
     {
-      "id": "d182f5b3-f390-4748-bd2b-65d225d27a76",
+      "id": "9f60c93b-912e-4e2e-9601-125457b3ca6e",
       "alias": "reset credentials",
       "description": "Reset credentials for a user if they forgot their password or something",
       "providerId": "basic-flow",
@@ -8602,7 +8732,7 @@
       ]
     },
     {
-      "id": "afd142c8-1d76-4054-bfa3-66c0ad5244b6",
+      "id": "d76d6584-e2e6-4118-b2cb-0156becb9e46",
       "alias": "saml ecp",
       "description": "SAML ECP Profile Authentication Flow",
       "providerId": "basic-flow",
@@ -8622,14 +8752,14 @@
   ],
   "authenticatorConfig": [
     {
-      "id": "54a381ca-598a-4516-bc2c-04aeea23c6cf",
+      "id": "1ae05e56-d46c-4323-9ae9-70d726ee0f3a",
       "alias": "create unique user config",
       "config": {
         "require.password.update.after.registration": "false"
       }
     },
     {
-      "id": "ad18ac62-bb08-478a-8260-0abad5be4c3d",
+      "id": "cf2f3097-698c-4832-8ef7-239a84a1b2f8",
       "alias": "review profile config",
       "config": {
         "update.profile.on.first.login": "missing"
@@ -8692,6 +8822,33 @@
       "config": {}
     },
     {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
       "alias": "update_user_locale",
       "name": "Update User Locale",
       "providerId": "update_user_locale",
@@ -8710,10 +8867,9 @@
   "attributes": {
     "cibaBackchannelTokenDeliveryMode": "poll",
     "cibaAuthRequestedUserHint": "login_hint",
-    "clientOfflineSessionMaxLifespan": "0",
     "oauth2DevicePollingInterval": "5",
+    "clientOfflineSessionMaxLifespan": "0",
     "clientSessionIdleTimeout": "0",
-    "userProfileEnabled": "false",
     "clientOfflineSessionIdleTimeout": "0",
     "cibaInterval": "5",
     "realmReusableOtpCode": "false",
@@ -8722,7 +8878,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "23.0.7",
+  "keycloakVersion": "25.0.6",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMemberOwnedApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMemberOwnedApi.kt
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
+import org.eclipse.tractusx.bpdm.pool.api.PoolMemberOwnedApi.Companion.MEMBER_OWNED_PATH
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@RequestMapping(MEMBER_OWNED_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+interface PoolMemberOwnedApi {
+    companion object{
+        const val MEMBER_OWNED_PATH = "${ApiCommons.BASE_PATH}/member-owned"
+
+        const val LEGAL_ENTITIES_SEARCH_PATH = "/legal-entities${CommonApiPathNames.SUBPATH_SEARCH}"
+        const val SITES_SEARCH_PATH = "/sites${CommonApiPathNames.SUBPATH_SEARCH}"
+        const val ADDRESSES_SEARCH_PATH = "/addresses${CommonApiPathNames.SUBPATH_SEARCH}"
+    }
+
+    @Operation(
+        summary = "Search legal entities that are owned by Catena-X members",
+        description = "This endpoint tries to find matches among business partners of type legal entity which are owned by Catena-X members. " +
+                "Partners which entirely do not match are filtered out and the remaining partners are ranked according to the accuracy of the match. " +
+                "In contrast to the `members/legal-entities` endpoint this endpoint also returns non-member legal entities that are owned by Catena-X members."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of business partners matching the search criteria, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed search or pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @PostMapping(LEGAL_ENTITIES_SEARCH_PATH)
+    fun searchLegalEntities(
+        @RequestBody searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
+
+    @Operation(
+        summary = "Search sites that are owned by Catena-X members",
+        description = "This endpoint tries to find matches among business partners of type site which are owned by Catena-X members. " +
+                "Partners which entirely do not match are filtered out and the remaining partners are ranked according to the accuracy of the match. " +
+                "In contrast to the `members/sites` endpoint this endpoint also returns sites of non-member legal entities which are owned by Catena-X members."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of business partners matching the search criteria, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed search or pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @PostMapping(SITES_SEARCH_PATH)
+    fun postSiteSearch(
+        @RequestBody searchRequest: SiteSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<SiteWithMainAddressVerboseDto>
+
+    @Operation(
+        summary = "Search logistic addresses that are owned by Catena-X members",
+        description = "This endpoint tries to find matches among business partners of type address which are owned by Catena-X members. " +
+                "Partners which entirely do not match are filtered out and the remaining partners are ranked according to the accuracy of the match. " +
+                "In contrast to the `members/addresses` endpoint this endpoint also returns addresses of non-member legal entities which are owned by Catena-X members."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of business partners matching the search criteria, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed search or pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
+    @PostMapping(ADDRESSES_SEARCH_PATH)
+    fun searchAddresses(
+        @RequestBody searchRequest: AddressSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto>
+
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MemberOwnedApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MemberOwnedApiClient.kt
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.client
+
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.PoolMemberOwnedApi
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteWithMainAddressVerboseDto
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PostExchange
+
+@HttpExchange(PoolMemberOwnedApi.MEMBER_OWNED_PATH)
+interface MemberOwnedApiClient: PoolMemberOwnedApi {
+    @PostExchange(PoolMemberOwnedApi.LEGAL_ENTITIES_SEARCH_PATH)
+    override fun searchLegalEntities(
+        @RequestBody searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
+
+    @PostExchange(PoolMemberOwnedApi.SITES_SEARCH_PATH)
+    override fun postSiteSearch(
+        @RequestBody searchRequest: SiteSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<SiteWithMainAddressVerboseDto>
+
+    @PostExchange(PoolMemberOwnedApi.ADDRESSES_SEARCH_PATH)
+    override fun searchAddresses(
+        @RequestBody searchRequest: AddressSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto>
+
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolApiClient.kt
@@ -35,5 +35,7 @@ interface PoolApiClient {
 
     val members: MembersApiClient
 
+    val memberOwned: MemberOwnedApiClient
+
     val memberships: CxMembershipApiClient
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
@@ -55,6 +55,8 @@ class PoolClientImpl(
 
     override val members by lazy { createClient<MembersApiClient>() }
 
+    override val memberOwned by lazy { createClient<MemberOwnedApiClient>() }
+
     override val memberships by lazy { createClient<CxMembershipApiClient>() }
 
     private inline fun <reified T> createClient() =

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PermissionConfigProperties.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/PermissionConfigProperties.kt
@@ -31,7 +31,8 @@ data class PermissionConfigProperties(
     val writeMetaData: String = "write_metadata",
     val readMemberPartner: String = "read_partner_member",
     val readChangelog: String = "read_changelog",
-    val readMemberChangelog: String = "read_changelog_member"
+    val readMemberChangelog: String = "read_changelog_member",
+    var readMemberOwnedPartner: String = "read_partner_member_owned"
 ) {
     companion object {
         const val PREFIX = "bpdm.security.permissions"
@@ -45,6 +46,7 @@ data class PermissionConfigProperties(
         const val READ_METADATA = "@${BEAN_QUALIFIER}.getReadMetaData()"
         const val WRITE_METADATA = "@${BEAN_QUALIFIER}.getWriteMetaData()"
         const val READ_MEMBER_PARTNER = "@${BEAN_QUALIFIER}.getReadMemberPartner()"
+        const val READ_MEMBER_OWNED_PARTNER = "@${BEAN_QUALIFIER}.getReadMemberOwnedPartner()"
         const val READ_CHANGELOG = "@${BEAN_QUALIFIER}.getReadChangelog()"
         const val READ_MEMBER_CHANGELOG = "@${BEAN_QUALIFIER}.getReadMemberChangelog()"
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
@@ -63,7 +63,8 @@ class AddressController(
                 siteBpns = searchRequest.siteBpns,
                 legalEntityBpns = searchRequest.legalEntityBpns,
                 name = searchRequest.name,
-                isCatenaXMemberData = null
+                isCatenaXMemberData = null,
+                isMemberOwnedData = null
             ),
             paginationRequest
         )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -58,7 +58,8 @@ class LegalEntityController(
             BusinessPartnerFetchService.LegalEntitySearchRequest(
                 bpnLs = searchRequest.bpnLs,
                 legalName = searchRequest.legalName,
-                isCatenaXMemberData = null
+                isCatenaXMemberData = null,
+                isMemberOwnedData = null
             ),
             paginationRequest
         )
@@ -80,7 +81,8 @@ class LegalEntityController(
             BusinessPartnerFetchService.LegalEntitySearchRequest(
                 searchRequest.bpnLs,
                 searchRequest.legalName,
-                isCatenaXMemberData = null
+                isCatenaXMemberData = null,
+                isMemberOwnedData = null
             ),
             paginationRequest
         )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -58,7 +58,8 @@ class SiteController(
                 siteBpns = searchRequest.siteBpns,
                 legalEntityBpns = searchRequest.legalEntityBpns,
                 name = searchRequest.name,
-                isCatenaXMemberData = null
+                isCatenaXMemberData = null,
+                isMemberOwnedData = null
             ),
             paginationRequest
         )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityRepository.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.pool.repository
 
+import org.eclipse.tractusx.bpdm.pool.entity.ConfidenceCriteriaDb
 import org.eclipse.tractusx.bpdm.pool.entity.IdentifierTypeDb
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
 import org.eclipse.tractusx.bpdm.pool.entity.NameDb
@@ -52,11 +53,20 @@ interface LegalEntityRepository : JpaRepository<LegalEntityDb, Long>, JpaSpecifi
                     builder.equal(root.get<Boolean>(LegalEntityDb::isCatenaXMemberData.name), isCatenaXMemberData)
                 }
             }
+
+        fun byIsMemberOwned(isSharedByOwner: Boolean?) =
+            Specification<LegalEntityDb> { root, _, builder ->
+                isSharedByOwner?.let {
+                    val propertyPath = root
+                        .get<ConfidenceCriteriaDb>(LegalEntityDb::confidenceCriteria.name)
+                        .get<Boolean>(ConfidenceCriteriaDb::sharedByOwner.name)
+
+                    builder.equal(propertyPath, isSharedByOwner)
+                }
+            }
     }
 
     fun findByBpnIgnoreCase(bpn: String): LegalEntityDb?
-
-    fun existsByBpn(bpn: String): Boolean
 
     fun findDistinctByBpnIn(bpns: Collection<String>): Set<LegalEntityDb>
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LogisticAddressRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LogisticAddressRepository.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.pool.repository
 
+import org.eclipse.tractusx.bpdm.pool.entity.ConfidenceCriteriaDb
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
 import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddressDb
 import org.eclipse.tractusx.bpdm.pool.entity.SiteDb
@@ -68,6 +69,18 @@ interface LogisticAddressRepository : JpaRepository<LogisticAddressDb, Long>, Jp
                             .get<Boolean>(LegalEntityDb::isCatenaXMemberData.name),
                         isCatenaXMemberData
                     )
+                }
+            }
+
+        fun byIsMemberOwned(isMemberOwned: Boolean?) =
+            Specification<LogisticAddressDb> { root, _, builder ->
+                isMemberOwned?.let {
+                    val propertyPath = root
+                        .get<LegalEntityDb>(LogisticAddressDb::legalEntity.name)
+                        .get<ConfidenceCriteriaDb>(LegalEntityDb::confidenceCriteria.name)
+                        .get<Boolean>(ConfidenceCriteriaDb::sharedByOwner.name)
+
+                    builder.equal(propertyPath, isMemberOwned)
                 }
             }
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/SiteRepository.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.bpdm.pool.repository
 
+import org.eclipse.tractusx.bpdm.pool.entity.ConfidenceCriteriaDb
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
 import org.eclipse.tractusx.bpdm.pool.entity.SiteDb
 import org.springframework.data.domain.Page
@@ -56,6 +57,18 @@ interface SiteRepository : JpaRepository<SiteDb, Long>, JpaSpecificationExecutor
             Specification<SiteDb> { root, _, builder ->
                 isCatenaXMemberData?.let {
                     builder.equal(root.get<LegalEntityDb>(SiteDb::legalEntity.name).get<Boolean>(LegalEntityDb::isCatenaXMemberData.name), isCatenaXMemberData)
+                }
+            }
+
+        fun byIsMemberOwned(isMemberOwned: Boolean?) =
+            Specification<SiteDb> { root, _, builder ->
+                isMemberOwned?.let {
+                    val propertyPath = root
+                        .get<LegalEntityDb>(SiteDb::legalEntity.name)
+                        .get<ConfidenceCriteriaDb>(LegalEntityDb::confidenceCriteria.name)
+                        .get<Boolean>(ConfidenceCriteriaDb::sharedByOwner.name)
+
+                    builder.equal(propertyPath, isMemberOwned)
                 }
             }
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressService.kt
@@ -28,7 +28,6 @@ import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddressDb
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
 import org.eclipse.tractusx.bpdm.pool.repository.LogisticAddressRepository
-import org.eclipse.tractusx.bpdm.pool.repository.SiteRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
@@ -36,8 +35,7 @@ import org.springframework.stereotype.Service
 @Service
 class AddressService(
     private val logisticAddressRepository: LogisticAddressRepository,
-    private val legalEntityRepository: LegalEntityRepository,
-    private val siteRepository: SiteRepository,
+    private val legalEntityRepository: LegalEntityRepository
 ) {
     private val logger = KotlinLogging.logger { }
 
@@ -52,7 +50,8 @@ class AddressService(
             LogisticAddressRepository.bySiteBpns(searchRequest.siteBpns),
             LogisticAddressRepository.byLegalEntityBpns(searchRequest.legalEntityBpns),
             LogisticAddressRepository.byName(searchRequest.name),
-            LogisticAddressRepository.byIsMember(searchRequest.isCatenaXMemberData)
+            LogisticAddressRepository.byIsMember(searchRequest.isCatenaXMemberData),
+            LogisticAddressRepository.byIsMemberOwned(searchRequest.isMemberOwnedData),
         )
         val addressPage = logisticAddressRepository.findAll(spec, paginationRequest.toPageRequest())
 
@@ -92,6 +91,7 @@ class AddressService(
         val siteBpns: List<String>?,
         val legalEntityBpns: List<String>?,
         val name: String?,
-        val isCatenaXMemberData: Boolean?
+        val isCatenaXMemberData: Boolean?,
+        val isMemberOwnedData: Boolean?
     )
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
@@ -60,7 +60,8 @@ class BusinessPartnerFetchService(
         val spec = Specification.allOf(
             LegalEntityRepository.byBpns(searchRequest.bpnLs),
             LegalEntityRepository.byLegalName(searchRequest.legalName),
-            LegalEntityRepository.byIsMember(searchRequest.isCatenaXMemberData)
+            LegalEntityRepository.byIsMember(searchRequest.isCatenaXMemberData),
+            LegalEntityRepository.byIsMemberOwned(searchRequest.isMemberOwnedData)
         )
 
         val legalEntityPage = legalEntityRepository.findAll(spec, PageRequest.of(paginationRequest.page, paginationRequest.size))
@@ -169,7 +170,8 @@ class BusinessPartnerFetchService(
     data class LegalEntitySearchRequest(
         val bpnLs: List<String>?,
         val legalName: String?,
-        val isCatenaXMemberData: Boolean?
+        val isCatenaXMemberData: Boolean?,
+        val isMemberOwnedData: Boolean?
     )
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SiteService.kt
@@ -51,7 +51,8 @@ class SiteService(
             SiteRepository.byBpns(searchRequest.siteBpns),
             SiteRepository.byParentBpns(searchRequest.legalEntityBpns),
             SiteRepository.byName(searchRequest.name),
-            SiteRepository.byIsMember(searchRequest.isCatenaXMemberData)
+            SiteRepository.byIsMember(searchRequest.isCatenaXMemberData),
+            SiteRepository.byIsMemberOwned(searchRequest.isMemberOwnedData),
         )
 
         val sitePage = siteRepository.findAll(spec, PageRequest.of(paginationRequest.page, paginationRequest.size))
@@ -96,7 +97,8 @@ class SiteService(
         val siteBpns: List<String>?,
         val legalEntityBpns: List<String>?,
         val name: String?,
-        val isCatenaXMemberData: Boolean?
+        val isCatenaXMemberData: Boolean?,
+        val isMemberOwnedData: Boolean?
     )
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -209,7 +209,7 @@ class TaskStepBuildService(
 
         val bpnResults = if(bpnS != null && site.hasChanged == false){
             //No need to upsert, just fetch the information
-            siteService.searchSites(SiteService.SiteSearchRequest(siteBpns = listOf(bpnS), null, null, null), PaginationRequest(0, 1))
+            siteService.searchSites(SiteService.SiteSearchRequest(siteBpns = listOf(bpnS), null, null, null, null), PaginationRequest(0, 1))
                 .content.firstOrNull()
                 ?.let { SiteBpns(it.site.bpns, it.mainAddress.bpna) }
                 ?: throw BpdmValidationException(CleaningError.MAINE_ADDRESS_IS_NULL.message)
@@ -308,7 +308,7 @@ class TaskStepBuildService(
 
         val addressBpn = if(bpnA != null && additionalAddress.hasChanged == false){
             // No need to upsert just fetch the data
-            addressService.searchAddresses(AddressService.AddressSearchRequest(addressBpns = listOf(bpnA), null, null, null, null), PaginationRequest(0, 1))
+            addressService.searchAddresses(AddressService.AddressSearchRequest(addressBpns = listOf(bpnA), null, null, null, null, null), PaginationRequest(0, 1))
                 .content.firstOrNull()?.bpna
                 ?: throw BpdmValidationException(CleaningError.BPNA_IS_NULL.message)
         }else{

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -106,8 +106,10 @@ bpdm:
       readPartner: read_partner
       # Name of the permission to upsert business partners
       writePartner: write_partner
-      # Name of the permission to read business partners that belong to a Catena-X member
+      # Name of the permission to read business partners that are Catena-X member data
       readMemberPartner: read_partner_member
+      # Name of the permission to read all business partners that are owned by Catena-X members
+      readMemberOwnedPartner: read_partner_member_owned
       # Name of the permission to read metadata
       readMetaData: read_metadata
       # Name of the permission to create new metadata
@@ -116,6 +118,7 @@ bpdm:
       readChangelog: read_changelog
       # Name of the permission to read changelog entries from Catena-X member business partners
       readMemberChangelog: read_changelog_member
+
   datasource:
     # Host name of the used datasource
     host: localhost

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthAdminIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthAdminIT.kt
@@ -76,6 +76,11 @@ class AuthAdminIT @Autowired constructor(
         postLegalEntitySearch = AuthExpectationType.Authorized,
         postChangelogSearch = AuthExpectationType.Authorized
     ),
+    MembersOwnedAuthExpectations(
+        postAddressSearch = AuthExpectationType.Authorized,
+        postSiteSearch = AuthExpectationType.Authorized,
+        postLegalEntitySearch = AuthExpectationType.Authorized
+    ),
     CxMembershipsAuthExpectations(
         getMemberships = AuthExpectationType.Authorized,
         putMemberships = AuthExpectationType.Authorized

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthCxMemberIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthCxMemberIT.kt
@@ -77,6 +77,11 @@ AuthCxMemberIT @Autowired constructor(
         postLegalEntitySearch = AuthExpectationType.Authorized,
         postChangelogSearch = AuthExpectationType.Authorized
     ),
+    MembersOwnedAuthExpectations(
+        postAddressSearch = AuthExpectationType.Forbidden,
+        postSiteSearch = AuthExpectationType.Forbidden,
+        postLegalEntitySearch = AuthExpectationType.Forbidden
+    ),
     CxMembershipsAuthExpectations(
         getMemberships = AuthExpectationType.Forbidden,
         putMemberships = AuthExpectationType.Forbidden

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthCxUseCaseConsumerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthCxUseCaseConsumerIT.kt
@@ -21,9 +21,9 @@ package org.eclipse.tractusx.bpdm.pool.auth
 
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.test.containers.CreateNewSelfClientInitializer
 import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
-import org.eclipse.tractusx.bpdm.test.containers.SelfClientInitializer
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -33,9 +33,10 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(initializers = [
     PostgreSQLContextInitializer::class,
     KeyCloakInitializer::class,
-    SelfClientAsSharingMemberInitializer::class
+    SelfClientAsCxUseCaseProviderInitializer::class
 ])
-class AuthSharingMemberIT @Autowired constructor(
+class
+AuthCxUseCaseConsumerIT @Autowired constructor(
     poolApiClient: PoolApiClient,
 ): AuthTestBase(
     poolApiClient,
@@ -77,9 +78,9 @@ class AuthSharingMemberIT @Autowired constructor(
         postChangelogSearch = AuthExpectationType.Forbidden
     ),
     MembersOwnedAuthExpectations(
-        postAddressSearch = AuthExpectationType.Forbidden,
-        postSiteSearch = AuthExpectationType.Forbidden,
-        postLegalEntitySearch = AuthExpectationType.Forbidden
+        postAddressSearch = AuthExpectationType.Authorized,
+        postSiteSearch = AuthExpectationType.Authorized,
+        postLegalEntitySearch = AuthExpectationType.Authorized
     ),
     CxMembershipsAuthExpectations(
         getMemberships = AuthExpectationType.Forbidden,
@@ -89,7 +90,10 @@ class AuthSharingMemberIT @Autowired constructor(
     bpnAuthExpectation = AuthExpectationType.Forbidden
 )
 
-class SelfClientAsSharingMemberInitializer : SelfClientInitializer() {
+class SelfClientAsCxUseCaseProviderInitializer : CreateNewSelfClientInitializer() {
     override val clientId: String
-        get() = "sa-cl7-cx-1"
+        get() = "EDC-USE-CASE-CONSUMER"
+
+    override val roleName: String
+        get() = "BPDM Pool Use Case Consumer"
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthTestBase.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthTestBase.kt
@@ -38,6 +38,7 @@ abstract class AuthTestBase(
     private val legalEntityAuthExpectations: LegalEntityAuthExpectations,
     private val metadataAuthExpectations: MetadataAuthExpectations,
     private val membersAuthExpectations: MembersAuthExpectations,
+    private val membersOwnedAuthExpectations: MembersOwnedAuthExpectations,
     private val membershipAuthExpectations: CxMembershipsAuthExpectations,
     private val changelogAuthExpectation: AuthExpectationType,
     private val bpnAuthExpectation: AuthExpectationType
@@ -205,6 +206,21 @@ abstract class AuthTestBase(
     fun `PUT CX Memberships`(){
         authAssertions.assert(membershipAuthExpectations.putMemberships) { poolApiClient.memberships.put(CxMembershipUpdateRequest(listOf())) }
     }
+
+    @Test
+    fun `POST Member Owned Address Search`(){
+        authAssertions.assert(membersOwnedAuthExpectations.postAddressSearch) { poolApiClient.memberOwned.searchAddresses(AddressSearchRequest(), PaginationRequest()) }
+    }
+
+    @Test
+    fun `POST Member Owned Site Search`(){
+        authAssertions.assert(membersOwnedAuthExpectations.postSiteSearch) { poolApiClient.memberOwned.postSiteSearch(SiteSearchRequest(), PaginationRequest()) }
+    }
+
+    @Test
+    fun `POST Member Owned Legal Entity Search`(){
+        authAssertions.assert(membersOwnedAuthExpectations.postLegalEntitySearch) { poolApiClient.memberOwned.searchLegalEntities(LegalEntitySearchRequest(), PaginationRequest()) }
+    }
 }
 
 
@@ -248,6 +264,12 @@ data class MembersAuthExpectations(
     val postSiteSearch: AuthExpectationType,
     val postLegalEntitySearch: AuthExpectationType,
     val postChangelogSearch: AuthExpectationType
+)
+
+data class MembersOwnedAuthExpectations(
+    val postAddressSearch: AuthExpectationType,
+    val postSiteSearch: AuthExpectationType,
+    val postLegalEntitySearch: AuthExpectationType
 )
 
 data class CxMembershipsAuthExpectations(

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/NoAuthIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/NoAuthIT.kt
@@ -74,6 +74,11 @@ class NoAuthIT @Autowired constructor(
         postLegalEntitySearch = AuthExpectationType.Unauthorized,
         postChangelogSearch = AuthExpectationType.Unauthorized
     ),
+    MembersOwnedAuthExpectations(
+        postAddressSearch = AuthExpectationType.Unauthorized,
+        postSiteSearch = AuthExpectationType.Unauthorized,
+        postLegalEntitySearch = AuthExpectationType.Unauthorized
+    ),
     CxMembershipsAuthExpectations(
         getMemberships = AuthExpectationType.Unauthorized,
         putMemberships = AuthExpectationType.Unauthorized

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerIT.kt
@@ -51,7 +51,7 @@ import org.springframework.test.context.ContextConfiguration
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = [Application::class, TestHelpers::class]
 )
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class AddressControllerIT @Autowired constructor(
     val testHelpers: TestHelpers,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressControllerSearchIT.kt
@@ -45,7 +45,7 @@ import org.springframework.test.context.ContextConfiguration
  */
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class])
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class AddressControllerSearchIT @Autowired constructor(
     val dbTestHelpers: DbTestHelpers,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
@@ -43,7 +43,7 @@ import org.springframework.test.context.ContextConfiguration
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class],
     properties = ["bpdm.controller.search-request-limit=2"]
 )
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class BpnControllerIT @Autowired constructor(
     val testHelpers: TestHelpers,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
@@ -48,7 +48,7 @@ import java.time.Instant
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class],
     properties = ["bpdm.controller.search-request-limit=2"]
 )
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class ChangelogControllerIT @Autowired constructor(
     val testHelpers: TestHelpers,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -55,7 +55,7 @@ import java.time.Instant
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class]
 )
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class LegalEntityControllerIT @Autowired constructor(
     val testHelpers: TestHelpers,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerSearchIT.kt
@@ -48,7 +48,7 @@ import org.springframework.test.context.ContextConfiguration
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class]
 )
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class LegalEntityControllerSearchIT @Autowired constructor(
     val dbTestHelpers: DbTestHelpers,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
@@ -68,7 +68,7 @@ private typealias GetFunction = (client: WebTestClient, page: Int, size: Int) ->
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class]
 )
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class MetadataControllerIT @Autowired constructor(
     private val dbTestHelpers: DbTestHelpers,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -49,7 +49,7 @@ import org.springframework.test.context.ContextConfiguration
 import java.time.Instant
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class, TestHelpers::class])
-@ActiveProfiles("test-no-auth")
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class SiteControllerIT @Autowired constructor(
     val testHelpers: TestHelpers,

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -897,6 +897,186 @@
         }
       }
     },
+    "/v6/member-owned/sites/search": {
+      "post": {
+        "tags": [
+          "Site Controller"
+        ],
+        "summary": "Search sites that are owned by Catena-X members",
+        "description": "This endpoint tries to find matches among business partners of type site which are owned by Catena-X members. Partners which entirely do not match are filtered out and the remaining partners are ranked according to the accuracy of the match. In contrast to the `members/sites` endpoint this endpoint also returns sites of non-member legal entities which are owned by Catena-X members.",
+        "operationId": "postSiteSearch_2",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiteSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Page of business partners matching the search criteria, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed search or pagination request"
+          }
+        }
+      }
+    },
+    "/v6/member-owned/legal-entities/search": {
+      "post": {
+        "tags": [
+          "Legal Entity Controller"
+        ],
+        "summary": "Search legal entities that are owned by Catena-X members",
+        "description": "This endpoint tries to find matches among business partners of type legal entity which are owned by Catena-X members. Partners which entirely do not match are filtered out and the remaining partners are ranked according to the accuracy of the match. In contrast to the `members/legal-entities` endpoint this endpoint also returns non-member legal entities that are owned by Catena-X members.",
+        "operationId": "searchLegalEntities_1",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LegalEntitySearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Page of business partners matching the search criteria, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed search or pagination request"
+          }
+        }
+      }
+    },
+    "/v6/member-owned/addresses/search": {
+      "post": {
+        "tags": [
+          "Address Controller"
+        ],
+        "summary": "Search logistic addresses that are owned by Catena-X members",
+        "description": "This endpoint tries to find matches among business partners of type address which are owned by Catena-X members. Partners which entirely do not match are filtered out and the remaining partners are ranked according to the accuracy of the match. In contrast to the `members/addresses` endpoint this endpoint also returns addresses of non-member legal entities which are owned by Catena-X members.",
+        "operationId": "searchAddresses_1",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Number of page to get results from",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "string",
+              "default": "0"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Size of each page",
+            "required": false,
+            "schema": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "string",
+              "default": "10"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddressSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Page of business partners matching the search criteria, may be empty",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "On malformed search or pagination request"
+          }
+        }
+      }
+    },
     "/v6/legal-forms": {
       "get": {
         "tags": [
@@ -1535,7 +1715,7 @@
         ],
         "summary": "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
         "description": "Search business partners of type address by their BPNA or their parents' BPNL or BPNS.",
-        "operationId": "searchAddresses_1",
+        "operationId": "searchAddresses_2",
         "parameters": [
           {
             "name": "page",
@@ -7137,8 +7317,7 @@
         "type": "oauth2",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "http://localhost:8180/realms/CX-Central/protocol/openid-connect/token",
-            "scopes": {}
+            "tokenUrl": "http://localhost:8180/realms/CX-Central/protocol/openid-connect/token"
           },
           "authorizationCode": {
             "authorizationUrl": "http://localhost:8180/realms/CX-Central/protocol/openid-connect/auth",

--- a/docs/architecture/08_Crosscutting_Concepts.md
+++ b/docs/architecture/08_Crosscutting_Concepts.md
@@ -46,11 +46,12 @@ We defined the following relevant permission groups in BPDM:
 5. Pool Admin: Read, create and update golden records as well as meta data in the Pool
 6. Pool Cx Member: Read golden records that belong to Catena-X members from the Pool
 7. Pool Sharing Member: Read golden records of Catena-X members and the overall changelog
-8. Orchestrator Admin: Full access to Golden Record Tasks
-9. Orchestrator Task Creator: Create Golden Record Tasks, view task results and status
-10. Orchestrator Clean And Sync Task Processor: Reserve and resolve Golden Record Tasks in step 'Clean And Sync'
-11. Orchestrator Clean Task Processor: Reserve and resolve Golden Record Tasks in step 'Clean'
-12. Orchestrator Pool Task Processor: Reserve and resolve Golden Record Tasks in step 'Pool'
+8. Pool Use Case Consumer:  Read golden records owned by Catena-X members from the Pool (including member-owned non-member legal entity business partner data)
+9. Orchestrator Admin: Full access to Golden Record Tasks
+10. Orchestrator Task Creator: Create Golden Record Tasks, view task results and status
+11. Orchestrator Clean And Sync Task Processor: Reserve and resolve Golden Record Tasks in step 'Clean And Sync'
+12. Orchestrator Clean Task Processor: Reserve and resolve Golden Record Tasks in step 'Clean'
+13. Orchestrator Pool Task Processor: Reserve and resolve Golden Record Tasks in step 'Pool'
 
 #### Permissions
 
@@ -69,6 +70,7 @@ We defined the following relevant permission groups in BPDM:
             <li>read_partner</li>
             <li>write_partner</li>
             <li>read_partner_member</li>
+            <li>read_partner_member_owned</li>
             <li>read_changelog</li>
             <li>read_changelog_member</li>
             <li>read_metadata</li>
@@ -158,6 +160,7 @@ Pool Permissions:
       <th>Admin</th>
       <th>Cx Member</th>
       <th>Sharing Member</th>
+      <th>Use Case Consumer</th>
     </tr>
     <tr>
       <td>
@@ -172,11 +175,17 @@ Pool Permissions:
       </td>
       <td>
         <ul>
-            <li>read_partner_member</li>
-            <li>read_changelog_member</li>
+            <li>read_partner</li>
             <li>read_metadata</li>
             <li>read_changelog</li>
         </ul>
+      </td>
+      <td>
+        <ul>
+            <li>read_partner_member_owned</li>
+            <li>read_metadata</li>
+        </ul>
+      </td>
     </tr>
   </tbody>
 </table>
@@ -226,10 +235,10 @@ Orchestrator Permissions:
 
 #### Mapping to Portal user roles for all companies (for all Catena-X members):
 
-| BPDM Permission Group         |  Portal Role |
-|--|--|
-| Gate Admin    |  Service Manager    |
-| Pool Cx Member    |  CX User   |
+| BPDM Permission Group | Portal Role     |
+|-----------------------|-----------------|
+| Gate Admin            | Service Manager |
+| Pool Cx Member        | CX User         |
 
 #### Technical Users:
 
@@ -243,6 +252,7 @@ For BPDM service:
 - Pool Admin
 - Pool Cx Member
 - Pool Sharing Member
+- Pool Use Case Consumer
 
 For VAS:
 

--- a/docs/postman/EDC BPDM Consumer.postman_collection.json
+++ b/docs/postman/EDC BPDM Consumer.postman_collection.json
@@ -243,6 +243,64 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Select Pool Use Case Consumer Read Access",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"var responseJson = pm.response.json();",
+											"var offerId = responseJson[\"dcat:dataset\"][\"odrl:hasPolicy\"][\"@id\"];",
+											"var assetId = responseJson[\"dcat:dataset\"][\"id\"];",
+											"pm.collectionVariables.set(\"OFFER\", offerId);",
+											"pm.collectionVariables.set(\"SELECTED_ASSET\", assetId)",
+											"pm.collectionVariables.set(\"SELECTED_PURPOSE\", \"cx.bpdm.pool:1\")"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"@context\": {\r\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\"\r\n    },\r\n    \"@type\": \"CatalogRequest\",\r\n    \"counterPartyAddress\": \"{{PROVIDER_EDC_DATASPACE_API}}\",\r\n    \"counterPartyId\": \"{{PROVIDER_BPNL}}\",\r\n    \"protocol\": \"dataspace-protocol-http\",\r\n    \"querySpec\": {\r\n        \"offset\": 0,\r\n        \"limit\": 1,\r\n        \"filterExpression\": [\r\n            {\r\n                \"operandLeft\": \"https://purl.org/dc/terms/subject\",\r\n                \"operator\": \"=\",\r\n                \"operandRight\": \"cx-taxo:ReadAccessPoolForUseCaseProvider\"\r\n            },\r\n            {\r\n                \"operandLeft\": \"https://w3id.org/catenax/ontology/common/version\",\r\n                \"operator\": \"=\",\r\n                \"operandRight\": \"6.0\"\r\n            }\r\n        ]\r\n    }\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{CONSUMER_EDC_MANAGEMENT_API}}/v3/catalog/request",
+									"host": [
+										"{{CONSUMER_EDC_MANAGEMENT_API}}"
+									],
+									"path": [
+										"v3",
+										"catalog",
+										"request"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},
@@ -1600,6 +1658,1534 @@
 							],
 							"path": [
 								"members",
+								"addresses",
+								"search"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0",
+									"description": "Number of page to get results from"
+								},
+								{
+									"key": "size",
+									"value": "10",
+									"description": "Size of each page"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "No Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/addresses/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"addresses",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"RE\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"VG\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"YT\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SK\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAndSiteMainAddress\"\n    },\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"ZR\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"CH\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"SR\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SO\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAddress\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Legal Entity BPN Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"legalEntityBpns\": [\n        \"BPNL0000000012F2\",\n        \"BPNL00000000052O\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/addresses/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"addresses",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"RE\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"VG\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"YT\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SK\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAndSiteMainAddress\"\n    },\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"ZR\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"CH\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"SR\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SO\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAddress\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Site BPN Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"siteBpns\": [\n        \"BPNS0000000000WN\",\n        \"BPNS0000000002V9\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/addresses/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"addresses",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"RE\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"VG\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"YT\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SK\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAndSiteMainAddress\"\n    },\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"ZR\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"CH\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"SR\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SO\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAddress\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "BPNA Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"addressBpns\": [\n        \"BPNA0000000014HF\",\n        \"BPNA0000000015GQ\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/addresses/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"addresses",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"RE\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"VG\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"YT\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SK\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAndSiteMainAddress\"\n    },\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"ZR\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"CH\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"SR\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SO\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAddress\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Name Search",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"name\": \"address\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/addresses/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"addresses",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"RE\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"VG\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"YT\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SK\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAndSiteMainAddress\"\n    },\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"ZR\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"CH\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"SR\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SO\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAddress\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "All Filters",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"legalEntityBpns\": [\n        \"BPNL0000000012F2\",\n        \"BPNL00000000052O\"\n    ],\n    \"siteBpns\": [\n        \"BPNS000000000COB\",\n        \"BPNS0000000009QE\"\n    ],\n    \"addressBpns\": [\n        \"BPNA000000007679\",\n        \"BPNA000000007956\"\n    ],\n   \"name\": \"address\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/addresses/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"addresses",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"RE\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"VG\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"YT\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SK\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAndSiteMainAddress\"\n    },\n    {\n      \"bpna\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"physicalPostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"ZR\"\n        },\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"CH\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"administrativeAreaLevel2\": \"<string>\",\n        \"administrativeAreaLevel3\": \"<string>\",\n        \"postalCode\": \"<string>\",\n        \"district\": \"<string>\",\n        \"street\": {\n          \"name\": \"<string>\",\n          \"houseNumber\": \"<string>\",\n          \"houseNumberSupplement\": \"<string>\",\n          \"milestone\": \"<string>\",\n          \"direction\": \"<string>\",\n          \"namePrefix\": \"<string>\",\n          \"additionalNamePrefix\": \"<string>\",\n          \"nameSuffix\": \"<string>\",\n          \"additionalNameSuffix\": \"<string>\"\n        },\n        \"companyPostalCode\": \"<string>\",\n        \"industrialZone\": \"<string>\",\n        \"building\": \"<string>\",\n        \"floor\": \"<string>\",\n        \"door\": \"<string>\"\n      },\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"name\": \"<string>\",\n      \"alternativePostalAddress\": {\n        \"city\": \"<string>\",\n        \"country\": {\n          \"name\": \"<string>\",\n          \"technicalKey\": \"SR\"\n        },\n        \"deliveryServiceNumber\": \"<string>\",\n        \"deliveryServiceType\": \"PO_BOX\",\n        \"geographicCoordinates\": {\n          \"latitude\": \"<float>\",\n          \"longitude\": \"<float>\",\n          \"altitude\": \"<float>\"\n        },\n        \"administrativeAreaLevel1\": {\n          \"countryCode\": \"SO\",\n          \"regionCode\": \"<string>\",\n          \"regionName\": \"<string>\"\n        },\n        \"postalCode\": \"<string>\",\n        \"deliveryServiceQualifier\": \"<string>\"\n      },\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpnSite\": \"<string>\",\n      \"addressType\": \"LegalAddress\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "/legal-forms",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/legal-forms?page=0&size=10",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"legal-forms"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0",
+									"description": "Number of page to get results from"
+								},
+								{
+									"key": "size",
+									"value": "10",
+									"description": "Size of each page"
+								}
+							]
+						},
+						"description": "Lists all currently known legal forms in a paginated result"
+					},
+					"response": [
+						{
+							"name": "Page of existing legal forms, may be empty",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/legal-forms?page=0&size=100",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"legal-forms"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "100",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\",\n      \"abbreviation\": \"<string>\"\n    },\n    {\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\",\n      \"abbreviation\": \"<string>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "/identifier-types",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/identifier-types?page=0&size=10&businessPartnerType=LEGAL_ENTITY&country=FJ",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"identifier-types"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0",
+									"description": "Number of page to get results from"
+								},
+								{
+									"key": "size",
+									"value": "10",
+									"description": "Size of each page"
+								},
+								{
+									"key": "businessPartnerType",
+									"value": "LEGAL_ENTITY",
+									"description": "(Required) "
+								},
+								{
+									"key": "country",
+									"value": "FJ"
+								}
+							]
+						},
+						"description": "Lists all matching identifier types including validity details in a paginated result"
+					},
+					"response": [
+						{
+							"name": "Legal Entity",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/identifier-types?page=0&size=10&businessPartnerType=LEGAL_ENTITY",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"identifier-types"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										},
+										{
+											"key": "businessPartnerType",
+											"value": "LEGAL_ENTITY",
+											"description": "(Required) "
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"businessPartnerType\": \"LEGAL_ENTITY\",\n      \"details\": [\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"SA\"\n        },\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"MX\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\"\n    },\n    {\n      \"businessPartnerType\": \"ADDRESS\",\n      \"details\": [\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"GN\"\n        },\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"LR\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Address",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/identifier-types?page=0&size=10&businessPartnerType=ADDRESS",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"identifier-types"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										},
+										{
+											"key": "businessPartnerType",
+											"value": "ADDRESS",
+											"description": "(Required) "
+										},
+										{
+											"key": "country",
+											"value": "FJ",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"businessPartnerType\": \"LEGAL_ENTITY\",\n      \"details\": [\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"SA\"\n        },\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"MX\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\"\n    },\n    {\n      \"businessPartnerType\": \"ADDRESS\",\n      \"details\": [\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"GN\"\n        },\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"LR\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Country",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/identifier-types?page=0&size=10&businessPartnerType=LEGAL_ENTITY&country=DE",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"identifier-types"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										},
+										{
+											"key": "businessPartnerType",
+											"value": "LEGAL_ENTITY",
+											"description": "(Required) "
+										},
+										{
+											"key": "country",
+											"value": "DE"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"businessPartnerType\": \"LEGAL_ENTITY\",\n      \"details\": [\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"SA\"\n        },\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"MX\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\"\n    },\n    {\n      \"businessPartnerType\": \"ADDRESS\",\n      \"details\": [\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"GN\"\n        },\n        {\n          \"mandatory\": \"<boolean>\",\n          \"country\": \"LR\"\n        }\n      ],\n      \"name\": \"<string>\",\n      \"technicalKey\": \"<string>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "/field-quality-rules/",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/field-quality-rules/?country=FJ",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"field-quality-rules",
+								""
+							],
+							"query": [
+								{
+									"key": "country",
+									"value": "FJ",
+									"description": "(Required) ISO 3166-1 alpha-2 country code"
+								}
+							]
+						},
+						"description": "List the country specific data rules for entity fields.All fields that are not in this list are considered to be forbidden."
+					},
+					"response": [
+						{
+							"name": "Germany",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/field-quality-rules/?country=DE",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"field-quality-rules",
+										""
+									],
+									"query": [
+										{
+											"key": "country",
+											"value": "DE",
+											"description": "(Required) ISO 3166-1 alpha-2 country code"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "[\n  {\n    \"country\": \"PS\",\n    \"fieldPath\": \"<string>\",\n    \"qualityLevel\": \"MANDATORY\",\n    \"schemaName\": \"<string>\"\n  },\n  {\n    \"country\": \"IL\",\n    \"fieldPath\": \"<string>\",\n    \"qualityLevel\": \"FORBIDDEN\",\n    \"schemaName\": \"<string>\"\n  }\n]"
+						}
+					]
+				},
+				{
+					"name": "/administrative-areas-level1",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/administrative-areas-level1?page=0&size=10",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"administrative-areas-level1"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0",
+									"description": "Number of page to get results from"
+								},
+								{
+									"key": "size",
+									"value": "10",
+									"description": "Size of each page"
+								}
+							]
+						},
+						"description": "Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result"
+					},
+					"response": [
+						{
+							"name": "Page of existing country subdivisions, may be empty",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/administrative-areas-level1?page=0&size=100",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"administrative-areas-level1"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "100",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"code\": \"<string>\",\n      \"countryCode\": \"BL\",\n      \"name\": \"<string>\"\n    },\n    {\n      \"code\": \"<string>\",\n      \"countryCode\": \"BV\",\n      \"name\": \"<string>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						}
+					]
+				}
+			],
+			"auth": {
+				"type": "apikey",
+				"apikey": [
+					{
+						"key": "value",
+						"value": "{{TRANSFER_TOKEN}}",
+						"type": "string"
+					},
+					{
+						"key": "key",
+						"value": "Authorization",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Pool Use Case Consumer Read",
+			"item": [
+				{
+					"name": "/member-owned/legal-entities/search",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"bpnLs\": [\n        \"<string>\",\n        \"<string>\"\n    ],\n    \"legalName\": \"<string>\"\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/member-owned/legal-entities/search?page=0&size=10",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"member-owned",
+								"legal-entities",
+								"search"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0",
+									"description": "Number of page to get results from"
+								},
+								{
+									"key": "size",
+									"value": "10",
+									"description": "Size of each page"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "No Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/legal-entities/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"legal-entities",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AT\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"KH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"RW\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"QA\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    },\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"UM\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"JE\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"GP\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_SUCCESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "BPN Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"bpnLs\": [\n        \"BPNL000000000065\",\n        \"BPNL00000000015G\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/legal-entities/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"legal-entities",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AT\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"KH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"RW\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"QA\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    },\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"UM\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"JE\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"GP\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_SUCCESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Legal Name Search",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"legalName\": \"testmanage\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/legal-entities/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"legal-entities",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AT\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"KH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"RW\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"QA\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    },\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"UM\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"JE\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"GP\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_SUCCESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "All Filters",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"bpnLs\": [\n        \"BPNL000000000065\",\n        \"BPNL00000000015G\"\n    ],\n    \"legalName\": \"testmanage\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/legal-entities/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"legal-entities",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AT\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"KH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"RW\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"QA\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    },\n    {\n      \"bpnl\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"currentness\": \"<dateTime>\",\n      \"identifiers\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"<string>\"\n          },\n          \"value\": \"<string>\",\n          \"issuingBody\": \"<string>\"\n        }\n      ],\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"legalAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"UM\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"JE\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"GP\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"legalName\": \"<string>\",\n      \"relations\": [\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_SUCCESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"endBpnl\": \"<string>\",\n          \"startBpnl\": \"<string>\",\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"CX_LEGAL_PREDECESSOR_OF\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\",\n      \"legalShortName\": \"<string>\",\n      \"legalForm\": {\n        \"name\": \"<string>\",\n        \"technicalKey\": \"<string>\",\n        \"abbreviation\": \"<string>\"\n      }\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "/member-owned/sites/search",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"legalEntityBpns\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"siteBpns\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"name\": \"<string>\"\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/member-owned/sites/search?page=0&size=10",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"member-owned",
+								"sites",
+								"search"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0",
+									"description": "Number of page to get results from"
+								},
+								{
+									"key": "size",
+									"value": "10",
+									"description": "Size of each page"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "No Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/sites/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"sites",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"KY\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"IL\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AI\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PRIVATE_BAG\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"XU\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    },\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"LB\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"PS\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"AT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Legal Entity BPN Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"legalEntityBpns\": [\n        \"BPNL0000000012F2\",\n        \"BPNL00000000052O\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/sites/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"sites",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"KY\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"IL\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AI\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PRIVATE_BAG\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"XU\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    },\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"LB\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"PS\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"AT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "BPNS Filter",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"siteBpns\": [\n        \"BPNS0000000000WN\",\n        \"BPNS0000000002V9\"\n    ]\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/sites/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"sites",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"KY\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"IL\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AI\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PRIVATE_BAG\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"XU\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    },\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"LB\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"PS\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"AT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "Name Search",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n     \"name\": \"site\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/sites/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"sites",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"KY\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"IL\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AI\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PRIVATE_BAG\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"XU\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    },\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"LB\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"PS\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"AT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						},
+						{
+							"name": "All Filters",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"legalEntityBpns\": [\n        \"BPNL0000000012F2\"\n    ],\n    \"siteBpns\": [\n        \"BPNS0000000000WN\",\n        \"BPNS0000000002V9\"\n    ],\n    \"name\": \"site\"\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/members/sites/search?page=0&size=10",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"sites",
+										"search"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0",
+											"description": "Number of page to get results from"
+										},
+										{
+											"key": "size",
+											"value": "10",
+											"description": "Size of each page"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"content\": [\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"KY\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"IL\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"AI\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PRIVATE_BAG\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"XU\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAndSiteMainAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    },\n    {\n      \"bpnLegalEntity\": \"<string>\",\n      \"bpns\": \"<string>\",\n      \"confidenceCriteria\": {\n        \"checkedByExternalDataSource\": \"<boolean>\",\n        \"confidenceLevel\": \"<integer>\",\n        \"lastConfidenceCheckAt\": \"<dateTime>\",\n        \"nextConfidenceCheckAt\": \"<dateTime>\",\n        \"numberOfSharingMembers\": \"<integer>\",\n        \"sharedByOwner\": \"<boolean>\"\n      },\n      \"createdAt\": \"<dateTime>\",\n      \"isCatenaXMemberData\": \"<boolean>\",\n      \"mainAddress\": {\n        \"bpna\": \"<string>\",\n        \"confidenceCriteria\": {\n          \"checkedByExternalDataSource\": \"<boolean>\",\n          \"confidenceLevel\": \"<integer>\",\n          \"lastConfidenceCheckAt\": \"<dateTime>\",\n          \"nextConfidenceCheckAt\": \"<dateTime>\",\n          \"numberOfSharingMembers\": \"<integer>\",\n          \"sharedByOwner\": \"<boolean>\"\n        },\n        \"createdAt\": \"<dateTime>\",\n        \"identifiers\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"<string>\"\n            },\n            \"value\": \"<string>\"\n          }\n        ],\n        \"isCatenaXMemberData\": \"<boolean>\",\n        \"physicalPostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"LB\"\n          },\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"PH\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"administrativeAreaLevel2\": \"<string>\",\n          \"administrativeAreaLevel3\": \"<string>\",\n          \"postalCode\": \"<string>\",\n          \"district\": \"<string>\",\n          \"street\": {\n            \"name\": \"<string>\",\n            \"houseNumber\": \"<string>\",\n            \"houseNumberSupplement\": \"<string>\",\n            \"milestone\": \"<string>\",\n            \"direction\": \"<string>\",\n            \"namePrefix\": \"<string>\",\n            \"additionalNamePrefix\": \"<string>\",\n            \"nameSuffix\": \"<string>\",\n            \"additionalNameSuffix\": \"<string>\"\n          },\n          \"companyPostalCode\": \"<string>\",\n          \"industrialZone\": \"<string>\",\n          \"building\": \"<string>\",\n          \"floor\": \"<string>\",\n          \"door\": \"<string>\"\n        },\n        \"states\": [\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"ACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          },\n          {\n            \"type\": {\n              \"name\": \"<string>\",\n              \"technicalKey\": \"INACTIVE\"\n            },\n            \"validFrom\": \"<dateTime>\",\n            \"validTo\": \"<dateTime>\"\n          }\n        ],\n        \"updatedAt\": \"<dateTime>\",\n        \"name\": \"<string>\",\n        \"alternativePostalAddress\": {\n          \"city\": \"<string>\",\n          \"country\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"PS\"\n          },\n          \"deliveryServiceNumber\": \"<string>\",\n          \"deliveryServiceType\": \"PO_BOX\",\n          \"geographicCoordinates\": {\n            \"latitude\": \"<float>\",\n            \"longitude\": \"<float>\",\n            \"altitude\": \"<float>\"\n          },\n          \"administrativeAreaLevel1\": {\n            \"countryCode\": \"AT\",\n            \"regionCode\": \"<string>\",\n            \"regionName\": \"<string>\"\n          },\n          \"postalCode\": \"<string>\",\n          \"deliveryServiceQualifier\": \"<string>\"\n        },\n        \"bpnLegalEntity\": \"<string>\",\n        \"bpnSite\": \"<string>\",\n        \"addressType\": \"LegalAddress\"\n      },\n      \"name\": \"<string>\",\n      \"states\": [\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"INACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        },\n        {\n          \"type\": {\n            \"name\": \"<string>\",\n            \"technicalKey\": \"ACTIVE\"\n          },\n          \"validFrom\": \"<dateTime>\",\n          \"validTo\": \"<dateTime>\"\n        }\n      ],\n      \"updatedAt\": \"<dateTime>\"\n    }\n  ],\n  \"contentSize\": \"<integer>\",\n  \"page\": \"<integer>\",\n  \"totalElements\": \"<long>\",\n  \"totalPages\": \"<integer>\"\n}"
+						}
+					]
+				},
+				{
+					"name": "/member-owned/addresses/search",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"addressBpns\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"legalEntityBpns\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"siteBpns\": [\n    \"<string>\",\n    \"<string>\"\n  ],\n  \"name\": \"<string>\"\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/member-owned/addresses/search?page=0&size=10",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"member-owned",
 								"addresses",
 								"search"
 							],

--- a/docs/postman/EDC Provider Setup.postman_collection.json
+++ b/docs/postman/EDC Provider Setup.postman_collection.json
@@ -547,6 +547,96 @@
 							"response": []
 						}
 					]
+				},
+				{
+					"name": "Pool Use Case Consumer Read Access",
+					"item": [
+						{
+							"name": "Create Asset",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
+											"    var uuid = require('uuid');",
+											"    pm.collectionVariables.set(\"ASSET_POOL_CX_MEMBER_OWNED_READ\", uuid.v4())",
+											"}"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"https://purl.org/dc/terms/\",\n        \"cx-taxo\": \"https://w3id.org/catenax/taxonomy/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n    },\n    \"@type\": \"Asset\", \n    \"@id\": \"{{ASSET_POOL_UCC_READ}}\", \n    \"properties\": { \n        \"dct:type\":  \"cx-taxo:BPDMPool\",\n        \"dct:subject\": \"cx-taxo:ReadAccessPoolForUseCaseConsumer\",\n        \"dct:description\": \"Grants the Catena-X Use Case consumer read access to the Pool API. This can be used to read legal entity, site, address, legal form, identifier type and administrative area level 1 data. The accessible business partner data encompasses data which is is owned by the Catena-X members, including data from non-member legal entities which are owned by Catena-X members.\",\n        \"cx-common:version\": \"6.0\"\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"{{POOL_API}}/v6\",\n        \"oauth2:tokenUrl\": \"{{TOKEN_URL}}\",\n        \"oauth2:clientId\": \"{{CLIENT_ID_POOL_UCC_READ}}\",\n        \"oauth2:clientSecretKey\": \"{{CLIENT_SECRET_PATH_POOL_UCC_READ_CLIENT}}\", \n        \"proxyMethod\": \"true\",\n        \"proxyPath\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/assets",
+									"host": [
+										"{{PROVIDER_EDC_MANAGEMENT_API}}"
+									],
+									"path": [
+										"v3",
+										"assets"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create Contract Definition Copy",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
+											"    var uuid = require('uuid');",
+											"    pm.collectionVariables.set(\"CONTRACT_POOL_CX_MEMBER_OWNED_READ\", uuid.v4())",
+											"}",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"https://purl.org/dc/terms/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common/\"\n    },\n    \"@id\": \"{{CONTRACT_POOL_UCC_READ}}\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"{{POLICY_BUSINESS_PARTNER_NUMBER}}\",\n    \"contractPolicyId\": \"{{POLICY_ACCEPT_PURPOSE_POOL}}\",\n    \"assetsSelector\": {\n        \"@type\": \"CriterionDto\",\n        \"operandLeft\": \"https://w3id.org/edc/v0.0.1/ns/id\",\n        \"operator\": \"in\",\n        \"operandRight\": [\n            \"{{ASSET_POOL_UCC_READ}}\"\n        ]\n    },\n    \"privateProperties\": {\n        \"BusinessPartnerNumber\": \"{{CONSUMER_BPNL}}\",\n        \"dct:type\": \"ReadAccessPoolForUseCaseConsumer\",\n        \"cx-common:version\": \"6.0\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{PROVIDER_EDC_MANAGEMENT_API}}/v3/contractdefinitions",
+									"host": [
+										"{{PROVIDER_EDC_MANAGEMENT_API}}"
+									],
+									"path": [
+										"v3",
+										"contractdefinitions"
+									]
+								}
+							},
+							"response": []
+						}
+					]
 				}
 			]
 		}
@@ -638,6 +728,11 @@
 			"type": "string"
 		},
 		{
+			"key": "CLIENT_ID_POOL_UCC_READ",
+			"value": "CLIENT_5_ID",
+			"type": "string"
+		},
+		{
 			"key": "CLIENT_SECRET_PATH_POOL_CX_MEMBER_READ_CLIENT",
 			"value": "vault/path/client/1/secret",
 			"type": "string"
@@ -654,7 +749,12 @@
 		},
 		{
 			"key": "CLIENT_SECRET_PATH_GATE_SHARING_MEMBER_READ_OUTPUT",
-			"value": "vault/path/client/3/secret",
+			"value": "vault/path/client/4/secret",
+			"type": "string"
+		},
+		{
+			"key": "CLIENT_SECRET_PATH_POOL_UCC_READ_CLIENT",
+			"value": "vault/path/client/5/secret",
 			"type": "string"
 		},
 		{
@@ -713,6 +813,16 @@
 		{
 			"key": "CONTRACT_GATE_SHARING_MEMBER_READ_OUTPUT",
 			"value": ""
+		},
+		{
+			"key": "ASSET_POOL_UCC_READ",
+			"value": "",
+			"type": "string"
+		},
+		{
+			"key": "CONTRACT_POOL_UCC_READ",
+			"value": "",
+			"type": "string"
 		}
 	]
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds endpoints to query member-owned business partner data which is Catena-X member data and their subsidiaries.

- add endpoints
- add Open-API descriptions
- add and adapt integration tests
- update documentation
- create new assets for use case providers accessing then new endpoints
- update the permissions and authorization documentation

Since this contribution contains new permissions, permission groups and assets, changes to the Portal and Central-IDP are needed. I will link the relevant issues here as soon as they are raised.


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Implements #1088 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
