### PR TITLE
feat(bpdm): added connection to dependencies in readiness check for bpdm services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate & Pool: Update linkage from AdditionalAddress to SiteMainAddress and LegalAddress to LegalAndSiteMainAddress.([#1121](https://github.com/eclipse-tractusx/bpdm/issues/1121))
 - BPDM Gate: Add endpoints for managing business partner relations ([#1027](https://github.com/eclipse-tractusx/bpdm/issues/1027))
 - BPDM System Test: End-to-end test CI/CD workflow setup for golden record process. ([#1155](https://github.com/eclipse-tractusx/bpdm/issues/1155))
+- Apps : Enhanced dependency readiness checks with a scheduler to verify connections to required services every 30 seconds and during startup for Pool, Cleaning Service Dummy, and Gate service. ([#1161](https://github.com/eclipse-tractusx/bpdm/issues/1161))
 
 ### Changed
 

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/DependencyHealthScheduler.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/DependencyHealthScheduler.kt
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.cleaning.config
+
+import jakarta.annotation.PostConstruct
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.cleaning.service.DependencyHealthService
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.support.CronTrigger
+
+@Configuration
+class DependencyHealthScheduler(
+    private val dependencyHealthService: DependencyHealthService,
+    private val taskScheduler: TaskScheduler,
+    private val configProperties: CleaningServiceConfigProperties
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    @PostConstruct
+    fun scheduleHealthChecks() {
+        taskScheduler.scheduleIfEnabled(
+            { performHealthCheck() },
+            configProperties.dependencyCheck.cron
+        )
+    }
+
+    private fun performHealthCheck() {
+        val healthStatus = dependencyHealthService.checkAllDependencies()
+        val unhealthyDependencies = healthStatus.filter { it.value == "Down" }
+
+        if (unhealthyDependencies.isNotEmpty()) {
+            logger.error("Dependencies not ready: ${unhealthyDependencies.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        } else {
+            logger.info("All dependencies are healthy: ${healthStatus.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        }
+    }
+
+    private fun TaskScheduler.scheduleIfEnabled(task: Runnable, cronExpression: String) {
+        if (cronExpression != "-") {
+            schedule(task, CronTrigger(cronExpression))
+        }
+    }
+
+}

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/OrchestratorClientConfig.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/OrchestratorClientConfig.kt
@@ -24,10 +24,12 @@ import org.eclipse.tractusx.bpdm.common.util.BpdmWebClientProvider
 import org.eclipse.tractusx.bpdm.common.util.ClientConfigurationProperties
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClientImpl
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
 
 @ConfigurationProperties(prefix = OrchestratorConfigProperties.PREFIX)
 data class OrchestratorConfigProperties(
@@ -45,8 +47,14 @@ data class OrchestratorConfigProperties(
 
 @Configuration
 class OrchestratorClientConfiguration{
+    
     @Bean
-    fun orchestratorClient(clientProperties: OrchestratorConfigProperties, webClientProvider: BpdmWebClientProvider): OrchestrationApiClient{
-        return OrchestrationApiClientImpl { webClientProvider.builder(clientProperties).build() }
+    fun orchestratorClient(@Qualifier("orchestratorWebClient") orchestratorWebClient: WebClient ): OrchestrationApiClient{
+        return OrchestrationApiClientImpl { orchestratorWebClient }
+    }
+
+    @Bean(name = ["orchestratorWebClient"])
+    fun orchestratorWebClient(clientProperties: OrchestratorConfigProperties, webClientProvider: BpdmWebClientProvider): WebClient{
+        return webClientProvider.builder(clientProperties).build()
     }
 }

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/DependencyHealthService.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/DependencyHealthService.kt
@@ -17,22 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.cleaning.config
+package org.eclipse.tractusx.bpdm.cleaning.service
 
-import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties.Companion.PREFIX
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+import org.eclipse.tractusx.bpdm.cleaning.util.OrchestratorHealthIndicator
+import org.springframework.boot.actuate.health.Status
+import org.springframework.stereotype.Service
 
-@ConfigurationProperties(prefix = PREFIX)
-class CleaningServiceConfigProperties (
-    val step: TaskStep,
-    val dependencyCheck: DependencyCheckConfig
-){
-    companion object{
-        const val PREFIX = "bpdm.golden-record-process"
+@Service
+class DependencyHealthService(
+    private val orchestratorHealthIndicator: OrchestratorHealthIndicator
+) {
+
+    fun checkAllDependencies(): Map<String, String> {
+        val orchestratorHealth = if (orchestratorHealthIndicator.health().status == Status.UP) "Healthy" else "Down"
+
+        return mapOf(
+            "Orchestrator Service" to orchestratorHealth
+        )
     }
-
-    data class DependencyCheckConfig(
-        val cron: String = "-"
-    )
 }

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/util/CleaningServiceStartupListner.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/util/CleaningServiceStartupListner.kt
@@ -17,22 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.cleaning.config
+package org.eclipse.tractusx.bpdm.cleaning.util
 
-import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties.Companion.PREFIX
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Component
 
-@ConfigurationProperties(prefix = PREFIX)
-class CleaningServiceConfigProperties (
-    val step: TaskStep,
-    val dependencyCheck: DependencyCheckConfig
-){
-    companion object{
-        const val PREFIX = "bpdm.golden-record-process"
+@Component
+class CleaningServiceStartupListner(
+    private val orchestratorHealthIndicator: OrchestratorHealthIndicator
+) : ApplicationListener<ApplicationReadyEvent> {
+
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        val orchestratorHealth = orchestratorHealthIndicator.health().status
+
+        if (orchestratorHealth != Status.UP) {
+            throw IllegalStateException("Dependencies not ready: Orchestrator: $orchestratorHealth")
+        }
     }
 
-    data class DependencyCheckConfig(
-        val cron: String = "-"
-    )
 }

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/util/OrchestratorHealthIndicator.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/util/OrchestratorHealthIndicator.kt
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.cleaning.util
+
+import org.eclipse.tractusx.bpdm.cleaning.config.OrchestratorConfigProperties
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+@Component("orchestratorHealth")
+class OrchestratorHealthIndicator(
+    private val orchestratorConfigProperties: OrchestratorConfigProperties,
+    @Qualifier("orchestratorWebClient") private val webClient: WebClient
+) : HealthIndicator {
+
+    override fun health(): Health {
+
+        val orchestratorHealthUrl = "${orchestratorConfigProperties.baseUrl}/actuator/health"
+
+        return try {
+            val response = webClient.get()
+                .uri(orchestratorHealthUrl)
+                .retrieve()
+                .toEntity(String::class.java)
+                .block()
+
+            if (response?.statusCode?.is2xxSuccessful == true) {
+                Health.up().withDetail("Orchestrator Service", "Available").build()
+            } else {
+                Health.down().withDetail("Orchestrator Service", "Unreachable").build()
+            }
+        } catch (e: Exception) {
+            Health.down().withDetail("Orchestrator Service", "Error: ${e.message}").build()
+        }
+    }
+}

--- a/bpdm-cleaning-service-dummy/src/main/resources/application.yml
+++ b/bpdm-cleaning-service-dummy/src/main/resources/application.yml
@@ -49,6 +49,9 @@ bpdm:
         client-secret: "**********"
   golden-record-process:
     step: CleanAndSync
+    dependencyCheck:
+       # How often the golden record connection dependencies should be checked for being healthy
+      cron: '*/30 * * * * *'
 
   cleaningService:
     # When and how often the cleaning service should poll for golden record tasks in the orchestrator
@@ -78,6 +81,7 @@ logging:
 management:
   endpoint:
     health:
+      show-details: always
       probes:
         # Enable actuator health endpoints for probing
         enabled: true

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/MockHealthIndicatorConfig.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/MockHealthIndicatorConfig.kt
@@ -19,20 +19,20 @@
 
 package org.eclipse.tractusx.bpdm.cleaning.config
 
-import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties.Companion.PREFIX
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+import io.mockk.every
+import io.mockk.mockk
+import org.eclipse.tractusx.bpdm.cleaning.util.OrchestratorHealthIndicator
+import org.springframework.boot.actuate.health.Health
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
-@ConfigurationProperties(prefix = PREFIX)
-class CleaningServiceConfigProperties (
-    val step: TaskStep,
-    val dependencyCheck: DependencyCheckConfig
-){
-    companion object{
-        const val PREFIX = "bpdm.golden-record-process"
+@Configuration
+class MockHealthIndicatorConfig {
+
+    @Bean
+    fun orchestratorHealthIndicator(): OrchestratorHealthIndicator {
+        return mockk<OrchestratorHealthIndicator> {
+            every { health() } returns Health.up().build()
+        }
     }
-
-    data class DependencyCheckConfig(
-        val cron: String = "-"
-    )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/DependencyHealthScheduler.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/config/DependencyHealthScheduler.kt
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.config
+
+import jakarta.annotation.PostConstruct
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.gate.service.DependencyHealthService
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.support.CronTrigger
+
+@Configuration
+class DependencyHealthScheduler(
+    private val dependencyHealthService: DependencyHealthService,
+    private val taskScheduler: TaskScheduler,
+    private val configProperties: GoldenRecordTaskConfigProperties
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    @PostConstruct
+    fun scheduleHealthChecks() {
+        taskScheduler.scheduleIfEnabled(
+            { performHealthCheck() },
+            configProperties.dependencyCheck.cron
+        )
+    }
+
+    private fun performHealthCheck() {
+        val healthStatus = dependencyHealthService.checkAllDependencies()
+        val unhealthyDependencies = healthStatus.filter { it.value == "Down" }
+
+        if (unhealthyDependencies.isNotEmpty()) {
+            logger.error("Dependencies not ready: ${unhealthyDependencies.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        } else {
+            logger.info("All dependencies are healthy: ${healthStatus.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        }
+    }
+
+    private fun TaskScheduler.scheduleIfEnabled(task: Runnable, cronExpression: String) {
+        if (cronExpression != "-") {
+            schedule(task, CronTrigger(cronExpression))
+        }
+    }
+
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/DependencyHealthService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/DependencyHealthService.kt
@@ -17,22 +17,26 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.cleaning.config
+package org.eclipse.tractusx.bpdm.gate.service
 
-import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties.Companion.PREFIX
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+import org.eclipse.tractusx.bpdm.gate.util.OrchestratorHealthIndicator
+import org.eclipse.tractusx.bpdm.gate.util.PoolHealthIndicator
+import org.springframework.boot.actuate.health.Status
+import org.springframework.stereotype.Service
 
-@ConfigurationProperties(prefix = PREFIX)
-class CleaningServiceConfigProperties (
-    val step: TaskStep,
-    val dependencyCheck: DependencyCheckConfig
-){
-    companion object{
-        const val PREFIX = "bpdm.golden-record-process"
+@Service
+class DependencyHealthService(
+    private val poolHealthIndicator: PoolHealthIndicator,
+    private val orchestratorHealthIndicator: OrchestratorHealthIndicator
+) {
+
+    fun checkAllDependencies(): Map<String, String> {
+        val poolHealth = if (poolHealthIndicator.health().status == Status.UP) "Healthy" else "Down"
+        val orchestratorHealth = if (orchestratorHealthIndicator.health().status == Status.UP) "Healthy" else "Down"
+
+        return mapOf(
+            "Pool Service" to poolHealth,
+            "Orchestrator Service" to orchestratorHealth
+        )
     }
-
-    data class DependencyCheckConfig(
-        val cron: String = "-"
-    )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/GateServiceStartupListener.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/GateServiceStartupListener.kt
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.util
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.gate.service.DependencyHealthService
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Component
+
+@Component
+class GateServiceStartupListener(
+    private val dependencyHealthService: DependencyHealthService
+) : ApplicationListener<ApplicationReadyEvent> {
+
+    private val logger = KotlinLogging.logger { }
+
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        val healthStatus = dependencyHealthService.checkAllDependencies()
+        val unhealthyDependencies = healthStatus.filter { it.value == "Down" }
+
+        if (unhealthyDependencies.isNotEmpty()) {
+            logger.error("Startup failed. Dependencies not ready: ${unhealthyDependencies.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+            throw IllegalStateException("Dependencies not ready: ${unhealthyDependencies.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        } else {
+            logger.info("All dependencies are healthy on startup: ${healthStatus.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        }
+    }
+
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/OrchestratorHealthIndicator.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/OrchestratorHealthIndicator.kt
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.util
+
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component("orchestratorHealth")
+class OrchestratorHealthIndicator(
+    private val orchestrationClient: OrchestrationApiClient
+) : HealthIndicator {
+
+    override fun health(): Health {
+
+        return try {
+            /*
+            We can directly use actuator heath response from Orchestrator service but that will not be an authenticated way.
+            So, included get finished task events request to achieve the same for now and in future we can create separate REST api endpoint which will provide
+            health of the service with readiness in authenticated way.
+            */
+            val response = orchestrationClient.finishedTaskEvents.getEvents(Instant.now(), PaginationRequest(page = 0, size = 1))
+            if (response.contentSize >= 0) {
+                Health.up().withDetail("Orchestrator Service", "Available").build()
+            } else {
+                Health.down().withDetail("Orchestrator Service", "Unreachable").build()
+            }
+        } catch (e: Exception) {
+            Health.down().withDetail("Orchestrator Service", "Error: ${e.message}").build()
+        }
+    }
+}

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/PoolHealthIndicator.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/util/PoolHealthIndicator.kt
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.util
+
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+
+@Component("poolHealth")
+class PoolHealthIndicator(
+    private val poolClient: PoolApiClient,
+) : HealthIndicator {
+
+    override fun health(): Health {
+
+        return try {
+            /*
+            We can directly use actuator heath response from Pool service but that will not be an authenticated way.
+            So, included changelog request to achieve the same for now and in future we can create separate REST api endpoint which will provide
+            health of the service with readiness in authenticated way.
+            */
+            val response = poolClient.changelogs.getChangelogEntries(ChangelogSearchRequest(), PaginationRequest(page = 0, size = 1))
+            if (response.contentSize >= 0) {
+                Health.up().withDetail("Pool Service", "Available").build()
+            } else {
+                Health.down().withDetail("Pool Service", "Unreachable").build()
+            }
+        } catch (e: Exception) {
+            Health.down().withDetail("Pool Service", "Error: ${e.message}").build()
+        }
+    }
+}

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -64,6 +64,9 @@ bpdm:
       batchSize: 1000
       # How often the golden record tasks should be checked for being healthy
       cron: '0 0 0 * * *'
+    dependencyCheck:
+      # How often the golden record connection dependencies should be checked for being healthy
+      cron: '*/30 * * * * *'
 
   # Connection to the pool and orchestrator
   client:
@@ -162,6 +165,7 @@ logging:
 management:
     endpoint:
         health:
+            show-details: always
             probes:
               # Enable actuator health endpoints for probing
                 enabled: true

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/config/MockHealthIndicatorConfig.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/config/MockHealthIndicatorConfig.kt
@@ -19,28 +19,28 @@
 
 package org.eclipse.tractusx.bpdm.gate.config
 
-import org.springframework.boot.context.properties.ConfigurationProperties
+import io.mockk.every
+import io.mockk.mockk
+import org.eclipse.tractusx.bpdm.gate.util.OrchestratorHealthIndicator
+import org.eclipse.tractusx.bpdm.gate.util.PoolHealthIndicator
+import org.springframework.boot.actuate.health.Health
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
-@ConfigurationProperties(prefix = "bpdm.tasks")
-data class GoldenRecordTaskConfigProperties(
-    val creation: CreationProperties = CreationProperties(),
-    val check: TaskProcessProperties = TaskProcessProperties(),
-    val healthCheck: TaskProcessProperties = TaskProcessProperties(),
-    val dependencyCheck: TaskProcessProperties = TaskProcessProperties()
-) {
-    data class CreationProperties(
-        val fromSharingMember: CreationTaskProperties = CreationTaskProperties(),
-        val fromPool: TaskProcessProperties = TaskProcessProperties()
-    )
+@Configuration
+class MockHealthIndicatorConfig {
 
-    data class TaskProcessProperties(
-        val batchSize: Int = 20,
-        val cron: String = "-",
-    )
+    @Bean
+    fun poolHealthIndicator(): PoolHealthIndicator {
+        return mockk<PoolHealthIndicator> {
+            every { health() } returns Health.up().build()
+        }
+    }
 
-    data class CreationTaskProperties(
-        val startsAsReady: Boolean = true,
-        val batchSize: Int = 20,
-        val cron: String = "-",
-    )
+    @Bean
+    fun orchestratorHealthIndicator(): OrchestratorHealthIndicator {
+        return mockk<OrchestratorHealthIndicator> {
+            every { health() } returns Health.up().build()
+        }
+    }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/DependencyHealthScheduler.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/DependencyHealthScheduler.kt
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.config
+
+import jakarta.annotation.PostConstruct
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.pool.service.DependencyHealthService
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.support.CronTrigger
+
+@Configuration
+class DependencyHealthScheduler(
+    private val dependencyHealthService: DependencyHealthService,
+    private val taskScheduler: TaskScheduler,
+    private val configProperties: GoldenRecordTaskConfigProperties
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    @PostConstruct
+    fun scheduleHealthChecks() {
+        taskScheduler.scheduleIfEnabled(
+            { performHealthCheck() },
+            configProperties.cron
+        )
+    }
+
+    private fun performHealthCheck() {
+        val healthStatus = dependencyHealthService.checkAllDependencies()
+        val unhealthyDependencies = healthStatus.filter { it.value == "Down" }
+
+        if (unhealthyDependencies.isNotEmpty()) {
+            logger.error("Dependencies not ready: ${unhealthyDependencies.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        } else {
+            logger.info("All dependencies are healthy: ${healthStatus.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        }
+    }
+
+    private fun TaskScheduler.scheduleIfEnabled(task: Runnable, cronExpression: String) {
+        if (cronExpression != "-") {
+            schedule(task, CronTrigger(cronExpression))
+        }
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/OrchestratorClientConfig.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/OrchestratorClientConfig.kt
@@ -24,10 +24,12 @@ import org.eclipse.tractusx.bpdm.common.util.BpdmWebClientProvider
 import org.eclipse.tractusx.bpdm.common.util.ClientConfigurationProperties
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClientImpl
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
 
 
 @ConfigurationProperties(prefix = OrchestratorClientConfigProperties.PREFIX)
@@ -47,8 +49,13 @@ data class OrchestratorClientConfigProperties(
 @Configuration
 class OrchestratorClientConfiguration{
     @Bean
-    fun orchestratorClient(clientProperties: OrchestratorClientConfigProperties, webClientProvider: BpdmWebClientProvider): OrchestrationApiClient{
-        return OrchestrationApiClientImpl { webClientProvider.builder(clientProperties).build() }
+    fun orchestratorClient(@Qualifier("orchestratorWebClient") orchestratorWebClient: WebClient): OrchestrationApiClient{
+        return OrchestrationApiClientImpl { orchestratorWebClient }
+    }
+
+    @Bean(name = ["orchestratorWebClient"])
+    fun orchestratorWebClient(clientProperties: OrchestratorClientConfigProperties, webClientProvider: BpdmWebClientProvider): WebClient {
+        return webClientProvider.builder(clientProperties).build()
     }
 }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/DependencyHealthService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/DependencyHealthService.kt
@@ -17,22 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.cleaning.config
+package org.eclipse.tractusx.bpdm.pool.service
 
-import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties.Companion.PREFIX
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+import org.eclipse.tractusx.bpdm.pool.util.OrchestratorHealthIndicator
+import org.springframework.boot.actuate.health.Status
+import org.springframework.stereotype.Service
 
-@ConfigurationProperties(prefix = PREFIX)
-class CleaningServiceConfigProperties (
-    val step: TaskStep,
-    val dependencyCheck: DependencyCheckConfig
-){
-    companion object{
-        const val PREFIX = "bpdm.golden-record-process"
+@Service
+class DependencyHealthService(
+    private val orchestratorHealthIndicator: OrchestratorHealthIndicator
+) {
+
+    fun checkAllDependencies(): Map<String, String> {
+        val orchestratorHealth = if (orchestratorHealthIndicator.health().status == Status.UP) "Healthy" else "Down"
+
+        return mapOf(
+            "Orchestrator Service" to orchestratorHealth
+        )
     }
-
-    data class DependencyCheckConfig(
-        val cron: String = "-"
-    )
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/util/OrchestratorHealthIndicator.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/util/OrchestratorHealthIndicator.kt
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.util
+
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.config.OrchestratorClientConfigProperties
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskStateRequest
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.reactive.function.client.WebClient
+import java.time.Instant
+
+@Component("orchestratorHealth")
+class OrchestratorHealthIndicator(
+    private val orchestratorConfigProperties: OrchestratorClientConfigProperties,
+    @Qualifier("orchestratorWebClient") private val webClient: WebClient
+) : HealthIndicator {
+
+    override fun health(): Health {
+
+        val orchestratorHealthUrl = "${orchestratorConfigProperties.baseUrl}/actuator/health"
+
+        return try {
+            val response = webClient.get()
+                .uri(orchestratorHealthUrl)
+                .retrieve()
+                .toEntity(String::class.java)
+                .block()
+
+            if (response?.statusCode?.is2xxSuccessful == true) {
+                Health.up().withDetail("Orchestrator Service", "Available").build()
+            } else {
+                Health.down().withDetail("Orchestrator Service", "Unreachable").build()
+            }
+        } catch (e: Exception) {
+            Health.down().withDetail("Orchestrator Service", "Error: ${e.message}").build()
+        }
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/util/PoolServiceStartupListner.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/util/PoolServiceStartupListner.kt
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.util
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.pool.service.DependencyHealthService
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Component
+
+@Component
+class PoolServiceStartupListner(
+    private val dependencyHealthService: DependencyHealthService
+) : ApplicationListener<ApplicationReadyEvent> {
+
+    private val logger = KotlinLogging.logger { }
+
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        val healthStatus = dependencyHealthService.checkAllDependencies()
+        val unhealthyDependencies = healthStatus.filter { it.value == "Down" }
+
+        if (unhealthyDependencies.isNotEmpty()) {
+            logger.error("Startup failed. Dependencies not ready: ${unhealthyDependencies.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+            throw IllegalStateException("Dependencies not ready: ${unhealthyDependencies.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        } else {
+            logger.info("All dependencies are healthy on startup: ${healthStatus.map { "${it.key}: ${it.value}" }.joinToString(", ")}")
+        }
+    }
+
+}

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -141,6 +141,7 @@ logging:
 management:
   endpoint:
     health:
+      show-details: always
       probes:
         # Enable actuator health endpoints for probing
         enabled: true

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/config/MockHealthIndicatorConfig.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/config/MockHealthIndicatorConfig.kt
@@ -17,22 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.cleaning.config
+package org.eclipse.tractusx.bpdm.pool.config
 
-import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties.Companion.PREFIX
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
-import org.springframework.boot.context.properties.ConfigurationProperties
+import io.mockk.every
+import io.mockk.mockk
+import org.eclipse.tractusx.bpdm.pool.util.OrchestratorHealthIndicator
+import org.springframework.boot.actuate.health.Health
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
-@ConfigurationProperties(prefix = PREFIX)
-class CleaningServiceConfigProperties (
-    val step: TaskStep,
-    val dependencyCheck: DependencyCheckConfig
-){
-    companion object{
-        const val PREFIX = "bpdm.golden-record-process"
+@Configuration
+class MockHealthIndicatorConfig {
+
+    @Bean
+    fun orchestratorHealthIndicator(): OrchestratorHealthIndicator {
+        return mockk<OrchestratorHealthIndicator> {
+            every { health() } returns Health.up().build()
+        }
     }
-
-    data class DependencyCheckConfig(
-        val cron: String = "-"
-    )
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request adds dependancy check for services in bpdm as below,

- [X] Upon startup the Pool is ready when a successful connection to the Orchestrator has been made.
- [X] Upon startup the Cleaning Service Dummy is ready when a successful connection to the Orchestrator has been made.
- [X] Upon startup the Gate is ready when a successful connection to the Orchestrator and Pool has been made.
- [X] Enhanced dependency readiness checks with a scheduler to verify connections to required services every 30 seconds and provided error log if any dependant service is not healthy.

Contributes to [#1161](https://github.com/eclipse-tractusx/bpdm/issues/1161)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
