### PR TITLE
fix(Pool): duplicate BPN request identifier mapping entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 - BPDM Gate: Fetched and updated legal name of legal entity from pool while performing partner upload process via CSV([#1141](https://github.com/eclipse-tractusx/bpdm/issues/1141))
 - BPDM Orchestrator: When trying to resolve tasks for a step that have has been resolved before, the request is ignored. A HTTP OK instead of a BadRequest will be returned ([#1092](https://github.com/eclipse-tractusx/bpdm/issues/1092))
-
+- BPDM Pool: Remove duplicate BPN request identifier mapping entries and prevent the creation of new duplicates ([#1159](https://github.com/eclipse-tractusx/bpdm/issues/1159))
 
 ## [6.2.0] - 2024-11-28
 

--- a/bpdm-pool/src/main/resources/db/migration/V6_3_0_0__fix_request_identifier_uc.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V6_3_0_0__fix_request_identifier_uc.sql
@@ -1,0 +1,11 @@
+DELETE
+FROM bpn_requestidentifier_mapping dup_mapping
+USING bpn_requestidentifier_mapping dist_mapping
+WHERE dup_mapping.id < dist_mapping.id
+AND dup_mapping.request_identifier = dist_mapping.request_identifier;
+
+alter table bpn_requestidentifier_mapping
+    drop constraint uc_field_request_identifier;
+
+alter table bpn_requestidentifier_mapping
+    add constraint uc_field_request_identifier unique(request_identifier);

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BpnControllerIT.kt
@@ -57,9 +57,9 @@ import java.util.*
 class BpnControllerIT @Autowired constructor(
     val testHelpers: TestHelpers,
     val poolClient: PoolClientImpl,
-    val bpnRequestIdentifierRepository: BpnRequestIdentifierRepository,
     val dbTestHelpers: DbTestHelpers,
     val poolDataHelpers: PoolDataHelpers,
+    val bpnRequestIdentifierRepository: BpnRequestIdentifierRepository
 ) {
 
     val identifierType = BusinessPartnerNonVerboseValues.legalEntityCreate1.legalEntity.identifiers.first().type

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/ChangelogControllerIT.kt
@@ -54,8 +54,8 @@ class ChangelogControllerIT @Autowired constructor(
     val testHelpers: TestHelpers,
     val poolClient: PoolClientImpl,
     val dbTestHelpers: DbTestHelpers,
-    val assertHelpers: AssertHelpers,
     val poolDataHelpers: PoolDataHelpers,
+    val assertHelpers: AssertHelpers
 ) {
 
     @BeforeEach


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the Pool's behaviour of creating duplicate BPN request identifier mapping entries

- Remove duplicate BPN request identifier mappings form the database
- Prevent creation of new duplicates
- Fix the request identifier unique constraint so that an exception will be thrown when a duplicate entry tries to be created in the database (just for data integrity, should not happen in normal logic)



<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1159

## How to test

In order to check the behaviour you can create a business partner with site information via the Gate, full golden record process. Then provide an update to that business partner without changing the names or BPNs (for example change a small field in the address). Look into the database, there should be no duplicate entries. In the previous version you should see a duplicate.

Please fill free to execute further test scenarios.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
