### PR TITLE
docs(DEPENDENCIES): update with approved cucumber dependencies

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -45,23 +45,23 @@ maven/mavencentral/commons-io/commons-io/2.18.0, Apache-2.0, approved, #17366
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/commons-logging/commons-logging/1.3.4, Apache-2.0, approved, #11783
 maven/mavencentral/io.cucumber/ci-environment/10.0.1, MIT, approved, #15218
-maven/mavencentral/io.cucumber/cucumber-core/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/cucumber-expressions/18.0.1, MIT, approved, clearlydefined
-maven/mavencentral/io.cucumber/cucumber-gherkin-messages/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/cucumber-gherkin/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/cucumber-java/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/cucumber-junit/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/cucumber-plugin/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/cucumber-spring/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/datatable/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/docstring/7.21.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/gherkin/31.0.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/html-formatter/21.9.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/junit-xml-formatter/0.7.1, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/messages/27.2.0, , restricted, clearlydefined
-maven/mavencentral/io.cucumber/query/13.2.0, , restricted, clearlydefined
+maven/mavencentral/io.cucumber/cucumber-core/7.21.0, MIT AND (Apache-2.0 AND MIT), approved, #19276
+maven/mavencentral/io.cucumber/cucumber-expressions/18.0.1, MIT, approved, #19277
+maven/mavencentral/io.cucumber/cucumber-gherkin-messages/7.21.0, MIT, approved, #19279
+maven/mavencentral/io.cucumber/cucumber-gherkin/7.21.0, MIT, approved, #19280
+maven/mavencentral/io.cucumber/cucumber-java/7.21.0, MIT, approved, #19281
+maven/mavencentral/io.cucumber/cucumber-junit/7.21.0, MIT, approved, #19282
+maven/mavencentral/io.cucumber/cucumber-plugin/7.21.0, MIT, approved, #19283
+maven/mavencentral/io.cucumber/cucumber-spring/7.21.0, MIT, approved, #19284
+maven/mavencentral/io.cucumber/datatable/7.21.0, MIT, approved, #19285
+maven/mavencentral/io.cucumber/docstring/7.21.0, MIT, approved, #19286
+maven/mavencentral/io.cucumber/gherkin/31.0.0, MIT, approved, #19287
+maven/mavencentral/io.cucumber/html-formatter/21.9.0, Apache-2.0 AND MIT, approved, #19288
+maven/mavencentral/io.cucumber/junit-xml-formatter/0.7.1, MIT, approved, #19289
+maven/mavencentral/io.cucumber/messages/27.2.0, MIT, approved, #19290
+maven/mavencentral/io.cucumber/query/13.2.0, MIT, approved, #19291
 maven/mavencentral/io.cucumber/tag-expressions/6.1.2, MIT AND (BSD-3-Clause AND MIT) AND BSD-3-Clause, approved, #14277
-maven/mavencentral/io.cucumber/testng-xml-formatter/0.3.1, , restricted, clearlydefined
+maven/mavencentral/io.cucumber/testng-xml-formatter/0.3.1, MIT, approved, #19292
 maven/mavencentral/io.github.microutils/kotlin-logging-jvm/3.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.micrometer/micrometer-commons/1.14.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #17272
 maven/mavencentral/io.micrometer/micrometer-core/1.14.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #17271


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Updating the DEPENDENCIES file to the newest state. Formerly restricted cucumber dependencies are now approved.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Contributes to quality checks #1203
Contributes to #1202 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
