### PR TITLE
cicd(Workflows): change trivy exit code

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -66,7 +66,7 @@ jobs:
           output: "trivy-${{ matrix.app }}-results.sarif"
           severity: "CRITICAL,HIGH"
           hide-progress: false
-          exit-code: "1"
+          exit-code: "0"
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

The regular trivy workflow check on main currently breaks when finding a vulnerabilty. This indicates that something is wrong with the workflow or some critical part of the cicd is not working correctly. This however, not the case as trivy just reports some found vulnerabilties. 

I propose we change the exit code for this trivy check to 0 making sure that the github workflow does not break but still reports any found vulnerabilities in the security section of github. 

The behaviour of the trivy check during the pull request which breaks on finding a vulnerabilty remains unchanged.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
