### PR TITLE
feat: endpoint to return bpnl/s/a based on the requested identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 ### Added
 
+- BPDM Pool: Post endpoint to fetch the BPNL/S/A based on the requested identifiers.([#1052](https://github.com/eclipse-tractusx/bpdm/issues/1052))
 
 ### Changed
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -117,12 +117,12 @@ maven/mavencentral/org.awaitility/awaitility/4.2.2, Apache-2.0, approved, #14178
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
 maven/mavencentral/org.eclipse.angus/angus-activation/2.0.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.angus/angus-mail/2.0.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
-maven/mavencentral/org.eclipse.tractusx/bpdm-common-test/6.2.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-common/6.2.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/6.2.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/6.2.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/6.2.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/6.2.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-common-test/6.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-common/6.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/6.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/6.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/6.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/6.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/10.10.0, Apache-2.0, approved, #14163
 maven/mavencentral/org.flywaydb/flyway-database-postgresql/10.10.0, Apache-2.0, approved, #14158
 maven/mavencentral/org.glassfish.jaxb/codemodel/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -149,11 +149,11 @@ maven/mavencentral/org.jboss.shrinkwrap/shrinkwrap-api/1.2.6, Apache-2.0, approv
 maven/mavencentral/org.jboss.shrinkwrap/shrinkwrap-impl-base/1.2.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss.shrinkwrap/shrinkwrap-spi/1.2.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss/jandex/2.4.3.Final, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect/2.1.0, , restricted, clearlydefined
+maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect/2.1.0, Apache-2.0, approved, #17637
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.0, Apache-2.0, approved, #8910
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/2.1.0, , restricted, clearlydefined
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/2.1.0, , restricted, clearlydefined
-maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/2.1.0, , restricted, clearlydefined
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/2.1.0, None, restricted, #17633
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/2.1.0, None, restricted, #17635
+maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib/2.1.0, Apache-2.0, approved, #17634
 maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.8.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-core/1.8.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearlydefined
@@ -227,11 +227,11 @@ maven/mavencentral/org.springframework/spring-tx/6.2.0, Apache-2.0, approved, #1
 maven/mavencentral/org.springframework/spring-web/6.2.0, Apache-2.0, approved, #17558
 maven/mavencentral/org.springframework/spring-webflux/6.2.0, Apache-2.0, approved, #17567
 maven/mavencentral/org.springframework/spring-webmvc/6.2.0, Apache-2.0, approved, #17532
-maven/mavencentral/org.testcontainers/database-commons/1.20.3, Apache-2.0, approved, #16630
-maven/mavencentral/org.testcontainers/jdbc/1.20.3, Apache-2.0, approved, #16621
-maven/mavencentral/org.testcontainers/junit-jupiter/1.20.3, MIT, approved, #16552
-maven/mavencentral/org.testcontainers/postgresql/1.20.3, MIT, approved, #16627
-maven/mavencentral/org.testcontainers/testcontainers/1.20.3, MIT, approved, #15747
+maven/mavencentral/org.testcontainers/database-commons/1.20.4, Apache-2.0, approved, #16630
+maven/mavencentral/org.testcontainers/jdbc/1.20.4, Apache-2.0, approved, #16621
+maven/mavencentral/org.testcontainers/junit-jupiter/1.20.4, MIT, approved, #16552
+maven/mavencentral/org.testcontainers/postgresql/1.20.4, MIT, approved, #16627
+maven/mavencentral/org.testcontainers/testcontainers/1.20.4, MIT, approved, #15747
 maven/mavencentral/org.webjars/swagger-ui/5.17.14, Apache-2.0 AND MIT, approved, #15701
 maven/mavencentral/org.xmlunit/xmlunit-core/2.10.0, Apache-2.0, approved, #14590
 maven/mavencentral/org.yaml/snakeyaml/2.3, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #16046

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
@@ -27,13 +27,11 @@ import org.eclipse.tractusx.bpdm.common.model.BusinessStateType
 import org.eclipse.tractusx.bpdm.common.model.ClassificationType
 import org.eclipse.tractusx.bpdm.common.service.toDto
 import org.eclipse.tractusx.bpdm.pool.api.model.*
-import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
-import org.eclipse.tractusx.bpdm.pool.api.model.response.SitePartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.*
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import java.util.UUID
 
 /**
  * Test values for response DTOs
@@ -67,6 +65,10 @@ object BusinessPartnerVerboseValues {
     val identifierType2 = TypeKeyNameVerboseDto("VAT_US", "VAT USA")
     val identifierType3 = TypeKeyNameVerboseDto("VAT_FR", "VAT France")
     val identifierType4 = TypeKeyNameVerboseDto("VAT_NL", "VAT Netherlands")
+
+    val bpnLRequestMapping = BpnRequestIdentifierMappingDto(UUID.randomUUID().toString(), bpn = secondBpnL)
+    val bpnSRequestMapping = BpnRequestIdentifierMappingDto(UUID.randomUUID().toString(), bpn = secondBpnS)
+    val bpnARequestMapping = BpnRequestIdentifierMappingDto(UUID.randomUUID().toString(), bpn = secondBpnA)
 
     val identifierTypeAbbreviation1 = "abbreviation1"
     val identifierTypeAbbreviation2 = "abbreviation2"

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi.Companion.BPN_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnRequestIdentifierMappingDto
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -62,4 +63,17 @@ interface PoolBpnApi {
     @Tag(name = ApiCommons.BPN_NAME, description = ApiCommons.BPN_DESCRIPTION)
     @PostMapping(CommonApiPathNames.SUBPATH_SEARCH)
     fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingDto>>
+
+    @Operation(
+        summary = "Return BPNL/S/A based on the requested identifiers",
+        description = "Find business partner numbers by requested-identifiers."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Found bpn to based on the requested identifiers"),
+        ]
+    )
+    @Tag(name = ApiCommons.BPN_NAME, description = ApiCommons.BPN_DESCRIPTION)
+    @PostMapping("/request-ids")
+    fun findBpnByRequestedIdentifiers(@RequestBody request: Set<String>): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi.Companion.BPN_PATH
+import org.eclipse.tractusx.bpdm.pool.api.model.request.BpnRequestIdentifierSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnRequestIdentifierMappingDto
@@ -74,6 +75,6 @@ interface PoolBpnApi {
         ]
     )
     @Tag(name = ApiCommons.BPN_NAME, description = ApiCommons.BPN_DESCRIPTION)
-    @PostMapping("/request-ids")
-    fun findBpnByRequestedIdentifiers(@RequestBody request: Set<String>): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
+    @PostMapping("/request-ids/search")
+    fun findBpnByRequestedIdentifiers(@RequestBody request: BpnRequestIdentifierSearchRequest): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/BpnApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/BpnApiClient.kt
@@ -23,6 +23,7 @@ import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnRequestIdentifierMappingDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.HttpExchange
@@ -32,4 +33,7 @@ import org.springframework.web.service.annotation.PostExchange
 interface BpnApiClient: PoolBpnApi {
     @PostExchange(CommonApiPathNames.SUBPATH_SEARCH)
     override fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingDto>>
+
+    @PostExchange(value = "/request-ids")
+    override fun findBpnByRequestedIdentifiers(@RequestBody identifiers: Set<String>): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/BpnApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/BpnApiClient.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi
+import org.eclipse.tractusx.bpdm.pool.api.model.request.BpnRequestIdentifierSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnRequestIdentifierMappingDto
@@ -34,6 +35,6 @@ interface BpnApiClient: PoolBpnApi {
     @PostExchange(CommonApiPathNames.SUBPATH_SEARCH)
     override fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingDto>>
 
-    @PostExchange(value = "/request-ids")
-    override fun findBpnByRequestedIdentifiers(@RequestBody identifiers: Set<String>): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
+    @PostExchange(value = "/request-ids/search")
+    override fun findBpnByRequestedIdentifiers(@RequestBody request: BpnRequestIdentifierSearchRequest): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/BpnRequestIdentifierSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/BpnRequestIdentifierSearchRequest.kt
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "BpnRequestIdentifierSearchRequest", description = "Mapping of Business Partner Number to requested-identifier value")
+data class BpnRequestIdentifierSearchRequest (
+    @Schema(description = "Value of the requested-identifier")
+    val requestedIdentifiers: Set<String>
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/BpnRequestIdentifierMappingDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/response/BpnRequestIdentifierMappingDto.kt
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "BpnRequestIdentifierMappingDto", description = "Mapping of Business Partner Number to requested-identifier value")
+data class BpnRequestIdentifierMappingDto(
+
+    @Schema(description = "Value of the requested-identifier")
+    val requestedIdentifier: String,
+
+    @Schema(description = "Business Partner Number")
+    val bpn: String
+)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi
+import org.eclipse.tractusx.bpdm.pool.api.model.request.BpnRequestIdentifierSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnRequestIdentifierMappingDto
@@ -48,11 +49,11 @@ class BpnController(
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
-    override fun findBpnByRequestedIdentifiers(@RequestBody request: Set<String>): ResponseEntity<Set<BpnRequestIdentifierMappingDto>> {
-        if (request.size > controllerConfigProperties.searchRequestLimit) {
+    override fun findBpnByRequestedIdentifiers(@RequestBody request: BpnRequestIdentifierSearchRequest): ResponseEntity<Set<BpnRequestIdentifierMappingDto>> {
+        if (request.requestedIdentifiers.size > controllerConfigProperties.searchRequestLimit) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)
         }
-        val bpnIdentifierMappings = businessPartnerFetchService.findBpnByRequestedIdentifiers(request)
+        val bpnIdentifierMappings = businessPartnerFetchService.findBpnByRequestedIdentifiers(request.requestedIdentifiers)
         return ResponseEntity(bpnIdentifierMappings, HttpStatus.OK)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnController.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.controller
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnRequestIdentifierMappingDto
 import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
 import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
@@ -43,6 +44,15 @@ class BpnController(
             return ResponseEntity(HttpStatus.BAD_REQUEST)
         }
         val bpnIdentifierMappings = businessPartnerFetchService.findBpnsByIdentifiers(request.idType, request.businessPartnerType, request.idValues)
+        return ResponseEntity(bpnIdentifierMappings, HttpStatus.OK)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun findBpnByRequestedIdentifiers(@RequestBody request: Set<String>): ResponseEntity<Set<BpnRequestIdentifierMappingDto>> {
+        if (request.size > controllerConfigProperties.searchRequestLimit) {
+            return ResponseEntity(HttpStatus.BAD_REQUEST)
+        }
+        val bpnIdentifierMappings = businessPartnerFetchService.findBpnByRequestedIdentifiers(request)
         return ResponseEntity(bpnIdentifierMappings, HttpStatus.OK)
     }
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolClientImpl
 import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
 import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.BpnRequestIdentifierSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.entity.BpnRequestIdentifierMappingDb
 import org.eclipse.tractusx.bpdm.pool.repository.BpnRequestIdentifierRepository
@@ -174,7 +175,7 @@ class BpnControllerIT @Autowired constructor(
             BusinessPartnerVerboseValues.bpnLRequestMapping.requestedIdentifier,
             BusinessPartnerVerboseValues.bpnSRequestMapping.requestedIdentifier,
         )
-        val response = poolClient.bpns.findBpnByRequestedIdentifiers(requestedIdentifiers)
+        val response = poolClient.bpns.findBpnByRequestedIdentifiers(BpnRequestIdentifierSearchRequest(requestedIdentifiers))
         response.body?.let { Assertions.assertEquals(requestedIdentifiers.size, it.size) }
     }
 
@@ -189,7 +190,7 @@ class BpnControllerIT @Autowired constructor(
             BusinessPartnerVerboseValues.bpnARequestMapping.requestedIdentifier,
         )
         try {
-            val result = poolClient.bpns.findBpnByRequestedIdentifiers(requestedIdentifiers)
+            val result = poolClient.bpns.findBpnByRequestedIdentifiers(BpnRequestIdentifierSearchRequest(requestedIdentifiers))
             assertThrows<WebClientResponseException> { result }
         } catch (e: WebClientResponseException) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.statusCode)
@@ -202,7 +203,7 @@ class BpnControllerIT @Autowired constructor(
     @Test
     fun `find bpn by invalid requested identifier`() {
         val requestedIdentifiers = setOf(UUID.randomUUID().toString())
-        val response = poolClient.bpns.findBpnByRequestedIdentifiers(requestedIdentifiers)
+        val response = poolClient.bpns.findBpnByRequestedIdentifiers(BpnRequestIdentifierSearchRequest(requestedIdentifiers))
         response.body?.let { Assertions.assertNotEquals(requestedIdentifiers.size, it.size) }
         response.body?.let { Assertions.assertTrue(it.isEmpty()) }
     }

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -1528,7 +1528,7 @@
         }
       }
     },
-    "/v6/bpn/request-ids": {
+    "/v6/bpn/request-ids/search": {
       "post": {
         "tags": [
           "Bpn Controller"
@@ -1540,11 +1540,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "uniqueItems": true,
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
+                "$ref": "#/components/schemas/BpnRequestIdentifierSearchRequest"
               }
             }
           },
@@ -2871,6 +2867,24 @@
           "bpn": {
             "type": "string",
             "description": "Business Partner Number"
+          }
+        },
+        "description": "Mapping of Business Partner Number to requested-identifier value"
+      },
+      "BpnRequestIdentifierSearchRequest": {
+        "required": [
+          "requestedIdentifiers"
+        ],
+        "type": "object",
+        "properties": {
+          "requestedIdentifiers": {
+            "uniqueItems": true,
+            "type": "array",
+            "description": "Value of the requested-identifier",
+            "items": {
+              "type": "string",
+              "description": "Value of the requested-identifier"
+            }
           }
         },
         "description": "Mapping of Business Partner Number to requested-identifier value"

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -1528,6 +1528,46 @@
         }
       }
     },
+    "/v6/bpn/request-ids": {
+      "post": {
+        "tags": [
+          "Bpn Controller"
+        ],
+        "summary": "Return BPNL/S/A based on the requested identifiers",
+        "description": "Find business partner numbers by requested-identifiers.",
+        "operationId": "findBpnByRequestedIdentifiers",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "uniqueItems": true,
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Found bpn to based on the requested identifiers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BpnRequestIdentifierMappingDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v6/addresses/search": {
       "post": {
         "tags": [
@@ -2816,6 +2856,24 @@
           }
         },
         "description": "Mapping of Business Partner Number to identifier value"
+      },
+      "BpnRequestIdentifierMappingDto": {
+        "required": [
+          "bpn",
+          "requestedIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "requestedIdentifier": {
+            "type": "string",
+            "description": "Value of the requested-identifier"
+          },
+          "bpn": {
+            "type": "string",
+            "description": "Business Partner Number"
+          }
+        },
+        "description": "Mapping of Business Partner Number to requested-identifier value"
       },
       "ChangelogEntryVerboseDto": {
         "required": [

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -1087,6 +1087,32 @@ paths:
           description: On malformed request parameters or if number of requested bpns exceeds limit
         '404':
           description: Specified identifier type not found
+  /v6/bpn/request-ids:
+    post:
+      tags:
+        - Bpn Controller
+      summary: Return BPNL/S/A based on the requested identifiers
+      description: Find business partner numbers by requested-identifiers.
+      operationId: findBpnByRequestedIdentifiers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              uniqueItems: true
+              type: array
+              items:
+                type: string
+        required: true
+      responses:
+        '200':
+          description: Found bpn to based on the requested identifiers
+          content:
+            application/json:
+              schema:
+                uniqueItems: true
+                type: array
+                items:
+                  $ref: '#/components/schemas/BpnRequestIdentifierMappingDto'
   /v6/addresses/search:
     post:
       tags:
@@ -2144,6 +2170,19 @@ components:
           type: string
           description: Business Partner Number
       description: Mapping of Business Partner Number to identifier value
+    BpnRequestIdentifierMappingDto:
+      required:
+        - bpn
+        - requestedIdentifier
+      type: object
+      properties:
+        requestedIdentifier:
+          type: string
+          description: Value of the requested-identifier
+        bpn:
+          type: string
+          description: Business Partner Number
+      description: Mapping of Business Partner Number to requested-identifier value
     ChangelogEntryVerboseDto:
       required:
         - bpn

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -1087,7 +1087,7 @@ paths:
           description: On malformed request parameters or if number of requested bpns exceeds limit
         '404':
           description: Specified identifier type not found
-  /v6/bpn/request-ids:
+  /v6/bpn/request-ids/search:
     post:
       tags:
         - Bpn Controller
@@ -1098,10 +1098,7 @@ paths:
         content:
           application/json:
             schema:
-              uniqueItems: true
-              type: array
-              items:
-                type: string
+              $ref: '#/components/schemas/BpnRequestIdentifierSearchRequest'
         required: true
       responses:
         '200':
@@ -2182,6 +2179,19 @@ components:
         bpn:
           type: string
           description: Business Partner Number
+      description: Mapping of Business Partner Number to requested-identifier value
+    BpnRequestIdentifierSearchRequest:
+      required:
+        - requestedIdentifiers
+      type: object
+      properties:
+        requestedIdentifiers:
+          uniqueItems: true
+          type: array
+          description: Value of the requested-identifier
+          items:
+            type: string
+            description: Value of the requested-identifier
       description: Mapping of Business Partner Number to requested-identifier value
     ChangelogEntryVerboseDto:
       required:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This PR introduces a new endpoint that returns the BPNL/S/A based on the provided request identifiers.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
For more information, please refer to https://github.com/eclipse-tractusx/bpdm/issues/1052.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
