### PR TITLE
fix(pool): add changelog entries when updating business partner relations

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsStepBuildService.kt
@@ -20,7 +20,10 @@
 package org.eclipse.tractusx.bpdm.pool.service
 
 import jakarta.transaction.Transactional
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 import org.eclipse.tractusx.bpdm.pool.api.model.RelationType
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
 import org.eclipse.tractusx.bpdm.pool.entity.RelationDb
 import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
@@ -33,6 +36,7 @@ import org.springframework.stereotype.Service
 class TaskRelationsStepBuildService(
     private val relationRepository: RelationRepository,
     private val legalEntityRepository: LegalEntityRepository,
+    private val changelogService: PartnerChangelogService
 ) {
 
     @Transactional
@@ -77,6 +81,9 @@ class TaskRelationsStepBuildService(
             )
 
             relationRepository.save(newRelation)
+
+            changelogService.createChangelogEntry(ChangelogEntryCreateRequest(sourceLegalEntity.bpn, ChangelogType.UPDATE, BusinessPartnerType.LEGAL_ENTITY))
+            changelogService.createChangelogEntry(ChangelogEntryCreateRequest(targetLegalEntity.bpn, ChangelogType.UPDATE, BusinessPartnerType.LEGAL_ENTITY))
 
             TaskRelationsStepResultEntryDto(
                 taskId = taskEntry.taskId,


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the Pool's behaviour of resolving business partner relations golden record tasks. Now, when a new relation has been added (or updated) the participating legal entities (source and target) will each get a changelog UPDATE entry.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1300 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
