### PR TITLE
feat(Gate): add 'IsAlternativeHeadquarterFor' relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Orchestrator: New POST api endpoint to reserve relations golden record tasks waiting in the given step queue. ([#1274](https://github.com/eclipse-tractusx/bpdm/issues/1274))
 - BPDM Orchestrator: New POST api endpoint to post step results for reserved relations golden record tasks in the given step queue. ([#1274](https://github.com/eclipse-tractusx/bpdm/issues/1274))
 - BPDM Orchestrator: New GET api endpoint to retrieve event log of relations golden record tasks that have finished processing. ([#1274](https://github.com/eclipse-tractusx/bpdm/issues/1274))
+- BPDM Gate: Added relation type IsAlternativeHeadquarterFor ([1286](https://github.com/eclipse-tractusx/bpdm/issues/1286))
 
 ### Changed
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/model/BaseEntity.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/model/BaseEntity.kt
@@ -62,5 +62,5 @@ abstract class BaseEntity(
 
     @Column(nullable = false, name = "UPDATED_AT")
     @UpdateTimestamp
-    val updatedAt: Instant = Instant.now().truncatedTo(ChronoUnit.MICROS)
+    var updatedAt: Instant = Instant.now().truncatedTo(ChronoUnit.MICROS)
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/RelationType.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/RelationType.kt
@@ -20,5 +20,6 @@
 package org.eclipse.tractusx.bpdm.gate.api.model
 
 enum class RelationType {
-    IsManagedBy
+    IsManagedBy,
+    IsAlternativeHeadquarterFor
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationDb.kt
@@ -29,7 +29,7 @@ import org.eclipse.tractusx.bpdm.gate.api.model.RelationType
 @Table(name = "business_partner_relations",
     uniqueConstraints = [
         UniqueConstraint(name = "uc_business_partner_relations_external_id_stage_tenant", columnNames = ["external_id, stage, tenant_bpnl"]),
-        UniqueConstraint(name = "uc_business_partner_relations_source_target", columnNames = ["source_sharing_state_id", "target_sharing_state_id"])
+        UniqueConstraint(name = "uc_source_target_relation_type", columnNames = ["source_sharing_state_id", "target_sharing_state_id, relation_type"])
     ]
 )
 class RelationDb(

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationConstraintProvider.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationConstraintProvider.kt
@@ -37,9 +37,21 @@ class RelationConstraintProvider: IRelationConstraintProvider {
         multipleTargetsAllowed = false
     )
 
+    private val isAlternativeHeadquarterForConstraints = IRelationConstraintProvider.RelationTypeConstraints(
+        selfRelateAllowed = false,
+        sourceMustBeOwnCompanyData = false,
+        targetMustBeOwnCompanyData = false,
+        sourceAllowedTypes = setOf(BusinessPartnerType.LEGAL_ENTITY),
+        targetAllowedTypes = setOf(BusinessPartnerType.LEGAL_ENTITY),
+        sourceCanBeTarget = true,
+        multipleSourcesAllowed = true,
+        multipleTargetsAllowed = true
+    )
+
     override fun getConstraints(relationType: RelationType): IRelationConstraintProvider.RelationTypeConstraints {
         return when(relationType){
             RelationType.IsManagedBy -> isManagedByConstraints
+            RelationType.IsAlternativeHeadquarterFor -> isAlternativeHeadquarterForConstraints
         }
     }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationService.kt
@@ -197,6 +197,7 @@ class RelationService(
             businessPartnerSourceExternalId = sourceBusinessPartnerExternalId.also { relationship.source = source },
             businessPartnerTargetExternalId = targetBusinessPartnerExternalId.also { relationship.target = target }
         )
+        relationship.updatedAt = Instant.now()
 
         assertValid(relationship)
 

--- a/bpdm-gate/src/main/resources/db/migration/V7_0_0_0__fix_relation_unique_constraint.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V7_0_0_0__fix_relation_unique_constraint.sql
@@ -1,0 +1,5 @@
+ALTER TABLE business_partner_relations
+DROP CONSTRAINT business_partner_relations_source_sharing_state_id_target_s_key;
+
+ALTER TABLE business_partner_relations
+ADD CONSTRAINT uc_source_target_relation_type UNIQUE(source_sharing_state_id, target_sharing_state_id, relation_type);

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthAdminIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthAdminIT.kt
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
@@ -36,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration
     KeyCloakInitializer::class,
     AuthAdminIT.SelfClientAsAdminInitializer::class
 ])
+@ActiveProfiles("test")
 class AuthAdminIT @Autowired constructor(
     gateClient: GateClient,
     authAssertionHelper: AuthAssertionHelper

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputConsumerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputConsumerIT.kt
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
@@ -36,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration
     KeyCloakInitializer::class,
     AuthInputConsumerIT.SelfClientAsInputConsumerInitializer::class
 ])
+@ActiveProfiles("test")
 class AuthInputConsumerIT @Autowired constructor(
     gateClient: GateClient,
     authAssertionHelper: AuthAssertionHelper

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputManagerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthInputManagerIT.kt
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
@@ -36,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration
     KeyCloakInitializer::class,
     AuthInputManagerIT.SelfClientAsInputManagerInitializer::class
 ])
+@ActiveProfiles("test")
 class AuthInputManagerIT @Autowired constructor(
     gateClient: GateClient,
     authAssertionHelper: AuthAssertionHelper

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthOutputConsumerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthOutputConsumerIT.kt
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
@@ -36,6 +37,7 @@ import org.springframework.test.context.ContextConfiguration
     KeyCloakInitializer::class,
     AuthOutputConsumerIT.SelfClientAsInputConsumerInitializer::class
 ])
+@ActiveProfiles("test")
 class AuthOutputConsumerIT @Autowired constructor(
     gateClient: GateClient,
     authAssertionHelper: AuthAssertionHelper

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/NoAuthIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/NoAuthIT.kt
@@ -27,6 +27,7 @@ import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
 import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
@@ -34,6 +35,7 @@ import org.springframework.test.context.ContextConfiguration
     PostgreSQLContextInitializer::class,
     KeyCloakInitializer::class
 ])
+@ActiveProfiles("test")
 class NoAuthIT @Autowired constructor(
     gateClient: GateClient,
     authAssertionHelper: AuthAssertionHelper

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/RelationControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/RelationControllerIT.kt
@@ -1,0 +1,1226 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.controller
+
+import org.assertj.core.api.Assertions
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
+import org.eclipse.tractusx.bpdm.gate.api.model.RelationDto
+import org.eclipse.tractusx.bpdm.gate.api.model.RelationType
+import org.eclipse.tractusx.bpdm.gate.api.model.request.RelationPutEntry
+import org.eclipse.tractusx.bpdm.gate.api.model.request.RelationPutRequest
+import org.eclipse.tractusx.bpdm.gate.api.model.request.RelationSearchRequest
+import org.eclipse.tractusx.bpdm.gate.util.MockAndAssertUtils
+import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.testdata.gate.GateInputFactory
+import org.eclipse.tractusx.bpdm.test.testdata.gate.withAddressType
+import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
+import org.eclipse.tractusx.bpdm.test.util.Timeframe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest
+import java.time.Instant
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = [
+    PostgreSQLContextInitializer::class,
+    KeyCloakInitializer::class,
+    SelfClientAsPartnerUploaderInitializer::class
+])
+@ActiveProfiles("test")
+class RelationControllerIT @Autowired constructor(
+    private val gateClient: GateClient,
+    private val testHelpers: DbTestHelpers,
+    private val inputFactory: GateInputFactory,
+    private val mockAndAssertUtils: MockAndAssertUtils
+){
+
+    var testName: String = ""
+
+    @BeforeEach
+    fun beforeEach(testInfo: TestInfo) {
+        testHelpers.truncateDbTables()
+        testName = testInfo.displayName
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelation(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        val beforeCreation = Instant.now()
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val beforeUpdate = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = false,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId3,
+                businessPartnerTargetExternalId = legalEntityId4
+            )
+        )
+        val afterUpdate = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = relationId,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId3,
+            businessPartnerTargetExternalId = legalEntityId4,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(
+            actual = response,
+            expectation = expectation,
+            updateTimeframe = Timeframe(beforeUpdate, afterUpdate),
+            createTimeframe = Timeframe(beforeCreation, afterCreation),
+            ignoreExternalId = false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelationWithLegalAndSiteMainAddress(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1).withAddressType(AddressType.LegalAndSiteMainAddress),
+            createLegalEntityRequest(legalEntityId2).withAddressType(AddressType.LegalAndSiteMainAddress),
+            createLegalEntityRequest(legalEntityId3).withAddressType(AddressType.LegalAndSiteMainAddress),
+            createLegalEntityRequest(legalEntityId4).withAddressType(AddressType.LegalAndSiteMainAddress)
+        ))
+
+        val beforeCreation = Instant.now()
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val beforeUpdate = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = false,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId3,
+                businessPartnerTargetExternalId = legalEntityId4
+            )
+        )
+        val afterUpdate = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = relationId,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId3,
+            businessPartnerTargetExternalId = legalEntityId4,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(
+            actual = response,
+            expectation = expectation,
+            updateTimeframe = Timeframe(beforeUpdate, afterUpdate),
+            createTimeframe = Timeframe(beforeCreation, afterCreation),
+            ignoreExternalId = false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelationWithTenant(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        val beforeCreation = Instant.now()
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val beforeUpdate = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = false,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId3,
+                businessPartnerTargetExternalId = legalEntityId4
+            )
+        )
+        val afterUpdate = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = relationId,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId3,
+            businessPartnerTargetExternalId = legalEntityId4,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(
+            actual = response,
+            expectation = expectation,
+            updateTimeframe = Timeframe(beforeUpdate, afterUpdate),
+            createTimeframe = Timeframe(beforeCreation, afterCreation),
+            ignoreExternalId = false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelationWithMultipleSources(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId1 = "$testName Relation 1"
+        val relationId2 = "$testName Relation 2"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        val beforeCreation = Instant.now()
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId1,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId2,
+                businessPartnerTargetExternalId = legalEntityId1
+            )
+        )
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId2,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId3,
+                businessPartnerTargetExternalId = legalEntityId1
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val beforeUpdate = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = false,
+            singleUpserRequest(
+                externalId = relationId2,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId4,
+                businessPartnerTargetExternalId = legalEntityId1
+            )
+        )
+        val afterUpdate = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = relationId2,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId4,
+            businessPartnerTargetExternalId = legalEntityId1,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(
+            actual = response,
+            expectation = expectation,
+            updateTimeframe = Timeframe(beforeUpdate, afterUpdate),
+            createTimeframe = Timeframe(beforeCreation, afterCreation),
+            ignoreExternalId = false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelationIdNotExist(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+        )
+        )
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = false,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId1,
+                    businessPartnerTargetExternalId = legalEntityId1
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelationWithSourceEqualsTarget(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = false,
+                singleUpserRequest(
+                    externalId = relationId,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId3,
+                    businessPartnerTargetExternalId = legalEntityId3
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelationWithSourceNotExist(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = false,
+                singleUpserRequest(
+                    externalId = relationId,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = "NOT EXISTS",
+                    businessPartnerTargetExternalId = legalEntityId3
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpdateRelationWithTargetNotExist(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = false,
+                singleUpserRequest(
+                    externalId = relationId,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId3,
+                    businessPartnerTargetExternalId = "NOT EXISTS"
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelation(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2)
+        ))
+
+        val beforePost = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+        val afterPost = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = relationId,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId1,
+            businessPartnerTargetExternalId = legalEntityId2,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(response, expectation, Timeframe(beforePost, afterPost), ignoreExternalId = false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithTenant(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val relationId = "$testName Relation"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2)
+        ))
+
+        val beforePost = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+        val afterPost = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = relationId,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId1,
+            businessPartnerTargetExternalId = legalEntityId2,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(response, expectation, Timeframe(beforePost, afterPost), ignoreExternalId =  false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithMultipleSources(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val relationId1 = "$testName Relation 1"
+        val relationId2 = "$testName Relation 2"
+
+        gateClient.businessParters.upsertBusinessPartnersInput( listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3)
+        ))
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId1,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId2,
+                businessPartnerTargetExternalId = legalEntityId1
+            )
+        )
+
+        val beforePost = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId2,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId3,
+                businessPartnerTargetExternalId = legalEntityId1
+            )
+        )
+        val afterPost = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = relationId2,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId3,
+            businessPartnerTargetExternalId = legalEntityId1,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(response, expectation, Timeframe(beforePost, afterPost), ignoreExternalId = false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithSameId(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+
+        val legalEntities = listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        )
+        gateClient.businessParters.upsertBusinessPartnersInput(legalEntities)
+        val beforeCreate = Instant.now()
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = testName,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId1,
+                businessPartnerTargetExternalId = legalEntityId2
+            )
+        )
+        val afterCreate = Instant.now()
+
+        val beforePut = Instant.now()
+        val response = gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = testName,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId3,
+                businessPartnerTargetExternalId = legalEntityId4
+            )
+        )
+        val afterPut = Instant.now()
+
+        val expectation = RelationDto(
+            externalId = testName,
+            relationType = relationType,
+            businessPartnerSourceExternalId = legalEntityId3,
+            businessPartnerTargetExternalId = legalEntityId4,
+            updatedAt = Instant.now(),
+            createdAt = Instant.now()
+        )
+
+        mockAndAssertUtils.assertRelation(
+            actual = response,
+            expectation = expectation,
+            updateTimeframe = Timeframe(beforePut, afterPut),
+            createTimeframe = Timeframe(beforeCreate, afterCreate),
+            ignoreExternalId = false
+        )
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithSourceSite(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+
+        val legalEntities = listOf(
+            createLegalEntityRequest(legalEntityId1).withAddressType(AddressType.SiteMainAddress),
+            createLegalEntityRequest(legalEntityId2)
+        )
+        gateClient.businessParters.upsertBusinessPartnersInput(legalEntities)
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = true,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId1,
+                    businessPartnerTargetExternalId = legalEntityId2
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithTargetSite(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+
+        val legalEntities = listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2).withAddressType(AddressType.SiteMainAddress)
+        )
+        gateClient.businessParters.upsertBusinessPartnersInput(legalEntities)
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = true,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId1,
+                    businessPartnerTargetExternalId = legalEntityId2
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithSourceAdditionalAddress(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+
+        val legalEntities = listOf(
+            createLegalEntityRequest(legalEntityId1).withAddressType(AddressType.AdditionalAddress),
+            createLegalEntityRequest(legalEntityId2)
+        )
+        gateClient.businessParters.upsertBusinessPartnersInput(legalEntities)
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = true,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId1,
+                    businessPartnerTargetExternalId = legalEntityId2
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithTargetAdditionalAddress(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+
+        val legalEntities = listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2).withAddressType(AddressType.AdditionalAddress)
+        )
+        gateClient.businessParters.upsertBusinessPartnersInput(legalEntities)
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = true,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId1,
+                    businessPartnerTargetExternalId = legalEntityId2
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithSourceEqualsTarget(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        gateClient.businessParters.upsertBusinessPartnersInput(
+            listOf(
+                createLegalEntityRequest(legalEntityId1)
+            )
+        )
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = true,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId1,
+                    businessPartnerTargetExternalId = legalEntityId1
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithSourceNotExist(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        gateClient.businessParters.upsertBusinessPartnersInput(
+            listOf(
+                createLegalEntityRequest(legalEntityId1)
+            )
+        )
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = true,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = "NOT EXIST",
+                    businessPartnerTargetExternalId = legalEntityId1
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun putUpsertRelationWithTargetNotExist(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        gateClient.businessParters.upsertBusinessPartnersInput(
+            listOf(
+                createLegalEntityRequest(legalEntityId1)
+            )
+        )
+
+        Assertions.assertThatExceptionOfType(BadRequest::class.java).isThrownBy {
+            gateClient.relation.put(
+                createIfNotExist = true,
+                singleUpserRequest(
+                    externalId = testName,
+                    relationType = relationType,
+                    businessPartnerSourceExternalId = legalEntityId1,
+                    businessPartnerTargetExternalId = "NOT EXIST"
+                )
+            )
+        }
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun getRelations(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId1 = "$testName Relation1"
+        val relationId2 = "$testName Relation2"
+        val relationId3 = "$testName Relation3"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        val beforeCreation = Instant.now()
+        val postResponse =  gateClient.relation.put(
+            createIfNotExist = true,
+            RelationPutRequest(
+                relations = listOf(
+                    RelationPutEntry(
+                        externalId = relationId1,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId2,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId2,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId3,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId3,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId4,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    )
+                )
+            )
+        )
+
+        val afterCreation = Instant.now()
+
+
+        val response = gateClient.relation.postSearch()
+
+        val expectation = PageDto(3, 1, 0, 3, postResponse.upsertedRelations)
+
+        mockAndAssertUtils.assertRelationPage(response, expectation, Timeframe(beforeCreation, afterCreation))
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun getRelationsViaExternalId(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId1 = "$testName Relation1"
+        val relationId2 = "$testName Relation2"
+        val relationId3 = "$testName Relation3"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        val beforeCreation = Instant.now()
+        val postResponse = gateClient.relation.put(
+            createIfNotExist = true,
+            RelationPutRequest(
+                relations = listOf(
+                    RelationPutEntry(
+                        externalId = relationId1,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId2,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId2,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId3,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId3,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId4,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    )
+                )
+            )
+        )
+
+        val afterCreation = Instant.now()
+
+        val response = gateClient.relation.postSearch(RelationSearchRequest(externalIds = listOf(relationId1, relationId2)))
+
+        val expectedRelations = postResponse.upsertedRelations.filter { it.externalId in listOf(relationId1, relationId2) }
+        val expectation = PageDto(2, 1, 0, 2, expectedRelations )
+
+        mockAndAssertUtils.assertRelationPage(response, expectation, Timeframe(beforeCreation, afterCreation))
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun getRelationsViaRelationType(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId1 = "$testName Relation1"
+        val relationId2 = "$testName Relation2"
+        val relationId3 = "$testName Relation3"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        val beforeCreation = Instant.now()
+        val postResponse = gateClient.relation.put(
+            createIfNotExist = true,
+            RelationPutRequest(
+                relations = listOf(
+                    RelationPutEntry(
+                        externalId = relationId1,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId2,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId2,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId3,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId3,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId4,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    )
+                )
+            )
+        )
+
+        val afterCreation = Instant.now()
+
+        val response = gateClient.relation.postSearch(RelationSearchRequest(relationType = relationType))
+
+        val expectation = PageDto(3, 1, 0, 3, postResponse.upsertedRelations)
+
+        mockAndAssertUtils.assertRelationPage(response, expectation, Timeframe(beforeCreation, afterCreation))
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun getRelationsViaTarget(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val legalEntityId5 = "$testName LE 5"
+        val legalEntityId6 = "$testName LE 6"
+        val relationId1 = "$testName Relation1"
+        val relationId2 = "$testName Relation2"
+        val relationId3 = "$testName Relation3"
+        val relationId4 = "$testName Relation4"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4),
+            createLegalEntityRequest(legalEntityId5),
+            createLegalEntityRequest(legalEntityId6),
+        ))
+
+        val beforeCreation = Instant.now()
+        val postResponse = gateClient.relation.put(
+            createIfNotExist = true,
+            RelationPutRequest(
+                relations = listOf(
+                    RelationPutEntry(
+                        externalId = relationId1,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId2,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId2,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId3,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId3,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId4,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId4,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId5,
+                        businessPartnerTargetExternalId = legalEntityId6
+                    )
+                )
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val response = gateClient.relation.postSearch(RelationSearchRequest(businessPartnerTargetExternalIds = listOf(legalEntityId1)))
+
+        val expectedRelations = postResponse.upsertedRelations.filter { it.externalId in listOf(relationId1, relationId2, relationId3) }
+        val expectation = PageDto(3, 1, 0, 3, expectedRelations )
+
+        mockAndAssertUtils.assertRelationPage(response, expectation, Timeframe(beforeCreation, afterCreation))
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun getRelationsViaSource(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId1 = "$testName Relation1"
+        val relationId2 = "$testName Relation2"
+        val relationId3 = "$testName Relation3"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        val beforeCreation = Instant.now()
+        val postResponse = gateClient.relation.put(
+            createIfNotExist = true,
+            RelationPutRequest(
+                relations = listOf(
+                    RelationPutEntry(
+                        externalId = relationId1,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId2,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId2,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId3,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId3,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId4,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    )
+                )
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val response = gateClient.relation.postSearch(RelationSearchRequest(businessPartnerSourceExternalIds = listOf(legalEntityId2, legalEntityId3)))
+
+        val expectedRelations = postResponse.upsertedRelations.filter { it.externalId in listOf(relationId1, relationId2) }
+        val expectation = PageDto(2, 1, 0, 2, expectedRelations )
+
+        mockAndAssertUtils.assertRelationPage(response, expectation, Timeframe(beforeCreation, afterCreation))
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun getRelationsViaUpdatedAtFrom(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId1 = "$testName Relation1"
+        val relationId2 = "$testName Relation2"
+        val relationId3 = "$testName Relation3"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId1,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId2,
+                businessPartnerTargetExternalId = legalEntityId1
+            )
+        )
+
+        val beforeCreation = Instant.now()
+        val postResponse = gateClient.relation.put(
+            createIfNotExist = true,
+            RelationPutRequest(
+                relations = listOf(
+                    RelationPutEntry(
+                        externalId = relationId2,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId3,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId3,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId4,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    )
+                )
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val response = gateClient.relation.postSearch(RelationSearchRequest(updatedAtFrom = beforeCreation))
+
+        val expectation = PageDto(2, 1, 0, 2, postResponse.upsertedRelations)
+
+        mockAndAssertUtils.assertRelationPage(response, expectation, Timeframe(beforeCreation, afterCreation))
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun getRelationsViaAllFilters(relationType: RelationType){
+        val legalEntityId1 = "$testName LE 1"
+        val legalEntityId2 = "$testName LE 2"
+        val legalEntityId3 = "$testName LE 3"
+        val legalEntityId4 = "$testName LE 4"
+        val relationId1 = "$testName Relation1"
+        val relationId2 = "$testName Relation2"
+        val relationId3 = "$testName Relation3"
+
+        gateClient.businessParters.upsertBusinessPartnersInput(listOf(
+            createLegalEntityRequest(legalEntityId1),
+            createLegalEntityRequest(legalEntityId2),
+            createLegalEntityRequest(legalEntityId3),
+            createLegalEntityRequest(legalEntityId4)
+        ))
+
+        gateClient.relation.put(
+            createIfNotExist = true,
+            singleUpserRequest(
+                externalId = relationId1,
+                relationType = relationType,
+                businessPartnerSourceExternalId = legalEntityId2,
+                businessPartnerTargetExternalId = legalEntityId1
+            )
+        )
+
+        val beforeCreation = Instant.now()
+        val postResponse = gateClient.relation.put(
+            createIfNotExist = true,
+            RelationPutRequest(
+                relations = listOf(
+                    RelationPutEntry(
+                        externalId = relationId2,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId3,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    ),
+                    RelationPutEntry(
+                        externalId = relationId3,
+                        relationType = relationType,
+                        businessPartnerSourceExternalId = legalEntityId4,
+                        businessPartnerTargetExternalId = legalEntityId1
+                    )
+                )
+            )
+        )
+        val afterCreation = Instant.now()
+
+        val response = gateClient.relation.postSearch(
+            RelationSearchRequest(
+                externalIds = listOf(relationId3),
+                relationType = relationType,
+                businessPartnerSourceExternalIds = listOf(legalEntityId4),
+                businessPartnerTargetExternalIds = listOf(legalEntityId1),
+                updatedAtFrom = beforeCreation
+            )
+        )
+
+        val expectedRelations = postResponse.upsertedRelations.filter { it.externalId == relationId3 }
+        val expectation = PageDto(1, 1, 0, 1, expectedRelations)
+
+        mockAndAssertUtils.assertRelationPage(response, expectation, Timeframe(beforeCreation, afterCreation))
+    }
+
+
+
+    private fun createLegalEntityRequest(externalId: String) =
+        inputFactory.createAllFieldsFilled(externalId).request
+            .withAddressType(AddressType.LegalAddress)
+            .copy(isOwnCompanyData = true)
+
+    private fun singleUpserRequest(
+        externalId: String,
+        relationType: RelationType,
+        businessPartnerSourceExternalId: String,
+        businessPartnerTargetExternalId: String
+    ) = RelationPutRequest(
+        listOf(
+            RelationPutEntry(
+                externalId = externalId,
+                relationType = relationType,
+                businessPartnerSourceExternalId = businessPartnerSourceExternalId,
+                businessPartnerTargetExternalId = businessPartnerTargetExternalId
+            )
+        )
+    )
+}

--- a/bpdm-gate/src/test/resources/application-test-no-auth.yml
+++ b/bpdm-gate/src/test/resources/application-test-no-auth.yml
@@ -8,3 +8,7 @@ bpdm:
       security-enabled: false
     orchestrator:
       security-enabled: false
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 2

--- a/bpdm-gate/src/test/resources/application-test.yml
+++ b/bpdm-gate/src/test/resources/application-test.yml
@@ -30,3 +30,7 @@ bpdm:
       cron: '-'
     healthCheck:
       cron: '-'
+spring:
+  datasource:
+      hikari:
+        maximum-pool-size: 2

--- a/docs/api/gate.json
+++ b/docs/api/gate.json
@@ -1418,7 +1418,7 @@
           "relationType" : {
             "type" : "string",
             "description" : "The type of relation between the business partners",
-            "enum" : [ "IsManagedBy" ]
+            "enum" : [ "IsManagedBy", "IsAlternativeHeadquarterFor" ]
           },
           "businessPartnerSourceExternalId" : {
             "type" : "string",
@@ -1452,7 +1452,7 @@
           "relationType" : {
             "type" : "string",
             "description" : "The type the relation should be",
-            "enum" : [ "IsManagedBy" ]
+            "enum" : [ "IsManagedBy", "IsAlternativeHeadquarterFor" ]
           },
           "businessPartnerSourceExternalId" : {
             "type" : "string",
@@ -1504,7 +1504,7 @@
           "relationType" : {
             "type" : "string",
             "description" : "Only show relations of the given type",
-            "enum" : [ "IsManagedBy" ]
+            "enum" : [ "IsManagedBy", "IsAlternativeHeadquarterFor" ]
           },
           "businessPartnerSourceExternalIds" : {
             "type" : "array",

--- a/docs/api/gate.yaml
+++ b/docs/api/gate.yaml
@@ -1872,6 +1872,7 @@ components:
           description: The type of relation between the business partners
           enum:
           - IsManagedBy
+          - IsAlternativeHeadquarterFor
         businessPartnerSourceExternalId:
           type: string
           description: The business partner from which the relation emerges (the source)
@@ -1906,6 +1907,7 @@ components:
           description: The type the relation should be
           enum:
           - IsManagedBy
+          - IsAlternativeHeadquarterFor
         businessPartnerSourceExternalId:
           type: string
           description: The external identifier of the business partner from which
@@ -1953,6 +1955,7 @@ components:
           description: Only show relations of the given type
           enum:
           - IsManagedBy
+          - IsAlternativeHeadquarterFor
         businessPartnerSourceExternalIds:
           type: array
           description: Only show relations which have the given business partners


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds the 'IsAlternativeHeadquarterFor' relation type to the input business partner relation endpoints.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Contibutes to #1286 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
