### PR TITLE
Fix/charts/initcontainer memory cpu

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - update BPDM Bridge Chart to version 3.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
 - Add missing seccomp profiles for BPDM application containers [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
-
+- Add missing resource limits to the initcontainer [##1154](https://github.com/eclipse-tractusx/bpdm/issues/1154)
 
 ## [5.2.0] -  2024-11-28
 

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
 - Add missing app armor profile [#1153](https://github.com/eclipse-tractusx/bpdm/issues/1153)
 - Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
+- Add missing resource limits to the initcontainer [##1154](https://github.com/eclipse-tractusx/bpdm/issues/1154)
 
 ## [3.2.0] - 2024-11-28
 

--- a/charts/bpdm/charts/bpdm-common/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-common/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 - Add template to infer Central-IDP service names [#994](https://github.com/eclipse-tractusx/bpdm/issues/994)
 - Add missing security context to startupDelay init containers in BPDM deployments [#1089](https://github.com/eclipse-tractusx/bpdm/pull/1089)
+- Add missing resource limits to the initcontainer [##1154](https://github.com/eclipse-tractusx/bpdm/issues/1154)
 
 ## [1.0.1] - 2024-07-10
 

--- a/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
@@ -83,6 +83,13 @@ spec:
           image: busybox:1.28
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            limits:
+              cpu: 10m
+              memory: 100Mi
+            requests:
+               cpu: 10m
+               memory: 100Mi
           command: ['sh', '-c', "sleep {{ $.Values.startupDelaySeconds }}"]
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
 - Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
+- Add missing resource limits to the initcontainer [##1154](https://github.com/eclipse-tractusx/bpdm/issues/1154)
 
 ## [6.2.0] - 2024-11-28
 

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
 - Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
+- Add missing resource limits to the initcontainer [##1154](https://github.com/eclipse-tractusx/bpdm/issues/1154)
 
 ## [3.2.0] - 2024-11-28
 

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)
 - Add missing seccomp profile [#1152](https://github.com/eclipse-tractusx/bpdm/issues/1152)
+- Add missing resource limits to the initcontainer [##1154](https://github.com/eclipse-tractusx/bpdm/issues/1154)
 
 ## [7.2.0] - 2024-11-28
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds the missing resource definitions for CPU and memory requests to the BPDM deployments's initcontainers.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1154

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
