### PR TITLE
build(release-25.03): BPDM 6.3.0 & BPDM Charts 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/CHANGELOG.md) of the charts directly.
 
-## [6.3.0] - tbd
+## [6.3.0] - 2025-03-06
 
 ### Added
 

--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [5.3.0] -  tbd
+## [5.3.0] -  2025-03-06
 
 ### Changed
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 5.3.0-SNAPSHOT
-appVersion: "6.3.0-SNAPSHOT"
+version: 5.3.0
+appVersion: "6.3.0"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,23 +33,23 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 6.3.0-SNAPSHOT
+    version: 6.3.0
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 7.3.0-SNAPSHOT
+    version: 7.3.0
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 3.3.0-SNAPSHOT
+    version: 3.3.0
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 3.3.0-SNAPSHOT
+    version: 3.3.0
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common
-    version: 1.0.3-SNAPSHOT
+    version: 1.0.3
   - name: postgresql
     version: 12.12.10
     repository: https://charts.bitnami.com/bitnami

--- a/charts/bpdm/README.md
+++ b/charts/bpdm/README.md
@@ -1,6 +1,6 @@
 # bpdm
 
-![Version: 5.3.0-rc3](https://img.shields.io/badge/Version-5.3.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0-rc3](https://img.shields.io/badge/AppVersion-6.3.0--rc3-informational?style=flat-square)
+![Version: 5.3.0](https://img.shields.io/badge/Version-5.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0](https://img.shields.io/badge/AppVersion-6.3.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes that deploys the BPDM applications
 
@@ -21,11 +21,11 @@ A Helm chart for Kubernetes that deploys the BPDM applications
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | bpdm-cleaning-service-dummy(bpdm-cleaning-service-dummy) | 3.3.0-rc3 |
-|  | bpdm-common | 1.0.3-rc3 |
-|  | bpdm-gate(bpdm-gate) | 6.3.0-rc3 |
-|  | bpdm-orchestrator(bpdm-orchestrator) | 3.3.0-rc3 |
-|  | bpdm-pool(bpdm-pool) | 7.3.0-rc3 |
+|  | bpdm-cleaning-service-dummy(bpdm-cleaning-service-dummy) | 3.3.0 |
+|  | bpdm-common | 1.0.3 |
+|  | bpdm-gate(bpdm-gate) | 6.3.0 |
+|  | bpdm-orchestrator(bpdm-orchestrator) | 3.3.0 |
+|  | bpdm-pool(bpdm-pool) | 7.3.0 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.0.1 |
 

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [3.3.0] - tbd
+## [3.3.0] - 2025-03-06
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,15 +21,15 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "6.3.0-SNAPSHOT"
-version: 3.3.0-SNAPSHOT
+appVersion: "6.3.0"
+version: 3.3.0
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.3-SNAPSHOT
+    version: 1.0.3
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 4.0.0

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
@@ -1,6 +1,6 @@
 # bpdm-cleaning-service-dummy
 
-![Version: 3.3.0-rc3](https://img.shields.io/badge/Version-3.3.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0-rc3](https://img.shields.io/badge/AppVersion-6.3.0--rc3-informational?style=flat-square)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0](https://img.shields.io/badge/AppVersion-6.3.0-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM cleaning service
 
@@ -21,7 +21,7 @@ A Helm chart for deploying the BPDM cleaning service
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../bpdm-common | bpdm-common | 1.0.3-rc3 |
+| file://../bpdm-common | bpdm-common | 1.0.3 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.0.0 |
 
 ## Values

--- a/charts/bpdm/charts/bpdm-common/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-common/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [1.0.3] - tbd
+## [1.0.3] - 2025-03-06
 
 ### Changed
 

--- a/charts/bpdm/charts/bpdm-common/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-common/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: library
 name: bpdm-common
-version: 1.0.3-SNAPSHOT
+version: 1.0.3
 description: A library Helm Chart for other BPDM Charts
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-gate/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [6.3.0] - tbd
+## [6.3.0] - 2025-03-06
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "6.3.0-SNAPSHOT"
-version: 6.3.0-SNAPSHOT
+appVersion: "6.3.0"
+version: 6.3.0
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.3-SNAPSHOT
+    version: 1.0.3
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 4.0.0

--- a/charts/bpdm/charts/bpdm-gate/README.md
+++ b/charts/bpdm/charts/bpdm-gate/README.md
@@ -1,6 +1,6 @@
 # bpdm-gate
 
-![Version: 6.3.0-rc3](https://img.shields.io/badge/Version-6.3.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0-rc3](https://img.shields.io/badge/AppVersion-6.3.0--rc3-informational?style=flat-square)
+![Version: 6.3.0](https://img.shields.io/badge/Version-6.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0](https://img.shields.io/badge/AppVersion-6.3.0-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM gate service
 
@@ -21,7 +21,7 @@ A Helm chart for deploying the BPDM gate service
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../bpdm-common | bpdm-common | 1.0.3-rc3 |
+| file://../bpdm-common | bpdm-common | 1.0.3 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.0.0 |
 

--- a/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [3.3.0] - tbd
+## [3.3.0] - 2025-03-06
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,15 +21,15 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "6.3.0-SNAPSHOT"
-version: 3.3.0-SNAPSHOT
+appVersion: "6.3.0"
+version: 3.3.0
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.3-SNAPSHOT
+    version: 1.0.3
     repository: "file://../bpdm-common"
   - name: postgresql
     version: 12.12.10

--- a/charts/bpdm/charts/bpdm-orchestrator/README.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/README.md
@@ -1,6 +1,6 @@
 # bpdm-orchestrator
 
-![Version: 3.3.0-rc3](https://img.shields.io/badge/Version-3.3.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0-rc3](https://img.shields.io/badge/AppVersion-6.3.0--rc3-informational?style=flat-square)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0](https://img.shields.io/badge/AppVersion-6.3.0-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM Orchestrator service
 
@@ -21,7 +21,7 @@ A Helm chart for deploying the BPDM Orchestrator service
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../bpdm-common | bpdm-common | 1.0.3-rc3 |
+| file://../bpdm-common | bpdm-common | 1.0.3 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.0.0 |
 

--- a/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
+++ b/charts/bpdm/charts/bpdm-pool/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
-## [7.3.0] - tbd
+## [7.3.0] - 2025-03-06
 
 - Increase appversion to 6.3.0
 - update Central-IDP dependency to 4.0.0 [#1145](https://github.com/eclipse-tractusx/bpdm/pull/1145)

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "6.3.0-SNAPSHOT"
-version: 7.3.0-SNAPSHOT
+appVersion: "6.3.0"
+version: 7.3.0
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.3-SNAPSHOT
+    version: 1.0.3
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 4.0.0

--- a/charts/bpdm/charts/bpdm-pool/README.md
+++ b/charts/bpdm/charts/bpdm-pool/README.md
@@ -1,6 +1,6 @@
 # bpdm-pool
 
-![Version: 7.3.0-rc3](https://img.shields.io/badge/Version-7.3.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0-rc3](https://img.shields.io/badge/AppVersion-6.3.0--rc3-informational?style=flat-square)
+![Version: 7.3.0](https://img.shields.io/badge/Version-7.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0](https://img.shields.io/badge/AppVersion-6.3.0-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM pool service
 
@@ -21,7 +21,7 @@ A Helm chart for deploying the BPDM pool service
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../bpdm-common | bpdm-common | 1.0.3-rc3 |
+| file://../bpdm-common | bpdm-common | 1.0.3 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.0.0 |
 

--- a/docs/api/gate.json
+++ b/docs/api/gate.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "Business Partner Data Management Gate",
     "description" : "A gate for a member to share business partner data with CatenaX",
-    "version" : "6.3.0-rc3"
+    "version" : "6.3.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8081",

--- a/docs/api/gate.yaml
+++ b/docs/api/gate.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Business Partner Data Management Gate
   description: A gate for a member to share business partner data with CatenaX
-  version: 6.3.0-rc3
+  version: 6.3.0
 servers:
 - url: http://localhost:8081
   description: Generated server url

--- a/docs/api/orchestrator.json
+++ b/docs/api/orchestrator.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "Business Partner Data Management Orchestrator",
     "description" : "Orchestrator component acts as a passive component and offers for each processing steps individual endpoints",
-    "version" : "6.3.0-rc3"
+    "version" : "6.3.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8085",

--- a/docs/api/orchestrator.yaml
+++ b/docs/api/orchestrator.yaml
@@ -3,7 +3,7 @@ info:
   title: Business Partner Data Management Orchestrator
   description: Orchestrator component acts as a passive component and offers for each
     processing steps individual endpoints
-  version: 6.3.0-rc3
+  version: 6.3.0
 servers:
 - url: http://localhost:8085
   description: Generated server url

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "Business Partner Data Management Pool",
     "description" : "Service that manages and shares business partner data with other CatenaX services",
-    "version" : "6.3.0-rc3"
+    "version" : "6.3.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8080",

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -3,7 +3,7 @@ info:
   title: Business Partner Data Management Pool
   description: Service that manages and shares business partner data with other CatenaX
     services
-  version: 6.3.0-rc3
+  version: 6.3.0
 servers:
 - url: http://localhost:8080
   description: Generated server url

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </modules>
 
     <properties>
-        <revision>6.3.0-SNAPSHOT</revision>
+        <revision>6.3.0</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request releases Catena-X 25.03 version  for BPDM App 6.3.0 and BPDM Chart 5.3.0.

Also updated below with new release version,

- Helm chart documents
- Api documents

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
