### PR TITLE
Fix/outdated resolved tasks

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionMapper.kt
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.pool.api.model.*
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.springframework.stereotype.Service
+import java.time.ZoneOffset
+
+@Service
+class TaskResolutionMapper {
+
+    fun toTaskResult(legalEntity: LegalEntityVerboseDto, legalAddress: LogisticAddressVerboseDto, hasChanged: Boolean?): LegalEntity{
+        return with(legalEntity){
+            LegalEntity(
+                bpnReference = BpnReference(bpnl, null, BpnReferenceType.Bpn),
+                legalName = legalName,
+                legalShortName = legalShortName,
+                legalForm = legalForm,
+                identifiers = identifiers.map { Identifier(it.value, it.type, it.issuingBody) },
+                states = states.map { BusinessState(it.validFrom?.toInstant(ZoneOffset.UTC), it.validTo?.toInstant(ZoneOffset.UTC), it.type) },
+                confidenceCriteria = toTaskResult(confidenceCriteria),
+                isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+                hasChanged = hasChanged,
+                legalAddress = toTaskResult(legalAddress, hasChanged)
+            )
+        }
+    }
+
+    fun toTaskResult(site: SiteVerboseDto, siteMainAddress: LogisticAddressVerboseDto, hasChanged: Boolean?): Site{
+        return with(site){
+            Site(
+                bpnReference = BpnReference(bpns, null, BpnReferenceType.Bpn),
+                siteName = name,
+                states = states.map { BusinessState(it.validFrom?.toInstant(ZoneOffset.UTC), it.validTo?.toInstant(ZoneOffset.UTC), it.type) },
+                confidenceCriteria = toTaskResult(confidenceCriteria),
+                hasChanged = hasChanged,
+                //Normally this should be null if the site main address is also the legal address
+                //However, due to synchronization issues we will pass the address here
+                // and perform that last step to set this to null later on after we use this site main address to override the legal entities legal address
+                siteMainAddress = toTaskResult(siteMainAddress, hasChanged)
+            )
+        }
+    }
+
+    fun toTaskResult(confidenceCriteria: ConfidenceCriteriaDto): ConfidenceCriteria{
+        return with(confidenceCriteria){
+            ConfidenceCriteria(
+                sharedByOwner = sharedByOwner,
+                checkedByExternalDataSource = checkedByExternalDataSource,
+                numberOfSharingMembers = numberOfSharingMembers,
+                lastConfidenceCheckAt = lastConfidenceCheckAt.toInstant(ZoneOffset.UTC),
+                nextConfidenceCheckAt = nextConfidenceCheckAt.toInstant(ZoneOffset.UTC),
+                confidenceLevel = confidenceLevel
+            )
+        }
+    }
+
+    fun toTaskResult(postalAddress: LogisticAddressVerboseDto, hasChanged: Boolean?): PostalAddress{
+        return with(postalAddress){
+            PostalAddress(
+                bpnReference = BpnReference(bpna, null, BpnReferenceType.Bpn),
+                addressName = name,
+                identifiers = identifiers.map { Identifier(it.value, it.type, null) },
+                states =  states.map { BusinessState(it.validFrom?.toInstant(ZoneOffset.UTC), it.validTo?.toInstant(ZoneOffset.UTC), it.type) },
+                confidenceCriteria = toTaskResult(confidenceCriteria),
+                physicalAddress = toTaskResult(physicalPostalAddress),
+                alternativeAddress =  alternativePostalAddress?.let { toTaskResult(it) },
+                hasChanged = hasChanged
+            )
+        }
+    }
+
+    fun toTaskResult(physicalAddress: PhysicalPostalAddressVerboseDto): PhysicalAddress{
+        return with(physicalAddress){
+            PhysicalAddress(
+                geographicCoordinates = geographicCoordinates?.let { with(it){ GeoCoordinate(longitude, latitude, altitude) } } ?: GeoCoordinate.empty,
+                country = physicalAddress.country.alpha2,
+                administrativeAreaLevel1 = physicalAddress.administrativeAreaLevel1,
+                administrativeAreaLevel2 = physicalAddress.administrativeAreaLevel2,
+                administrativeAreaLevel3 = physicalAddress.administrativeAreaLevel3,
+                postalCode = postalCode,
+                city = city,
+                district = district,
+                street = street?.let { toTaskResult(it) } ?: Street.empty,
+                companyPostalCode = companyPostalCode,
+                industrialZone = industrialZone,
+                building = building,
+                floor = floor,
+                door = door,
+                taxJurisdictionCode = taxJurisdictionCode
+
+            )
+        }
+    }
+
+    fun toTaskResult(alternativeAddress: AlternativePostalAddressVerboseDto): AlternativeAddress{
+        return with(alternativeAddress){
+            AlternativeAddress(
+                geographicCoordinates = geographicCoordinates?.let { with(it){ GeoCoordinate(longitude, latitude, altitude) } } ?: GeoCoordinate.empty,
+                country = country.alpha2,
+                administrativeAreaLevel1 = administrativeAreaLevel1,
+                postalCode = postalCode,
+                city = city,
+                deliveryServiceType = deliveryServiceType,
+                deliveryServiceQualifier = deliveryServiceQualifier,
+                deliveryServiceNumber = deliveryServiceNumber
+            )
+        }
+    }
+
+
+    fun toTaskResult(street: StreetDto): Street{
+        return with(street){
+            Street(
+                name = name,
+                houseNumber = houseNumber,
+                houseNumberSupplement = houseNumberSupplement,
+                milestone = milestone,
+                direction = direction,
+                namePrefix = namePrefix,
+                additionalNamePrefix = additionalNamePrefix,
+                nameSuffix = nameSuffix,
+                additionalNameSuffix = additionalNameSuffix
+            )
+        }
+    }
+
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -47,7 +47,8 @@ class TaskStepBuildService(
     private val businessPartnerFetchService: BusinessPartnerFetchService,
     private val siteService: SiteService,
     private val addressService: AddressService,
-    private val bpnRequestIdentifierRepository: BpnRequestIdentifierRepository
+    private val bpnRequestIdentifierRepository: BpnRequestIdentifierRepository,
+    private val taskResolutionMapper: TaskResolutionMapper
 ) {
 
     enum class CleaningError(val message: String) {
@@ -82,65 +83,61 @@ class TaskStepBuildService(
         val taskEntryBpnMapping = TaskEntryBpnMapping(listOf(taskEntry), bpnRequestIdentifierRepository)
         val businessPartnerDto = taskEntry.businessPartner
 
-        val legalEntityBpns = processLegalEntity(businessPartnerDto, taskEntryBpnMapping)
-        val siteBpns = processSite(businessPartnerDto, legalEntityBpns.legalEntityBpn, taskEntryBpnMapping)
-        val addressBpn = processAdditionalAddress(businessPartnerDto, legalEntityBpns.legalEntityBpn, siteBpns?.siteBpn, taskEntryBpnMapping)
+        val legalEntityResult = processLegalEntity(businessPartnerDto, taskEntryBpnMapping)
+        val siteResult = processSite(businessPartnerDto, legalEntityResult.bpnReference.referenceValue!!, taskEntryBpnMapping)
+        val addressResult = processAdditionalAddress(businessPartnerDto, legalEntityResult.bpnReference.referenceValue!!, siteResult?.bpnReference?.referenceValue, taskEntryBpnMapping)
 
-        val businessPartnerWithBpns = with(businessPartnerDto){
+        //We do this for one special case:
+        //Legal Entity has not changed but site has changed and the main address is legal address
+        //In this case we want to return the most up-to-date address which is stored in the siteResult
+        val isLegalAndSiteMainAddress =  siteResult?.siteMainAddress?.bpnReference == legalEntityResult.legalAddress.bpnReference
+
+        val businessPartnerResult = with(businessPartnerDto){
             copy(
-                legalEntity = legalEntity.copy(
-                    bpnReference = toBpnReference(legalEntityBpns.legalEntityBpn),
-                    legalAddress = legalEntity.legalAddress.copy(
-                        bpnReference = toBpnReference(legalEntityBpns.legalAddressBpn)
-                    ),
-                    isCatenaXMemberData = legalEntityBpns.isCatenaXMember
-                ),
-                site = siteBpns?.let { site?.copy(
-                    bpnReference = toBpnReference(siteBpns.siteBpn),
-                    siteMainAddress = site!!.siteMainAddress?.copy(bpnReference = toBpnReference(siteBpns.mainAddressBpn))
-                ) },
-                additionalAddress = addressBpn?.let { additionalAddress?.copy(bpnReference = toBpnReference(addressBpn)) }
+                legalEntity = if(isLegalAndSiteMainAddress) legalEntityResult.copy(legalAddress = siteResult!!.siteMainAddress!!) else legalEntityResult,
+                site = if(isLegalAndSiteMainAddress) siteResult?.copy(siteMainAddress = null) else siteResult,
+                additionalAddress = addressResult
             )
         }
 
         taskEntryBpnMapping.writeCreatedMappingsToDb(bpnRequestIdentifierRepository)
         return TaskStepResultEntryDto(
             taskId = taskEntry.taskId,
-            businessPartner = businessPartnerWithBpns,
+            businessPartner = businessPartnerResult,
             errors = emptyList()
         )
     }
 
     private fun processLegalEntity(
         businessPartner: BusinessPartner, taskEntryBpnMapping: TaskEntryBpnMapping
-    ): LegalEntityBpns{
+    ): LegalEntity{
         val legalEntity = businessPartner.legalEntity
         val bpnLReference = legalEntity.bpnReference
         val bpnL = taskEntryBpnMapping.getBpn(bpnLReference)
 
         val existingLegalEntityInformation by lazy {
-            businessPartnerFetchService.fetchByBpns(listOf(bpnL!!))
+            businessPartnerFetchService.fetchDtosByBpns(listOf(bpnL!!))
                 .firstOrNull()
-                ?.let { LegalEntityBpns(it.bpn, it.legalAddress.bpn, it.isCatenaXMemberData) } ?:
+                ?.let { taskResolutionMapper.toTaskResult(it.legalEntity, it.legalAddress, false) } ?:
             throw BpdmValidationException("Legal entity with specified BPNL $bpnL not found")
         }
 
-        val isCatenaXMember = legalEntity.isCatenaXMemberData ?: if(bpnL != null) existingLegalEntityInformation.isCatenaXMember else false
+        val isCatenaXMember = legalEntity.isCatenaXMemberData ?: if(bpnL != null) existingLegalEntityInformation.isCatenaXMemberData else false
 
-        val bpnResults = if(bpnL != null && legalEntity.hasChanged == false){
+        val legalEntityResult = if(bpnL != null && legalEntity.hasChanged == false){
             //No need to upsert, just fetch the information
             existingLegalEntityInformation
         }else{
             upsertLegalEntity(legalEntity.copy(isCatenaXMemberData = isCatenaXMember), taskEntryBpnMapping)
         }
 
-        return bpnResults
+        return legalEntityResult
     }
 
 
     private fun upsertLegalEntity(
         legalEntity: LegalEntity, taskEntryBpnMapping: TaskEntryBpnMapping
-    ): LegalEntityBpns {
+    ): LegalEntity {
         val legalAddress = legalEntity.legalAddress
         val bpnLReference = legalEntity.bpnReference
         val bpnL = taskEntryBpnMapping.getBpn(bpnLReference)
@@ -148,20 +145,20 @@ class TaskStepBuildService(
         val poolLegalEntity = toPoolDto(legalEntity)
         val poolLegalAddress = toPoolDto(legalAddress)
 
-        val bpnResults = if (bpnL == null) {
+        val legalEntityResult = if (bpnL == null) {
             createLegalEntity(poolLegalEntity, poolLegalAddress)
         }
         else{
             updateLegalEntity(bpnL, poolLegalEntity, poolLegalAddress)
         }
 
-        taskEntryBpnMapping.addMapping(bpnLReference, bpnResults.legalEntityBpn)
-        taskEntryBpnMapping.addMapping(legalAddress.bpnReference, bpnResults.legalAddressBpn)
+        taskEntryBpnMapping.addMapping(bpnLReference, legalEntityResult.bpnReference.referenceValue!!)
+        taskEntryBpnMapping.addMapping(legalAddress.bpnReference, legalEntityResult.legalAddress.bpnReference.referenceValue!!)
 
-        return bpnResults
+        return legalEntityResult
     }
 
-    private fun createLegalEntity(legalEntityDto: LegalEntityPoolDto, legalAddressDto: LogisticAddressPoolDto): LegalEntityBpns {
+    private fun createLegalEntity(legalEntityDto: LegalEntityPoolDto, legalAddressDto: LogisticAddressPoolDto): LegalEntity {
 
         val createRequest = LegalEntityPartnerCreateRequest(
             legalEntity = legalEntityDto,
@@ -174,17 +171,14 @@ class TaskStepBuildService(
 
         val legalEntityResult = result.entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to create legal entity")
 
-        val bpnL = legalEntityResult.legalEntity.bpnl
-        val legalAddressBpnA = legalEntityResult.legalAddress.bpna
-
-        return LegalEntityBpns(bpnL, legalAddressBpnA, legalEntityResult.legalEntity.isCatenaXMemberData)
+        return taskResolutionMapper.toTaskResult(legalEntityResult.legalEntity, legalEntityResult.legalAddress, true)
     }
 
     private fun updateLegalEntity(
         bpnL: String,
         legalEntityDto: LegalEntityPoolDto,
         legalAddressDto: LogisticAddressPoolDto
-    ): LegalEntityBpns {
+    ): LegalEntity {
         val updateRequest = LegalEntityPartnerUpdateRequest(
             bpnl = bpnL,
             legalEntity = legalEntityDto,
@@ -196,27 +190,27 @@ class TaskStepBuildService(
 
         val legalEntityResult = result.entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to update legal entity")
 
-        return LegalEntityBpns(legalEntityResult.legalEntity.bpnl, legalEntityResult.legalAddress.bpna, legalEntityResult.legalEntity.isCatenaXMemberData)
+        return taskResolutionMapper.toTaskResult(legalEntityResult.legalEntity, legalEntityResult.legalAddress, true)
     }
 
     private fun processSite(
         businessPartner: BusinessPartner,
         legalEntityBpn: String,
         taskEntryBpnMapping: TaskEntryBpnMapping
-    ): SiteBpns? {
+    ): Site? {
         val site = businessPartner.site ?: return null
 
         val bpnSReference = site.bpnReference
         val bpnS = taskEntryBpnMapping.getBpn(bpnSReference)
 
-        val bpnResults = if(bpnS != null && site.hasChanged == false){
+        val siteResult = if(bpnS != null && site.hasChanged == false){
             //No need to upsert, just fetch the information
             siteService.searchSites(SiteService.SiteSearchRequest(siteBpns = listOf(bpnS), null, null, null), PaginationRequest(0, 1))
                 .content.firstOrNull()
-                ?.let { SiteBpns(it.site.bpns, it.mainAddress.bpna) }
+                ?.let { taskResolutionMapper.toTaskResult(it.site, it.mainAddress, false) }
                 ?: throw BpdmValidationException(CleaningError.MAINE_ADDRESS_IS_NULL.message)
         } else {
-            var bpnA = taskEntryBpnMapping.getBpn(site.siteMainAddress?.bpnReference)
+            val bpnA = taskEntryBpnMapping.getBpn(site.siteMainAddress?.bpnReference)
             if (bpnA == null) {
                 upsertSite(site, businessPartner, legalEntityBpn, taskEntryBpnMapping)
             } else {
@@ -224,7 +218,7 @@ class TaskStepBuildService(
             }
         }
 
-        return bpnResults
+        return siteResult
     }
 
     private fun updateAddressLinkage(
@@ -233,8 +227,8 @@ class TaskStepBuildService(
         businessPartner: BusinessPartner,
         legalEntityBpn: String,
         taskEntryBpnMapping: TaskEntryBpnMapping
-    ): SiteBpns {
-        var address = addressService.findAddressByBpn(bpnA)
+    ): Site {
+        val address = addressService.findAddressByBpn(bpnA)
         return if (address == null) {
             upsertSite(site, businessPartner, legalEntityBpn, taskEntryBpnMapping)
         } else {
@@ -252,7 +246,7 @@ class TaskStepBuildService(
         additionalAddress: LogisticAddressDb,
         legalEntityBpn: String,
         taskEntryBpnMapping: TaskEntryBpnMapping
-    ): SiteBpns {
+    ): Site {
         val siteMainAddress = if (site.siteMainIsLegalAddress) businessPartner.legalEntity.legalAddress else site.siteMainAddress
             ?: throw BpdmValidationException(CleaningError.MAINE_ADDRESS_IS_NULL.message)
         val bpnSReference = site.bpnReference
@@ -262,12 +256,13 @@ class TaskStepBuildService(
             site = poolSite,
             index = ""
         )
-        var result = businessPartnerBuildService.createSiteMainAddressFromAdditionalAddress(listOf(createRequest), additionalAddress)
-        val siteResult = result.entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to creating site")
-        var bpnResults = SiteBpns(siteResult.site.bpns, siteResult.mainAddress.bpna)
-        taskEntryBpnMapping.addMapping(bpnSReference, bpnResults.siteBpn)
-        taskEntryBpnMapping.addMapping(siteMainAddress.bpnReference, bpnResults.mainAddressBpn)
-        return bpnResults
+        val result = businessPartnerBuildService.createSiteMainAddressFromAdditionalAddress(listOf(createRequest), additionalAddress)
+            .entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to creating site")
+        val siteResult = taskResolutionMapper.toTaskResult(result.site, result.mainAddress, true)
+
+        taskEntryBpnMapping.addMapping(bpnSReference, siteResult.bpnReference.referenceValue!!)
+        taskEntryBpnMapping.addMapping(siteMainAddress.bpnReference, siteResult.siteMainAddress!!.bpnReference.referenceValue!!)
+        return siteResult
     }
 
     private fun upsertSite(
@@ -275,7 +270,7 @@ class TaskStepBuildService(
         businessPartner: BusinessPartner,
         legalEntityBpn: String,
         taskEntryBpnMapping: TaskEntryBpnMapping
-    ): SiteBpns {
+    ): Site {
         val siteMainAddress = if(site.siteMainIsLegalAddress) businessPartner.legalEntity.legalAddress else site.siteMainAddress
             ?: throw BpdmValidationException(CleaningError.MAINE_ADDRESS_IS_NULL.message)
 
@@ -284,24 +279,25 @@ class TaskStepBuildService(
 
         val poolSite = toPoolDto(site, siteMainAddress)
 
-        val bpnResults = if (bpnS == null) {
+        val siteResult = if (bpnS == null) {
             createSite(poolSite, legalEntityBpn, site.siteMainAddress == null)
         }
         else {
             updateSite(bpnS, poolSite)
         }
 
-        taskEntryBpnMapping.addMapping(bpnSReference, bpnResults.siteBpn)
-        taskEntryBpnMapping.addMapping(siteMainAddress.bpnReference, bpnResults.mainAddressBpn)
+        taskEntryBpnMapping.addMapping(bpnSReference, siteResult.bpnReference.referenceValue!!)
+        if(!siteResult.siteMainIsLegalAddress)
+            taskEntryBpnMapping.addMapping(siteMainAddress.bpnReference, siteResult.siteMainAddress!!.bpnReference.referenceValue!!)
 
-        return bpnResults
+        return siteResult
     }
 
     private fun createSite(
         poolSite: SitePoolDto,
         legalEntityBpn: String,
         isSiteMainAndLegalAddress: Boolean
-    ): SiteBpns {
+    ): Site {
 
         val result = if(isSiteMainAndLegalAddress){
             val createRequest = SiteCreateRequestWithLegalAddressAsMain(
@@ -325,13 +321,13 @@ class TaskStepBuildService(
 
         val siteResult = result.entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to creating site")
 
-        return SiteBpns(siteResult.site.bpns, siteResult.mainAddress.bpna)
+        return taskResolutionMapper.toTaskResult(siteResult.site, siteResult.mainAddress, true)
     }
 
     private fun updateSite(
         bpnS: String,
         poolSite: SitePoolDto,
-    ): SiteBpns {
+    ): Site {
         val updateRequest = SitePartnerUpdateRequest(
             bpns = bpnS,
             site = poolSite
@@ -342,7 +338,7 @@ class TaskStepBuildService(
 
         val siteResult = result.entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to updating site")
 
-        return SiteBpns(siteResult.site.bpns, siteResult.mainAddress.bpna)
+        return taskResolutionMapper.toTaskResult(siteResult.site, siteResult.mainAddress, true)
     }
 
     private fun processAdditionalAddress(
@@ -350,22 +346,22 @@ class TaskStepBuildService(
         legalEntityBpn: String,
         siteBpn: String?,
         taskEntryBpnMapping: TaskEntryBpnMapping
-    ): String?{
+    ): PostalAddress? {
         val additionalAddress = businessPartner.additionalAddress ?: return null
 
         val bpnAReference = additionalAddress.bpnReference
         val bpnA = taskEntryBpnMapping.getBpn(bpnAReference)
 
-        val addressBpn = if(bpnA != null && additionalAddress.hasChanged == false){
+        val addressResult = if(bpnA != null && additionalAddress.hasChanged == false){
             // No need to upsert just fetch the data
-            addressService.searchAddresses(AddressService.AddressSearchRequest(addressBpns = listOf(bpnA), null, null, null, null), PaginationRequest(0, 1))
-                .content.firstOrNull()?.bpna
-                ?: throw BpdmValidationException(CleaningError.BPNA_IS_NULL.message)
+            val result = addressService.searchAddresses(AddressService.AddressSearchRequest(addressBpns = listOf(bpnA), null, null, null, null), PaginationRequest(0, 1))
+                .content.firstOrNull() ?: throw BpdmValidationException(CleaningError.BPNA_IS_NULL.message)
+            taskResolutionMapper.toTaskResult(result, false)
         }else{
             upsertAdditionalAddress(additionalAddress, legalEntityBpn, siteBpn, taskEntryBpnMapping)
         }
 
-        return addressBpn
+        return addressResult
     }
 
     private fun upsertAdditionalAddress(
@@ -373,29 +369,29 @@ class TaskStepBuildService(
         legalEntityBpn: String,
         siteBpn: String?,
         taskEntryBpnMapping: TaskEntryBpnMapping
-    ): String {
+    ): PostalAddress {
         val bpnAReference = additionalAddress.bpnReference
         val bpnA = taskEntryBpnMapping.getBpn(bpnAReference)
 
         val poolAddress = toPoolDto(additionalAddress)
 
-        val addressBpn = if (bpnA == null) {
+        val addressResult = if (bpnA == null) {
             createLogisticAddress(poolAddress, legalEntityBpn, siteBpn)
         }
         else {
             updateLogisticAddress(bpnA, poolAddress)
         }
 
-        taskEntryBpnMapping.addMapping(bpnAReference, addressBpn)
+        taskEntryBpnMapping.addMapping(bpnAReference, addressResult.bpnReference.referenceValue!!)
 
-        return addressBpn
+        return addressResult
     }
 
     private fun createLogisticAddress(
         poolAddress: LogisticAddressPoolDto,
         legalEntityBpn: String,
         siteBpn: String?
-    ): String {
+    ): PostalAddress {
         val addressCreateRequest = AddressPartnerCreateRequest(
             bpnParent = siteBpn ?: legalEntityBpn,
             index = "",
@@ -408,13 +404,13 @@ class TaskStepBuildService(
 
         val addressResult = result.entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to creating address")
 
-        return addressResult.address.bpna
+        return taskResolutionMapper.toTaskResult(addressResult.address, true)
     }
 
     private fun updateLogisticAddress(
         bpnA: String,
         poolAddress: LogisticAddressPoolDto,
-    ): String {
+    ): PostalAddress {
         val addressUpdateRequest = AddressPartnerUpdateRequest(
             bpna = bpnA,
             address =  poolAddress
@@ -426,7 +422,7 @@ class TaskStepBuildService(
 
         val addressResult = result.entities.firstOrNull() ?: throw BpdmValidationException("Unknown error when trying to updating address")
 
-        return addressResult.bpna
+        return  taskResolutionMapper.toTaskResult(addressResult, true)
     }
 
     private fun toPoolDto(legalEntity: LegalEntity) =
@@ -538,9 +534,6 @@ class TaskStepBuildService(
         state.type ?: throw BpdmValidationException("Business Partner state type is null")
         return state
     }
-
-    private fun toBpnReference(bpn: String) = BpnReference(bpn, null, BpnReferenceType.Bpn)
-
     private fun Instant?.toLocalDateTime() =
         this?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
 
@@ -551,15 +544,4 @@ class TaskStepBuildService(
             throw BpdmValidationException("Country Code not recognized")
         }
     }
-
-    data class LegalEntityBpns(
-        val legalEntityBpn: String,
-        val legalAddressBpn: String,
-        val isCatenaXMember: Boolean
-    )
-
-    data class SiteBpns(
-        val siteBpn: String,
-        val mainAddressBpn: String
-    )
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the Gate not updating business partner output data when it receives already outdated output data form the golden record process. Now, when the Gate receives the result of golden record tasks it performs a check against the Pool again and may update data if it is already outdated.

This pull request needs the fix for the Pool returning full task results based on the database state in order to work.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes #1185 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
