### PR TITLE
fix: Open-API docs in YAML format being authenticated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Pool: Fix not returning the most-up-to-date legal and site main address when it has been modified by an update to the site ([#1209](https://github.com/eclipse-tractusx/bpdm/issues/1209))
 - BPDM Pool: Add check for correct LSA parent hierarchy when consuming golden record tasks ([#1230](https://github.com/eclipse-tractusx/bpdm/issues/1230))
 - BPDM Apps: Fix Open-API specification not having scopes property in clientCredentials flow ([#1234](https://github.com/eclipse-tractusx/bpdm/issues/1234))
+- BPDM Apps: Fix access rights for the Open-API documents in YAML format ([#1237](https://github.com/eclipse-tractusx/bpdm/issues/1237))
 
 ## [6.2.0] - 2024-11-28
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/SecurityConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/SecurityConfig.kt
@@ -92,6 +92,7 @@ class OAuthSecurityConfig(
             it.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.OPTIONS, "/**")).permitAll()
             it.requestMatchers(AntPathRequestMatcher.antMatcher("/")).permitAll() // forwards to swagger
             it.requestMatchers(AntPathRequestMatcher.antMatcher("/docs/api-docs/**")).permitAll()
+            it.requestMatchers(AntPathRequestMatcher.antMatcher("/docs/api-docs.yaml/**")).permitAll()
             it.requestMatchers(AntPathRequestMatcher.antMatcher("/ui/swagger-ui/**")).permitAll()
             it.requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health/**")).permitAll()
             it.requestMatchers(AntPathRequestMatcher.antMatcher("/error")).permitAll()


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request now allows also unauthenticated users to access the YAML Open-API docs on the Swagger-UI of BPDM apps.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes #1237

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
