### PR TITLE
fix(bpdm-system-tester): update cumcumber feature file to generate new partner data

### DIFF
--- a/bpdm-system-tester/src/main/resources/cucumber/share_generic_business_partner.feature
+++ b/bpdm-system-tester/src/main/resources/cucumber/share_generic_business_partner.feature
@@ -5,18 +5,18 @@ Feature: Share own company business partner data without BPNs
     Then the sharing member receives output "CC_SHG_UWAT_2" with external-ID "CC_SHG_UWAT" with address type "LegalAndSiteMainAddress"
 
   Scenario: Share Without Address Type
-    When the sharing member uploads full valid input "CC_SHG_WAT" with external-ID "CC_SHG_WAT" without address type
-    Then the sharing member receives output "CC_SHG_WAT" with external-ID "CC_SHG_WAT" with address type "LegalAndSiteMainAddress"
+    When the sharing member uploads full valid input "CC_SHG_WAT_0" with external-ID "CC_SHG_WAT_0" without address type
+    Then the sharing member receives output "CC_SHG_WAT_0" with external-ID "CC_SHG_WAT_0" with address type "LegalAndSiteMainAddress"
 
   Scenario Outline: Share With Address Type
-    When the sharing member uploads full valid input "CC_SHG_WAT" with external-ID "<externalId>" with address type "<inputAddressType>"
-    Then the sharing member receives output "CC_SHG_WAT" with external-ID "<externalId>" with address type "<outputAddressType>"
+    When the sharing member uploads full valid input "<externalId>" with external-ID "<externalId>" with address type "<inputAddressType>"
+    Then the sharing member receives output "<externalId>" with external-ID "<externalId>" with address type "<outputAddressType>"
 
     Examples:
       | externalId   | inputAddressType           | outputAddressType          |
       | CC_SHG_WAT_1 | LegalAndSiteMainAddress    | LegalAndSiteMainAddress    |
       | CC_SHG_WAT_2 | LegalAddress               | LegalAndSiteMainAddress    |
-      | CC_SHG_WAT_3 | SiteMainAddress            | LegalAndSiteMainAddress    |
+      | CC_SHG_WAT_3 | SiteMainAddress            | SiteMainAddress            |
       | CC_SHG_WAT_4 | AdditionalAddress          | AdditionalAddress          |
 
   Scenario Outline: Share With Missing or Invalid data


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request fixes issue we were facing while performing E2E tests, as there was same business partner data being checked again and again during step execution which was resulting into unpredicted address type for golden records.
From now on, new business partner data will inserted every time while performing step execution.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
