### PR TITLE
fix(bpdm-gate): added missing value for externalSequenceTimestamp attribute in response

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/BusinessPartnerMappings.kt
@@ -47,6 +47,7 @@ class BusinessPartnerMappings {
             legalEntity = toLegalEntityComponentInputDto(entity),
             site = toSiteComponentInputDto(entity),
             address = toAddressComponentInputDto(entity),
+            externalSequenceTimestamp = entity.externalSequenceTimestamp,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt
         )
@@ -79,6 +80,7 @@ class BusinessPartnerMappings {
             legalEntity = toLegalEntityComponentOutputDto(entity),
             site = toSiteComponentOutputDto(entity),
             address = toAddressComponentOutputDto(entity),
+            externalSequenceTimestamp = entity.externalSequenceTimestamp,
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt
         )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request adds missing value for `externalSequenceTimestamp` attribute in Gate input response. 

Fixes #1245 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
