### PR TITLE
feat(bpdm-orchestrator): api version increased with simultaneous v6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: Add functionality to resolve golden record tasks for business partner relations ([1277](https://github.com/eclipse-tractusx/bpdm/issues/1277))
 - BPDM Gate: Add business partner relation output endpoints to Gate API ([1277](https://github.com/eclipse-tractusx/bpdm/issues/1277))
 - BPDM Gate: Add relation information to business partner outputs ([1278](https://github.com/eclipse-tractusx/bpdm/issues/1278))
+- BPDM Orchestrator: Increased api version to v7 with simultaneous support for version v6([#1294](https://github.com/eclipse-tractusx/bpdm/issues/1294)) 
 
 ### Changed
 

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceApiCallsTest.kt
@@ -32,7 +32,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties
 import org.eclipse.tractusx.bpdm.cleaning.config.OrchestratorConfigProperties
 import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.*
-import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -58,8 +58,8 @@ class CleaningServiceApiCallsTest @Autowired constructor(
 ) {
 
     companion object {
-        const val ORCHESTRATOR_RESERVE_TASKS_URL = "${GoldenRecordTaskApi.TASKS_PATH}/step-reservations"
-        const val ORCHESTRATOR_RESOLVE_TASKS_URL = "${GoldenRecordTaskApi.TASKS_PATH}/step-results"
+        const val ORCHESTRATOR_RESERVE_TASKS_URL = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-reservations"
+        const val ORCHESTRATOR_RESOLVE_TASKS_URL = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-results"
 
         const val RESERVATION_SCENARIO = "Reservation"
         const val RESERVED_STATE = "Reserved"

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/OpenApiConfig.kt
@@ -67,6 +67,17 @@ class OpenApiConfig(
     }
 
     @Bean
+    fun version7Group(openApiCustomizerFactory: OpenApiCustomizerFactory): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("v7")
+            .pathsToMatch("/v7/**")
+            .displayName("V7")
+            .addOpenApiCustomizer(openApiCustomizerFactory.sortSchemaCustomiser())
+            .addOpenApiCustomizer(openApiCustomizerFactory.versionApiCustomizer("v7"))
+            .build()
+    }
+
+    @Bean
     fun openApiCustomizerFactory(): OpenApiCustomizerFactory{
         return OpenApiCustomizerFactory()
     }

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServiceIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServiceIT.kt
@@ -58,8 +58,7 @@ import org.eclipse.tractusx.bpdm.test.testdata.gate.withAddressType
 import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.BusinessPartnerTestDataFactory
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerVerboseValues
 import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
-import org.eclipse.tractusx.orchestrator.api.FinishedTaskEventApi
-import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -257,14 +256,14 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
         ))
 
         orchestratorWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(FinishedTaskEventApi.FINISHED_TASK_EVENT_PATH))
+            WireMock.get(WireMock.urlPathEqualTo("${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/finished-events"))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(orchestratorMockEventResponse))
                 )
         )
 
         orchestratorWireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo("${GoldenRecordTaskApi.TASKS_PATH}/state/search"))
+            WireMock.post(WireMock.urlPathEqualTo("${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/state/search"))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(orchestratorMockResultResponse))
                 )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskCreationServiceIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskCreationServiceIT.kt
@@ -43,6 +43,7 @@ import org.eclipse.tractusx.bpdm.test.testdata.gate.GateInputFactory
 import org.eclipse.tractusx.bpdm.test.testdata.gate.withAddressType
 import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
 import org.eclipse.tractusx.bpdm.test.util.Timeframe
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.RelationsGoldenRecordTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.junit.jupiter.api.BeforeEach
@@ -126,7 +127,7 @@ class RelationTaskCreationServiceIT @Autowired constructor(
         ))
 
         orchestratorWireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo(RelationsGoldenRecordTaskApi.RELATIONS_TASKS_PATH))
+            WireMock.post(WireMock.urlPathEqualTo(ApiCommons.BASE_PATH_V7_RELATIONS))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(orchestratorMockResponse))
                 )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskResolutionServiceIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskResolutionServiceIT.kt
@@ -40,8 +40,7 @@ import org.eclipse.tractusx.bpdm.gate.util.PrincipalUtil
 import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
-import org.eclipse.tractusx.orchestrator.api.RelationsFinishedTaskEventApi.Companion.RELATIONS_FINISHED_TASK_EVENT_PATH
-import org.eclipse.tractusx.orchestrator.api.RelationsGoldenRecordTaskApi.Companion.RELATIONS_TASKS_PATH
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -132,14 +131,14 @@ class RelationTaskResolutionServiceIT @Autowired constructor(
         ))
 
         orchestratorWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(RELATIONS_FINISHED_TASK_EVENT_PATH))
+            WireMock.get(WireMock.urlPathEqualTo("${ApiCommons.BASE_PATH_V7_RELATIONS}/finished-events"))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(orchestratorMockEventResponse))
                 )
         )
 
         orchestratorWireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo("$RELATIONS_TASKS_PATH/state/search"))
+            WireMock.post(WireMock.urlPathEqualTo("${ApiCommons.BASE_PATH_V7_RELATIONS}/state/search"))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(orchestratorMockResultResponse))
                 )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -43,6 +43,7 @@ import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerGenericCommon
 import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerVerboseValues
 import org.eclipse.tractusx.bpdm.test.util.AssertHelpers
 import org.eclipse.tractusx.bpdm.test.util.Timeframe
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.FinishedTaskEventApi
 import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
@@ -57,9 +58,9 @@ class MockAndAssertUtils @Autowired constructor(
     val assertHelpers: AssertHelpers
 ) {
 
-    val ORCHESTRATOR_CREATE_TASKS_URL = GoldenRecordTaskApi.TASKS_PATH
-    val ORCHESTRATOR_SEARCH_TASK_STATES_URL = "${GoldenRecordTaskApi.TASKS_PATH}/state/search"
-    val ORCHESTRATOR_SEARCH_TASK_RESULT_STATES_URL = "${GoldenRecordTaskApi.TASKS_PATH}/result-state/search"
+    val ORCHESTRATOR_CREATE_TASKS_URL = ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS
+    val ORCHESTRATOR_SEARCH_TASK_STATES_URL = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/state/search"
+    val ORCHESTRATOR_SEARCH_TASK_RESULT_STATES_URL = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/result-state/search"
     val POOL_API_SEARCH_CHANGE_LOG_URL = "${PoolChangelogApi.CHANGELOG_PATH}/search"
 
     val taskStep = TaskStep.entries.first()
@@ -181,7 +182,7 @@ class MockAndAssertUtils @Autowired constructor(
         )
 
         gateWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(FinishedTaskEventApi.FINISHED_TASK_EVENT_PATH)).willReturn(
+            WireMock.get(WireMock.urlPathEqualTo("${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/finished-events")).willReturn(
                 WireMock.okJson(objectMapper.writeValueAsString(
                     FinishedTaskEventsResponse(2, 1, 0, 2, content =
                         listOf(
@@ -231,7 +232,7 @@ class MockAndAssertUtils @Autowired constructor(
         )
 
         gateWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(FinishedTaskEventApi.FINISHED_TASK_EVENT_PATH)).willReturn(
+            WireMock.get(WireMock.urlPathEqualTo("${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/finished-events")).willReturn(
                 WireMock.okJson(objectMapper.writeValueAsString(
                     FinishedTaskEventsResponse(1, 1, 0, 1, content =
                     listOf(

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/ApiCommons.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/ApiCommons.kt
@@ -21,5 +21,7 @@ package org.eclipse.tractusx.orchestrator.api
 
 object ApiCommons {
 
-    const val BASE_PATH = "/v6"
+    const val BASE_PATH_V6 = "/v6/golden-record-tasks"
+    const val BASE_PATH_V7_RELATIONS = "/v7/relations/golden-record-tasks"
+    const val BASE_PATH_V7_BUSINESS_PARTNERS = "/v7/business-partners/golden-record-tasks"
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/FinishedTaskEventApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/FinishedTaskEventApi.kt
@@ -25,8 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.orchestrator.api.FinishedTaskEventApi.Companion.FINISHED_TASK_EVENT_PATH
-import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi.Companion.TASKS_PATH
 import org.eclipse.tractusx.orchestrator.api.model.FinishedTaskEventsResponse
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
@@ -36,11 +34,8 @@ import org.springframework.web.bind.annotation.RequestParam
 import java.time.Instant
 
 
-@RequestMapping(FINISHED_TASK_EVENT_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface FinishedTaskEventApi {
-    companion object{
-        const val FINISHED_TASK_EVENT_PATH = "${TASKS_PATH}/finished-events"
-    }
 
     @Operation(
         summary = "Get event log of golden record tasks that have finished processing",
@@ -58,7 +53,7 @@ interface FinishedTaskEventApi {
         ]
     )
     @Tag(name = TagClient)
-    @GetMapping
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/finished-events", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/finished-events"])
     fun getEvents(@RequestParam timestamp: Instant,
                   @ParameterObject paginationRequest: PaginationRequest
     ): FinishedTaskEventsResponse

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi.Companion.TASKS_PATH
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
@@ -34,12 +33,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 const val TagClient = "Task Client"
 const val TagWorker = "Task Worker"
 
-@RequestMapping(TASKS_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface GoldenRecordTaskApi {
-
-    companion object{
-        const val TASKS_PATH = "${ApiCommons.BASE_PATH}/golden-record-tasks"
-    }
 
     @Operation(
         summary = "Create new golden record tasks for given business partner data",
@@ -59,7 +54,7 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping
+    @PostMapping(value = [ApiCommons.BASE_PATH_V6, ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS])
     fun createTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
 
     @Operation(
@@ -76,7 +71,7 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping("/state/search")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/state/search", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/state/search"])
     fun searchTaskStates(@RequestBody stateRequest: TaskStateRequest): TaskStateResponse
 
     @Operation(
@@ -93,7 +88,7 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping("/result-state/search")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/result-state/search", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/result-state/search"])
     fun searchTaskResultStates(@RequestBody stateRequest: TaskResultStateSearchRequest): TaskResultStateSearchResponse
 
     @Operation(
@@ -113,7 +108,7 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagWorker)
-    @PostMapping("/step-reservations")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/step-reservations", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-reservations"])
     fun reserveTasksForStep(@RequestBody reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse
 
     @Operation(
@@ -138,6 +133,6 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagWorker)
-    @PostMapping("/step-results")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/step-results", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-results"])
     fun resolveStepResults(@RequestBody resultRequest: TaskStepResultRequest)
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/RelationsFinishedTaskEventApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/RelationsFinishedTaskEventApi.kt
@@ -25,8 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.orchestrator.api.RelationsFinishedTaskEventApi.Companion.RELATIONS_FINISHED_TASK_EVENT_PATH
-import org.eclipse.tractusx.orchestrator.api.RelationsGoldenRecordTaskApi.Companion.RELATIONS_TASKS_PATH
 import org.eclipse.tractusx.orchestrator.api.model.FinishedTaskEventsResponse
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
@@ -35,12 +33,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import java.time.Instant
 
-@RequestMapping(RELATIONS_FINISHED_TASK_EVENT_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface RelationsFinishedTaskEventApi {
-
-    companion object{
-        const val RELATIONS_FINISHED_TASK_EVENT_PATH = "${RELATIONS_TASKS_PATH}/finished-events"
-    }
 
     @Operation(
         summary = "Get event log of relations golden record tasks that have finished processing",
@@ -58,7 +52,7 @@ interface RelationsFinishedTaskEventApi {
         ]
     )
     @Tag(name = TagClient)
-    @GetMapping
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V7_RELATIONS}/finished-events"])
     fun getRelationsEvents(@RequestParam timestamp: Instant,
                   @ParameterObject paginationRequest: PaginationRequest
     ): FinishedTaskEventsResponse

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/RelationsGoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/RelationsGoldenRecordTaskApi.kt
@@ -28,16 +28,11 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.eclipse.tractusx.orchestrator.api.RelationsGoldenRecordTaskApi.Companion.RELATIONS_TASKS_PATH
 import org.eclipse.tractusx.orchestrator.api.model.*
 
 
-@RequestMapping(RELATIONS_TASKS_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface RelationsGoldenRecordTaskApi {
-
-    companion object{
-        const val RELATIONS_TASKS_PATH = "${ApiCommons.BASE_PATH}/relations/golden-record-tasks"
-    }
 
     @Operation(
         summary = "Create new golden record relations tasks for given business partner relationship data",
@@ -57,7 +52,7 @@ interface RelationsGoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping
+    @PostMapping(value = [ApiCommons.BASE_PATH_V7_RELATIONS])
     fun createTasks(@RequestBody createRequest: TaskCreateRelationsRequest): TaskCreateRelationsResponse
 
     @Operation(
@@ -74,7 +69,7 @@ interface RelationsGoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping("/state/search")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7_RELATIONS}/state/search"])
     fun searchTaskStates(@RequestBody stateRequest: TaskStateRequest): TaskRelationsStateResponse
 
     @Operation(
@@ -91,7 +86,7 @@ interface RelationsGoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping("/result-state/search")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7_RELATIONS}/result-state/search"])
     fun searchTaskResultStates(@RequestBody stateRequest: TaskResultStateSearchRequest): TaskResultStateSearchResponse
 
     @Operation(
@@ -111,7 +106,7 @@ interface RelationsGoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagWorker)
-    @PostMapping("/step-reservations")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7_RELATIONS}/step-reservations"])
     fun reserveTasksForStep(@RequestBody reservationRequest: TaskStepReservationRequest): TaskRelationsStepReservationResponse
 
     @Operation(
@@ -136,6 +131,6 @@ interface RelationsGoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagWorker)
-    @PostMapping("/step-results")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7_RELATIONS}/step-results"])
     fun resolveStepResults(@RequestBody resultRequest: TaskRelationsStepResultRequest)
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/FinishedTaskEventApiClient.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/FinishedTaskEventApiClient.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.orchestrator.api.client
 
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.FinishedTaskEventApi
 import org.eclipse.tractusx.orchestrator.api.model.FinishedTaskEventsResponse
 import org.springdoc.core.annotations.ParameterObject
@@ -28,9 +29,9 @@ import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
 import java.time.Instant
 
-@HttpExchange(FinishedTaskEventApi.FINISHED_TASK_EVENT_PATH)
+@HttpExchange
 interface FinishedTaskEventApiClient: FinishedTaskEventApi  {
 
-    @GetExchange
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/finished-events")
     override fun getEvents(@RequestParam timestamp: Instant, @ParameterObject paginationRequest: PaginationRequest): FinishedTaskEventsResponse
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/GoldenRecordTaskApiClient.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/GoldenRecordTaskApiClient.kt
@@ -19,36 +19,37 @@
 
 package org.eclipse.tractusx.orchestrator.api.client
 
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-@HttpExchange(GoldenRecordTaskApi.TASKS_PATH)
+@HttpExchange
 interface GoldenRecordTaskApiClient : GoldenRecordTaskApi {
 
-    @PostExchange
+    @PostExchange(value = ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS)
     override fun createTasks(
         @RequestBody createRequest: TaskCreateRequest
     ): TaskCreateResponse
 
-    @PostExchange("/step-reservations")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-reservations")
     override fun reserveTasksForStep(
         @RequestBody reservationRequest: TaskStepReservationRequest
     ): TaskStepReservationResponse
 
-    @PostExchange("/step-results")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-results")
     override fun resolveStepResults(
         @RequestBody resultRequest: TaskStepResultRequest
     )
 
-    @PostExchange("/state/search")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/state/search")
     override fun searchTaskStates(
         @RequestBody stateRequest: TaskStateRequest
     ): TaskStateResponse
 
-    @PostExchange("/result-state/search")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/result-state/search")
     override fun searchTaskResultStates(
         @RequestBody stateRequest: TaskResultStateSearchRequest
     ): TaskResultStateSearchResponse

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/RelationsFinishedTaskEventApiClient.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/RelationsFinishedTaskEventApiClient.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.orchestrator.api.client
 
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.RelationsFinishedTaskEventApi
 import org.eclipse.tractusx.orchestrator.api.model.FinishedTaskEventsResponse
 import org.springdoc.core.annotations.ParameterObject
@@ -28,9 +29,9 @@ import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
 import java.time.Instant
 
-@HttpExchange(RelationsFinishedTaskEventApi.RELATIONS_FINISHED_TASK_EVENT_PATH)
+@HttpExchange
 interface RelationsFinishedTaskEventApiClient : RelationsFinishedTaskEventApi{
 
-    @GetExchange
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V7_RELATIONS}/finished-events")
     override fun getRelationsEvents(@RequestParam timestamp: Instant, @ParameterObject paginationRequest: PaginationRequest): FinishedTaskEventsResponse
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/RelationsGoldenRecordTaskApiClient.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/client/RelationsGoldenRecordTaskApiClient.kt
@@ -19,36 +19,37 @@
 
 package org.eclipse.tractusx.orchestrator.api.client
 
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
 import org.eclipse.tractusx.orchestrator.api.RelationsGoldenRecordTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-@HttpExchange(RelationsGoldenRecordTaskApi.RELATIONS_TASKS_PATH)
+@HttpExchange
 interface RelationsGoldenRecordTaskApiClient: RelationsGoldenRecordTaskApi {
 
-    @PostExchange
+    @PostExchange(value = ApiCommons.BASE_PATH_V7_RELATIONS)
     override fun createTasks(
         @RequestBody createRequest: TaskCreateRelationsRequest
     ): TaskCreateRelationsResponse
 
-    @PostExchange("/state/search")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_RELATIONS}/state/search")
     override fun searchTaskStates(
         @RequestBody stateRequest: TaskStateRequest
     ): TaskRelationsStateResponse
 
-    @PostExchange("/result-state/search")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_RELATIONS}/result-state/search")
     override fun searchTaskResultStates(
         @RequestBody stateRequest: TaskResultStateSearchRequest
     ): TaskResultStateSearchResponse
 
-    @PostExchange("/step-reservations")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_RELATIONS}/step-reservations")
     override fun reserveTasksForStep(
         @RequestBody reservationRequest: TaskStepReservationRequest
     ): TaskRelationsStepReservationResponse
 
-    @PostExchange("/step-results")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7_RELATIONS}/step-results")
     override fun resolveStepResults(
         @RequestBody resultRequest: TaskRelationsStepResultRequest
     )

--- a/docs/api/orchestrator.json
+++ b/docs/api/orchestrator.json
@@ -15,7 +15,7 @@
     "bearer_scheme" : [ ]
   } ],
   "paths" : {
-    "/v6/relations/golden-record-tasks" : {
+    "/v7/relations/golden-record-tasks" : {
       "post" : {
         "tags" : [ "Task Client" ],
         "summary" : "Create new golden record relations tasks for given business partner relationship data",
@@ -48,7 +48,7 @@
         }
       }
     },
-    "/v6/relations/golden-record-tasks/step-results" : {
+    "/v7/relations/golden-record-tasks/step-results" : {
       "post" : {
         "tags" : [ "Task Worker" ],
         "summary" : "Post step results for reserved relations golden record tasks in the given step queue",
@@ -74,7 +74,7 @@
         }
       }
     },
-    "/v6/relations/golden-record-tasks/step-reservations" : {
+    "/v7/relations/golden-record-tasks/step-reservations" : {
       "post" : {
         "tags" : [ "Task Worker" ],
         "summary" : "Reserve the next relations golden record tasks waiting in the given step queue",
@@ -107,7 +107,7 @@
         }
       }
     },
-    "/v6/relations/golden-record-tasks/state/search" : {
+    "/v7/relations/golden-record-tasks/state/search" : {
       "post" : {
         "tags" : [ "Task Client" ],
         "summary" : "Search for the state of relations golden record tasks by task identifiers",
@@ -140,7 +140,7 @@
         }
       }
     },
-    "/v6/relations/golden-record-tasks/result-state/search" : {
+    "/v7/relations/golden-record-tasks/result-state/search" : {
       "post" : {
         "tags" : [ "Task Client" ],
         "summary" : "Search for result states by giving a list of task IDs",
@@ -172,35 +172,28 @@
         }
       }
     },
-    "/v6/golden-record-tasks" : {
+    "/v7/business-partners/golden-record-tasks/step-results" : {
       "post" : {
-        "tags" : [ "Task Client" ],
-        "summary" : "Create new golden record tasks for given business partner data",
-        "description" : "Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.",
-        "operationId" : "createTasks_1",
+        "tags" : [ "Task Worker" ],
+        "summary" : "Post step results for reserved golden record tasks in the given step queue",
+        "description" : "Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.",
+        "operationId" : "resolveStepResults_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/TaskCreateRequest"
+                "$ref" : "#/components/schemas/TaskStepResultRequest"
               }
             }
           },
           "required" : true
         },
         "responses" : {
-          "200" : {
-            "description" : "The states of successfully created tasks including the task identifier for tracking purposes.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TaskCreateResponse"
-                }
-              }
-            }
+          "204" : {
+            "description" : "If the results could be processed"
           },
           "400" : {
-            "description" : "On malformed task create requests or reaching upsert limit"
+            "description" : "On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue"
           }
         }
       }
@@ -210,7 +203,7 @@
         "tags" : [ "Task Worker" ],
         "summary" : "Post step results for reserved golden record tasks in the given step queue",
         "description" : "Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.",
-        "operationId" : "resolveStepResults_1",
+        "operationId" : "resolveStepResults_2",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -264,12 +257,78 @@
         }
       }
     },
-    "/v6/golden-record-tasks/state/search" : {
+    "/v7/business-partners/golden-record-tasks/step-reservations" : {
+      "post" : {
+        "tags" : [ "Task Worker" ],
+        "summary" : "Reserve the next golden record tasks waiting in the given step queue",
+        "description" : "Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.",
+        "operationId" : "reserveTasksForStep_2",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskStepReservationRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The reserved tasks with their business partner data to process.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskStepReservationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
+    "/v7/business-partners/golden-record-tasks/state/search" : {
       "post" : {
         "tags" : [ "Task Client" ],
         "summary" : "Search for the state of golden record tasks by task identifiers",
         "description" : "Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.",
         "operationId" : "searchTaskStates_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskStateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The state of the tasks for the provided task identifiers.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskStateResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task search requests"
+          }
+        }
+      }
+    },
+    "/v6/golden-record-tasks/state/search" : {
+      "post" : {
+        "tags" : [ "Task Client" ],
+        "summary" : "Search for the state of golden record tasks by task identifiers",
+        "description" : "Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.",
+        "operationId" : "searchTaskStates_2",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -329,7 +388,105 @@
         }
       }
     },
-    "/v6/relations/golden-record-tasks/finished-events" : {
+    "/v7/business-partners/golden-record-tasks/result-state/search" : {
+      "post" : {
+        "tags" : [ "Task Client" ],
+        "summary" : "Search for result states by giving a list of task IDs",
+        "operationId" : "searchTaskResultStates_2",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskResultStateSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The list of corresponding result states in the same order as has been received. A null indicates that a task could not be found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskResultStateSearchResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task search requests"
+          }
+        }
+      }
+    },
+    "/v7/business-partners/golden-record-tasks" : {
+      "post" : {
+        "tags" : [ "Task Client" ],
+        "summary" : "Create new golden record tasks for given business partner data",
+        "description" : "Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.",
+        "operationId" : "createTasks_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskCreateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The states of successfully created tasks including the task identifier for tracking purposes.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskCreateResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
+    "/v6/golden-record-tasks" : {
+      "post" : {
+        "tags" : [ "Task Client" ],
+        "summary" : "Create new golden record tasks for given business partner data",
+        "description" : "Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.",
+        "operationId" : "createTasks_2",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskCreateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The states of successfully created tasks including the task identifier for tracking purposes.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskCreateResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
+    "/v7/relations/golden-record-tasks/finished-events" : {
       "get" : {
         "tags" : [ "Task Client" ],
         "summary" : "Get event log of relations golden record tasks that have finished processing",
@@ -380,12 +537,63 @@
         }
       }
     },
-    "/v6/golden-record-tasks/finished-events" : {
+    "/v7/business-partners/golden-record-tasks/finished-events" : {
       "get" : {
         "tags" : [ "Task Client" ],
         "summary" : "Get event log of golden record tasks that have finished processing",
         "description" : "The event log contains all events of when golden record tasks finish processing. These events are helpful for the task creator to check whether created tasks have finished processing. A paginated list of events that happened after a given time is returned. ",
         "operationId" : "getEvents",
+        "parameters" : [ {
+          "name" : "timestamp",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The paginated events after the given timestamp",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/FinishedTaskEventsResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      }
+    },
+    "/v6/golden-record-tasks/finished-events" : {
+      "get" : {
+        "tags" : [ "Task Client" ],
+        "summary" : "Get event log of golden record tasks that have finished processing",
+        "description" : "The event log contains all events of when golden record tasks finish processing. These events are helpful for the task creator to check whether created tasks have finished processing. A paginated list of events that happened after a given time is returned. ",
+        "operationId" : "getEvents_1",
         "parameters" : [ {
           "name" : "timestamp",
           "in" : "query",
@@ -1230,12 +1438,9 @@
           "businessPartnerRelations" : {
             "$ref" : "#/components/schemas/BusinessPartnerRelations",
             "description" : "The business partner relations data to process"
-          },
-          "requestKey" : {
-            "type" : "string"
           }
         },
-        "required" : [ "businessPartnerRelations", "recordId", "requestKey", "taskId" ]
+        "required" : [ "businessPartnerRelations", "recordId", "taskId" ]
       },
       "TaskRelationsStepReservationResponse" : {
         "type" : "object",

--- a/docs/api/orchestrator.yaml
+++ b/docs/api/orchestrator.yaml
@@ -10,7 +10,7 @@ security:
   - open_id_scheme: []
   - bearer_scheme: []
 paths:
-  /v6/relations/golden-record-tasks:
+  /v7/relations/golden-record-tasks:
     post:
       tags:
         - Task Client
@@ -32,7 +32,7 @@ paths:
                 $ref: '#/components/schemas/TaskCreateRelationsResponse'
         '400':
           description: On malformed task create requests or reaching upsert limit
-  /v6/relations/golden-record-tasks/step-results:
+  /v7/relations/golden-record-tasks/step-results:
     post:
       tags:
         - Task Worker
@@ -50,7 +50,7 @@ paths:
           description: If the results could be processed
         '400':
           description: On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue
-  /v6/relations/golden-record-tasks/step-reservations:
+  /v7/relations/golden-record-tasks/step-reservations:
     post:
       tags:
         - Task Worker
@@ -72,7 +72,7 @@ paths:
                 $ref: '#/components/schemas/TaskRelationsStepReservationResponse'
         '400':
           description: On malformed task create requests or reaching upsert limit
-  /v6/relations/golden-record-tasks/state/search:
+  /v7/relations/golden-record-tasks/state/search:
     post:
       tags:
         - Task Client
@@ -94,7 +94,7 @@ paths:
                 $ref: '#/components/schemas/TaskRelationsStateResponse'
         '400':
           description: On malformed task search requests
-  /v6/relations/golden-record-tasks/result-state/search:
+  /v7/relations/golden-record-tasks/result-state/search:
     post:
       tags:
         - Task Client
@@ -115,35 +115,31 @@ paths:
                 $ref: '#/components/schemas/TaskResultStateSearchResponse'
         '400':
           description: On malformed task search requests
-  /v6/golden-record-tasks:
-    post:
-      tags:
-        - Task Client
-      summary: Create new golden record tasks for given business partner data
-      description: Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.
-      operationId: createTasks_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TaskCreateRequest'
-        required: true
-      responses:
-        '200':
-          description: The states of successfully created tasks including the task identifier for tracking purposes.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaskCreateResponse'
-        '400':
-          description: On malformed task create requests or reaching upsert limit
-  /v6/golden-record-tasks/step-results:
+  /v7/business-partners/golden-record-tasks/step-results:
     post:
       tags:
         - Task Worker
       summary: Post step results for reserved golden record tasks in the given step queue
       description: Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.
       operationId: resolveStepResults_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskStepResultRequest'
+        required: true
+      responses:
+        '204':
+          description: If the results could be processed
+        '400':
+          description: On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue
+  /v6/golden-record-tasks/step-results:
+    post:
+      tags:
+        - Task Worker
+      summary: Post step results for reserved golden record tasks in the given step queue
+      description: Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.
+      operationId: resolveStepResults_2
       requestBody:
         content:
           application/json:
@@ -177,13 +173,57 @@ paths:
                 $ref: '#/components/schemas/TaskStepReservationResponse'
         '400':
           description: On malformed task create requests or reaching upsert limit
-  /v6/golden-record-tasks/state/search:
+  /v7/business-partners/golden-record-tasks/step-reservations:
+    post:
+      tags:
+        - Task Worker
+      summary: Reserve the next golden record tasks waiting in the given step queue
+      description: Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.
+      operationId: reserveTasksForStep_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskStepReservationRequest'
+        required: true
+      responses:
+        '200':
+          description: The reserved tasks with their business partner data to process.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskStepReservationResponse'
+        '400':
+          description: On malformed task create requests or reaching upsert limit
+  /v7/business-partners/golden-record-tasks/state/search:
     post:
       tags:
         - Task Client
       summary: Search for the state of golden record tasks by task identifiers
       description: Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.
       operationId: searchTaskStates_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskStateRequest'
+        required: true
+      responses:
+        '200':
+          description: The state of the tasks for the provided task identifiers.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskStateResponse'
+        '400':
+          description: On malformed task search requests
+  /v6/golden-record-tasks/state/search:
+    post:
+      tags:
+        - Task Client
+      summary: Search for the state of golden record tasks by task identifiers
+      description: Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.
+      operationId: searchTaskStates_2
       requestBody:
         content:
           application/json:
@@ -220,7 +260,72 @@ paths:
                 $ref: '#/components/schemas/TaskResultStateSearchResponse'
         '400':
           description: On malformed task search requests
-  /v6/relations/golden-record-tasks/finished-events:
+  /v7/business-partners/golden-record-tasks/result-state/search:
+    post:
+      tags:
+        - Task Client
+      summary: Search for result states by giving a list of task IDs
+      operationId: searchTaskResultStates_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskResultStateSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: The list of corresponding result states in the same order as has been received. A null indicates that a task could not be found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskResultStateSearchResponse'
+        '400':
+          description: On malformed task search requests
+  /v7/business-partners/golden-record-tasks:
+    post:
+      tags:
+        - Task Client
+      summary: Create new golden record tasks for given business partner data
+      description: Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.
+      operationId: createTasks_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: The states of successfully created tasks including the task identifier for tracking purposes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskCreateResponse'
+        '400':
+          description: On malformed task create requests or reaching upsert limit
+  /v6/golden-record-tasks:
+    post:
+      tags:
+        - Task Client
+      summary: Create new golden record tasks for given business partner data
+      description: Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.
+      operationId: createTasks_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: The states of successfully created tasks including the task identifier for tracking purposes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskCreateResponse'
+        '400':
+          description: On malformed task create requests or reaching upsert limit
+  /v7/relations/golden-record-tasks/finished-events:
     get:
       tags:
         - Task Client
@@ -258,13 +363,51 @@ paths:
                 $ref: '#/components/schemas/FinishedTaskEventsResponse'
         '400':
           description: On malformed requests
-  /v6/golden-record-tasks/finished-events:
+  /v7/business-partners/golden-record-tasks/finished-events:
     get:
       tags:
         - Task Client
       summary: Get event log of golden record tasks that have finished processing
       description: 'The event log contains all events of when golden record tasks finish processing. These events are helpful for the task creator to check whether created tasks have finished processing. A paginated list of events that happened after a given time is returned. '
       operationId: getEvents
+      parameters:
+        - name: timestamp
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: The paginated events after the given timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FinishedTaskEventsResponse'
+        '400':
+          description: On malformed requests
+  /v6/golden-record-tasks/finished-events:
+    get:
+      tags:
+        - Task Client
+      summary: Get event log of golden record tasks that have finished processing
+      description: 'The event log contains all events of when golden record tasks finish processing. These events are helpful for the task creator to check whether created tasks have finished processing. A paginated list of events that happened after a given time is returned. '
+      operationId: getEvents_1
       parameters:
         - name: timestamp
           in: query
@@ -1027,12 +1170,9 @@ components:
         businessPartnerRelations:
           $ref: '#/components/schemas/BusinessPartnerRelations'
           description: The business partner relations data to process
-        requestKey:
-          type: string
       required:
         - businessPartnerRelations
         - recordId
-        - requestKey
         - taskId
     TaskRelationsStepReservationResponse:
       type: object


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
This pull request adds new api version for BPDM Orchestrator service. 
The new api version is now v7 along with simultanous support for previous version v6. 
Currently, bpdm-orchestraor service will support for both versioned apis but for round trip test we have enabled only v7.

Contributes to #1294 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
