### PR TITLE
feat(bpdm-pool): api version increased with simultaneous v6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: Add functionality to resolve golden record tasks for business partner relations ([1277](https://github.com/eclipse-tractusx/bpdm/issues/1277))
 - BPDM Gate: Add business partner relation output endpoints to Gate API ([1277](https://github.com/eclipse-tractusx/bpdm/issues/1277))
 - BPDM Gate: Add relation information to business partner outputs ([1278](https://github.com/eclipse-tractusx/bpdm/issues/1278))
-- BPDM Orchestrator: Increased api version to v7 with simultaneous support for version v6([#1294](https://github.com/eclipse-tractusx/bpdm/issues/1294)) 
+- BPDM Orchestrator: Increased api version to v7 with simultaneous support for version v6([#1294](https://github.com/eclipse-tractusx/bpdm/issues/1294))
+- BPDM Pool: Increased api version to v7 with simultaneous support for version v6([#1294](https://github.com/eclipse-tractusx/bpdm/issues/1294))
 
 ### Changed
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PartnerUploadControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PartnerUploadControllerIT.kt
@@ -31,6 +31,7 @@ import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
 import org.eclipse.tractusx.bpdm.gate.api.model.request.BusinessPartnerInputRequest
 import org.eclipse.tractusx.bpdm.gate.api.model.response.LegalEntityRepresentationInputDto
 import org.eclipse.tractusx.bpdm.gate.util.MockAndAssertUtils
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.model.ConfidenceCriteriaDto
 import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
@@ -259,7 +260,7 @@ class PartnerUploadControllerIT @Autowired constructor(
         )
 
         poolWireMockApi.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo("/v6/legal-entities"))
+            WireMock.get(WireMock.urlPathEqualTo(ApiCommons.LEGAL_ENTITY_BASE_PATH_V7))
                 .withQueryParam("bpnLs", WireMock.equalTo(tenantBpnl))
                 .withQueryParam("page", WireMock.equalTo("0"))
                 .withQueryParam("size", WireMock.equalTo("1"))

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServiceIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServiceIT.kt
@@ -43,9 +43,6 @@ import org.eclipse.tractusx.bpdm.gate.entity.generic.PostalAddressDb
 import org.eclipse.tractusx.bpdm.gate.repository.SharingStateRepository
 import org.eclipse.tractusx.bpdm.gate.repository.generic.BusinessPartnerRepository
 import org.eclipse.tractusx.bpdm.gate.util.PrincipalUtil
-import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi
-import org.eclipse.tractusx.bpdm.pool.api.PoolChangelogApi
-import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 import org.eclipse.tractusx.bpdm.pool.api.model.RelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.RelationVerboseDto
@@ -144,7 +141,7 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
         ))
 
         poolWireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo(PoolChangelogApi.CHANGELOG_PATH + PoolChangelogApi.SUBPATH_SEARCH))
+            WireMock.post(WireMock.urlPathEqualTo("${org.eclipse.tractusx.bpdm.pool.api.ApiCommons.CHANGELOG_BASE_PATH_V7}/search"))
                 .inScenario("Changelog")
                 .whenScenarioStateIs(Scenario.STARTED)
                 .willSetStateTo("Requested")
@@ -153,7 +150,7 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
                 )
         )
         poolWireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo(PoolChangelogApi.CHANGELOG_PATH + PoolChangelogApi.SUBPATH_SEARCH))
+            WireMock.post(WireMock.urlPathEqualTo("${org.eclipse.tractusx.bpdm.pool.api.ApiCommons.CHANGELOG_BASE_PATH_V7}/search"))
                 .inScenario("Changelog")
                 .whenScenarioStateIs("Requested")
                 .willReturn(
@@ -162,7 +159,7 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
         )
 
         poolWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(PoolLegalEntityApi.LEGAL_ENTITY_PATH))
+            WireMock.get(WireMock.urlPathEqualTo(org.eclipse.tractusx.bpdm.pool.api.ApiCommons.LEGAL_ENTITY_BASE_PATH_V7))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(mockedLegalEntityResponse))
                 )
@@ -200,7 +197,7 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
         ))
 
         poolWireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo(PoolChangelogApi.CHANGELOG_PATH + PoolChangelogApi.SUBPATH_SEARCH))
+            WireMock.post(WireMock.urlPathEqualTo("${org.eclipse.tractusx.bpdm.pool.api.ApiCommons.CHANGELOG_BASE_PATH_V7}/search"))
                 .inScenario("Changelog")
                 .whenScenarioStateIs(Scenario.STARTED)
                 .willSetStateTo("Requested")
@@ -209,7 +206,7 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
                 )
         )
         poolWireMockServer.stubFor(
-            WireMock.post(WireMock.urlPathEqualTo(PoolChangelogApi.CHANGELOG_PATH + PoolChangelogApi.SUBPATH_SEARCH))
+            WireMock.post(WireMock.urlPathEqualTo("${org.eclipse.tractusx.bpdm.pool.api.ApiCommons.CHANGELOG_BASE_PATH_V7}/search"))
                 .inScenario("Changelog")
                 .whenScenarioStateIs("Requested")
                 .willReturn(
@@ -218,7 +215,7 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
         )
 
         poolWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(PoolLegalEntityApi.LEGAL_ENTITY_PATH))
+            WireMock.get(WireMock.urlPathEqualTo(org.eclipse.tractusx.bpdm.pool.api.ApiCommons.LEGAL_ENTITY_BASE_PATH_V7))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(mockedLegalEntityResponse))
                 )
@@ -271,13 +268,13 @@ class GoldenRecordUpdateServiceIT @Autowired constructor(
 
         val mockEmptyResponse = PageDto<Any>(0, 0, 0, 0, emptyList<Any>())
         poolWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(PoolLegalEntityApi.LEGAL_ENTITY_PATH))
+            WireMock.get(WireMock.urlPathEqualTo(org.eclipse.tractusx.bpdm.pool.api.ApiCommons.LEGAL_ENTITY_BASE_PATH_V7))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(mockEmptyResponse))
                 )
         )
         poolWireMockServer.stubFor(
-            WireMock.get(WireMock.urlPathEqualTo(PoolAddressApi.ADDRESS_PATH))
+            WireMock.get(WireMock.urlPathEqualTo(org.eclipse.tractusx.bpdm.pool.api.ApiCommons.ADDRESS_BASE_PATH_V7))
                 .willReturn(
                     WireMock.okJson(objectMapper.writeValueAsString(mockEmptyResponse))
                 )

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/util/MockAndAssertUtils.kt
@@ -36,7 +36,6 @@ import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerInputDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.BusinessPartnerOutputDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.RelationPutResponse
 import org.eclipse.tractusx.bpdm.gate.api.model.response.SharingStateDto
-import org.eclipse.tractusx.bpdm.pool.api.PoolChangelogApi
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDto
 import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerGenericCommonValues
@@ -44,8 +43,6 @@ import org.eclipse.tractusx.bpdm.test.testdata.gate.BusinessPartnerVerboseValues
 import org.eclipse.tractusx.bpdm.test.util.AssertHelpers
 import org.eclipse.tractusx.bpdm.test.util.Timeframe
 import org.eclipse.tractusx.orchestrator.api.ApiCommons
-import org.eclipse.tractusx.orchestrator.api.FinishedTaskEventApi
-import org.eclipse.tractusx.orchestrator.api.GoldenRecordTaskApi
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -61,7 +58,7 @@ class MockAndAssertUtils @Autowired constructor(
     val ORCHESTRATOR_CREATE_TASKS_URL = ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS
     val ORCHESTRATOR_SEARCH_TASK_STATES_URL = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/state/search"
     val ORCHESTRATOR_SEARCH_TASK_RESULT_STATES_URL = "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/result-state/search"
-    val POOL_API_SEARCH_CHANGE_LOG_URL = "${PoolChangelogApi.CHANGELOG_PATH}/search"
+    val POOL_API_SEARCH_CHANGE_LOG_URL = "${org.eclipse.tractusx.bpdm.pool.api.ApiCommons.CHANGELOG_BASE_PATH_V7}/search"
 
     val taskStep = TaskStep.entries.first()
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/ApiCommons.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/ApiCommons.kt
@@ -19,9 +19,40 @@
 
 package org.eclipse.tractusx.bpdm.pool.api
 
+import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
+
 object ApiCommons {
 
-    const val BASE_PATH = "/v6"
+    const val BASE_PATH_V6 = "/v6"
+    const val BASE_PATH_V7 = "/v7"
+
+    const val LEGAL_ENTITY_BASE_PATH_V6 = "${BASE_PATH_V6}/legal-entities"
+    const val LEGAL_ENTITY_BASE_PATH_V7 = "${BASE_PATH_V7}/legal-entities"
+
+    const val ADDRESS_BASE_PATH_V6 = "${BASE_PATH_V6}/addresses"
+    const val ADDRESS_BASE_PATH_V7 = "${BASE_PATH_V7}/addresses"
+
+    const val SITE_BASE_PATH_V6 = "${BASE_PATH_V6}/sites"
+    const val SITE_BASE_PATH_V7 = "${BASE_PATH_V7}/sites"
+
+    const val MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V6 = "${BASE_PATH_V6}/members/legal-entities${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_SITES_SEARCH_PATH_V6 = "${BASE_PATH_V6}/members/sites${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_ADDRESSES_SEARCH_PATH_V6 = "${BASE_PATH_V6}/members/addresses${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_CHANGELOG_SEARCH_PATH_V6 = "${BASE_PATH_V6}/members/changelog${CommonApiPathNames.SUBPATH_SEARCH}"
+
+    const val MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/legal-entities${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_SITES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/sites${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_ADDRESSES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/addresses${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_CHANGELOG_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/changelog${CommonApiPathNames.SUBPATH_SEARCH}"
+
+    const val CHANGELOG_BASE_PATH_V6 = "${BASE_PATH_V6}/business-partners/changelog"
+    const val CHANGELOG_BASE_PATH_V7 = "${BASE_PATH_V7}/business-partners/changelog"
+
+    const val BPN_BASE_PATH_V6 = "${BASE_PATH_V6}/bpn"
+    const val BPN_BASE_PATH_V7 = "${BASE_PATH_V7}/bpn"
+
+    const val MEMBERSHIP_BASE_PATH_V6 = "${BASE_PATH_V6}/cx-memberships"
+    const val MEMBERSHIP_BASE_PATH_V7 = "${BASE_PATH_V7}/cx-memberships"
 
     const val LEGAL_ENTITIES_NAME = "Legal Entity Controller"
     const val LEGAL_ENTITIES_DESCRIPTION = "Read, create and update business partner of type legal entity"

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
-import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi.Companion.ADDRESS_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
@@ -40,14 +39,8 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 
 
-@RequestMapping(ADDRESS_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolAddressApi {
-
-    companion object{
-        const val ADDRESS_PATH = "${ApiCommons.BASE_PATH}/addresses"
-        const val PATHVAR_BPNA = "bpna"
-        const val SUBPATH_BPNA = "/{$PATHVAR_BPNA}"
-    }
 
     @Operation(
         summary = "Returns addresses by different search parameters",
@@ -62,7 +55,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @GetMapping
+    @GetMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6, ApiCommons.ADDRESS_BASE_PATH_V7])
     fun getAddresses(
         @ParameterObject addressSearchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -80,9 +73,9 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @GetMapping(SUBPATH_BPNA)
+    @GetMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V6}/{bpna}", "${ApiCommons.ADDRESS_BASE_PATH_V7}/{bpna}"])
     fun getAddress(
-        @Parameter(description = "BPNA value") @PathVariable(PATHVAR_BPNA) bpna: String
+        @Parameter(description = "BPNA value") @PathVariable bpna: String
     ): LogisticAddressVerboseDto
 
     @Operation(
@@ -96,7 +89,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PostMapping(CommonApiPathNames.SUBPATH_SEARCH)
+    @PostMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V6}${CommonApiPathNames.SUBPATH_SEARCH}", "${ApiCommons.ADDRESS_BASE_PATH_V7}${CommonApiPathNames.SUBPATH_SEARCH}"])
     fun searchAddresses(
         @RequestBody searchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -116,7 +109,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PostMapping
+    @PostMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6, ApiCommons.ADDRESS_BASE_PATH_V7])
     fun createAddresses(
         @RequestBody
         requests: Collection<AddressPartnerCreateRequest>
@@ -134,7 +127,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PutMapping
+    @PutMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6, ApiCommons.ADDRESS_BASE_PATH_V7])
     fun updateAddresses(
         @RequestBody
         requests: Collection<AddressPartnerUpdateRequest>

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolBpnApi.kt
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
-import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi.Companion.BPN_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BpnRequestIdentifierSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.BpnIdentifierMappingDto
@@ -37,12 +36,8 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 
-@RequestMapping(BPN_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolBpnApi {
-
-    companion object{
-        const val BPN_PATH = "${ApiCommons.BASE_PATH}/bpn"
-    }
 
     @Operation(
         summary = "Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values",
@@ -62,7 +57,7 @@ interface PoolBpnApi {
         ]
     )
     @Tag(name = ApiCommons.BPN_NAME, description = ApiCommons.BPN_DESCRIPTION)
-    @PostMapping(CommonApiPathNames.SUBPATH_SEARCH)
+    @PostMapping(value = ["${ApiCommons.BPN_BASE_PATH_V6}${CommonApiPathNames.SUBPATH_SEARCH}", "${ApiCommons.BPN_BASE_PATH_V7}${CommonApiPathNames.SUBPATH_SEARCH}"])
     fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingDto>>
 
     @Operation(
@@ -75,6 +70,6 @@ interface PoolBpnApi {
         ]
     )
     @Tag(name = ApiCommons.BPN_NAME, description = ApiCommons.BPN_DESCRIPTION)
-    @PostMapping("/request-ids/search")
+    @PostMapping(value = ["${ApiCommons.BPN_BASE_PATH_V6}/request-ids/search", "${ApiCommons.BPN_BASE_PATH_V7}/request-ids/search"])
     fun findBpnByRequestedIdentifiers(@RequestBody request: BpnRequestIdentifierSearchRequest): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolChangelogApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolChangelogApi.kt
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.PoolChangelogApi.Companion.CHANGELOG_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDto
 import org.springdoc.core.annotations.ParameterObject
@@ -36,12 +35,8 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 
-@RequestMapping(CHANGELOG_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolChangelogApi {
-    companion object {
-        const val CHANGELOG_PATH = "${ApiCommons.BASE_PATH}/business-partners/changelog"
-        const val SUBPATH_SEARCH = "/search"
-    }
 
     @Operation(
         summary = "Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types"
@@ -54,7 +49,7 @@ interface PoolChangelogApi {
         ]
     )
     @Tag(name = ApiCommons.CHANGELOG_NAME, description = ApiCommons.CHANGELOG_DESCRIPTION)
-    @PostMapping(SUBPATH_SEARCH)
+    @PostMapping(value = ["${ApiCommons.CHANGELOG_BASE_PATH_V6}/search", "${ApiCommons.CHANGELOG_BASE_PATH_V7}/search"])
     fun getChangelogEntries(
         @RequestBody changelogSearchRequest: ChangelogSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolCxMembershipApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolCxMembershipApi.kt
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.bpdm.pool.api
 
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.PoolCxMembershipApi.Companion.MEMBERSHIP_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.CxMembershipDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipUpdateRequest
@@ -32,20 +31,16 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 
-@RequestMapping(MEMBERSHIP_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolCxMembershipApi {
 
-    companion object{
-        const val MEMBERSHIP_PATH = "${ApiCommons.BASE_PATH}/cx-memberships"
-    }
-
-    @GetMapping
+    @GetMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V6, ApiCommons.MEMBERSHIP_BASE_PATH_V7])
     fun get(
         @ParameterObject searchRequest: CxMembershipSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<CxMembershipDto>
 
 
-    @PutMapping
+    @PutMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V6, ApiCommons.MEMBERSHIP_BASE_PATH_V7])
     fun put(@RequestBody updateRequest: CxMembershipUpdateRequest)
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi.Companion.LEGAL_ENTITY_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntityPartnerCreateRequest
@@ -42,12 +41,8 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 
-@RequestMapping(LEGAL_ENTITY_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolLegalEntityApi {
-
-    companion object{
-        const val LEGAL_ENTITY_PATH = "${ApiCommons.BASE_PATH}/legal-entities"
-    }
 
     @Operation(
         summary = "Returns legal entities by different search parameters",
@@ -61,7 +56,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping
+    @GetMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6, ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
     fun getLegalEntities(
         @ParameterObject searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -87,7 +82,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping("/{idValue}")
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{idValue}", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{idValue}"])
     fun getLegalEntity(
         @Parameter(description = "Identifier value") @PathVariable("idValue") idValue: String,
         @Parameter(description = "Type of identifier to use, defaults to BPN when omitted", schema = Schema(defaultValue = "BPN"))
@@ -111,7 +106,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping("/search")
+    @PostMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/search", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/search"])
     fun postLegalEntitySearch(
         @RequestBody searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -129,7 +124,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping("/{bpnl}/sites")
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{bpnl}/sites", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/sites"])
     fun getSites(
         @Parameter(description = "BPNL value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
@@ -147,7 +142,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping("/{bpnl}/addresses")
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{bpnl}/addresses", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/addresses"])
     fun getAddresses(
         @Parameter(description = "BPNL value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
@@ -166,7 +161,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping
+    @PostMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6, ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
     fun createBusinessPartners(
         @RequestBody
         businessPartners: Collection<LegalEntityPartnerCreateRequest>
@@ -185,7 +180,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PutMapping
+    @PutMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6, ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
     fun updateBusinessPartners(
         @RequestBody
         businessPartners: Collection<LegalEntityPartnerUpdateRequest>

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMembersApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMembersApi.kt
@@ -22,8 +22,6 @@ package org.eclipse.tractusx.bpdm.pool.api
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
-import org.eclipse.tractusx.bpdm.pool.api.PoolMembersApi.Companion.MEMBERS_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
@@ -39,41 +37,32 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 
 
-@RequestMapping(MEMBERS_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolMembersApi {
 
-    companion object{
-        const val MEMBERS_PATH = "${ApiCommons.BASE_PATH}/members"
-
-        const val LEGAL_ENTITIES_SEARCH_PATH = "/legal-entities${CommonApiPathNames.SUBPATH_SEARCH}"
-        const val SITES_SEARCH_PATH = "/sites${CommonApiPathNames.SUBPATH_SEARCH}"
-        const val ADDRESSES_SEARCH_PATH = "/addresses${CommonApiPathNames.SUBPATH_SEARCH}"
-        const val CHANGELOG_SEARCH_PATH = "/changelog/search"
-    }
-
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping(LEGAL_ENTITIES_SEARCH_PATH)
+    @PostMapping(value = [ApiCommons.MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V6, ApiCommons.MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V7])
     fun searchLegalEntities(
         @RequestBody searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping(SITES_SEARCH_PATH)
+    @PostMapping(value = [ApiCommons.MEMBERS_SITES_SEARCH_PATH_V6, ApiCommons.MEMBERS_SITES_SEARCH_PATH_V7])
     fun postSiteSearch(
         @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
 
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PostMapping(ADDRESSES_SEARCH_PATH)
+    @PostMapping(value = [ApiCommons.MEMBERS_ADDRESSES_SEARCH_PATH_V6, ApiCommons.MEMBERS_ADDRESSES_SEARCH_PATH_V7])
     fun searchAddresses(
         @RequestBody searchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
     @Tag(name = ApiCommons.CHANGELOG_NAME, description = ApiCommons.CHANGELOG_DESCRIPTION)
-    @PostMapping(CHANGELOG_SEARCH_PATH)
+    @PostMapping(value = [ApiCommons.MEMBERS_CHANGELOG_SEARCH_PATH_V6, ApiCommons.MEMBERS_CHANGELOG_SEARCH_PATH_V7])
     fun searchChangelogEntries(
         @RequestBody changelogSearchRequest: ChangelogSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.PoolMetadataApi.DescriptionObject.METADATA_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.*
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
 import org.springdoc.core.annotations.ParameterObject
@@ -37,12 +36,10 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 
-@RequestMapping(METADATA_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolMetadataApi {
 
     companion object DescriptionObject {
-        const val METADATA_PATH = ApiCommons.BASE_PATH
-
         const val technicalKeyDisclaimer =
             "The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. " +
                     "A recommendation for technical keys: They should be short, descriptive and " +
@@ -63,7 +60,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @PostMapping("/identifier-types")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/identifier-types", "${ApiCommons.BASE_PATH_V7}/identifier-types"])
     fun createIdentifierType(@RequestBody identifierType: IdentifierTypeDto): IdentifierTypeDto
 
     @Operation(
@@ -77,7 +74,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @GetMapping("/identifier-types")
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/identifier-types", "${ApiCommons.BASE_PATH_V7}/identifier-types"])
     fun getIdentifierTypes(
         @ParameterObject paginationRequest: PaginationRequest,
         @Parameter businessPartnerType: IdentifierBusinessPartnerType,
@@ -99,7 +96,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @PostMapping("/legal-forms")
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/legal-forms", "${ApiCommons.BASE_PATH_V7}/legal-forms"])
     fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormDto
 
     @Operation(
@@ -113,7 +110,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @GetMapping("/legal-forms")
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/legal-forms", "${ApiCommons.BASE_PATH_V7}/legal-forms"])
     fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageDto<LegalFormDto>
 
 
@@ -129,7 +126,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @GetMapping("/field-quality-rules/")
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/field-quality-rules/", "${ApiCommons.BASE_PATH_V7}/field-quality-rules/"])
     fun getFieldQualityRules(@Parameter(description = "ISO 3166-1 alpha-2 country code") @RequestParam country: CountryCode): ResponseEntity<Collection<FieldQualityRuleDto>>
 
     @Operation(
@@ -143,7 +140,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @GetMapping("/administrative-areas-level1")
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/administrative-areas-level1", "${ApiCommons.BASE_PATH_V7}/administrative-areas-level1"])
     fun getAdminAreasLevel1(@ParameterObject paginationRequest: PaginationRequest): PageDto<CountrySubdivisionDto>
 
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi.Companion.SITE_PATH
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
@@ -40,12 +39,8 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 
-@RequestMapping(SITE_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 interface PoolSiteApi {
-
-    companion object{
-        const val SITE_PATH = "${ApiCommons.BASE_PATH}/sites"
-    }
 
     @Operation(
         summary = "Returns a site by its BPNS",
@@ -59,7 +54,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @GetMapping("/{bpns}")
+    @GetMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/{bpns}", "${ApiCommons.SITE_BASE_PATH_V7}/{bpns}"])
     fun getSite(
         @Parameter(description = "BPNS value") @PathVariable bpns: String
     ): SiteWithMainAddressVerboseDto
@@ -75,7 +70,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping("/search")
+    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/search", "${ApiCommons.SITE_BASE_PATH_V7}/search"])
     fun postSiteSearch(
         @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -94,7 +89,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping
+    @PostMapping(value = [ApiCommons.SITE_BASE_PATH_V6, ApiCommons.SITE_BASE_PATH_V7])
     fun createSite(
         @RequestBody
         requests: Collection<SitePartnerCreateRequest>
@@ -112,7 +107,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PutMapping
+    @PutMapping(value = [ApiCommons.SITE_BASE_PATH_V6, ApiCommons.SITE_BASE_PATH_V7])
     fun updateSite(
         @RequestBody
         requests: Collection<SitePartnerUpdateRequest>
@@ -129,7 +124,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @GetMapping
+    @GetMapping(value = [ApiCommons.SITE_BASE_PATH_V6, ApiCommons.SITE_BASE_PATH_V7])
     fun getSites(
         @ParameterObject searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -147,7 +142,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping("/legal-main-sites")
+    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/legal-main-sites", "${ApiCommons.SITE_BASE_PATH_V7}/legal-main-sites"])
     fun createSiteWithLegalReference(
         @RequestBody request: Collection<SiteCreateRequestWithLegalAddressAsMain>
     ): SitePartnerCreateResponseWrapper

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/AddressApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/AddressApiClient.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolAddressApi
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
@@ -37,27 +38,27 @@ import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 import org.springframework.web.service.annotation.PutExchange
 
-@HttpExchange(PoolAddressApi.ADDRESS_PATH)
+@HttpExchange
 interface AddressApiClient: PoolAddressApi {
 
-    @GetExchange
+    @GetExchange(value = ApiCommons.ADDRESS_BASE_PATH_V7)
     override fun getAddresses(
         @ParameterObject addressSearchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
-    @GetExchange(PoolAddressApi.SUBPATH_BPNA)
-    override fun getAddress(@PathVariable(PoolAddressApi.PATHVAR_BPNA) bpna: String): LogisticAddressVerboseDto
+    @GetExchange(value = "${ApiCommons.ADDRESS_BASE_PATH_V7}/{bpna}")
+    override fun getAddress(@PathVariable bpna: String): LogisticAddressVerboseDto
 
-    @PostExchange(CommonApiPathNames.SUBPATH_SEARCH)
+    @PostExchange(value = "${ApiCommons.ADDRESS_BASE_PATH_V7}${CommonApiPathNames.SUBPATH_SEARCH}")
     override fun searchAddresses(
         @RequestBody searchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
-    @PostExchange
+    @PostExchange(value = ApiCommons.ADDRESS_BASE_PATH_V7)
     override fun createAddresses(@RequestBody requests: Collection<AddressPartnerCreateRequest>): AddressPartnerCreateResponseWrapper
 
-    @PutExchange
+    @PutExchange(value = ApiCommons.ADDRESS_BASE_PATH_V7)
     override fun updateAddresses(@RequestBody requests: Collection<AddressPartnerUpdateRequest>): AddressPartnerUpdateResponseWrapper
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/BpnApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/BpnApiClient.kt
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.bpdm.pool.api.client
 
 import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolBpnApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.BpnRequestIdentifierSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.request.IdentifiersSearchRequest
@@ -30,11 +31,11 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-@HttpExchange(PoolBpnApi.BPN_PATH)
+@HttpExchange
 interface BpnApiClient: PoolBpnApi {
-    @PostExchange(CommonApiPathNames.SUBPATH_SEARCH)
+    @PostExchange(value = "${ApiCommons.BPN_BASE_PATH_V7}${CommonApiPathNames.SUBPATH_SEARCH}")
     override fun findBpnsByIdentifiers(@RequestBody request: IdentifiersSearchRequest): ResponseEntity<Set<BpnIdentifierMappingDto>>
 
-    @PostExchange(value = "/request-ids/search")
+    @PostExchange(value = "${ApiCommons.BPN_BASE_PATH_V7}/request-ids/search")
     override fun findBpnByRequestedIdentifiers(@RequestBody request: BpnRequestIdentifierSearchRequest): ResponseEntity<Set<BpnRequestIdentifierMappingDto>>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/ChangeLogApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/ChangeLogApiClient.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolChangelogApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDto
@@ -29,10 +30,10 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-@HttpExchange(PoolChangelogApi.CHANGELOG_PATH)
+@HttpExchange
 interface ChangeLogApiClient : PoolChangelogApi {
 
-    @PostExchange(PoolChangelogApi.SUBPATH_SEARCH)
+    @PostExchange(value = "${ApiCommons.CHANGELOG_BASE_PATH_V7}/search")
     override fun getChangelogEntries(
         @RequestBody changelogSearchRequest: ChangelogSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/CxMembershipApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/CxMembershipApiClient.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolCxMembershipApi
 import org.eclipse.tractusx.bpdm.pool.api.model.CxMembershipDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipSearchRequest
@@ -31,13 +32,13 @@ import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PutExchange
 
-@HttpExchange(PoolCxMembershipApi.MEMBERSHIP_PATH)
+@HttpExchange
 interface CxMembershipApiClient: PoolCxMembershipApi {
 
-    @GetExchange
+    @GetExchange(value = ApiCommons.MEMBERSHIP_BASE_PATH_V7)
     override fun get(@ParameterObject searchRequest: CxMembershipSearchRequest, @ParameterObject paginationRequest: PaginationRequest): PageDto<CxMembershipDto>
 
-    @PutExchange
+    @PutExchange(value = ApiCommons.MEMBERSHIP_BASE_PATH_V7)
     override fun put(@RequestBody updateRequest: CxMembershipUpdateRequest)
 
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/LegalEntityApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/LegalEntityApiClient.kt
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.SiteVerboseDto
@@ -41,45 +42,45 @@ import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 import org.springframework.web.service.annotation.PutExchange
 
-@HttpExchange(PoolLegalEntityApi.LEGAL_ENTITY_PATH)
+@HttpExchange
 interface LegalEntityApiClient : PoolLegalEntityApi {
-    @PostExchange
+    @PostExchange(value = ApiCommons.LEGAL_ENTITY_BASE_PATH_V7)
     override fun createBusinessPartners(
         @RequestBody businessPartners: Collection<LegalEntityPartnerCreateRequest>
     ): LegalEntityPartnerCreateResponseWrapper
 
-    @GetExchange("/{bpnl}/addresses")
+    @GetExchange(value = "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/addresses")
     override fun getAddresses(
         @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
-    @GetExchange
+    @GetExchange(value = ApiCommons.LEGAL_ENTITY_BASE_PATH_V7)
     override fun getLegalEntities(
         @ParameterObject searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
-    @GetExchange("/{idValue}")
+    @GetExchange(value = "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{idValue}")
     override fun getLegalEntity(
         @PathVariable idValue: String,
         @Parameter(description = "Type of identifier to use, defaults to BPN when omitted", schema = Schema(defaultValue = "BPN"))
         @RequestParam idType: String?
     ): LegalEntityWithLegalAddressVerboseDto
 
-    @GetExchange("/{bpnl}/sites")
+    @GetExchange(value = "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/sites")
     override fun getSites(
         @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteVerboseDto>
 
-    @PostExchange("/search")
+    @PostExchange(value = "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/search")
     override fun postLegalEntitySearch(
         @RequestBody searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
-    @PutExchange
+    @PutExchange(value = ApiCommons.LEGAL_ENTITY_BASE_PATH_V7)
     override fun updateBusinessPartners(
         @RequestBody
         businessPartners: Collection<LegalEntityPartnerUpdateRequest>

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MembersApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MembersApiClient.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolMembersApi
 import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
@@ -35,28 +36,28 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-@HttpExchange(PoolMembersApi.MEMBERS_PATH)
+@HttpExchange
 interface MembersApiClient : PoolMembersApi {
 
-    @PostExchange(PoolMembersApi.LEGAL_ENTITIES_SEARCH_PATH)
+    @PostExchange(value = ApiCommons.MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V7)
     override fun searchLegalEntities(
         @RequestBody searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
-    @PostExchange(PoolMembersApi.SITES_SEARCH_PATH)
+    @PostExchange(value = ApiCommons.MEMBERS_SITES_SEARCH_PATH_V7)
     override fun postSiteSearch(
         @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
 
-    @PostExchange(PoolMembersApi.ADDRESSES_SEARCH_PATH)
+    @PostExchange(value = ApiCommons.MEMBERS_ADDRESSES_SEARCH_PATH_V7)
     override fun searchAddresses(
         @RequestBody searchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
-    @PostExchange(PoolMembersApi.CHANGELOG_SEARCH_PATH)
+    @PostExchange(value = ApiCommons.MEMBERS_CHANGELOG_SEARCH_PATH_V7)
     override fun searchChangelogEntries(
         @RequestBody changelogSearchRequest: ChangelogSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MetadataApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/MetadataApiClient.kt
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 import com.neovisionaries.i18n.CountryCode
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolMetadataApi
 import org.eclipse.tractusx.bpdm.pool.api.model.*
 import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalFormRequest
@@ -33,28 +34,28 @@ import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 
-@HttpExchange(PoolMetadataApi.METADATA_PATH)
+@HttpExchange
 interface MetadataApiClient: PoolMetadataApi {
 
-    @PostExchange("/identifier-types")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7}/identifier-types")
     override fun createIdentifierType(@RequestBody identifierType: IdentifierTypeDto): IdentifierTypeDto
 
-    @PostExchange("/legal-forms")
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V7}/legal-forms")
     override fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormDto
 
-    @GetExchange("/administrative-areas-level1")
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V7}/administrative-areas-level1")
     override fun getAdminAreasLevel1(@ParameterObject paginationRequest: PaginationRequest): PageDto<CountrySubdivisionDto>
 
-    @GetExchange("/field-quality-rules/")
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V7}/field-quality-rules/")
     override fun getFieldQualityRules(@RequestParam country: CountryCode): ResponseEntity<Collection<FieldQualityRuleDto>>
 
-    @GetExchange("/identifier-types")
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V7}/identifier-types")
     override fun getIdentifierTypes(
         @ParameterObject paginationRequest: PaginationRequest,
         @RequestParam businessPartnerType: IdentifierBusinessPartnerType,
         @RequestParam country: CountryCode?
     ): PageDto<IdentifierTypeDto>
 
-    @GetExchange("/legal-forms")
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V7}/legal-forms")
     override fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageDto<LegalFormDto>
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/SiteApiClient.kt
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 import org.eclipse.tractusx.bpdm.pool.api.PoolSiteApi
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
 import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
@@ -37,36 +38,36 @@ import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PostExchange
 import org.springframework.web.service.annotation.PutExchange
 
-@HttpExchange(PoolSiteApi.SITE_PATH)
+@HttpExchange
 interface SiteApiClient : PoolSiteApi {
-    @PostExchange
+    @PostExchange(value = ApiCommons.SITE_BASE_PATH_V7)
     override fun createSite(
         @RequestBody requests: Collection<SitePartnerCreateRequest>
     ): SitePartnerCreateResponseWrapper
 
-    @GetExchange("/{bpns}")
+    @GetExchange(value = "${ApiCommons.SITE_BASE_PATH_V7}/{bpns}")
     override fun getSite(
         @PathVariable bpns: String
     ): SiteWithMainAddressVerboseDto
 
-    @GetExchange
+    @GetExchange(value = ApiCommons.SITE_BASE_PATH_V7)
     override fun getSites(
         @ParameterObject searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
 
-    @PostExchange("/search")
+    @PostExchange(value = "${ApiCommons.SITE_BASE_PATH_V7}/search")
     override fun postSiteSearch(
         @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
 
-    @PutExchange
+    @PutExchange(value = ApiCommons.SITE_BASE_PATH_V7)
     override fun updateSite(
         @RequestBody requests: Collection<SitePartnerUpdateRequest>
     ): SitePartnerUpdateResponseWrapper
 
-    @PostExchange("/legal-main-sites")
+    @PostExchange(value = "${ApiCommons.SITE_BASE_PATH_V7}/legal-main-sites")
     override fun createSiteWithLegalReference(
         @RequestBody request: Collection<SiteCreateRequestWithLegalAddressAsMain>
     ): SitePartnerCreateResponseWrapper

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/EndpointValues.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/util/EndpointValues.kt
@@ -19,14 +19,13 @@
 
 package org.eclipse.tractusx.bpdm.pool.util
 
-import org.eclipse.tractusx.bpdm.pool.api.PoolLegalEntityApi
-import org.eclipse.tractusx.bpdm.pool.api.PoolMetadataApi
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
 
 object EndpointValues {
 
-    const val CATENA_LEGAL_ENTITY_PATH = PoolLegalEntityApi.LEGAL_ENTITY_PATH
+    const val CATENA_LEGAL_ENTITY_PATH = ApiCommons.LEGAL_ENTITY_BASE_PATH_V7
 
-    const val CATENA_METADATA_IDENTIFIER_TYPE_PATH = "${PoolMetadataApi.METADATA_PATH}/identifier-types"
-    const val CATENA_METADATA_LEGAL_FORM_PATH = "${PoolMetadataApi.METADATA_PATH}/legal-forms"
+    const val CATENA_METADATA_IDENTIFIER_TYPE_PATH = "${ApiCommons.BASE_PATH_V7}/identifier-types"
+    const val CATENA_METADATA_LEGAL_FORM_PATH = "${ApiCommons.BASE_PATH_V7}/legal-forms"
 
 }

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -34,7 +34,7 @@
     "description" : "Read, create and update business partner of type address"
   } ],
   "paths" : {
-    "/v6/sites" : {
+    "/v7/sites" : {
       "get" : {
         "tags" : [ "Site Controller" ],
         "summary" : "Get page of sites matching the pagination search criteria",
@@ -142,6 +142,144 @@
         "summary" : "Creates a new site",
         "description" : "Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
         "operationId" : "createSite",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/SitePartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New sites request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SitePartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      }
+    },
+    "/v6/sites" : {
+      "get" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Get page of sites matching the pagination search criteria",
+        "description" : "This endpoint retrieves all existing business partners of type sites.",
+        "operationId" : "getSites_1",
+        "parameters" : [ {
+          "name" : "siteBpns",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "legalEntityBpns",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of business partners matching the search criteria, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Updates an existing site",
+        "description" : "Update existing business partner records of type site referenced via BPNS. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId" : "updateSite_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/SitePartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Update sites request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SitePartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Creates a new site",
+        "description" : "Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId" : "createSite_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -300,7 +438,135 @@
         }
       }
     },
-    "/v6/cx-memberships" : {
+    "/v7/legal-entities" : {
+      "get" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns legal entities by different search parameters",
+        "description" : "This endpoint tries to find matches among all existing business partners of type legal entity, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. ",
+        "operationId" : "getLegalEntities_1",
+        "parameters" : [ {
+          "name" : "bpnLs",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "legalName",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of business partners matching the search criteria, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed search or pagination request"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Updates an existing legal entity",
+        "description" : "Update existing business partner records of type legal entity referenced via BPNL. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId" : "updateBusinessPartners_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Update legal entities request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Creates a new legal entity",
+        "description" : "Create new business partners of type legal entity. The given additional identifiers of a record need to be unique, otherwise they are ignored. For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId" : "createBusinessPartners_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New legal entities request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      }
+    },
+    "/v7/cx-memberships" : {
       "get" : {
         "tags" : [ "cx-membership-controller" ],
         "operationId" : "get",
@@ -350,6 +616,73 @@
       "put" : {
         "tags" : [ "cx-membership-controller" ],
         "operationId" : "put",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CxMembershipUpdateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      }
+    },
+    "/v6/cx-memberships" : {
+      "get" : {
+        "tags" : [ "cx-membership-controller" ],
+        "operationId" : "get_1",
+        "parameters" : [ {
+          "name" : "bpnLs",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoCxMembershipDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "cx-membership-controller" ],
+        "operationId" : "put_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -515,12 +848,213 @@
         }
       }
     },
+    "/v7/addresses" : {
+      "get" : {
+        "tags" : [ "Address Controller" ],
+        "summary" : "Returns addresses by different search parameters",
+        "description" : "This endpoint tries to find matches among all existing business partners of type address, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. The match of a partner is better the higher its relevancy score. ",
+        "operationId" : "getAddresses_1",
+        "parameters" : [ {
+          "name" : "addressBpns",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "legalEntityBpns",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "siteBpns",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of addresses matching the search criteria, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed search or pagination request"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "Address Controller" ],
+        "summary" : "Updates an existing address",
+        "description" : "Update existing business partner records of type address referenced via BPNA. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId" : "updateAddresses_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/AddressPartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The successfully updated records, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AddressPartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Address Controller" ],
+        "summary" : "Creates a new address",
+        "description" : "Create new business partners of type address by specifying the BPN of the parent each address belongs to. A parent can be either a site or legal entity business partner. If the parent cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId" : "createAddresses_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/AddressPartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New business partner record successfully created, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AddressPartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      }
+    },
     "/v6/sites/search" : {
       "post" : {
         "tags" : [ "Site Controller" ],
         "summary" : "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
         "description" : "Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities",
         "operationId" : "postSiteSearch",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SiteSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found sites that belong to specified legal entites",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          }
+        }
+      }
+    },
+    "/v7/sites/search" : {
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
+        "description" : "Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities",
+        "operationId" : "postSiteSearch_1",
         "parameters" : [ {
           "name" : "page",
           "in" : "query",
@@ -604,10 +1138,46 @@
         }
       }
     },
-    "/v6/members/sites/search" : {
+    "/v7/sites/legal-main-sites" : {
       "post" : {
         "tags" : [ "Site Controller" ],
-        "operationId" : "postSiteSearch_1",
+        "summary" : "Create a new site with legal entity reference",
+        "description" : "Create a business partner site with the given legal entity reference. It will designate the address information as both legal and site main address.",
+        "operationId" : "createSiteWithLegalReference_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/SiteCreateRequestWithLegalAddressAsMain"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New sites request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SitePartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/v7/members/sites/search" : {
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "operationId" : "postSiteSearch_2",
         "parameters" : [ {
           "name" : "page",
           "in" : "query",
@@ -652,7 +1222,55 @@
         }
       }
     },
-    "/v6/members/legal-entities/search" : {
+    "/v6/members/sites/search" : {
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "operationId" : "postSiteSearch_3",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SiteSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v7/members/legal-entities/search" : {
       "post" : {
         "tags" : [ "Legal Entity Controller" ],
         "operationId" : "searchLegalEntities",
@@ -700,10 +1318,106 @@
         }
       }
     },
-    "/v6/members/changelog/search" : {
+    "/v6/members/legal-entities/search" : {
+      "post" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "operationId" : "searchLegalEntities_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LegalEntitySearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v7/members/changelog/search" : {
       "post" : {
         "tags" : [ "Changelog Controller" ],
         "operationId" : "searchChangelogEntries",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ChangelogSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoChangelogEntryVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v6/members/changelog/search" : {
+      "post" : {
+        "tags" : [ "Changelog Controller" ],
+        "operationId" : "searchChangelogEntries_1",
         "parameters" : [ {
           "name" : "page",
           "in" : "query",
@@ -752,6 +1466,54 @@
       "post" : {
         "tags" : [ "Address Controller" ],
         "operationId" : "searchAddresses",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AddressSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v7/members/addresses/search" : {
+      "post" : {
+        "tags" : [ "Address Controller" ],
+        "operationId" : "searchAddresses_1",
         "parameters" : [ {
           "name" : "page",
           "in" : "query",
@@ -873,6 +1635,83 @@
         }
       }
     },
+    "/v7/legal-forms" : {
+      "get" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Returns all legal forms",
+        "description" : "Lists all currently known legal forms in a paginated result",
+        "operationId" : "getLegalForms_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of existing legal forms, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalFormDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Creates a new legal form",
+        "description" : "Create a new legal form which can be referenced by business partner records. The actual name of the legal form is free to choose and doesn't need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.",
+        "operationId" : "createLegalForm_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LegalFormRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New legal form successfully created",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalFormDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "409" : {
+            "description" : "Legal form with specified technical key already exists"
+          }
+        }
+      }
+    },
     "/v6/legal-entities/search" : {
       "post" : {
         "tags" : [ "Legal Entity Controller" ],
@@ -926,7 +1765,60 @@
         }
       }
     },
-    "/v6/identifier-types" : {
+    "/v7/legal-entities/search" : {
+      "post" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns legal entities by different search parameters",
+        "description" : "Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
+        "operationId" : "postLegalEntitySearch_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LegalEntitySearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found legal entites",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters or if number of requested bpns exceeds limit"
+          }
+        }
+      }
+    },
+    "/v7/identifier-types" : {
       "get" : {
         "tags" : [ "Metadata Controller" ],
         "summary" : "Returns all identifier types filtered by business partner type and country.",
@@ -1020,7 +1912,101 @@
         }
       }
     },
-    "/v6/business-partners/changelog/search" : {
+    "/v6/identifier-types" : {
+      "get" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Returns all identifier types filtered by business partner type and country.",
+        "description" : "Lists all matching identifier types including validity details in a paginated result",
+        "operationId" : "getIdentifierTypes_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        }, {
+          "name" : "businessPartnerType",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "Specifies if an identifier type is valid for legal entities (L) or addresses (A). Sites (S) are not supported.",
+            "enum" : [ "LEGAL_ENTITY", "ADDRESS" ]
+          }
+        }, {
+          "name" : "country",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "UNDEFINED", "AC", "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AN", "AO", "AQ", "AR", "AS", "AT", "AU", "AW", "AX", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ", "BR", "BS", "BT", "BU", "BV", "BW", "BY", "BZ", "CA", "CC", "CD", "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN", "CO", "CP", "CR", "CS", "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DG", "DJ", "DK", "DM", "DO", "DZ", "EA", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "EU", "EZ", "FI", "FJ", "FK", "FM", "FO", "FR", "FX", "GA", "GB", "GD", "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS", "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT", "HU", "IC", "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT", "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MQ", "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR", "NT", "NU", "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM", "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS", "RU", "RW", "SA", "SB", "SC", "SD", "SE", "SF", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST", "SU", "SV", "SX", "SY", "SZ", "TA", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO", "TP", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "UK", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI", "VN", "VU", "WF", "WS", "XI", "XU", "XK", "YE", "YT", "YU", "ZA", "ZM", "ZR", "ZW" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of existing identifier types, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoIdentifierTypeDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Creates a new identifier type",
+        "description" : "Create a new identifier type (including validity details) which can be referenced by business partner records. Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. The actual name of the identifier type is free to choose and doesn't need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.",
+        "operationId" : "createIdentifierType_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IdentifierTypeDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New identifier type successfully created",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/IdentifierTypeDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "409" : {
+            "description" : "Identifier type with specified technical key already exists"
+          }
+        }
+      }
+    },
+    "/v7/business-partners/changelog/search" : {
       "post" : {
         "tags" : [ "Changelog Controller" ],
         "summary" : "Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types",
@@ -1075,12 +2061,107 @@
         }
       }
     },
-    "/v6/bpn/search" : {
+    "/v6/business-partners/changelog/search" : {
+      "post" : {
+        "tags" : [ "Changelog Controller" ],
+        "summary" : "Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types",
+        "operationId" : "getChangelogEntries_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ChangelogSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The specified changelog entries",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoChangelogEntryVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          },
+          "404" : {
+            "description" : "No business partner found for specified bpn"
+          }
+        }
+      }
+    },
+    "/v7/bpn/search" : {
       "post" : {
         "tags" : [ "Bpn Controller" ],
         "summary" : "Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values",
         "description" : "Find business partner numbers by identifiers. The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. For a single request, the maximum number of identifier values to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
         "operationId" : "findBpnsByIdentifiers",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/IdentifiersSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found bpn to identifier value mappings",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/BpnIdentifierMappingDto"
+                  },
+                  "uniqueItems" : true
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters or if number of requested bpns exceeds limit"
+          },
+          "404" : {
+            "description" : "Specified identifier type not found"
+          }
+        }
+      }
+    },
+    "/v6/bpn/search" : {
+      "post" : {
+        "tags" : [ "Bpn Controller" ],
+        "summary" : "Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values",
+        "description" : "Find business partner numbers by identifiers. The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. For a single request, the maximum number of identifier values to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
+        "operationId" : "findBpnsByIdentifiers_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -1149,12 +2230,46 @@
         }
       }
     },
+    "/v7/bpn/request-ids/search" : {
+      "post" : {
+        "tags" : [ "Bpn Controller" ],
+        "summary" : "Return BPNL/S/A based on the requested identifiers",
+        "description" : "Find business partner numbers by requested-identifiers.",
+        "operationId" : "findBpnByRequestedIdentifiers_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BpnRequestIdentifierSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found bpn to based on the requested identifiers",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/BpnRequestIdentifierMappingDto"
+                  },
+                  "uniqueItems" : true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v6/addresses/search" : {
       "post" : {
         "tags" : [ "Address Controller" ],
         "summary" : "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
         "description" : "Search business partners of type address by their BPNA or their parents' BPNL or BPNS.",
-        "operationId" : "searchAddresses_1",
+        "operationId" : "searchAddresses_2",
         "parameters" : [ {
           "name" : "page",
           "in" : "query",
@@ -1202,12 +2317,100 @@
         }
       }
     },
-    "/v6/sites/{bpns}" : {
+    "/v7/addresses/search" : {
+      "post" : {
+        "tags" : [ "Address Controller" ],
+        "summary" : "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
+        "description" : "Search business partners of type address by their BPNA or their parents' BPNL or BPNS.",
+        "operationId" : "searchAddresses_3",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AddressSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found sites for the specified sites and legal entities",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/v7/sites/{bpns}" : {
       "get" : {
         "tags" : [ "Site Controller" ],
         "summary" : "Returns a site by its BPNS",
         "description" : "Get business partners of type site by BPNS ignoring case.",
         "operationId" : "getSite",
+        "parameters" : [ {
+          "name" : "bpns",
+          "in" : "path",
+          "description" : "BPNS value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Found site with specified BPNS",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "404" : {
+            "description" : "No site found under specified BPNS"
+          }
+        }
+      }
+    },
+    "/v6/sites/{bpns}" : {
+      "get" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Returns a site by its BPNS",
+        "description" : "Get business partners of type site by BPNS ignoring case.",
+        "operationId" : "getSite_1",
         "parameters" : [ {
           "name" : "bpns",
           "in" : "path",
@@ -1280,12 +2483,109 @@
         }
       }
     },
+    "/v7/legal-entities/{idValue}" : {
+      "get" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
+        "description" : "This endpoint tries to find a business partner by the specified identifier. The identifier value is case insensitively compared but needs to be given exactly. By default the value given is interpreted as a BPN. By specifying the technical key of another identifier typethe value is matched against the identifiers of that given type.",
+        "operationId" : "getLegalEntity_1",
+        "parameters" : [ {
+          "name" : "idValue",
+          "in" : "path",
+          "description" : "Identifier value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "idType",
+          "in" : "query",
+          "description" : "Type of identifier to use, defaults to BPN when omitted",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Found business partner with specified identifier",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "404" : {
+            "description" : "No business partner found under specified identifier or specified identifier type not found"
+          }
+        }
+      }
+    },
     "/v6/legal-entities/{bpnl}/sites" : {
       "get" : {
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns all sites of a legal entity with a specific BPNL",
         "description" : "Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case.",
-        "operationId" : "getSites_1",
+        "operationId" : "getSites_2",
+        "parameters" : [ {
+          "name" : "bpnl",
+          "in" : "path",
+          "description" : "BPNL value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The sites for the specified bpnl",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoSiteVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          },
+          "404" : {
+            "description" : "No business partner found for specified bpnl"
+          }
+        }
+      }
+    },
+    "/v7/legal-entities/{bpnl}/sites" : {
+      "get" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns all sites of a legal entity with a specific BPNL",
+        "description" : "Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case.",
+        "operationId" : "getSites_3",
         "parameters" : [ {
           "name" : "bpnl",
           "in" : "path",
@@ -1339,7 +2639,61 @@
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns all addresses of a legal entity with a specific BPNL",
         "description" : "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.",
-        "operationId" : "getAddresses_1",
+        "operationId" : "getAddresses_2",
+        "parameters" : [ {
+          "name" : "bpnl",
+          "in" : "path",
+          "description" : "BPNL value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The addresses for the specified BPNL",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          },
+          "404" : {
+            "description" : "No business partner found for specified BPNL"
+          }
+        }
+      }
+    },
+    "/v7/legal-entities/{bpnl}/addresses" : {
+      "get" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns all addresses of a legal entity with a specific BPNL",
+        "description" : "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.",
+        "operationId" : "getAddresses_3",
         "parameters" : [ {
           "name" : "bpnl",
           "in" : "path",
@@ -1424,6 +2778,42 @@
         }
       }
     },
+    "/v7/field-quality-rules/" : {
+      "get" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Get all field quality rules filtered by country (specified by its ISO 3166-1 alpha-2 country code)",
+        "description" : "List the country specific data rules for entity fields.All fields that are not in this list are considered to be forbidden.",
+        "operationId" : "getFieldQualityRules_1",
+        "parameters" : [ {
+          "name" : "country",
+          "in" : "query",
+          "description" : "ISO 3166-1 alpha-2 country code",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "UNDEFINED", "AC", "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AN", "AO", "AQ", "AR", "AS", "AT", "AU", "AW", "AX", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ", "BR", "BS", "BT", "BU", "BV", "BW", "BY", "BZ", "CA", "CC", "CD", "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN", "CO", "CP", "CR", "CS", "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DG", "DJ", "DK", "DM", "DO", "DZ", "EA", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "EU", "EZ", "FI", "FJ", "FK", "FM", "FO", "FR", "FX", "GA", "GB", "GD", "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS", "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT", "HU", "IC", "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT", "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MQ", "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR", "NT", "NU", "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM", "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS", "RU", "RW", "SA", "SB", "SC", "SD", "SE", "SF", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST", "SU", "SV", "SX", "SY", "SZ", "TA", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO", "TP", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "UK", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI", "VN", "VU", "WF", "WS", "XI", "XU", "XK", "YE", "YT", "YU", "ZA", "ZM", "ZR", "ZW" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "List of the existing rules for the given country",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/FieldQualityRuleDto"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          }
+        }
+      }
+    },
     "/v6/administrative-areas-level1" : {
       "get" : {
         "tags" : [ "Metadata Controller" ],
@@ -1467,12 +2857,90 @@
         }
       }
     },
+    "/v7/administrative-areas-level1" : {
+      "get" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Get page of country subdivisions suitable for the administrativeAreaLevel1 address property",
+        "description" : "Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result",
+        "operationId" : "getAdminAreasLevel1_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of existing country subdivisions, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoCountrySubdivisionDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          }
+        }
+      }
+    },
     "/v6/addresses/{bpna}" : {
       "get" : {
         "tags" : [ "Address Controller" ],
         "summary" : "Returns an address by its BPNA",
         "description" : "Get business partners of type address by BPNA ignoring case.",
         "operationId" : "getAddress",
+        "parameters" : [ {
+          "name" : "bpna",
+          "in" : "path",
+          "description" : "BPNA value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Found address with specified BPNA",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "404" : {
+            "description" : "No address found under specified BPNA"
+          }
+        }
+      }
+    },
+    "/v7/addresses/{bpna}" : {
+      "get" : {
+        "tags" : [ "Address Controller" ],
+        "summary" : "Returns an address by its BPNA",
+        "description" : "Get business partners of type address by BPNA ignoring case.",
+        "operationId" : "getAddress_1",
         "parameters" : [ {
           "name" : "bpna",
           "in" : "path",

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -23,7 +23,7 @@ tags:
   - name: Address Controller
     description: Read, create and update business partner of type address
 paths:
-  /v6/sites:
+  /v7/sites:
     get:
       tags:
         - Site Controller
@@ -103,6 +103,103 @@ paths:
       summary: Creates a new site
       description: Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
       operationId: createSite
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/SitePartnerCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: New sites request was processed successfully, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SitePartnerCreateResponseWrapper'
+        '400':
+          description: On malformed requests
+  /v6/sites:
+    get:
+      tags:
+        - Site Controller
+      summary: Get page of sites matching the pagination search criteria
+      description: This endpoint retrieves all existing business partners of type sites.
+      operationId: getSites_1
+      parameters:
+        - name: siteBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: legalEntityBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of business partners matching the search criteria, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
+        '400':
+          description: On malformed pagination request
+    put:
+      tags:
+        - Site Controller
+      summary: Updates an existing site
+      description: Update existing business partner records of type site referenced via BPNS. The endpoint expects to receive the full updated record, including values that didn't change.
+      operationId: updateSite_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/SitePartnerUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Update sites request was processed successfully, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SitePartnerUpdateResponseWrapper'
+        '400':
+          description: On malformed requests
+    post:
+      tags:
+        - Site Controller
+      summary: Creates a new site
+      description: Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
+      operationId: createSite_1
       requestBody:
         content:
           application/json:
@@ -210,7 +307,97 @@ paths:
                 $ref: '#/components/schemas/LegalEntityPartnerCreateResponseWrapper'
         '400':
           description: On malformed requests
-  /v6/cx-memberships:
+  /v7/legal-entities:
+    get:
+      tags:
+        - Legal Entity Controller
+      summary: Returns legal entities by different search parameters
+      description: 'This endpoint tries to find matches among all existing business partners of type legal entity, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. '
+      operationId: getLegalEntities_1
+      parameters:
+        - name: bpnLs
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: legalName
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of business partners matching the search criteria, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
+        '400':
+          description: On malformed search or pagination request
+    put:
+      tags:
+        - Legal Entity Controller
+      summary: Updates an existing legal entity
+      description: Update existing business partner records of type legal entity referenced via BPNL. The endpoint expects to receive the full updated record, including values that didn't change.
+      operationId: updateBusinessPartners_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/LegalEntityPartnerUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Update legal entities request was processed successfully, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalEntityPartnerUpdateResponseWrapper'
+        '400':
+          description: On malformed requests
+    post:
+      tags:
+        - Legal Entity Controller
+      summary: Creates a new legal entity
+      description: Create new business partners of type legal entity. The given additional identifiers of a record need to be unique, otherwise they are ignored. For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
+      operationId: createBusinessPartners_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/LegalEntityPartnerCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: New legal entities request was processed successfully, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalEntityPartnerCreateResponseWrapper'
+        '400':
+          description: On malformed requests
+  /v7/cx-memberships:
     get:
       tags:
         - cx-membership-controller
@@ -249,6 +436,54 @@ paths:
       tags:
         - cx-membership-controller
       operationId: put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CxMembershipUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+  /v6/cx-memberships:
+    get:
+      tags:
+        - cx-membership-controller
+      operationId: get_1
+      parameters:
+        - name: bpnLs
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoCxMembershipDto'
+    put:
+      tags:
+        - cx-membership-controller
+      operationId: put_1
       requestBody:
         content:
           application/json:
@@ -362,6 +597,110 @@ paths:
                 $ref: '#/components/schemas/AddressPartnerCreateResponseWrapper'
         '400':
           description: On malformed requests
+  /v7/addresses:
+    get:
+      tags:
+        - Address Controller
+      summary: Returns addresses by different search parameters
+      description: 'This endpoint tries to find matches among all existing business partners of type address, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. The match of a partner is better the higher its relevancy score. '
+      operationId: getAddresses_1
+      parameters:
+        - name: addressBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: legalEntityBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: siteBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of addresses matching the search criteria, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+        '400':
+          description: On malformed search or pagination request
+    put:
+      tags:
+        - Address Controller
+      summary: Updates an existing address
+      description: Update existing business partner records of type address referenced via BPNA. The endpoint expects to receive the full updated record, including values that didn't change.
+      operationId: updateAddresses_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/AddressPartnerUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: The successfully updated records, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddressPartnerUpdateResponseWrapper'
+        '400':
+          description: On malformed requests
+    post:
+      tags:
+        - Address Controller
+      summary: Creates a new address
+      description: Create new business partners of type address by specifying the BPN of the parent each address belongs to. A parent can be either a site or legal entity business partner. If the parent cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
+      operationId: createAddresses_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/AddressPartnerCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: New business partner record successfully created, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddressPartnerCreateResponseWrapper'
+        '400':
+          description: On malformed requests
   /v6/sites/search:
     post:
       tags:
@@ -369,6 +708,44 @@ paths:
       summary: Returns sites by an array of BPNS and/or an array of corresponding BPNL
       description: Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities
       operationId: postSiteSearch
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SiteSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Found sites that belong to specified legal entites
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
+        '400':
+          description: On malformed request parameters
+  /v7/sites/search:
+    post:
+      tags:
+        - Site Controller
+      summary: Returns sites by an array of BPNS and/or an array of corresponding BPNL
+      description: Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities
+      operationId: postSiteSearch_1
       parameters:
         - name: page
           in: query
@@ -424,11 +801,35 @@ paths:
                 $ref: '#/components/schemas/SitePartnerCreateResponseWrapper'
         '400':
           description: On malformed pagination request
-  /v6/members/sites/search:
+  /v7/sites/legal-main-sites:
     post:
       tags:
         - Site Controller
-      operationId: postSiteSearch_1
+      summary: Create a new site with legal entity reference
+      description: Create a business partner site with the given legal entity reference. It will designate the address information as both legal and site main address.
+      operationId: createSiteWithLegalReference_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/SiteCreateRequestWithLegalAddressAsMain'
+        required: true
+      responses:
+        '200':
+          description: New sites request was processed successfully, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SitePartnerCreateResponseWrapper'
+        '400':
+          description: On malformed pagination request
+  /v7/members/sites/search:
+    post:
+      tags:
+        - Site Controller
+      operationId: postSiteSearch_2
       parameters:
         - name: page
           in: query
@@ -458,7 +859,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
-  /v6/members/legal-entities/search:
+  /v6/members/sites/search:
+    post:
+      tags:
+        - Site Controller
+      operationId: postSiteSearch_3
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SiteSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
+  /v7/members/legal-entities/search:
     post:
       tags:
         - Legal Entity Controller
@@ -492,11 +927,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
-  /v6/members/changelog/search:
+  /v6/members/legal-entities/search:
+    post:
+      tags:
+        - Legal Entity Controller
+      operationId: searchLegalEntities_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalEntitySearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
+  /v7/members/changelog/search:
     post:
       tags:
         - Changelog Controller
       operationId: searchChangelogEntries
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangelogSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoChangelogEntryVerboseDto'
+  /v6/members/changelog/search:
+    post:
+      tags:
+        - Changelog Controller
+      operationId: searchChangelogEntries_1
       parameters:
         - name: page
           in: query
@@ -531,6 +1034,40 @@ paths:
       tags:
         - Address Controller
       operationId: searchAddresses
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddressSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+  /v7/members/addresses/search:
+    post:
+      tags:
+        - Address Controller
+      operationId: searchAddresses_1
       parameters:
         - name: page
           in: query
@@ -615,6 +1152,61 @@ paths:
           description: On malformed request parameters
         '409':
           description: Legal form with specified technical key already exists
+  /v7/legal-forms:
+    get:
+      tags:
+        - Metadata Controller
+      summary: Returns all legal forms
+      description: Lists all currently known legal forms in a paginated result
+      operationId: getLegalForms_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of existing legal forms, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLegalFormDto'
+        '400':
+          description: On malformed request parameters
+    post:
+      tags:
+        - Metadata Controller
+      summary: Creates a new legal form
+      description: 'Create a new legal form which can be referenced by business partner records. The actual name of the legal form is free to choose and doesn''t need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.'
+      operationId: createLegalForm_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalFormRequest'
+        required: true
+      responses:
+        '200':
+          description: New legal form successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalFormDto'
+        '400':
+          description: On malformed request parameters
+        '409':
+          description: Legal form with specified technical key already exists
   /v6/legal-entities/search:
     post:
       tags:
@@ -653,7 +1245,45 @@ paths:
                 $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
         '400':
           description: On malformed request parameters or if number of requested bpns exceeds limit
-  /v6/identifier-types:
+  /v7/legal-entities/search:
+    post:
+      tags:
+        - Legal Entity Controller
+      summary: Returns legal entities by different search parameters
+      description: Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.
+      operationId: postLegalEntitySearch_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalEntitySearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Found legal entites
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
+        '400':
+          description: On malformed request parameters or if number of requested bpns exceeds limit
+  /v7/identifier-types:
     get:
       tags:
         - Metadata Controller
@@ -995,7 +1625,349 @@ paths:
           description: On malformed request parameters
         '409':
           description: Identifier type with specified technical key already exists
-  /v6/business-partners/changelog/search:
+  /v6/identifier-types:
+    get:
+      tags:
+        - Metadata Controller
+      summary: Returns all identifier types filtered by business partner type and country.
+      description: Lists all matching identifier types including validity details in a paginated result
+      operationId: getIdentifierTypes_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+        - name: businessPartnerType
+          in: query
+          required: true
+          schema:
+            type: string
+            description: Specifies if an identifier type is valid for legal entities (L) or addresses (A). Sites (S) are not supported.
+            enum:
+              - LEGAL_ENTITY
+              - ADDRESS
+        - name: country
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - UNDEFINED
+              - AC
+              - AD
+              - AE
+              - AF
+              - AG
+              - AI
+              - AL
+              - AM
+              - AN
+              - AO
+              - AQ
+              - AR
+              - AS
+              - AT
+              - AU
+              - AW
+              - AX
+              - AZ
+              - BA
+              - BB
+              - BD
+              - BE
+              - BF
+              - BG
+              - BH
+              - BI
+              - BJ
+              - BL
+              - BM
+              - BN
+              - BO
+              - BQ
+              - BR
+              - BS
+              - BT
+              - BU
+              - BV
+              - BW
+              - BY
+              - BZ
+              - CA
+              - CC
+              - CD
+              - CF
+              - CG
+              - CH
+              - CI
+              - CK
+              - CL
+              - CM
+              - CN
+              - CO
+              - CP
+              - CR
+              - CS
+              - CU
+              - CV
+              - CW
+              - CX
+              - CY
+              - CZ
+              - DE
+              - DG
+              - DJ
+              - DK
+              - DM
+              - DO
+              - DZ
+              - EA
+              - EC
+              - EE
+              - EG
+              - EH
+              - ER
+              - ES
+              - ET
+              - EU
+              - EZ
+              - FI
+              - FJ
+              - FK
+              - FM
+              - FO
+              - FR
+              - FX
+              - GA
+              - GB
+              - GD
+              - GE
+              - GF
+              - GG
+              - GH
+              - GI
+              - GL
+              - GM
+              - GN
+              - GP
+              - GQ
+              - GR
+              - GS
+              - GT
+              - GU
+              - GW
+              - GY
+              - HK
+              - HM
+              - HN
+              - HR
+              - HT
+              - HU
+              - IC
+              - ID
+              - IE
+              - IL
+              - IM
+              - IN
+              - IO
+              - IQ
+              - IR
+              - IS
+              - IT
+              - JE
+              - JM
+              - JO
+              - JP
+              - KE
+              - KG
+              - KH
+              - KI
+              - KM
+              - KN
+              - KP
+              - KR
+              - KW
+              - KY
+              - KZ
+              - LA
+              - LB
+              - LC
+              - LI
+              - LK
+              - LR
+              - LS
+              - LT
+              - LU
+              - LV
+              - LY
+              - MA
+              - MC
+              - MD
+              - ME
+              - MF
+              - MG
+              - MH
+              - MK
+              - ML
+              - MM
+              - MN
+              - MO
+              - MP
+              - MQ
+              - MR
+              - MS
+              - MT
+              - MU
+              - MV
+              - MW
+              - MX
+              - MY
+              - MZ
+              - NA
+              - NC
+              - NE
+              - NF
+              - NG
+              - NI
+              - NL
+              - 'NO'
+              - NP
+              - NR
+              - NT
+              - NU
+              - NZ
+              - OM
+              - PA
+              - PE
+              - PF
+              - PG
+              - PH
+              - PK
+              - PL
+              - PM
+              - PN
+              - PR
+              - PS
+              - PT
+              - PW
+              - PY
+              - QA
+              - RE
+              - RO
+              - RS
+              - RU
+              - RW
+              - SA
+              - SB
+              - SC
+              - SD
+              - SE
+              - SF
+              - SG
+              - SH
+              - SI
+              - SJ
+              - SK
+              - SL
+              - SM
+              - SN
+              - SO
+              - SR
+              - SS
+              - ST
+              - SU
+              - SV
+              - SX
+              - SY
+              - SZ
+              - TA
+              - TC
+              - TD
+              - TF
+              - TG
+              - TH
+              - TJ
+              - TK
+              - TL
+              - TM
+              - TN
+              - TO
+              - TP
+              - TR
+              - TT
+              - TV
+              - TW
+              - TZ
+              - UA
+              - UG
+              - UK
+              - UM
+              - US
+              - UY
+              - UZ
+              - VA
+              - VC
+              - VE
+              - VG
+              - VI
+              - VN
+              - VU
+              - WF
+              - WS
+              - XI
+              - XU
+              - XK
+              - YE
+              - YT
+              - YU
+              - ZA
+              - ZM
+              - ZR
+              - ZW
+      responses:
+        '200':
+          description: Page of existing identifier types, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoIdentifierTypeDto'
+        '400':
+          description: On malformed request parameters
+    post:
+      tags:
+        - Metadata Controller
+      summary: Creates a new identifier type
+      description: 'Create a new identifier type (including validity details) which can be referenced by business partner records. Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. The actual name of the identifier type is free to choose and doesn''t need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.'
+      operationId: createIdentifierType_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentifierTypeDto'
+        required: true
+      responses:
+        '200':
+          description: New identifier type successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentifierTypeDto'
+        '400':
+          description: On malformed request parameters
+        '409':
+          description: Identifier type with specified technical key already exists
+  /v7/business-partners/changelog/search:
     post:
       tags:
         - Changelog Controller
@@ -1034,13 +2006,79 @@ paths:
           description: On malformed pagination request
         '404':
           description: No business partner found for specified bpn
-  /v6/bpn/search:
+  /v6/business-partners/changelog/search:
+    post:
+      tags:
+        - Changelog Controller
+      summary: Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types
+      operationId: getChangelogEntries_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangelogSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: The specified changelog entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoChangelogEntryVerboseDto'
+        '400':
+          description: On malformed pagination request
+        '404':
+          description: No business partner found for specified bpn
+  /v7/bpn/search:
     post:
       tags:
         - Bpn Controller
       summary: Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values
       description: Find business partner numbers by identifiers. The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. For a single request, the maximum number of identifier values to search for is limited to ${bpdm.bpn.search-request-limit} entries.
       operationId: findBpnsByIdentifiers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentifiersSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Found bpn to identifier value mappings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BpnIdentifierMappingDto'
+                uniqueItems: true
+        '400':
+          description: On malformed request parameters or if number of requested bpns exceeds limit
+        '404':
+          description: Specified identifier type not found
+  /v6/bpn/search:
+    post:
+      tags:
+        - Bpn Controller
+      summary: Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values
+      description: Find business partner numbers by identifiers. The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. For a single request, the maximum number of identifier values to search for is limited to ${bpdm.bpn.search-request-limit} entries.
+      operationId: findBpnsByIdentifiers_1
       requestBody:
         content:
           application/json:
@@ -1084,13 +2122,36 @@ paths:
                 items:
                   $ref: '#/components/schemas/BpnRequestIdentifierMappingDto'
                 uniqueItems: true
+  /v7/bpn/request-ids/search:
+    post:
+      tags:
+        - Bpn Controller
+      summary: Return BPNL/S/A based on the requested identifiers
+      description: Find business partner numbers by requested-identifiers.
+      operationId: findBpnByRequestedIdentifiers_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BpnRequestIdentifierSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Found bpn to based on the requested identifiers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BpnRequestIdentifierMappingDto'
+                uniqueItems: true
   /v6/addresses/search:
     post:
       tags:
         - Address Controller
       summary: Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.
       description: Search business partners of type address by their BPNA or their parents' BPNL or BPNS.
-      operationId: searchAddresses_1
+      operationId: searchAddresses_2
       parameters:
         - name: page
           in: query
@@ -1122,13 +2183,76 @@ paths:
                 $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
         '400':
           description: On malformed pagination request
-  /v6/sites/{bpns}:
+  /v7/addresses/search:
+    post:
+      tags:
+        - Address Controller
+      summary: Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.
+      description: Search business partners of type address by their BPNA or their parents' BPNL or BPNS.
+      operationId: searchAddresses_3
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddressSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Found sites for the specified sites and legal entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+        '400':
+          description: On malformed pagination request
+  /v7/sites/{bpns}:
     get:
       tags:
         - Site Controller
       summary: Returns a site by its BPNS
       description: Get business partners of type site by BPNS ignoring case.
       operationId: getSite
+      parameters:
+        - name: bpns
+          in: path
+          description: BPNS value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Found site with specified BPNS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiteWithMainAddressVerboseDto'
+        '400':
+          description: On malformed request parameters
+        '404':
+          description: No site found under specified BPNS
+  /v6/sites/{bpns}:
+    get:
+      tags:
+        - Site Controller
+      summary: Returns a site by its BPNS
+      description: Get business partners of type site by BPNS ignoring case.
+      operationId: getSite_1
       parameters:
         - name: bpns
           in: path
@@ -1178,13 +2302,84 @@ paths:
           description: On malformed request parameters
         '404':
           description: No business partner found under specified identifier or specified identifier type not found
+  /v7/legal-entities/{idValue}:
+    get:
+      tags:
+        - Legal Entity Controller
+      summary: Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type
+      description: This endpoint tries to find a business partner by the specified identifier. The identifier value is case insensitively compared but needs to be given exactly. By default the value given is interpreted as a BPN. By specifying the technical key of another identifier typethe value is matched against the identifiers of that given type.
+      operationId: getLegalEntity_1
+      parameters:
+        - name: idValue
+          in: path
+          description: Identifier value
+          required: true
+          schema:
+            type: string
+        - name: idType
+          in: query
+          description: Type of identifier to use, defaults to BPN when omitted
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Found business partner with specified identifier
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalEntityWithLegalAddressVerboseDto'
+        '400':
+          description: On malformed request parameters
+        '404':
+          description: No business partner found under specified identifier or specified identifier type not found
   /v6/legal-entities/{bpnl}/sites:
     get:
       tags:
         - Legal Entity Controller
       summary: Returns all sites of a legal entity with a specific BPNL
       description: Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case.
-      operationId: getSites_1
+      operationId: getSites_2
+      parameters:
+        - name: bpnl
+          in: path
+          description: BPNL value
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: The sites for the specified bpnl
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoSiteVerboseDto'
+        '400':
+          description: On malformed pagination request
+        '404':
+          description: No business partner found for specified bpnl
+  /v7/legal-entities/{bpnl}/sites:
+    get:
+      tags:
+        - Legal Entity Controller
+      summary: Returns all sites of a legal entity with a specific BPNL
+      description: Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case.
+      operationId: getSites_3
       parameters:
         - name: bpnl
           in: path
@@ -1224,7 +2419,47 @@ paths:
         - Legal Entity Controller
       summary: Returns all addresses of a legal entity with a specific BPNL
       description: Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.
-      operationId: getAddresses_1
+      operationId: getAddresses_2
+      parameters:
+        - name: bpnl
+          in: path
+          description: BPNL value
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: The addresses for the specified BPNL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+        '400':
+          description: On malformed pagination request
+        '404':
+          description: No business partner found for specified BPNL
+  /v7/legal-entities/{bpnl}/addresses:
+    get:
+      tags:
+        - Legal Entity Controller
+      summary: Returns all addresses of a legal entity with a specific BPNL
+      description: Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.
+      operationId: getAddresses_3
       parameters:
         - name: bpnl
           in: path
@@ -1556,6 +2791,304 @@ paths:
                   $ref: '#/components/schemas/FieldQualityRuleDto'
         '400':
           description: On malformed request parameters
+  /v7/field-quality-rules/:
+    get:
+      tags:
+        - Metadata Controller
+      summary: Get all field quality rules filtered by country (specified by its ISO 3166-1 alpha-2 country code)
+      description: List the country specific data rules for entity fields.All fields that are not in this list are considered to be forbidden.
+      operationId: getFieldQualityRules_1
+      parameters:
+        - name: country
+          in: query
+          description: ISO 3166-1 alpha-2 country code
+          required: true
+          schema:
+            type: string
+            enum:
+              - UNDEFINED
+              - AC
+              - AD
+              - AE
+              - AF
+              - AG
+              - AI
+              - AL
+              - AM
+              - AN
+              - AO
+              - AQ
+              - AR
+              - AS
+              - AT
+              - AU
+              - AW
+              - AX
+              - AZ
+              - BA
+              - BB
+              - BD
+              - BE
+              - BF
+              - BG
+              - BH
+              - BI
+              - BJ
+              - BL
+              - BM
+              - BN
+              - BO
+              - BQ
+              - BR
+              - BS
+              - BT
+              - BU
+              - BV
+              - BW
+              - BY
+              - BZ
+              - CA
+              - CC
+              - CD
+              - CF
+              - CG
+              - CH
+              - CI
+              - CK
+              - CL
+              - CM
+              - CN
+              - CO
+              - CP
+              - CR
+              - CS
+              - CU
+              - CV
+              - CW
+              - CX
+              - CY
+              - CZ
+              - DE
+              - DG
+              - DJ
+              - DK
+              - DM
+              - DO
+              - DZ
+              - EA
+              - EC
+              - EE
+              - EG
+              - EH
+              - ER
+              - ES
+              - ET
+              - EU
+              - EZ
+              - FI
+              - FJ
+              - FK
+              - FM
+              - FO
+              - FR
+              - FX
+              - GA
+              - GB
+              - GD
+              - GE
+              - GF
+              - GG
+              - GH
+              - GI
+              - GL
+              - GM
+              - GN
+              - GP
+              - GQ
+              - GR
+              - GS
+              - GT
+              - GU
+              - GW
+              - GY
+              - HK
+              - HM
+              - HN
+              - HR
+              - HT
+              - HU
+              - IC
+              - ID
+              - IE
+              - IL
+              - IM
+              - IN
+              - IO
+              - IQ
+              - IR
+              - IS
+              - IT
+              - JE
+              - JM
+              - JO
+              - JP
+              - KE
+              - KG
+              - KH
+              - KI
+              - KM
+              - KN
+              - KP
+              - KR
+              - KW
+              - KY
+              - KZ
+              - LA
+              - LB
+              - LC
+              - LI
+              - LK
+              - LR
+              - LS
+              - LT
+              - LU
+              - LV
+              - LY
+              - MA
+              - MC
+              - MD
+              - ME
+              - MF
+              - MG
+              - MH
+              - MK
+              - ML
+              - MM
+              - MN
+              - MO
+              - MP
+              - MQ
+              - MR
+              - MS
+              - MT
+              - MU
+              - MV
+              - MW
+              - MX
+              - MY
+              - MZ
+              - NA
+              - NC
+              - NE
+              - NF
+              - NG
+              - NI
+              - NL
+              - 'NO'
+              - NP
+              - NR
+              - NT
+              - NU
+              - NZ
+              - OM
+              - PA
+              - PE
+              - PF
+              - PG
+              - PH
+              - PK
+              - PL
+              - PM
+              - PN
+              - PR
+              - PS
+              - PT
+              - PW
+              - PY
+              - QA
+              - RE
+              - RO
+              - RS
+              - RU
+              - RW
+              - SA
+              - SB
+              - SC
+              - SD
+              - SE
+              - SF
+              - SG
+              - SH
+              - SI
+              - SJ
+              - SK
+              - SL
+              - SM
+              - SN
+              - SO
+              - SR
+              - SS
+              - ST
+              - SU
+              - SV
+              - SX
+              - SY
+              - SZ
+              - TA
+              - TC
+              - TD
+              - TF
+              - TG
+              - TH
+              - TJ
+              - TK
+              - TL
+              - TM
+              - TN
+              - TO
+              - TP
+              - TR
+              - TT
+              - TV
+              - TW
+              - TZ
+              - UA
+              - UG
+              - UK
+              - UM
+              - US
+              - UY
+              - UZ
+              - VA
+              - VC
+              - VE
+              - VG
+              - VI
+              - VN
+              - VU
+              - WF
+              - WS
+              - XI
+              - XU
+              - XK
+              - YE
+              - YT
+              - YU
+              - ZA
+              - ZM
+              - ZR
+              - ZW
+      responses:
+        '200':
+          description: List of the existing rules for the given country
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FieldQualityRuleDto'
+        '400':
+          description: On malformed request parameters
   /v6/administrative-areas-level1:
     get:
       tags:
@@ -1588,6 +3121,38 @@ paths:
                 $ref: '#/components/schemas/PageDtoCountrySubdivisionDto'
         '400':
           description: On malformed request parameters
+  /v7/administrative-areas-level1:
+    get:
+      tags:
+        - Metadata Controller
+      summary: Get page of country subdivisions suitable for the administrativeAreaLevel1 address property
+      description: Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result
+      operationId: getAdminAreasLevel1_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of existing country subdivisions, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoCountrySubdivisionDto'
+        '400':
+          description: On malformed request parameters
   /v6/addresses/{bpna}:
     get:
       tags:
@@ -1595,6 +3160,31 @@ paths:
       summary: Returns an address by its BPNA
       description: Get business partners of type address by BPNA ignoring case.
       operationId: getAddress
+      parameters:
+        - name: bpna
+          in: path
+          description: BPNA value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Found address with specified BPNA
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogisticAddressVerboseDto'
+        '400':
+          description: On malformed request parameters
+        '404':
+          description: No address found under specified BPNA
+  /v7/addresses/{bpna}:
+    get:
+      tags:
+        - Address Controller
+      summary: Returns an address by its BPNA
+      description: Get business partners of type address by BPNA ignoring case.
+      operationId: getAddress_1
       parameters:
         - name: bpna
           in: path


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds new api version for BPDM Pool service.
The new api version is now v7 along with simultanous support for previous version v6.
Currently, bpdm-pool service will support for both versioned apis but for round trip test we have enabled only v7.

Contributes to https://github.com/eclipse-tractusx/bpdm/issues/1294

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
