### PR TITLE
feat(bpdm-pool): added functionality to consume relation golden record tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Orchestrator: New POST api endpoint to post step results for reserved relations golden record tasks in the given step queue. ([#1274](https://github.com/eclipse-tractusx/bpdm/issues/1274))
 - BPDM Orchestrator: New GET api endpoint to retrieve event log of relations golden record tasks that have finished processing. ([#1274](https://github.com/eclipse-tractusx/bpdm/issues/1274))
 - BPDM Gate: Added relation type IsAlternativeHeadquarterFor ([1286](https://github.com/eclipse-tractusx/bpdm/issues/1286))
+- BPDM Pool: Added functionality to consume relation golden record tasks. ([#1279](https://github.com/eclipse-tractusx/bpdm/issues/1279))
 
 ### Changed
 

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerRelations.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerRelations.kt
@@ -29,7 +29,15 @@ data class BusinessPartnerRelations(
     val businessPartnerSourceBpnl: String,
     @Schema(description = "The business partner to which this relation goes (the target)")
     val businessPartnerTargetBpnl: String
-)
+) {
+    companion object {
+        val empty = BusinessPartnerRelations(
+            relationType = RelationType.IsAlternativeHeadquarterFor, // or a default type
+            businessPartnerSourceBpnl = "",
+            businessPartnerTargetBpnl = ""
+        )
+    }
+}
 
 enum class RelationType {
     IsAlternativeHeadquarterFor

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/RelationRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/RelationRepository.kt
@@ -19,9 +19,34 @@
 
 package org.eclipse.tractusx.bpdm.pool.repository
 
+import jakarta.persistence.criteria.Predicate
+import org.eclipse.tractusx.bpdm.pool.api.model.RelationType
+import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
 import org.eclipse.tractusx.bpdm.pool.entity.RelationDb
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 
 interface RelationRepository : JpaRepository<RelationDb, Long>, JpaSpecificationExecutor<RelationDb> {
+
+    companion object {
+        fun byRelation(startNode: LegalEntityDb?, endNode: LegalEntityDb?, type: RelationType?) =
+            Specification<RelationDb> { root, _, builder ->
+                val predicates = mutableListOf<Predicate>()
+
+                startNode?.let {
+                    predicates.add(builder.equal(root.get<LegalEntityDb>(RelationDb::startNode.name), it))
+                }
+
+                endNode?.let {
+                    predicates.add(builder.equal(root.get<LegalEntityDb>(RelationDb::endNode.name), it))
+                }
+
+                type?.let {
+                    predicates.add(builder.equal(root.get<RelationType>(RelationDb::type.name), it))
+                }
+
+                builder.and(*predicates.toTypedArray())
+            }
+    }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsBatchResolutionService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsBatchResolutionService.kt
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import jakarta.persistence.EntityManager
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordTaskConfigProperties
+import org.eclipse.tractusx.bpdm.pool.entity.GoldenRecordTaskDb
+import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
+import org.eclipse.tractusx.bpdm.pool.repository.GoldenRecordTaskRepository
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.time.Instant
+
+@Service
+class TaskRelationsBatchResolutionService(
+    private val taskRelationsResolutionService: TaskRelationsResolutionService,
+    private val goldenRecordTaskConfigProperties: GoldenRecordTaskConfigProperties,
+    private val orchestrationClient: OrchestrationApiClient,
+    private val goldenRecordTaskRepository: GoldenRecordTaskRepository,
+    private val entityManager: EntityManager,
+    ) {
+
+    private val logger = KotlinLogging.logger { }
+
+    @Scheduled(cron = "#{${GoldenRecordTaskConfigProperties.GET_CRON}}", zone = "UTC")
+    fun processTasks(){
+        logger.info { "Start Relations golden record task processing schedule..." }
+        reserveAndResolve()
+        resolveUnresolved()
+        deleteResolved()
+    }
+
+    fun reserveAndResolve(){
+        var totalTasksProcessed = 0
+        do{
+            val reservationRequest = TaskStepReservationRequest(step = goldenRecordTaskConfigProperties.step, amount = goldenRecordTaskConfigProperties.batchSize)
+            val taskStepReservation = orchestrationClient.relationsGoldenRecordTasks.reserveTasksForStep(reservationRequest = reservationRequest)
+
+            val successfullyResolved = try{
+                taskRelationsResolutionService.resolveTasks(taskStepReservation)
+                true
+            } catch (ex: Throwable) {
+                logger.error(ex) { "Error while processing cleaning task" }
+                false
+            }
+
+            totalTasksProcessed += taskStepReservation.reservedTasks.size
+
+            if(!successfullyResolved)
+                goldenRecordTaskRepository.saveAll(taskStepReservation.reservedTasks.map { GoldenRecordTaskDb(it.taskId, true, Instant.now()) })
+
+            entityManager.clear()
+        }while (taskStepReservation.reservedTasks.isNotEmpty())
+
+        logger.info { "Total of $totalTasksProcessed processed" }
+    }
+
+    fun resolveUnresolved(){
+        val scheduleTime = Instant.now()
+
+        val resultTemplate = TaskRelationsStepResultEntryDto("", BusinessPartnerRelations.empty, listOf(TaskRelationsErrorDto(TaskRelationsErrorType.Unspecified, "Unknown golden record process error during Pool communication")))
+
+        var processedTasks = 0
+        var resolvedTasks = 0
+        do{
+            val task = goldenRecordTaskRepository.findFirstByLastCheckedBefore(scheduleTime)?.let { task ->
+                if(!task.isResolved){
+                    try{
+                        orchestrationClient.relationsGoldenRecordTasks.resolveStepResults(TaskRelationsStepResultRequest(goldenRecordTaskConfigProperties.step, listOf(resultTemplate.copy(taskId = task.taskId))))
+                        task.isResolved = true
+                        resolvedTasks++
+                    }catch (e: WebClientResponseException.BadRequest){
+                        logger.warn { "Tracked task ${task.taskId} seems to be missing in Orchestrator. Marking it as resolved..." }
+                        task.isResolved = true
+                        resolvedTasks++
+                    }catch (e: WebClientException){
+                        logger.error { "Could not resolve task '${task.taskId}: ${e.message}'" }
+                        task.isResolved = false
+                    }
+                }
+
+                task.lastChecked = scheduleTime
+                goldenRecordTaskRepository.save(task)
+                entityManager.clear()
+
+                processedTasks++
+            }
+        }while (task != null)
+
+        logger.info { "Resolving tasks: Checked $processedTasks tasks and resolved $resolvedTasks tasks as errors" }
+
+    }
+
+    fun deleteResolved(){
+        var tasksDeleted = 0
+        do{
+            val task = goldenRecordTaskRepository.findFirstByIsResolved(true)?.let { task ->
+                goldenRecordTaskRepository.delete(task)
+                entityManager.clear()
+                tasksDeleted++
+            }
+        }while (task != null)
+
+        logger.info { "Deleted $tasksDeleted resolved tasks" }
+    }
+
+}
+
+@Service
+class TaskRelationsResolutionService(
+    private val orchestrationClient: OrchestrationApiClient,
+    private val goldenRecordTaskConfigProperties: GoldenRecordTaskConfigProperties,
+    private val taskRelationsStepBuildService: TaskRelationsStepBuildService
+) {
+    private val logger = KotlinLogging.logger { }
+
+    fun resolveTasks(taskStepReservation: TaskRelationsStepReservationResponse) {
+        logger.info { "${taskStepReservation.reservedTasks.size} tasks found for cleaning. Proceeding with cleaning..." }
+
+        if (taskStepReservation.reservedTasks.isNotEmpty()) {
+            val taskResults = upsertRelationsGoldenRecordIntoPool(taskStepReservation.reservedTasks)
+
+            //Limit the length of errors so for the Orchestrator to not reject it
+            val resultsWithSafeErrors = taskResults.map { result ->
+                result.copy(errors = result.errors.map { error ->
+                    error.copy(description = error.description.take(250))
+                })
+            }
+            orchestrationClient.relationsGoldenRecordTasks.resolveStepResults(TaskRelationsStepResultRequest(step = goldenRecordTaskConfigProperties.step, results = resultsWithSafeErrors))
+        }
+        logger.info { "Cleaning tasks processing completed for this iteration." }
+    }
+
+    fun upsertRelationsGoldenRecordIntoPool(taskEntries: List<TaskRelationsStepReservationEntryDto>) : List<TaskRelationsStepResultEntryDto> {
+        val taskResults = taskEntries.map { businessPartnerRelationsTaskResult(it) }
+
+        return taskResults
+    }
+
+    private fun businessPartnerRelationsTaskResult(taskStep: TaskRelationsStepReservationEntryDto): TaskRelationsStepResultEntryDto {
+        return try {
+            taskRelationsStepBuildService.upsertBusinessPartnerRelations(taskStep)
+        }catch (ex: BpdmValidationException) {
+            TaskRelationsStepResultEntryDto(
+                taskId = taskStep.taskId,
+                errors = listOf(
+                    TaskRelationsErrorDto(
+                        type = TaskRelationsErrorType.Unspecified,
+                        description = ex.message ?: ""
+                    )
+                ),
+                businessPartnerRelations = taskStep.businessPartnerRelations
+            )
+        } catch (ex: Throwable) {
+            logger.error(ex) { "An unexpected error occurred during golden record task processing" }
+            TaskRelationsStepResultEntryDto(
+                taskId = taskStep.taskId,
+                errors = listOf(
+                    TaskRelationsErrorDto(
+                        type = TaskRelationsErrorType.Unspecified,
+                        description = "An unexpected error occurred during Pool update"
+                    )
+                ),
+                businessPartnerRelations = taskStep.businessPartnerRelations
+            )
+        }
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsStepBuildService.kt
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import jakarta.transaction.Transactional
+import org.eclipse.tractusx.bpdm.pool.api.model.RelationType
+import org.eclipse.tractusx.bpdm.pool.entity.RelationDb
+import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
+import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
+import org.eclipse.tractusx.bpdm.pool.repository.RelationRepository
+import org.eclipse.tractusx.orchestrator.api.model.TaskRelationsStepReservationEntryDto
+import org.eclipse.tractusx.orchestrator.api.model.TaskRelationsStepResultEntryDto
+import org.springframework.stereotype.Service
+
+@Service
+class TaskRelationsStepBuildService(
+    private val relationRepository: RelationRepository,
+    private val legalEntityRepository: LegalEntityRepository,
+) {
+
+    @Transactional
+    fun upsertBusinessPartnerRelations(taskEntry: TaskRelationsStepReservationEntryDto): TaskRelationsStepResultEntryDto {
+        val relationDto = taskEntry.businessPartnerRelations
+
+        // Fetch legal entities by BPNL
+        val sourceLegalEntity = legalEntityRepository.findByBpnIgnoreCase(relationDto.businessPartnerSourceBpnl)
+            ?: throw BpdmValidationException("Source legal entity with specified BPNL : ${relationDto.businessPartnerSourceBpnl} not found")
+
+        val targetLegalEntity = legalEntityRepository.findByBpnIgnoreCase(relationDto.businessPartnerTargetBpnl)
+            ?: throw BpdmValidationException("Target legal entity with specified BPNL : ${relationDto.businessPartnerTargetBpnl} not found")
+
+
+        // Prevent self-referencing relations
+        if (sourceLegalEntity == targetLegalEntity) {
+            throw BpdmValidationException("A legal entity cannot have a relation to itself (BPNL: ${relationDto.businessPartnerSourceBpnl}).")
+        }
+
+        val existingRelation = relationRepository.findOne(
+            RelationRepository.byRelation(
+                startNode = sourceLegalEntity,
+                endNode = targetLegalEntity,
+                type = RelationType.valueOf(relationDto.relationType.name)
+            )
+        )
+
+        return if (existingRelation.isPresent) {
+            // Relation already exists, return existing details
+            TaskRelationsStepResultEntryDto(
+                taskId = taskEntry.taskId,
+                errors = emptyList(),
+                businessPartnerRelations = relationDto
+            )
+        } else {
+            // Create new relation
+            val newRelation = RelationDb(
+                type = RelationType.valueOf(relationDto.relationType.name),
+                startNode = sourceLegalEntity,
+                endNode = targetLegalEntity,
+                isActive = true
+            )
+
+            relationRepository.save(newRelation)
+
+            TaskRelationsStepResultEntryDto(
+                taskId = taskEntry.taskId,
+                errors = emptyList(),
+                businessPartnerRelations = relationDto
+            )
+        }
+    }
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.tractusx.bpdm.pool.Application
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues
+import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerVerboseValues
+import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
+import org.eclipse.tractusx.bpdm.test.util.PoolDataHelpers
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import java.util.*
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
+)
+@ActiveProfiles("test-no-auth")
+@ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
+class TaskRelationsResolutionServiceTest @Autowired constructor(
+    val taskRelationsResolutionService: TaskRelationsResolutionService,
+    val poolClient: PoolApiClient,
+    val dbTestHelpers: DbTestHelpers,
+    val poolDataHelpers: PoolDataHelpers
+) {
+
+    @BeforeEach
+    fun beforeEach() {
+        dbTestHelpers.truncateDbTables()
+        poolDataHelpers.createPoolMetadata()
+    }
+
+    /*
+    * GIVEN: An empty BusinessPartnerRelations request
+    * WHEN: Attempting to upsert the empty relations into the pool
+    * THEN: The operation should fail, returning an error message
+    * */
+    @Test
+    fun `create empty relations`() {
+
+        val createRelationsRequest = BusinessPartnerRelations.empty
+
+        val result = upsertRelationsGoldenRecordIntoPool(taskId = "TASK_1", businessPartnerRelations = createRelationsRequest)
+        assertThat(result[0].taskId).isEqualTo("TASK_1")
+        assertThat(result[0].errors.size).isEqualTo(1)
+    }
+
+    /*
+    * GIVEN: A relation request with non-existing source and target legal entities
+    * WHEN: Attempting to upsert the relations into the pool
+    * THEN: The operation should fail, returning an error message
+    * */
+    @Test
+    fun `create relations with non existing source and target legal entity`() {
+
+        val createRelationsRequest = BusinessPartnerRelations(
+            relationType = RelationType.IsAlternativeHeadquarterFor,
+            businessPartnerSourceBpnl = BusinessPartnerVerboseValues.firstBpnL,
+            businessPartnerTargetBpnl = BusinessPartnerVerboseValues.secondBpnL
+        )
+
+        val result = upsertRelationsGoldenRecordIntoPool(taskId = "TASK_1", businessPartnerRelations = createRelationsRequest)
+        assertThat(result[0].taskId).isEqualTo("TASK_1")
+        assertThat(result[0].errors.size).isEqualTo(1)
+    }
+
+    /*
+    * GIVEN: A created legal entity
+    * WHEN: Attempting to create a relation where source and target are the same entity
+    * THEN: The operation should fail, returning an error indicating self-relation is not allowed
+    * */
+    @Test
+    fun `create relations with same source and target legal entity`() {
+
+        // Step 1: Create legal entity
+        val entity1 = BusinessPartnerNonVerboseValues.legalEntityCreate1
+
+        val response = poolClient.legalEntities.createBusinessPartners(listOf(entity1))
+
+        assertThat(response.entities.size).isEqualTo(1)
+        val savedEntity1 = response.entities.toList()[0]
+
+        val createRelationsRequest = BusinessPartnerRelations(
+            relationType = RelationType.IsAlternativeHeadquarterFor,
+            businessPartnerSourceBpnl = savedEntity1.legalEntity.bpnl,
+            businessPartnerTargetBpnl = savedEntity1.legalEntity.bpnl
+        )
+
+        val result = upsertRelationsGoldenRecordIntoPool(taskId = "TASK_1", businessPartnerRelations = createRelationsRequest)
+        assertThat(result[0].taskId).isEqualTo("TASK_1")
+        assertThat(result[0].errors.size).isEqualTo(1)
+        assertThat(result[0].errors[0].description).isEqualTo("A legal entity cannot have a relation to itself (BPNL: ${savedEntity1.legalEntity.bpnl}).")
+    }
+
+    /*
+    * GIVEN: Two created legal entities
+    * WHEN: A valid relation request is made between the two entities
+    * THEN: The operation should succeed without errors, and the relation should be retrievable by querying legal entity
+    * */
+    @Test
+    fun `create relations with provided source and target legal entity`() {
+
+        // Step 1: Create two legal entities
+        val entity1 = BusinessPartnerNonVerboseValues.legalEntityCreate1
+        val entity2 = BusinessPartnerNonVerboseValues.legalEntityCreate2
+
+        val response = poolClient.legalEntities.createBusinessPartners(listOf(entity1, entity2))
+
+        assertThat(response.entities.size).isEqualTo(2)
+        val savedEntity1 = response.entities.toList()[0]
+        val savedEntity2 = response.entities.toList()[1]
+
+        // Step 2: Create a relation request
+        val createRelationsRequest = BusinessPartnerRelations(
+            relationType = RelationType.IsAlternativeHeadquarterFor,
+            businessPartnerSourceBpnl = savedEntity1.legalEntity.bpnl,
+            businessPartnerTargetBpnl = savedEntity2.legalEntity.bpnl
+        )
+
+        val result = upsertRelationsGoldenRecordIntoPool(taskId = "TASK_1", businessPartnerRelations = createRelationsRequest)
+        assertThat(result[0].taskId).isEqualTo("TASK_1")
+        assertThat(result[0].errors.size).isEqualTo(0)
+
+        // Step 3: Retrieve legal entity with the relation exists
+        val bpnToFind = changeCase(savedEntity1.legalEntity.bpnl)
+        val responseLegalEntity = poolClient.legalEntities.getLegalEntity(bpnToFind).legalEntity
+        assertThat(responseLegalEntity.relations).isNotNull
+        assertThat(responseLegalEntity.relations.first().type.name).isEqualTo(createRelationsRequest.relationType.name)
+        assertThat(responseLegalEntity.relations.first().businessPartnerSourceBpnl).isEqualTo(createRelationsRequest.businessPartnerSourceBpnl)
+        assertThat(responseLegalEntity.relations.first().businessPartnerTargetBpnl).isEqualTo(createRelationsRequest.businessPartnerTargetBpnl)
+        assertThat(responseLegalEntity.relations.first().isActive).isEqualTo(true)
+    }
+
+
+
+    private fun upsertRelationsGoldenRecordIntoPool(taskId: String, businessPartnerRelations: BusinessPartnerRelations): List<TaskRelationsStepResultEntryDto> {
+
+        val taskStep = singleTaskStep(taskId = taskId, businessPartnerRelations = businessPartnerRelations)
+        return taskRelationsResolutionService.upsertRelationsGoldenRecordIntoPool(taskStep)
+    }
+
+    private fun singleTaskStep(taskId: String, businessPartnerRelations: BusinessPartnerRelations): List<TaskRelationsStepReservationEntryDto> {
+
+        return listOf(
+            TaskRelationsStepReservationEntryDto(
+                taskId = taskId,
+                recordId = UUID.randomUUID().toString(),
+                businessPartnerRelations = businessPartnerRelations
+            )
+        )
+    }
+
+    private fun changeCase(value: String): String {
+        return if (value.uppercase() != value)
+            value.uppercase()
+        else if (value.lowercase() != value)
+            value.lowercase()
+        else
+            throw IllegalArgumentException("Can't change case of string $value")
+    }
+
+}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request adds functionality for bpdm-pool service to consume relation data from created relation golden record tasks.

- Created logic to reserve relation golden record tasks and consume the relation information
- Relation can retrieve from Legal Entity envolved.

Contributes to #1279 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
