### PR TITLE
cicd(Workflows): remove OS vulnerabilities from trivy pull request check

### DIFF
--- a/.github/workflows/app-test-trivy.yaml
+++ b/.github/workflows/app-test-trivy.yaml
@@ -53,3 +53,4 @@ jobs:
           exit-code: "1"
           severity: "CRITICAL,HIGH"
           timeout: 15m
+          vuln-type: library


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request limits the trivy check during the pull request to not report OS related vulnerabilities.

Since OS vulnerabilities come from the actual base image (we do not add any packages or other modifications to the OS) we are unable to fix any such vulnerabilties per TRG. Therefore, it is a good idea to remove the reporting of such vulnerabilties and rather limit it to JAVA vulnerabilties which we can in fact fix.

NOTE, for transparency we keep the the reporting of OS issues in the scheduled trivy check on main.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
