### PR TITLE
refactor: BPDM apps now create Open-API documents in pretty JSON

### DIFF
--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -221,6 +221,8 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 springdoc:
+    # Api document should be in pretty JSON
+    writer-with-default-pretty-printer: true
     api-docs:
       # Generate Open-API document
       enabled: true

--- a/bpdm-orchestrator/src/main/resources/application.yml
+++ b/bpdm-orchestrator/src/main/resources/application.yml
@@ -141,6 +141,8 @@ management:
       # Include readiness state in health response (ready to accept traffic)
       enabled: true
 springdoc:
+  # Api document should be in pretty JSON
+  writer-with-default-pretty-printer: true
   api-docs:
     # Generate Open-API document
     enabled: true

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -188,6 +188,8 @@ spring:
         order_inserts: true
         order_updates: true
 springdoc:
+  # Api document should be in pretty JSON
+  writer-with-default-pretty-printer: true
   api-docs:
     # Generate Open-API document
     enabled: true


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request enables pretty print of the OpenApi specification for BPDM services.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
