### PR TITLE
fix(Gate): golden record Pool update process

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
@@ -222,7 +222,7 @@ class GoldenRecordUpdateChunkService(
             legalEntityBpn = bpnL ?: throw createMappingException(BusinessPartnerDb::bpnL, id),
             siteBpn = bpnS,
             addressBpn = bpnA ?: throw createMappingException(BusinessPartnerDb::bpnA, id),
-            legalName = legalName ?: throw createMappingException(BusinessPartnerDb::legalName, id),
+            legalName = legalName,
             legalForm = legalForm,
             shortName = shortName,
             siteName = siteName,


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the golden record Pool update process breaking on business partner output data without legal names.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1227

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
