### PR TITLE
build(deps): overwrite netty-handler version to fix vulnerability

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -80,7 +80,7 @@ maven/mavencentral/io.netty/netty-codec-socks/4.1.117.Final, Apache-2.0 AND BSD-
 maven/mavencentral/io.netty/netty-codec/4.1.117.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-common/4.1.117.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
 maven/mavencentral/io.netty/netty-handler-proxy/4.1.117.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.117.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.118.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.117.Final, Apache-2.0, approved, #6367
 maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.117.Final, Apache-2.0, approved, #7004
 maven/mavencentral/io.netty/netty-resolver-dns/4.1.117.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926

--- a/pom.xml
+++ b/pom.xml
@@ -175,10 +175,17 @@
             </dependency>
             <!-- overwrite with newer version to fix vulnerability  -->
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.118.Final</version>
+            </dependency>
+            <!-- overwrite with newer version to fix vulnerability  -->
+            <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
                 <version>${json-smart.version}</version>
             </dependency>
+
 
             <!-- Test -->
             <dependency>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request overwrites the netty-handler dependency version referenced by the spring boot framework in order to fix a  vulnerability. Since Spring boot has no newer reference available we manually bump the version of this dependency by overwrite in the pom. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

#1225

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
