### PR TITLE
fix(bpdm-system-tester): removed docker deployment for system tester module

### DIFF
--- a/.github/workflows/app-test-charts.yaml
+++ b/.github/workflows/app-test-charts.yaml
@@ -60,6 +60,8 @@ on:
       - 'pom.xml'
       - 'bpdm-**'
       - 'charts/**'
+      - '.github/workflows/app-test-charts.yaml'
+      - 'docker/**'
   push:
     branches:
       - main
@@ -163,21 +165,25 @@ jobs:
               registry: kind-registry:5000
               repository: bpdm-pool
               tag: test
+            startupDelaySeconds: 120
           bpdm-gate:
             image:
               registry: kind-registry:5000
               repository: bpdm-gate
               tag: test
+            startupDelaySeconds: 120
           bpdm-orchestrator:
             image:
               registry: kind-registry:5000
               repository: bpdm-orchestrator
               tag: test
+            startupDelaySeconds: 120
           bpdm-cleaning-service-dummy:
             image:
               registry: kind-registry:5000
               repository: bpdm-cleaning-service-dummy
               tag: test
+            startupDelaySeconds: 120
           tests:
             image:
               registry: kind-registry:5000

--- a/.github/workflows/deploy-docker-all.yaml
+++ b/.github/workflows/deploy-docker-all.yaml
@@ -54,3 +54,10 @@ jobs:
     with:
       imageName: bpdm-orchestrator
       dockerfilePath: ./docker/orchestrator
+
+  build-docker-system-tester:
+    uses: ./.github/workflows/deploy-docker.yaml
+    secrets: inherit
+    with:
+      imageName: bpdm-system-tester
+      dockerfilePath: ./docker/system-tester

--- a/.github/workflows/deploy-docker-all.yaml
+++ b/.github/workflows/deploy-docker-all.yaml
@@ -54,10 +54,3 @@ jobs:
     with:
       imageName: bpdm-orchestrator
       dockerfilePath: ./docker/orchestrator
-
-  build-docker-system-tester:
-    uses: ./.github/workflows/deploy-docker.yaml
-    secrets: inherit
-    with:
-      imageName: bpdm-system-tester
-      dockerfilePath: ./docker/system-tester

--- a/docker/system-tester/DOCKER_NOTICE.md
+++ b/docker/system-tester/DOCKER_NOTICE.md
@@ -1,0 +1,28 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/bpdm-system-tester](https://hub.docker.com/r/tractusx/bpdm-system-tester)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+**BPDM System Tester**
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/bpdm 
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- System Tester Dockerfile: https://github.com/eclipse-tractusx/bpdm/blob/main/docker/system-tester/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/bpdm/blob/main/LICENSE)
+
+
+**Used base image**
+
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
This pull request removed unnecessary deployment for bpdm-system-tester module on DockerHub.
As module is only needed to perform chart tests.
 - [ ] Excluded system-tester module from Deploy - All Docker Images github workflow.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
