### PR TITLE
test(Pool): fix how additional addresses of sites are compared

### DIFF
--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/PoolAssertHelper.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/PoolAssertHelper.kt
@@ -105,7 +105,8 @@ class PoolAssertHelper(
         creationTimeframe: Timeframe,
         updateTimeframe: Timeframe = creationTimeframe
     ) {
-        Assertions.assertThat(actual.first())
+
+        Assertions.assertThat(actual)
             .usingRecursiveComparison()
             .ignoringCollectionOrder()
             .ignoringAllOverriddenEquals()
@@ -117,7 +118,9 @@ class PoolAssertHelper(
             .withComparatorForType(instantSecondsComparator, Instant::class.java)
             .withComparatorForType(localDatetimeSecondsComparator, LocalDateTime::class.java)
             .withComparatorForType(stringIgnoreComparator, String::class.java)
-            .isEqualTo(expected.first())
+            .isEqualTo(expected)
+
+
 
         actual.forEach { Assertions.assertThat(it.createdAt).isBetween(creationTimeframe.startTime, creationTimeframe.endTime) }
         actual.forEach { Assertions.assertThat(it.updatedAt).isBetween(updateTimeframe.startTime, updateTimeframe.endTime) }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes test assertion logic for how additional addresses of sites are compared.

Beforehand, on querying addresses the addresses' parent BPNL was not expected to be set if the address is an additional address of a site.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
