### PR TITLE
fix(bpdm-pool): added missing legal entity (BPNL) associated to address in response while performing entity search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM System Test: End-to-end test CI/CD workflow setup for golden record process. ([#1155](https://github.com/eclipse-tractusx/bpdm/issues/1155))
 - Apps : Enhanced dependency readiness checks with a scheduler to verify connections to required services every 30 seconds and during startup for Pool, Cleaning Service Dummy, and Gate service. ([#1161](https://github.com/eclipse-tractusx/bpdm/issues/1161))
 - BPDM Gate: Add consistency check with the golden record Pool making sure that referenced BPNs are still existing ([#1130](https://github.com/eclipse-tractusx/bpdm/issues/1130))
-- BPDM Gate: Add externalTimestamp to prevent old request overwrite newer request 
+- BPDM Gate: Add externalTimestamp to prevent old request overwrite newer request ([#986](https://github.com/eclipse-tractusx/bpdm/pull/986))
 
 ### Changed
 
@@ -26,6 +26,8 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Orchestrator: When trying to resolve tasks for a step that have has been resolved before, the request is ignored. A HTTP OK instead of a BadRequest will be returned ([#1092](https://github.com/eclipse-tractusx/bpdm/issues/1092))
 - BPDM Pool: Remove duplicate BPN request identifier mapping entries and prevent the creation of new duplicates ([#1159](https://github.com/eclipse-tractusx/bpdm/issues/1159))
 - BPDM Gate: Fix the Gate not updating business partner output data when it receives already outdated output ([#1185](https://github.com/eclipse-tractusx/bpdm/issues/1185))
+- BPDM Pool: Fix resolved tasks by providing business partner data based on the database state. Returned result is now consistent. ([#1158](https://github.com/eclipse-tractusx/bpdm/issues/1158))
+- BPDM Pool: Fix missing legal entity (BPNL) associated to address in response while performing entity search ([#1191](https://github.com/eclipse-tractusx/bpdm/issues/1191))
 
 ## [6.2.0] - 2024-11-28
 
@@ -63,7 +65,6 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Pool: Fix error querying legal forms when non-gleif legacy legal forms are present in the database ([#1107](https://github.com/eclipse-tractusx/bpdm/issues/1107))
 - BPDM: Fix denial of service attack vulnerability CVE-2024-47535 ([#1112](https://github.com/eclipse-tractusx/bpdm/issues/1112))
 - BPDM Gate: Fix error on writing golden record task result missing legal name into output stage. Result is now correctly written. ([#1115](https://github.com/eclipse-tractusx/bpdm/issues/1115))
-- BPDM Pool: Fix resolved tasks by providing business partner data based on the database state. Returned result is now consistent. ([#1158](https://github.com/eclipse-tractusx/bpdm/issues/1158))
 
 ## [6.1.0] - [2024-07-15]
 
@@ -116,15 +117,15 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 ### Added
 
-- BPDM Gate: Configuration to prevent the uploaded business partner input data to immediately enter the golden record process.
-  In this configuration the business partner data needs to be sent to the golden record process manually over the new state/ready API endpoint.
-  Default configuration remains automatically sharing.
+- BPDM Gate: Configuration to prevent the uploaded business partner input data to immediately enter the golden record process. 
+In this configuration the business partner data needs to be sent to the golden record process manually over the new state/ready API endpoint.
+Default configuration remains automatically sharing.
 - BPDM Gate: Limited multi-tenancy support. Business partners are now separated by owner-BPNL.
-  The owner is determined from the 'bpn' claim in the token.
-  This means users of a Gate can only see and edit their own business partner data.
+The owner is determined from the 'bpn' claim in the token.
+This means users of a Gate can only see and edit their own business partner data.
 - BPDM Pool: New API endpoints to query business partner data which belongs to Catena-X members only
 - APIs: Added a major version number to all API endpoint paths indicating the current version of the BPDM APIs.
-  In the future we will use version numbers in the URL to differentiate between all currently supported major versions of the API
+In the future we will use version numbers in the URL to differentiate between all currently supported major versions of the API
 - BPDM Gate Client: Now supports the stats endpoints of the BPDM API
 
 ### Changed
@@ -136,15 +137,15 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: Fix not correctly updating business partner output data from golden record updates in the Pool.
 - JAVA version to 21
 - BPDM API Permissions: Overhaul of the permissions needed to access the BPDM API endpoints.
-  Permissions are now more fine-granular and differentiate more clearly between read or write.
-  For more details consult the Arc42, API documentation and properties files of the respective applications.
+Permissions are now more fine-granular and differentiate more clearly between read or write.
+For more details consult the Arc42, API documentation and properties files of the respective applications.
 - BPDM App Configuration: Now all applications are secured (authenticated and authorized) by default.
-  You can still deactivate security in the BPDM apps for testing or development purposes though.
+You can still deactivate security in the BPDM apps for testing or development purposes though.
 - BPDM Pool: Fix Pool trying to update golden records which the golden record process indicated to have no changes
 - BPDM Orchestrator: The business partner data for golden record process tasks has been completely overhauled.
-  Now business partner data is clearly divided into `uncategorized`, `legal entity`, `site` and `additonal address` data.
-  This model is less verbose and contains less duplicate data.
-  Additionally, both Pool and Gate can write and read from it making it unnecessary for a cleaning service to provide the data in two different models.
+Now business partner data is clearly divided into `uncategorized`, `legal entity`, `site` and `additonal address` data.
+This model is less verbose and contains less duplicate data.
+Additionally, both Pool and Gate can write and read from it making it unnecessary for a cleaning service to provide the data in two different models.
 
 
 
@@ -192,7 +193,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: New business partner type 'GENERIC' for changelog
 - BPDM Gate: New business partner type 'GENERIC' for sharing state
 - Workflows: Trivy now targets the latest alpha Docker image instead of the latest release version
-- Apps: Increase projectreactor.netty version to fix Trivy vulnerability
+- Apps: Increase projectreactor.netty version to fix Trivy vulnerability 
 
 
 ## [4.0.1] - 2023-08-28
@@ -230,8 +231,8 @@ Please create a back-up of your business partner data before updating.
 - BPDM: Umbrella Chart with BPDM Bridge Dummy.
 
 ### Fixed
-- BPDM: Deprecated endpoints for retrieving business partners in legacy format.
-- Endpoint for retrieving changelog entries has now improved filtering (breaking API change)
+  - BPDM: Deprecated endpoints for retrieving business partners in legacy format.
+  - Endpoint for retrieving changelog entries has now improved filtering (breaking API change)
 
 ## [3.2.2] - 2023-05-12
 
@@ -275,7 +276,7 @@ Please create a back-up of your business partner data before updating.
 
 ### Fixed
 
-- BPDM Gate: For a business partner with a child relation, this relation could be returned as parent relation erroneously.
+- BPDM Gate: For a business partner with a child relation, this relation could be returned as parent relation erroneously. 
 - BPDM Gate: When a business partner with a child relation was updated, this relation was erroneously deleted, rendering the previous child invalid.
 
 ## [3.0.3] - 2023-02-23

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/ExpectedBusinessPartnerResultFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/ExpectedBusinessPartnerResultFactory.kt
@@ -116,7 +116,7 @@ class ExpectedBusinessPartnerResultFactory(
             mainAddress = mapToExpectedResult(
                 givenRequest.site.mainAddress,
                 givenBpnA,
-                null,
+                givenRequest.bpnlParent,
                 givenBpnS,
                 AddressType.SiteMainAddress,
                 isCatenaXMemberData,
@@ -164,7 +164,7 @@ class ExpectedBusinessPartnerResultFactory(
         return mapToExpectedResult(
             givenRequest = givenRequest.site.mainAddress,
             givenBpnA = givenBpnA,
-            bpnLegalEntity = null,
+            bpnLegalEntity = givenRequest.bpnlParent,
             bpnSite = bpnSite,
             addressType = AddressType.SiteMainAddress,
             isCatenaXMemberData = isCatenaXMemberData,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -125,7 +125,7 @@ fun AddressStateDb.toDto(): AddressStateVerboseDto {
 fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
     return LogisticAddressVerboseDto(
         bpna = bpn,
-        bpnLegalEntity = legalEntity.takeIf { site == null }?.bpn,
+        bpnLegalEntity = legalEntity?.bpn,
         bpnSite = site?.bpn,
         createdAt = createdAt,
         updatedAt = updatedAt,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteControllerIT.kt
@@ -124,6 +124,7 @@ class SiteControllerIT @Autowired constructor(
             site = BusinessPartnerVerboseValues.site1.copy(bpnLegalEntity = bpnL),
             mainAddress = BusinessPartnerVerboseValues.addressPartner1.copy(
                 addressType = AddressType.SiteMainAddress,
+                bpnLegalEntity = bpnL,
                 bpnSite = BusinessPartnerVerboseValues.site1.bpns
             )
         )
@@ -131,6 +132,7 @@ class SiteControllerIT @Autowired constructor(
             site = BusinessPartnerVerboseValues.site2.copy(bpnLegalEntity = bpnL),
             mainAddress = BusinessPartnerVerboseValues.addressPartner2.copy(
                 addressType = AddressType.SiteMainAddress,
+                bpnLegalEntity = bpnL,
                 bpnSite = BusinessPartnerVerboseValues.site2.bpns
             )
         )
@@ -177,6 +179,7 @@ class SiteControllerIT @Autowired constructor(
                 site = BusinessPartnerVerboseValues.site1.copy(bpnLegalEntity = bpnL1),
                 mainAddress = BusinessPartnerVerboseValues.addressPartner1.copy(
                     addressType = AddressType.SiteMainAddress,
+                    bpnLegalEntity = bpnL1,
                     bpnSite = BusinessPartnerVerboseValues.site1.bpns
                 )
             )
@@ -185,6 +188,7 @@ class SiteControllerIT @Autowired constructor(
                 site = BusinessPartnerVerboseValues.site2.copy(bpnLegalEntity = bpnL1),
                 mainAddress = BusinessPartnerVerboseValues.addressPartner2.copy(
                     addressType = AddressType.SiteMainAddress,
+                    bpnLegalEntity = bpnL1,
                     bpnSite = BusinessPartnerVerboseValues.site2.bpns
                 )
             )
@@ -193,6 +197,7 @@ class SiteControllerIT @Autowired constructor(
                 site = BusinessPartnerVerboseValues.site3.copy(bpnLegalEntity = bpnL2),
                 mainAddress = BusinessPartnerVerboseValues.addressPartner3.copy(
                     addressType = AddressType.SiteMainAddress,
+                    bpnLegalEntity = bpnL2,
                     bpnSite = BusinessPartnerVerboseValues.site3.bpns
                 )
             )
@@ -520,6 +525,7 @@ class SiteControllerIT @Autowired constructor(
         val legalAddress1: LogisticAddressVerboseDto =
             BusinessPartnerVerboseValues.addressPartner1.copy(
                 addressType = AddressType.SiteMainAddress,
+                bpnLegalEntity = bpnL1,
                 bpnSite = BusinessPartnerVerboseValues.site1.bpns,
                 bpna = BusinessPartnerVerboseValues.secondBpnA
             )
@@ -528,6 +534,7 @@ class SiteControllerIT @Autowired constructor(
         val legalAddress2: LogisticAddressVerboseDto =
             BusinessPartnerVerboseValues.addressPartner2.copy(
                 addressType = AddressType.SiteMainAddress,
+                bpnLegalEntity = bpnL1,
                 bpnSite = BusinessPartnerVerboseValues.site2.bpns,
                 bpna = BusinessPartnerVerboseValues.thirdBpnA
             )
@@ -555,6 +562,7 @@ class SiteControllerIT @Autowired constructor(
                 SitePartnerCreateVerboseDto::site.name + "." + SiteVerboseDto::bpnLegalEntity.name,
                 SitePartnerCreateVerboseDto::mainAddress.name + "." + LogisticAddressVerboseDto::bpna.name,
                 SitePartnerCreateVerboseDto::mainAddress.name + "." + LogisticAddressVerboseDto::bpnSite.name,
+                SitePartnerCreateVerboseDto::mainAddress.name + "." + LogisticAddressVerboseDto::bpnLegalEntity.name,
                 SitePartnerCreateVerboseDto::index.name
             )
             .isEqualTo(expected)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionServiceTest.kt
@@ -618,7 +618,7 @@ class TaskResolutionServiceTest @Autowired constructor(
         assertThat(createResult[0].errors).hasSize(0)
         assertThat(createdLeAddress.name).isEqualTo(createSiteRequest.legalEntity.legalAddress.addressName)
         compareLogisticAddress(createdAdditionalAddress, createResult[0].businessPartner.additionalAddress)
-        assertThat(createdAdditionalAddress.bpnLegalEntity).isNull()
+        assertThat(createdAdditionalAddress.bpnLegalEntity).isEqualTo(createResult[0].businessPartner.legalEntity.bpnReference.referenceValue)
         assertThat(createdAdditionalAddress.bpnSite).isEqualTo(createResult[0].businessPartner.site?.bpnReference?.referenceValue)
         assertThat(createdAdditionalAddress.addressType == AddressType.AdditionalAddress).isTrue()
     }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request updates associated legal entity BPNL details for address of any type with attribute `bpnLegalEntity `. 

Fixes #1191

To test the functionality, I recommend the following way:
1.  Setup golden record process or have pool service running
2. Create legal entity with site and addresses (Legal address, Site main address and Additional Address)
3. Query address with generated bpna
4. You should see legal entity bpnl associated  for particular address in value of attribute  `bpnLegalEntity `.

I have also updated current unit tests in same pull request.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
