### PR TITLE
fix(charts): add security profiles to BPDM deployment containers

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - update BPDM Cleaning Service Dummy Chart to version 3.3.0
 - update BPDM Bridge Chart to version 3.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
+- Add missing seccomp profiles for BPDM application containers [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
+
 
 ## [5.2.0] -  2024-11-28
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common
-    version: 1.0.2
+    version: 1.0.3-SNAPSHOT
   - name: postgresql
     version: 12.12.10
     repository: https://charts.bitnami.com/bitnami

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
+- Add missing app armor profile [#1153](https://github.com/eclipse-tractusx/bpdm/issues/1153)
+- Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
 
 ## [3.2.0] - 2024-11-28
 

--- a/charts/bpdm/charts/bpdm-common/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-common/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
+## [1.0.3] - tbd
+
+### Changed
+
+- Add security context configuration to the deployment's init container
+
 ## [1.0.2] - 2024-10-25
 
 ### Changed

--- a/charts/bpdm/charts/bpdm-common/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-common/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: library
 name: bpdm-common
-version: 1.0.2
+version: 1.0.3-SNAPSHOT
 description: A library Helm Chart for other BPDM Charts
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
@@ -48,8 +48,6 @@ spec:
       {{- end }}
       # @url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
       automountServiceAccountToken: false
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -84,14 +82,7 @@ spec:
         - name: startup-delay
           image: busybox:1.28
           securityContext:
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-            runAsUser: 10001
-            runAsGroup: 10001
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command: ['sh', '-c', "sleep {{ $.Values.startupDelaySeconds }}"]
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
+- Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
 
 ## [6.2.0] - 2024-11-28
 

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -38,6 +38,8 @@ podAnnotations: {}
 springProfiles: []
 
 securityContext:
+  seccompProfile:
+    type: RuntimeDefault
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   readOnlyRootFilesystem: true

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
+- Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
 
 ## [3.2.0] - 2024-11-28
 

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
+- Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
 
 ## [7.2.0] - 2024-11-28
 

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -38,6 +38,8 @@ podAnnotations: {}
 springProfiles: []
 
 securityContext:
+  seccompProfile:
+    type: RuntimeDefault
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   readOnlyRootFilesystem: true


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds missing security profile configuratioon to BPDM deployment containers

- adds seccomp profiles
- security context configuration now affects also initcontainers


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1152 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
