### PR TITLE
feat(bpdm): renaming api attributes for each service as per the standards 25.06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - Gate: Replace GET endpoint for business partner relations with a POST search endpoint having the same capabilties [#1264](https://github.com/eclipse-tractusx/bpdm/issues/1264)
 - Gate: Replaced PUT endpoint for business partner relations with a bulk upsert variant [#1264](https://github.com/eclipse-tractusx/bpdm/issues/1264)
 - Gate: Removed constraint checks when upserting business partner relations ([1288](https://github.com/eclipse-tractusx/bpdm/issues/1288))
+- App: Renamed api attributes/fields with corresponding 25.06 standards for BPDM Pool, Gate and Orchestrator Services([#1304](https://github.com/eclipse-tractusx/bpdm/issues/1304))
 
 ### Added
 

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/CleaningServiceDummy.kt
@@ -115,7 +115,7 @@ class CleaningServiceDummy(
                     states = states,
                     confidenceCriteria = dummyConfidenceCriteria.copy(sharedByOwner = sharedByOwner),
                     hasChanged = businessPartner.type == GoldenRecordType.LegalEntity,
-                    isCatenaXMemberData = sharedByOwner,
+                    isParticipantData = sharedByOwner,
                     legalAddress = cleanAddress(addressToClean, legalAddressBpnReference, true, sharedByOwner),
                 )
             }

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerGenericCommonValues.kt
@@ -129,7 +129,7 @@ object BusinessPartnerGenericCommonValues {
             ),
             identifiers = emptyList(),
             states = emptyList(),
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             hasChanged = true,
             legalAddress = address
         ),

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/BusinessPartnerVerboseValues.kt
@@ -199,7 +199,7 @@ object BusinessPartnerVerboseValues {
         legalShortName = "short1",
         legalForm = "LF1",
         states = listOf(legalEntityBusinessStatus1),
-        isCatenaXMemberData = false
+        isParticipantData = false
     )
 
     val legalEntity2 = LegalEntityDto(
@@ -207,7 +207,7 @@ object BusinessPartnerVerboseValues {
         legalShortName = "short3",
         legalForm = "LF2",
         states = listOf(legalEntityBusinessStatus2),
-        isCatenaXMemberData = false
+        isParticipantData = false
     )
 
     val legalEntity3 = LegalEntityDto(
@@ -215,7 +215,7 @@ object BusinessPartnerVerboseValues {
         legalShortName = "short1",
         legalForm = "LF1",
         states = listOf(legalEntityBusinessStatus1),
-        isCatenaXMemberData = false
+        isParticipantData = false
     )
 
     val siteBusinessStatus1 = SiteStateDto(

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/orchestrator/BusinessPartnerHelpers.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/orchestrator/BusinessPartnerHelpers.kt
@@ -91,5 +91,5 @@ fun BusinessPartner.copyWithBpnRequests() =
 
 fun BusinessPartner.copyAsCxMemberData() =
     copy(
-        legalEntity = legalEntity.copy(isCatenaXMemberData = true)
+        legalEntity = legalEntity.copy(isParticipantData = true)
     )

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/orchestrator/BusinessPartnerTestDataFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/orchestrator/BusinessPartnerTestDataFactory.kt
@@ -81,7 +81,7 @@ class BusinessPartnerTestDataFactory(
             identifiers = createIdentifiers(seed, random, metadata?.legalEntityIdentifierTypes),
             states = createStates(seed, random.nextInt(2, 5), random),
             confidenceCriteria = createConfidenceCriteria(random),
-            isCatenaXMemberData = random.nextBoolean(),
+            isParticipantData = random.nextBoolean(),
             hasChanged = true,
             legalAddress = createAddress("Legal Address $seed")
         )

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerNonVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerNonVerboseValues.kt
@@ -84,7 +84,7 @@ object BusinessPartnerNonVerboseValues {
         technicalKey = BusinessPartnerVerboseValues.legalForm1.technicalKey,
         name = BusinessPartnerVerboseValues.legalForm1.name,
         transliteratedName = BusinessPartnerVerboseValues.legalForm1.transliteratedName,
-        abbreviation = BusinessPartnerVerboseValues.legalForm1.abbreviation,
+        abbreviations = BusinessPartnerVerboseValues.legalForm1.abbreviations,
         transliteratedAbbreviations = BusinessPartnerVerboseValues.legalForm1.transliteratedAbbreviations,
         country = BusinessPartnerVerboseValues.legalForm1.country,
         language = BusinessPartnerVerboseValues.legalForm1.language,
@@ -95,7 +95,7 @@ object BusinessPartnerNonVerboseValues {
         technicalKey = BusinessPartnerVerboseValues.legalForm2.technicalKey,
         name = BusinessPartnerVerboseValues.legalForm2.name,
         transliteratedName = BusinessPartnerVerboseValues.legalForm2.transliteratedName,
-        abbreviation = BusinessPartnerVerboseValues.legalForm2.abbreviation,
+        abbreviations = BusinessPartnerVerboseValues.legalForm2.abbreviations,
         transliteratedAbbreviations = BusinessPartnerVerboseValues.legalForm2.transliteratedAbbreviations,
         country = BusinessPartnerVerboseValues.legalForm2.country,
         language = BusinessPartnerVerboseValues.legalForm2.language,
@@ -106,7 +106,7 @@ object BusinessPartnerNonVerboseValues {
         technicalKey = BusinessPartnerVerboseValues.legalForm3.technicalKey,
         name = BusinessPartnerVerboseValues.legalForm3.name,
         transliteratedName = BusinessPartnerVerboseValues.legalForm3.transliteratedName,
-        abbreviation = BusinessPartnerVerboseValues.legalForm3.abbreviation,
+        abbreviations = BusinessPartnerVerboseValues.legalForm3.abbreviations,
         transliteratedAbbreviations = BusinessPartnerVerboseValues.legalForm3.transliteratedAbbreviations,
         country = BusinessPartnerVerboseValues.legalForm3.country,
         language = BusinessPartnerVerboseValues.legalForm3.language,
@@ -266,7 +266,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier1),
             states = listOf(leStatus1),
             confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria,
-            isCatenaXMemberData = false
+            isParticipantData = false
         ),
         legalAddress = logisticAddress1,
         index = BusinessPartnerVerboseValues.legalEntityUpsert1.index
@@ -280,7 +280,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier2),
             states = listOf(leStatus2),
             confidenceCriteria = BusinessPartnerVerboseValues.legalEntity2.legalEntity.confidenceCriteria,
-            isCatenaXMemberData = false
+            isParticipantData = false
         ),
         legalAddress = logisticAddress2,
         index = BusinessPartnerVerboseValues.legalEntityUpsert2.index
@@ -294,7 +294,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier3),
             states = listOf(leStatus3),
             confidenceCriteria = BusinessPartnerVerboseValues.legalEntity3.legalEntity.confidenceCriteria,
-            isCatenaXMemberData = false
+            isParticipantData = false
         ),
         legalAddress = logisticAddress3,
         index = BusinessPartnerVerboseValues.legalEntityUpsert3.index
@@ -308,7 +308,7 @@ object BusinessPartnerNonVerboseValues {
             identifiers = listOf(identifier1, identifier2),
             states = listOf(leStatus1),
             confidenceCriteria = BusinessPartnerVerboseValues.legalEntity1.legalEntity.confidenceCriteria,
-            isCatenaXMemberData = false
+            isParticipantData = false
         ),
         legalAddress = logisticAddress1,
         index = BusinessPartnerVerboseValues.legalEntityUpsertMultipleIdentifier.index

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerRequestFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerRequestFactory.kt
@@ -45,13 +45,13 @@ class BusinessPartnerRequestFactory(
 
     fun createLegalEntityRequest(
         seed: String,
-        isCatenaXMemberData: Boolean = true
+        isParticipantData: Boolean = true
     ): LegalEntityPartnerCreateRequest {
         val longSeed = seed.hashCode().toLong()
         val random = Random(longSeed)
 
         return LegalEntityPartnerCreateRequest(
-            legalEntity = createLegalEntityDto(seed, random, isCatenaXMemberData),
+            legalEntity = createLegalEntityDto(seed, random, isParticipantData),
             legalAddress = createAddressDto(seed, random),
             index = seed
         )
@@ -90,7 +90,7 @@ class BusinessPartnerRequestFactory(
                 nextConfidenceCheckAt = timeStamp.plusDays(7),
                 confidenceLevel = 5
             ),
-            isCatenaXMemberData = isCatenaXMemberData
+            isParticipantData = isCatenaXMemberData
         )
     }
 

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
@@ -96,7 +96,7 @@ object BusinessPartnerVerboseValues {
     val legalForm1 = LegalFormDto(
         technicalKey = "EI4J",
         name = "Limited Liability Company",
-        abbreviation = "LLC;L.L.C.",
+        abbreviations = "LLC;L.L.C.",
         transliteratedName = "Limited Liability Company",
         country = CountryCode.US,
         language = LanguageCode.en,
@@ -108,7 +108,7 @@ object BusinessPartnerVerboseValues {
     val legalForm2 = LegalFormDto(
         technicalKey = "2HBR",
         name = "Gesellschaft mit beschränkter Haftung",
-        abbreviation = "GmbH",
+        abbreviations = "GmbH",
         transliteratedName = "Gesellschaft mit beschränkter Haftung",
         country = CountryCode.DE,
         language = LanguageCode.de,
@@ -119,7 +119,7 @@ object BusinessPartnerVerboseValues {
     val legalForm3 = LegalFormDto(
         technicalKey = "2M6Y",
         name = "基金会",
-        abbreviation = null,
+        abbreviations = null,
         transliteratedName = "ji jin hui",
         country = CountryCode.CN,
         language = LanguageCode.zh,
@@ -268,7 +268,7 @@ object BusinessPartnerVerboseValues {
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
         addressType = AddressType.AdditionalAddress,
-        isCatenaXMemberData = false
+        isParticipantData = false
     )
 
     val addressPartner2 = LogisticAddressVerboseDto(
@@ -280,7 +280,7 @@ object BusinessPartnerVerboseValues {
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
         addressType = AddressType.AdditionalAddress,
-        isCatenaXMemberData = false
+        isParticipantData = false
     )
 
     val addressPartner3 = LogisticAddressVerboseDto(
@@ -292,7 +292,7 @@ object BusinessPartnerVerboseValues {
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
         addressType = AddressType.AdditionalAddress,
-        isCatenaXMemberData = false
+        isParticipantData = false
     )
 
     val addressPartnerCreate1 = AddressPartnerCreateVerboseDto(
@@ -316,7 +316,7 @@ object BusinessPartnerVerboseValues {
         states = listOf(siteStatus1),
         bpnLegalEntity = firstBpnL,
         confidenceCriteria = confidenceCriteria1,
-        isCatenaXMemberData = false,
+        isParticipantData = false,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -327,7 +327,7 @@ object BusinessPartnerVerboseValues {
         states = listOf(siteStatus2),
         bpnLegalEntity = secondBpnL,
         confidenceCriteria = confidenceCriteria2,
-        isCatenaXMemberData = false,
+        isParticipantData = false,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -338,7 +338,7 @@ object BusinessPartnerVerboseValues {
         states = listOf(siteStatus3),
         bpnLegalEntity = thirdBpnl,
         confidenceCriteria = confidenceCriteria3,
-        isCatenaXMemberData = false,
+        isParticipantData = false,
         createdAt = Instant.now(),
         updatedAt = Instant.now(),
     )
@@ -398,7 +398,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria1,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -424,7 +424,7 @@ object BusinessPartnerVerboseValues {
             bpnLegalEntity = null,
             bpnSite = null,
             confidenceCriteria = confidenceCriteria1,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -439,7 +439,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria2,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -465,7 +465,7 @@ object BusinessPartnerVerboseValues {
             bpnLegalEntity = null,
             bpnSite = null,
             confidenceCriteria = confidenceCriteria2,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -480,7 +480,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus3),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria3,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now(),
         ),
@@ -506,7 +506,7 @@ object BusinessPartnerVerboseValues {
             bpnLegalEntity = null,
             bpnSite = null,
             confidenceCriteria = confidenceCriteria3,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -521,7 +521,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria1,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -541,7 +541,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus2),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria2,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -561,7 +561,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus3),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria3,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),
@@ -584,7 +584,7 @@ object BusinessPartnerVerboseValues {
             states = listOf(leStatus1),
             currentness = createdTime1.toInstant(ZoneOffset.UTC),
             confidenceCriteria = confidenceCriteria1,
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         ),

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/ExpectedBusinessPartnerResultFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/ExpectedBusinessPartnerResultFactory.kt
@@ -66,7 +66,7 @@ class ExpectedBusinessPartnerResultFactory(
                     relations = emptyList(),
                     currentness = currentness,
                     confidenceCriteria = confidenceCriteria,
-                    isCatenaXMemberData = isCatenaXMemberData,
+                    isParticipantData = isParticipantData,
                     createdAt = legalEntityCreatedAt,
                     updatedAt = legalEntityUpdatedAt
                 )
@@ -77,7 +77,7 @@ class ExpectedBusinessPartnerResultFactory(
                 givenBpnL,
                 null,
                 AddressType.LegalAddress,
-                givenRequest.legalEntity.isCatenaXMemberData,
+                givenRequest.legalEntity.isParticipantData,
                 addressCreatedAt,
                 addressUpdatedAt
             )
@@ -87,7 +87,7 @@ class ExpectedBusinessPartnerResultFactory(
     fun mapToExpectedSites(
         hierarchy: LegalEntityHierarchy
     ): List<SiteWithMainAddressVerboseDto> {
-        return hierarchy.getAllSites().map { mapToExpectedSite(it, hierarchy.legalEntity.legalEntity.isCatenaXMemberData) }
+        return hierarchy.getAllSites().map { mapToExpectedSite(it, hierarchy.legalEntity.legalEntity.isParticipantData) }
     }
 
     fun mapToExpectedSite(
@@ -106,7 +106,7 @@ class ExpectedBusinessPartnerResultFactory(
                     bpns = givenBpnS,
                     name = name,
                     states = states.map { mapToExpectedResult(it) },
-                    isCatenaXMemberData = isCatenaXMemberData,
+                    isParticipantData = isCatenaXMemberData,
                     bpnLegalEntity = givenRequest.bpnlParent,
                     createdAt = siteCreatedAt,
                     updatedAt = siteUpdatedAt,
@@ -129,7 +129,7 @@ class ExpectedBusinessPartnerResultFactory(
     fun mapToExpectedAddresses(
         hierarchy: LegalEntityHierarchy
     ): List<LogisticAddressVerboseDto> {
-        val isCxMember = hierarchy.legalEntity.legalEntity.isCatenaXMemberData
+        val isCxMember = hierarchy.legalEntity.legalEntity.isParticipantData
         val legalEntityAdditionalAddresses = hierarchy.addresses
         val siteAdditionalAddressesWithBpnl = hierarchy.siteHierarchy
             .flatMap{ siteHierarchy -> siteHierarchy.addresses.map { Pair(it, siteHierarchy.site.bpnlParent) } }
@@ -153,7 +153,7 @@ class ExpectedBusinessPartnerResultFactory(
             bpnLegalEntity = bpnLegalEntity,
             bpnSite = null,
             addressType = AddressType.LegalAddress,
-            isCatenaXMemberData = givenRequest.legalEntity.isCatenaXMemberData,
+            isCatenaXMemberData = givenRequest.legalEntity.isParticipantData,
             createdAt = createdAt,
             updatedAt = updatedAt
         )
@@ -219,7 +219,7 @@ class ExpectedBusinessPartnerResultFactory(
                 alternativePostalAddress = alternativePostalAddress?.let { mapToExpectedResult(it) },
                 bpnLegalEntity = bpnLegalEntity,
                 bpnSite = bpnSite,
-                isCatenaXMemberData = isCatenaXMemberData,
+                isParticipantData = isCatenaXMemberData,
                 createdAt = createdAt,
                 updatedAt = updatedAt,
                 confidenceCriteria = confidenceCriteria,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/IBaseLegalEntityDto.kt
@@ -39,7 +39,4 @@ interface IBaseLegalEntityDto {
     val states: Collection<ILegalEntityStateDto>
 
     val confidenceCriteria: IConfidenceCriteriaDto?
-
-    @get:Schema(description = "Indicates whether the legal entity is owned and thus provided by a Catena-X Member.")
-    val isCatenaXMemberData: Boolean
 }

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/LegalEntityDto.kt
@@ -42,6 +42,7 @@ data class LegalEntityDto(
 
     override val confidenceCriteria: ConfidenceCriteriaDto? = null,
 
-    override val isCatenaXMemberData: Boolean
+    @get:Schema(description = "Indicates whether the legal entity is owned and thus provided by a Catena-X Member.")
+    val isParticipantData: Boolean
 
 ) : IBaseLegalEntityDto

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -70,7 +70,7 @@ class OrchestratorMappings(
                 identifiers = entity.identifiers.filter { it.businessPartnerType == BusinessPartnerType.LEGAL_ENTITY }.map { Identifier(it.value, it.type, it.issuingBody) },
                 states = entity.states.filter { it.businessPartnerTyp == BusinessPartnerType.LEGAL_ENTITY }.map { toState(it) },
                 confidenceCriteria = toConfidenceCriteria(entity.legalEntityConfidence),
-                isCatenaXMemberData = null,
+                isParticipantData = null,
                 hasChanged = true,
                 legalAddress = postalAddress.takeIf { entity.postalAddress.addressType == AddressType.LegalAddress || entity.postalAddress.addressType == AddressType.LegalAndSiteMainAddress } ?: PostalAddress.empty
             ),

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PartnerUploadControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/PartnerUploadControllerIT.kt
@@ -213,7 +213,7 @@ class PartnerUploadControllerIT @Autowired constructor(
                 nextConfidenceCheckAt = LocalDateTime.of(2024, 10, 10, 10, 10, 10),
                 confidenceLevel = 0
             ),
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )
@@ -247,7 +247,7 @@ class PartnerUploadControllerIT @Autowired constructor(
                 nextConfidenceCheckAt = LocalDateTime.of(2024, 10, 10, 10, 10, 10),
                 confidenceLevel = 0
             ),
-            isCatenaXMemberData = false,
+            isParticipantData = false,
             createdAt = Instant.now(),
             updatedAt = Instant.now()
         )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/GoldenRecordTaskApi.kt
@@ -54,7 +54,7 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping(value = [ApiCommons.BASE_PATH_V6, ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS])
+    @PostMapping(value = [ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS])
     fun createTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
 
     @Operation(
@@ -71,7 +71,7 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagClient)
-    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/state/search", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/state/search"])
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/state/search"])
     fun searchTaskStates(@RequestBody stateRequest: TaskStateRequest): TaskStateResponse
 
     @Operation(
@@ -108,7 +108,7 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagWorker)
-    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/step-reservations", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-reservations"])
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-reservations"])
     fun reserveTasksForStep(@RequestBody reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse
 
     @Operation(
@@ -133,6 +133,6 @@ interface GoldenRecordTaskApi {
         ]
     )
     @Tag(name = TagWorker)
-    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/step-results", "${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-results"])
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7_BUSINESS_PARTNERS}/step-results"])
     fun resolveStepResults(@RequestBody resultRequest: TaskStepResultRequest)
 }

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartner.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartner.kt
@@ -311,8 +311,8 @@ data class LegalEntity(
     @Schema(description = "The business state history of this legal entity")
     val states: List<BusinessState>,
     val confidenceCriteria: ConfidenceCriteria,
-    @Schema(description = "Whether this legal entity is part of the Catena-X network")
-    val isCatenaXMemberData: Boolean?,
+    @Schema(description = "Whether this legal entity is part of the Data Space network")
+    val isParticipantData: Boolean?,
     @Schema(description = "Whether this legal entity information differs from its golden record counterpart in the Pool. +" +
             "The Pool will not update the legal entity if it is set to false. " +
             "However, if this legal entity constitutes a new legal entity golden record, it is still created independent of this flag.")
@@ -328,7 +328,7 @@ data class LegalEntity(
             identifiers = emptyList(),
             states = emptyList(),
             confidenceCriteria = ConfidenceCriteria.empty,
-            isCatenaXMemberData = null,
+            isParticipantData = null,
             hasChanged = null,
             legalAddress = PostalAddress.empty
         )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/GoldenRecordTaskApi.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/GoldenRecordTaskApi.kt
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskCreateRequest
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskCreateResponse
+import org.eclipse.tractusx.orchestrator.api.model.TaskStateRequest
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStateResponse
+import org.eclipse.tractusx.orchestrator.api.model.TaskStepReservationRequest
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStepReservationResponse
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStepResultRequest
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+const val TagClient = "Task Client"
+const val TagWorker = "Task Worker"
+
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+interface GoldenRecordTaskApi {
+
+    @Operation(
+        summary = "Create new golden record tasks for given business partner data",
+        description = "Create golden record tasks for given business partner data in given mode. " +
+                "The mode decides through which processing steps the given business partner data will go through. " +
+                "The response contains the states of the created tasks in the order of given business partner data." +
+                "If there is an error in the request no tasks are created (all or nothing). " +
+                "For a single request, the maximum number of business partners in the request is limited to \${bpdm.api.upsert-limit} entries."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The states of successfully created tasks including the task identifier for tracking purposes."
+            ),
+            ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
+        ]
+    )
+    @Tag(name = TagClient)
+    @PostMapping(value = [ApiCommons.BASE_PATH_V6])
+    fun createTasks(@RequestBody createRequest: TaskCreateRequest): TaskCreateResponse
+
+    @Operation(
+        summary = "Search for the state of golden record tasks by task identifiers",
+        description = "Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The state of the tasks for the provided task identifiers."
+            ),
+            ApiResponse(responseCode = "400", description = "On malformed task search requests", content = [Content()]),
+        ]
+    )
+    @Tag(name = TagClient)
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/state/search"])
+    fun searchTaskStates(@RequestBody stateRequest: TaskStateRequest): TaskStateResponse
+
+    @Operation(
+        summary = "Reserve the next golden record tasks waiting in the given step queue",
+        description = "Reserve up to a given number of golden record tasks in the given step queue. " +
+                "The response entries contain the business partner data to process which consists of the generic and L/S/A data. " +
+                "The reservation has a time limit which is returned. " +
+                "For a single request, the maximum number of reservable tasks is limited to \${bpdm.api.upsert-limit}."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "The reserved tasks with their business partner data to process."
+            ),
+            ApiResponse(responseCode = "400", description = "On malformed task create requests or reaching upsert limit", content = [Content()]),
+        ]
+    )
+    @Tag(name = TagWorker)
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/step-reservations"])
+    fun reserveTasksForStep(@RequestBody reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse
+
+    @Operation(
+        summary = "Post step results for reserved golden record tasks in the given step queue",
+        description = "Post business partner step results for the given tasks in the given step queue. " +
+                "In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. " +
+                "The number of results you can post at a time does not need to match the original number of reserved tasks. " +
+                "Results are accepted via strategy 'all or nothing'. " +
+                "For a single request, the maximum number of postable results is limited to \${bpdm.api.upsert-limit}."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "If the results could be processed"
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue",
+                content = [Content()]
+            ),
+        ]
+    )
+    @Tag(name = TagWorker)
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/step-results"])
+    fun resolveStepResults(@RequestBody resultRequest: TaskStepResultRequest)
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/BusinessPartner.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/BusinessPartner.kt
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.orchestrator.api.model.NamePart
+import org.eclipse.tractusx.orchestrator.api.model.PostalAddress
+import org.eclipse.tractusx.orchestrator.api.model.Site
+import org.eclipse.tractusx.orchestrator.api.model.UncategorizedProperties
+import org.eclipse.tractusx.orchestrator.api.model.GoldenRecordType
+import org.eclipse.tractusx.orchestrator.api.model.BpnReference
+import org.eclipse.tractusx.orchestrator.api.model.Identifier
+import org.eclipse.tractusx.orchestrator.api.model.BusinessState
+import org.eclipse.tractusx.orchestrator.api.model.ConfidenceCriteria
+
+@Schema(description = "Generic business partner data for golden record processing. " +
+        "Typically a sharing member shares incomplete and/or uncategorized business partner data to the golden record process. " +
+        "The golden record process categorizes and completes the data in order to create and update the resulting golden records. " +
+        "The golden records are found in the legalEntity, site and additionalAddress fields. " +
+        "The business partner data needs to contain the full golden record parent relationship. " +
+        "This means, if an additional address is specified in the business partner data, also its legal entity and also its site parent (if a site exists) needs to be specified. ")
+data class BusinessPartner(
+    @Schema(description = "Fully categorized and cleaned name parts based on the uncategorized name parts provided")
+    val nameParts: List<NamePart>,
+    @Schema(description = "The BPNL of the legal entity to which this business partner data belongs to")
+    val owningCompany: String?,
+    val uncategorized: UncategorizedProperties,
+    val legalEntity: LegalEntity,
+    val site: Site?,
+    val additionalAddress: PostalAddress?,
+){
+    companion object{
+        val empty = BusinessPartner(
+            nameParts = emptyList(),
+            owningCompany = null,
+            uncategorized = UncategorizedProperties.empty,
+            legalEntity = LegalEntity.empty,
+            site = null,
+            additionalAddress = null
+        )
+    }
+
+    @Schema(description = "The recognized golden record type this business partner data contains.\n" +
+            "* `Legal Entity`: The business partner data only contains legal entity and legal address information.\n" +
+            "* `Site`: The business partner data contains site, site main address and its parent legal entity information.\n" +
+            "* `Additional Address`: The business partner data contains an additional address, (optional) parent site and parent legal entity information.\n" +
+            "* `Null`: No clear type determined, undecided. The golden record process will not create golden record from this business partner data.")
+    val type: GoldenRecordType? = when{
+        additionalAddress != null -> GoldenRecordType.Address
+        site != null -> GoldenRecordType.Site
+        legalEntity != LegalEntity.empty -> GoldenRecordType.LegalEntity
+        else -> null
+    }
+}
+
+@Schema(description = "Legal entity information for this business partner data. " +
+        "Every business partner either is a legal entity or belongs to a legal entity." +
+        "There, a legal entity property is not allowed to be 'null'. " )
+data class LegalEntity(
+    val bpnReference: BpnReference,
+    @Schema(description = "The legal name of this legal entity according to official registers")
+    val legalName: String?,
+    @Schema(description = "The abbreviated name of this legal entity, if it exists")
+    val legalShortName: String?,
+    @Schema(description = "The legal form of this legal entity")
+    val legalForm: String?,
+    @Schema(description = "Identifiers for this legal entity (in addition to the BPNL)")
+    val identifiers: List<Identifier>,
+    @Schema(description = "The business state history of this legal entity")
+    val states: List<BusinessState>,
+    val confidenceCriteria: ConfidenceCriteria,
+    @Schema(description = "Whether this legal entity is part of the Catena-X network")
+    val isCatenaXMemberData: Boolean?,
+    @Schema(description = "Whether this legal entity information differs from its golden record counterpart in the Pool. +" +
+            "The Pool will not update the legal entity if it is set to false. " +
+            "However, if this legal entity constitutes a new legal entity golden record, it is still created independent of this flag.")
+    val hasChanged: Boolean?,
+    val legalAddress: PostalAddress
+){
+    companion object{
+        val empty = LegalEntity(
+            bpnReference = BpnReference.empty,
+            legalName = null,
+            legalShortName = null,
+            legalForm = null,
+            identifiers = emptyList(),
+            states = emptyList(),
+            confidenceCriteria = ConfidenceCriteria.empty,
+            isCatenaXMemberData = null,
+            hasChanged = null,
+            legalAddress = PostalAddress.empty
+        )
+    }
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskClientStateDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskClientStateDto.kt
@@ -17,9 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model
+package org.eclipse.tractusx.orchestrator.api.v6.model
 
-data class CxMembershipDto (
-    val bpnL: String,
-    val isCatenaXMember: Boolean
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.orchestrator.api.model.TaskProcessingStateDto
+
+@Schema(description = "The golden record task's processing state together with optional business partner data in case processing is done")
+data class TaskClientStateDto(
+
+    @get:Schema(required = true)
+    val taskId: String,
+
+    @get:Schema(required = true, description = "The identifier of the gate record for which this task has been created")
+    val recordId: String,
+
+    val businessPartnerResult: BusinessPartner,
+
+    @get:Schema(required = true)
+    val processingState: TaskProcessingStateDto
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskCreateRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskCreateRequest.kt
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.orchestrator.api.model.TaskMode
+
+@Schema(description = "Request object to specify for which business partner data tasks should be created and in which mode")
+data class TaskCreateRequest(
+
+    @get:Schema(required = true, description = "The mode affecting which processing steps the business partner goes through")
+    val mode: TaskMode,
+
+    @get:ArraySchema(arraySchema = Schema(description = "The list of tasks to create"))
+    val requests: List<TaskCreateRequestEntry>
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskCreateRequestEntry.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskCreateRequestEntry.kt
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class TaskCreateRequestEntry(
+    @get:Schema(description = "The unique identifier for this record which was previously issued by the Orchestrator")
+    val recordId: String?,
+    @get:Schema(description = "The business partner data to be processed")
+    val businessPartner: BusinessPartner
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskCreateResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskCreateResponse.kt
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Response object for giving a list of created tasks")
+data class TaskCreateResponse(
+
+    val createdTasks: List<TaskClientStateDto>
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStateResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStateResponse.kt
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Response object for giving a list of task states")
+data class TaskStateResponse(
+
+    val tasks: List<TaskClientStateDto>
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepReservationEntryDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepReservationEntryDto.kt
@@ -17,10 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.request
+package org.eclipse.tractusx.orchestrator.api.v6.model
 
-import org.eclipse.tractusx.bpdm.pool.api.model.CxMembershipDto
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.RequestWithKey
 
-data class CxMembershipUpdateRequest(
-    val memberships: List<CxMembershipDto>
-)
+@Schema(description = "Task reservation entry")
+data class TaskStepReservationEntryDto(
+
+    @get:Schema(description = "The identifier of the reserved task")
+    val taskId: String,
+
+    @get:Schema(description = "The identifier of the gate record for which this task has been created")
+    val recordId: String,
+
+    @get:Schema(description = "The business partner data to process")
+    val businessPartner: BusinessPartner
+) : RequestWithKey {
+    override fun getRequestKey(): String {
+        return taskId
+    }
+}

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepReservationResponse.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepReservationResponse.kt
@@ -17,9 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.request
+package org.eclipse.tractusx.orchestrator.api.v6.model
 
-data class CxMembershipSearchRequest(
-    val bpnLs: List<String>? = null,
-    val isCatenaXMember: Boolean? = null
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "Response object for giving a list of reserved tasks")
+data class TaskStepReservationResponse(
+
+    @get:ArraySchema(arraySchema = Schema(description = "The reserved tasks with their business partner data to process"))
+    val reservedTasks: List<TaskStepReservationEntryDto>,
+
+    @get:Schema(description = "The timestamp until the reservation is valid and results are accepted", deprecated = true)
+    val timeout: Instant
 )

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepResultEntryDto.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepResultEntryDto.kt
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.orchestrator.api.model.TaskErrorDto
+
+
+@Schema(description = "A step result for a golden record task")
+data class TaskStepResultEntryDto(
+
+    @get:Schema(description = "The identifier of the task for which this is a result", required = true)
+    val taskId: String,
+
+    @get:Schema(description = "The actual result in form of business partner data. Maybe null if an error occurred during processing of this task.")
+    val businessPartner: BusinessPartner,
+
+    @get:ArraySchema(arraySchema = Schema(description = "Errors that occurred during processing of this task"))
+    val errors: List<TaskErrorDto> = emptyList()
+)

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepResultRequest.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/v6/model/TaskStepResultRequest.kt
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.orchestrator.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
+
+@Schema(description = "Request object for posting step results of previously reserved tasks")
+data class TaskStepResultRequest(
+
+    @get:Schema(description = "The step queue containing the tasks for which results are posted", required = true)
+    val step: TaskStep,
+
+    val results: List<TaskStepResultEntryDto>
+)

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/v6/GoldenRecordTaskController.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/v6/GoldenRecordTaskController.kt
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.controller.v6
+
+import org.eclipse.tractusx.bpdm.common.exception.BpdmUpsertLimitException
+import org.eclipse.tractusx.bpdm.orchestrator.config.ApiConfigProperties
+import org.eclipse.tractusx.bpdm.orchestrator.config.PermissionConfigProperties
+import org.eclipse.tractusx.orchestrator.api.model.TaskStateRequest
+import org.eclipse.tractusx.orchestrator.api.model.TaskStepReservationRequest
+import org.eclipse.tractusx.orchestrator.api.v6.GoldenRecordTaskApi
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskCreateRequest
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskCreateResponse
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStepReservationResponse
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStepResultRequest
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStateResponse
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("GoldenRecordTaskControllerLegacy")
+class GoldenRecordTaskController(
+    val goldenRecordTaskLegacyServiceMapper: GoldenRecordTaskLegacyServiceMapper,
+    val apiConfigProperties: ApiConfigProperties,
+) : GoldenRecordTaskApi {
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.CREATE_TASK})")
+    override fun createTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
+        if (createRequest.requests.size > apiConfigProperties.upsertLimit)
+            throw BpdmUpsertLimitException(createRequest.requests.size, apiConfigProperties.upsertLimit)
+
+        return goldenRecordTaskLegacyServiceMapper.createTasks(createRequest)
+    }
+
+    @PreAuthorize("@stepSecurityService.assertHasReservationAuthority(authentication, #reservationRequest.step)")
+    override fun reserveTasksForStep(reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse {
+        if (reservationRequest.amount > apiConfigProperties.upsertLimit)
+            throw BpdmUpsertLimitException(reservationRequest.amount, apiConfigProperties.upsertLimit)
+
+        return goldenRecordTaskLegacyServiceMapper.reserveTasksForStep(reservationRequest)
+    }
+
+    @PreAuthorize("@stepSecurityService.assertHasResultAuthority(authentication, #resultRequest.step)")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun resolveStepResults(resultRequest: TaskStepResultRequest) {
+        if (resultRequest.results.size > apiConfigProperties.upsertLimit)
+            throw BpdmUpsertLimitException(resultRequest.results.size, apiConfigProperties.upsertLimit)
+
+        goldenRecordTaskLegacyServiceMapper.resolveStepResults(resultRequest)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.VIEW_TASK})")
+    override fun searchTaskStates(stateRequest: TaskStateRequest): TaskStateResponse {
+        return goldenRecordTaskLegacyServiceMapper.searchTaskStates(stateRequest)
+    }
+
+}

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/v6/GoldenRecordTaskLegacyServiceMapper.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/controller/v6/GoldenRecordTaskLegacyServiceMapper.kt
@@ -1,0 +1,669 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.controller.v6
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.orchestrator.config.StateMachineConfigProperties
+import org.eclipse.tractusx.bpdm.orchestrator.config.TaskConfigProperties
+import org.eclipse.tractusx.bpdm.orchestrator.entity.*
+import org.eclipse.tractusx.bpdm.orchestrator.exception.BpdmIllegalStateException
+import org.eclipse.tractusx.bpdm.orchestrator.exception.BpdmRecordNotFoundException
+import org.eclipse.tractusx.bpdm.orchestrator.exception.BpdmTaskNotFoundException
+import org.eclipse.tractusx.bpdm.orchestrator.repository.GateRecordRepository
+import org.eclipse.tractusx.bpdm.orchestrator.repository.GoldenRecordTaskRepository
+import org.eclipse.tractusx.bpdm.orchestrator.repository.fetchBusinessPartnerData
+import org.eclipse.tractusx.bpdm.orchestrator.service.GoldenRecordTaskStateMachine
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.eclipse.tractusx.orchestrator.api.v6.model.BusinessPartner
+import org.eclipse.tractusx.orchestrator.api.v6.model.LegalEntity
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskClientStateDto
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskCreateRequestEntry
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskCreateRequest
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskCreateResponse
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStepReservationEntryDto
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStepReservationResponse
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStepResultRequest
+import org.eclipse.tractusx.orchestrator.api.v6.model.TaskStateResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.*
+
+@Service
+class GoldenRecordTaskLegacyServiceMapper(
+    private val goldenRecordTaskStateMachine: GoldenRecordTaskStateMachine,
+    private val taskConfigProperties: TaskConfigProperties,
+    private val taskRepository: GoldenRecordTaskRepository,
+    private val gateRecordRepository: GateRecordRepository,
+    private val stateMachineConfigProperties: StateMachineConfigProperties
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    @Transactional
+    fun createTasks(createRequest: TaskCreateRequest): TaskCreateResponse {
+        logger.debug { "Creation of new golden record tasks: executing createTasks() with parameters $createRequest" }
+
+        val gateRecords = getOrCreateGateRecords(createRequest.requests)
+        abortOutdatedTasks(gateRecords.toSet())
+
+        return createRequest.requests.zip(gateRecords)
+            .map { (request, record) -> initTask(createRequest.mode, request.businessPartner, record) }
+            .map { task -> responseToClientState(task, calculateTaskRetentionTimeout(task)) }
+            .let { TaskCreateResponse(createdTasks = it) }
+    }
+
+    private fun getOrCreateGateRecords(requests: List<TaskCreateRequestEntry>): List<GateRecordDb> {
+        val privateIds = requests.map { request -> request.recordId?.let { toUUID(it) } }
+        val notNullPrivateIds = privateIds.filterNotNull()
+
+        val foundRecords = gateRecordRepository.findByPrivateIdIn(notNullPrivateIds.toSet())
+        val foundRecordsByPrivateId = foundRecords.associateBy { it.privateId }
+        val requestedNotFoundRecords = notNullPrivateIds.minus(foundRecordsByPrivateId.keys)
+
+        if (requestedNotFoundRecords.isNotEmpty())
+            throw BpdmRecordNotFoundException(requestedNotFoundRecords)
+
+        return privateIds.map { privateId ->
+            val gateRecord = privateId?.let { foundRecordsByPrivateId[it] } ?: GateRecordDb(publicId = UUID.randomUUID(), privateId = UUID.randomUUID())
+            gateRecordRepository.save(gateRecord)
+        }
+    }
+
+    private fun toUUID(uuidString: String) =
+        try {
+            UUID.fromString(uuidString)
+        } catch (e: IllegalArgumentException) {
+            throw BpdmTaskNotFoundException(uuidString)
+        }
+
+
+    private fun abortOutdatedTasks(records: Set<GateRecordDb>){
+        return taskRepository.findTasksByGateRecordInAndProcessingStateResultState(records, GoldenRecordTaskDb.ResultState.Pending)
+            .forEach { task -> goldenRecordTaskStateMachine.doAbortTask(task) }
+    }
+
+    fun initTask(mode: TaskMode, initBusinessPartner: BusinessPartner, record: GateRecordDb): GoldenRecordTaskDb {
+        logger.debug { "Executing initProcessingState() with parameters mode: $mode and business partner data: $initBusinessPartner" }
+
+        val initialStep = getInitialStep(mode)
+        val initProcessingState = GoldenRecordTaskDb.ProcessingState(
+            mode = mode,
+            resultState = GoldenRecordTaskDb.ResultState.Pending,
+            step = initialStep,
+            errors = mutableListOf(),
+            stepState = GoldenRecordTaskDb.StepState.Queued,
+            pendingTimeout =  Instant.now().plus(taskConfigProperties.taskPendingTimeout).toTimestamp(),
+            retentionTimeout = null
+        )
+
+        val initialTask = DbTimestamp.now().let { nowTime ->
+            GoldenRecordTaskDb(
+                gateRecord = record,
+                processingState = initProcessingState,
+                businessPartner = requestedToBusinessPartner(initBusinessPartner),
+                createdAt = nowTime,
+                updatedAt = nowTime
+            )
+        }
+
+        return taskRepository.save(initialTask)
+    }
+
+    fun requestedToBusinessPartner(businessPartner: BusinessPartner) =
+        with(businessPartner){
+            GoldenRecordTaskDb.BusinessPartner(
+                nameParts = toNameParts(businessPartner),
+                identifiers = toIdentifiers(businessPartner),
+                businessStates = toStates(businessPartner),
+                confidences = toConfidences(businessPartner),
+                addresses = toPostalAddresses(businessPartner),
+                bpnReferences = toBpnReferences(businessPartner),
+                legalName = legalEntity.legalName,
+                legalShortName = legalEntity.legalShortName,
+                siteExists = site != null,
+                siteName = site?.siteName,
+                legalForm = legalEntity.legalForm,
+                isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+                owningCompany = owningCompany,
+                legalEntityHasChanged = legalEntity.hasChanged,
+                siteHasChanged = site?.hasChanged
+            )
+        }
+
+    fun toNameParts(businessPartner: BusinessPartner) =
+        mutableListOf(
+            businessPartner.uncategorized.nameParts.map { NamePartDb(it, null) },
+            businessPartner.nameParts.map { NamePartDb(it.name, it.type) }
+        ).flatten().toMutableList()
+
+    fun toIdentifiers(businessPartner: BusinessPartner) =
+        IdentifierDb.Scope.entries.mapNotNull { scope ->
+            when (scope) {
+                IdentifierDb.Scope.LegalEntity -> businessPartner.legalEntity.identifiers
+                IdentifierDb.Scope.LegalAddress -> businessPartner.legalEntity.legalAddress.identifiers
+                IdentifierDb.Scope.SiteMainAddress -> businessPartner.site?.siteMainAddress?.identifiers
+                IdentifierDb.Scope.AdditionalAddress -> businessPartner.additionalAddress?.identifiers
+                IdentifierDb.Scope.Uncategorized -> businessPartner.uncategorized.identifiers
+                IdentifierDb.Scope.UncategorizedAddress -> businessPartner.uncategorized.address?.identifiers
+            }?.map { toIdentifier(it, scope) }
+        }.flatten().toMutableList()
+
+    fun toIdentifier(identifier: Identifier, scope: IdentifierDb.Scope) =
+        with(identifier) {
+            IdentifierDb(value, type, issuingBody, scope)
+        }
+
+    fun toStates(businessPartner: BusinessPartner) =
+        BusinessStateDb.Scope.entries.mapNotNull { scope ->
+            when (scope) {
+                BusinessStateDb.Scope.LegalEntity -> businessPartner.legalEntity.states
+                BusinessStateDb.Scope.Site -> businessPartner.site?.states
+                BusinessStateDb.Scope.LegalAddress -> businessPartner.legalEntity.legalAddress.states
+                BusinessStateDb.Scope.SiteMainAddress -> businessPartner.site?.siteMainAddress?.states
+                BusinessStateDb.Scope.AdditionalAddress -> businessPartner.additionalAddress?.states
+                BusinessStateDb.Scope.Uncategorized -> businessPartner.uncategorized.states
+                BusinessStateDb.Scope.UncategorizedAddress -> businessPartner.uncategorized.address?.states
+            }?.map { toState(it, scope) }
+        }.flatten().toMutableList()
+
+    fun toState(state: BusinessState, scope: BusinessStateDb.Scope) =
+        with(state) {
+            BusinessStateDb(validFrom?.toTimestamp(), validTo?.toTimestamp(), type, scope)
+        }
+
+    fun toConfidences(businessPartner: BusinessPartner) =
+        ConfidenceCriteriaDb.Scope.entries.mapNotNull { scope ->
+            when (scope) {
+                ConfidenceCriteriaDb.Scope.LegalEntity -> businessPartner.legalEntity.confidenceCriteria
+                ConfidenceCriteriaDb.Scope.Site -> businessPartner.site?.confidenceCriteria
+                ConfidenceCriteriaDb.Scope.LegalAddress -> businessPartner.legalEntity.legalAddress.confidenceCriteria
+                ConfidenceCriteriaDb.Scope.SiteMainAddress -> businessPartner.site?.siteMainAddress?.confidenceCriteria
+                ConfidenceCriteriaDb.Scope.AdditionalAddress -> businessPartner.additionalAddress?.confidenceCriteria
+                ConfidenceCriteriaDb.Scope.UncategorizedAddress -> businessPartner.uncategorized.address?.confidenceCriteria
+            }?.let { scope to toConfidence(it) }
+        }.toMap().toMutableMap()
+
+    fun toConfidence(confidenceCriteria: ConfidenceCriteria) =
+        with(confidenceCriteria) {
+            ConfidenceCriteriaDb(
+                sharedByOwner,
+                checkedByExternalDataSource,
+                numberOfSharingMembers,
+                lastConfidenceCheckAt?.toTimestamp(),
+                nextConfidenceCheckAt?.toTimestamp(),
+                confidenceLevel
+            )
+        }
+
+    fun toPostalAddresses(businessPartner: BusinessPartner) =
+        PostalAddressDb.Scope.entries.mapNotNull { scope ->
+            when (scope) {
+                PostalAddressDb.Scope.LegalAddress -> businessPartner.legalEntity.legalAddress
+                PostalAddressDb.Scope.SiteMainAddress -> businessPartner.site?.siteMainAddress
+                PostalAddressDb.Scope.AdditionalAddress -> businessPartner.additionalAddress
+                PostalAddressDb.Scope.UncategorizedAddress -> businessPartner.uncategorized.address
+            }?.let { scope to toPostalAddress(it, scope) }
+        }.toMap().toMutableMap()
+
+    fun toPostalAddress(postalAddress: PostalAddress, scope: PostalAddressDb.Scope) =
+        with(postalAddress) {
+            PostalAddressDb(
+                addressName = addressName,
+                physicalAddress = toPhysicalAddress(physicalAddress),
+                alternativeAddress = toAlternativeAddress(alternativeAddress),
+                hasChanged = hasChanged
+            )
+        }
+
+    fun toPhysicalAddress(physicalAddress: PhysicalAddress) =
+        with(physicalAddress) {
+            PostalAddressDb.PhysicalAddressDb(
+                geographicCoordinates = toGeoCoordinate(geographicCoordinates),
+                country = country,
+                administrativeAreaLevel1 = administrativeAreaLevel1,
+                administrativeAreaLevel2 = administrativeAreaLevel2,
+                administrativeAreaLevel3 = administrativeAreaLevel3,
+                postalCode = postalCode,
+                city = city,
+                district = district,
+                street = toStreet(street),
+                companyPostalCode = companyPostalCode,
+                industrialZone = industrialZone,
+                building = building,
+                floor = floor,
+                door = door,
+                taxJurisdictionCode = taxJurisdictionCode
+            )
+        }
+
+    fun toStreet(street: Street) =
+        with(street) {
+            PostalAddressDb.Street(
+                name,
+                houseNumber,
+                houseNumberSupplement,
+                milestone,
+                direction,
+                namePrefix,
+                additionalNamePrefix,
+                nameSuffix,
+                additionalNameSuffix
+            )
+        }
+
+    fun toGeoCoordinate(geoCoordinate: GeoCoordinate) =
+        with(geoCoordinate) {
+            PostalAddressDb.GeoCoordinate(longitude, latitude, altitude)
+        }
+
+    fun toAlternativeAddress(alternativeAddress: AlternativeAddress?) =
+        alternativeAddress?.let {
+            with(alternativeAddress) {
+                PostalAddressDb.AlternativeAddress(
+                    exists = true,
+                    geographicCoordinates = toGeoCoordinate(geographicCoordinates),
+                    country = country,
+                    administrativeAreaLevel1 = administrativeAreaLevel1,
+                    postalCode = postalCode,
+                    city = city,
+                    deliveryServiceType = deliveryServiceType,
+                    deliveryServiceQualifier = deliveryServiceQualifier,
+                    deliveryServiceNumber = deliveryServiceNumber
+                )
+            }
+        } ?: PostalAddressDb.AlternativeAddress(
+            exists = false,
+            geographicCoordinates = PostalAddressDb.GeoCoordinate(
+                longitude = null,
+                latitude = null,
+                altitude = null
+            ),
+            country = null,
+            administrativeAreaLevel1 = null,
+            postalCode = null,
+            city = null,
+            deliveryServiceType = null,
+            deliveryServiceQualifier = null,
+            deliveryServiceNumber = null
+        )
+
+    fun toBpnReferences(businessPartner: BusinessPartner) =
+        BpnReferenceDb.Scope.entries.mapNotNull { scope ->
+            when (scope) {
+                BpnReferenceDb.Scope.LegalEntity -> businessPartner.legalEntity.bpnReference
+                BpnReferenceDb.Scope.Site -> businessPartner.site?.bpnReference
+                BpnReferenceDb.Scope.LegalAddress -> businessPartner.legalEntity.legalAddress.bpnReference
+                BpnReferenceDb.Scope.SiteMainAddress -> businessPartner.site?.siteMainAddress?.bpnReference
+                BpnReferenceDb.Scope.AdditionalAddress -> businessPartner.additionalAddress?.bpnReference
+                BpnReferenceDb.Scope.UncategorizedAddress ->  businessPartner.uncategorized.address?.bpnReference
+            }?.let { scope to toBpnReference(it) }
+        }.toMap().toMutableMap()
+
+    fun toBpnReference(bpnReference: BpnReference) =
+        with(bpnReference) {
+            BpnReferenceDb(
+                referenceValue = referenceValue,
+                desiredBpn = desiredBpn,
+                referenceType = referenceType
+            )
+        }
+
+    private fun getInitialStep(mode: TaskMode): TaskStep {
+        return stateMachineConfigProperties.modeSteps[mode]!!.first()
+    }
+
+    private fun calculateTaskRetentionTimeout(task: GoldenRecordTaskDb) =
+        task.createdAt.instant.plus(taskConfigProperties.taskRetentionTimeout)
+
+    fun responseToClientState(task: GoldenRecordTaskDb, timeout: Instant) =
+        with(task) {
+            TaskClientStateDto(
+                taskId = task.uuid.toString(),
+                recordId = task.gateRecord.privateId.toString(),
+                businessPartnerResult = toBusinessPartnerResult(businessPartner),
+                processingState = toResponseProcessingState(task, timeout)
+            )
+        }
+
+    fun toBusinessPartnerResult(businessPartner: GoldenRecordTaskDb.BusinessPartner) =
+        with(businessPartner) {
+            BusinessPartner(
+                nameParts = toResponseCategorizedNameParts(nameParts),
+                owningCompany = owningCompany,
+                uncategorized = toResponseUncategorizedProperties(businessPartner),
+                legalEntity = toResponseLegalEntity(businessPartner),
+                site = toResponseSite(businessPartner),
+                additionalAddress = toResponsePostalAddress(businessPartner, PostalAddressDb.Scope.AdditionalAddress)
+            )
+        }
+
+    fun toResponseCategorizedNameParts(nameParts: List<NamePartDb>) =
+        nameParts.filter { it.type != null }.map { NamePart(it.name, it.type!!) }
+
+    fun toResponseUncategorizedProperties(businessPartner: GoldenRecordTaskDb.BusinessPartner) =
+        UncategorizedProperties(
+            nameParts = toResponseUncategorizedNameParts(businessPartner.nameParts),
+            identifiers = toResponseIdentifiers(businessPartner, IdentifierDb.Scope.Uncategorized),
+            states = toResponseStates(businessPartner, BusinessStateDb.Scope.Uncategorized),
+            address = toResponsePostalAddress(businessPartner, PostalAddressDb.Scope.UncategorizedAddress)
+        )
+
+    fun toResponseUncategorizedNameParts(nameParts: List<NamePartDb>) =
+        nameParts.filter { it.type == null }.map { it.name }
+
+    fun toResponseIdentifiers(businessPartner: GoldenRecordTaskDb.BusinessPartner, scope: IdentifierDb.Scope) =
+        businessPartner.identifiers.filter { it.scope == scope }.map { Identifier(it.value, it.type, it.issuingBody) }
+
+    fun toResponseStates(businessPartner: GoldenRecordTaskDb.BusinessPartner, scope: BusinessStateDb.Scope) =
+        businessPartner.businessStates.filter { it.scope == scope }.map { BusinessState(it.validFrom?.instant, it.validTo?.instant, it.type) }
+
+    fun toResponsePostalAddress(businessPartner: GoldenRecordTaskDb.BusinessPartner, scope: PostalAddressDb.Scope) =
+        businessPartner.addresses[scope]?.let { postalAddress ->
+            with(postalAddress) {
+                PostalAddress(
+                    bpnReference = toResponseBpnReference(businessPartner, scope.bpnReference),
+                    addressName = addressName,
+                    identifiers = toResponseIdentifiers(businessPartner, scope.identifier),
+                    states = toResponseStates(businessPartner, scope.state),
+                    confidenceCriteria = toResponseConfidence(businessPartner, scope.confidence),
+                    physicalAddress = toResponsePhysicalAddress(physicalAddress),
+                    alternativeAddress = toResponseAlternativeAddress(alternativeAddress),
+                    hasChanged = hasChanged
+                )
+            }
+        }
+
+    fun toResponseBpnReference(businessPartner: GoldenRecordTaskDb.BusinessPartner, scope: BpnReferenceDb.Scope) =
+        businessPartner.bpnReferences[scope]?.let { toResponseBpnReferences(it) } ?: BpnReference.empty
+
+    fun toResponseBpnReferences(bpnReference: BpnReferenceDb) =
+        with(bpnReference) {
+            BpnReference(referenceValue = referenceValue, desiredBpn = desiredBpn, referenceType = referenceType)
+        }
+
+    fun toResponseConfidence(businessPartner: GoldenRecordTaskDb.BusinessPartner, scope: ConfidenceCriteriaDb.Scope) =
+        businessPartner.confidences[scope]?.let { toResponseConfidences(it) } ?: ConfidenceCriteria.empty
+
+    fun toResponseConfidences(confidenceCriteria: ConfidenceCriteriaDb) =
+        with(confidenceCriteria) {
+            ConfidenceCriteria(
+                sharedByOwner = sharedByOwner,
+                checkedByExternalDataSource = checkedByExternalDataSource,
+                numberOfSharingMembers = numberOfSharingMembers,
+                lastConfidenceCheckAt = lastConfidenceCheckAt?.instant,
+                nextConfidenceCheckAt = nextConfidenceCheckAt?.instant,
+                confidenceLevel = confidenceLevel
+            )
+        }
+
+    fun toResponsePhysicalAddress(physicalAddress: PostalAddressDb.PhysicalAddressDb) =
+        with(physicalAddress) {
+            PhysicalAddress(
+                geographicCoordinates = toResponseGeoCoordinate(geographicCoordinates),
+                country = country,
+                administrativeAreaLevel1 = administrativeAreaLevel1,
+                administrativeAreaLevel2 = administrativeAreaLevel2,
+                administrativeAreaLevel3 = administrativeAreaLevel3,
+                postalCode = postalCode,
+                city = city,
+                district = district,
+                street = toResponseStreet(street),
+                companyPostalCode = companyPostalCode,
+                industrialZone = industrialZone,
+                building = building,
+                floor = floor,
+                door = door,
+                taxJurisdictionCode = taxJurisdictionCode
+            )
+        }
+
+    fun toResponseGeoCoordinate(geoCoordinate: PostalAddressDb.GeoCoordinate) =
+        with(geoCoordinate) {
+            GeoCoordinate(longitude = longitude, latitude = latitude, altitude = altitude)
+        }
+
+    fun toResponseStreet(street: PostalAddressDb.Street) =
+        with(street) {
+            Street(
+                name, houseNumber,
+                houseNumberSupplement = houseNumberSupplement,
+                milestone = milestone,
+                direction = direction,
+                namePrefix = namePrefix,
+                additionalNamePrefix = additionalNamePrefix,
+                nameSuffix = nameSuffix,
+                additionalNameSuffix = additionalNameSuffix
+            )
+        }
+
+    fun toResponseAlternativeAddress(alternativeAddress: PostalAddressDb.AlternativeAddress) =
+        alternativeAddress.takeIf { it.exists }?.let {
+            with(alternativeAddress) {
+                AlternativeAddress(
+                    geographicCoordinates = toResponseGeoCoordinate(geographicCoordinates),
+                    country = country,
+                    administrativeAreaLevel1 = administrativeAreaLevel1,
+                    postalCode = postalCode,
+                    city = city,
+                    deliveryServiceType = deliveryServiceType,
+                    deliveryServiceQualifier = deliveryServiceQualifier,
+                    deliveryServiceNumber = deliveryServiceNumber
+                )
+            }
+        }
+
+    fun toResponseLegalEntity(businessPartner: GoldenRecordTaskDb.BusinessPartner) =
+        with(businessPartner) {
+            LegalEntity(
+                bpnReference = toResponseBpnReference(businessPartner, BpnReferenceDb.Scope.LegalEntity),
+                legalName = legalName,
+                legalShortName = legalShortName,
+                legalForm = legalForm,
+                identifiers = toResponseIdentifiers(businessPartner, IdentifierDb.Scope.LegalEntity),
+                states = toResponseStates(businessPartner, BusinessStateDb.Scope.LegalEntity),
+                confidenceCriteria = toResponseConfidence(businessPartner, ConfidenceCriteriaDb.Scope.LegalEntity),
+                isCatenaXMemberData = isCatenaXMemberData,
+                hasChanged = legalEntityHasChanged,
+                legalAddress = toResponsePostalAddressOrEmpty(businessPartner, PostalAddressDb.Scope.LegalAddress)!!
+            )
+        }
+    fun toResponsePostalAddressOrEmpty(businessPartner: GoldenRecordTaskDb.BusinessPartner, scope: PostalAddressDb.Scope) =
+        toResponsePostalAddress(businessPartner, scope)
+
+    fun toResponseProcessingState(task: GoldenRecordTaskDb, timeout: Instant) =
+        with(task.processingState) {
+            TaskProcessingStateDto(
+                resultState = toResponseResultState(resultState),
+                step = step,
+                stepState = toResponseStepState(stepState),
+                errors = errors.map { toResponseTaskError(it) },
+                createdAt = task.createdAt.instant,
+                modifiedAt = task.updatedAt.instant,
+                timeout = timeout
+            )
+        }
+
+    fun toResponseResultState(resultState: GoldenRecordTaskDb.ResultState) =
+        when(resultState){
+            GoldenRecordTaskDb.ResultState.Pending -> ResultState.Pending
+            GoldenRecordTaskDb.ResultState.Success ->  ResultState.Success
+            GoldenRecordTaskDb.ResultState.Error ->  ResultState.Error
+            GoldenRecordTaskDb.ResultState.Aborted ->  ResultState.Error
+        }
+
+    fun toResponseStepState(stepState: GoldenRecordTaskDb.StepState) =
+        when(stepState){
+            GoldenRecordTaskDb.StepState.Queued -> StepState.Queued
+            GoldenRecordTaskDb.StepState.Reserved -> StepState.Reserved
+            GoldenRecordTaskDb.StepState.Success -> StepState.Success
+            GoldenRecordTaskDb.StepState.Error -> StepState.Error
+            GoldenRecordTaskDb.StepState.Aborted -> StepState.Error
+        }
+
+    fun toResponseTaskError(taskError: TaskErrorDb) =
+        with(taskError) {
+            TaskErrorDto(type = type, description = description)
+        }
+
+    fun toResponseSite(businessPartner: GoldenRecordTaskDb.BusinessPartner) =
+        businessPartner.takeIf { it.siteExists }?.let {
+            with(businessPartner) {
+                Site(
+                    bpnReference = toResponseBpnReference(businessPartner, BpnReferenceDb.Scope.Site),
+                    siteName = siteName,
+                    states = toResponseStates(businessPartner, BusinessStateDb.Scope.Site),
+                    confidenceCriteria = toResponseConfidence(businessPartner, ConfidenceCriteriaDb.Scope.Site),
+                    hasChanged = siteHasChanged,
+                    siteMainAddress = toResponsePostalAddress(businessPartner, PostalAddressDb.Scope.SiteMainAddress)
+                )
+            }
+        }
+
+    @Transactional
+    fun reserveTasksForStep(reservationRequest: TaskStepReservationRequest): TaskStepReservationResponse {
+        logger.debug { "Reservation of next golden record tasks: executing reserveTasksForStep() with parameters $reservationRequest" }
+        val now = Instant.now()
+
+        val foundTasks = taskRepository.findByStepAndStepState(reservationRequest.step, GoldenRecordTaskDb.StepState.Queued, Pageable.ofSize(reservationRequest.amount))
+            .content.toSet()
+            .also { taskRepository.fetchBusinessPartnerData(it) }
+        val reservedTasks = foundTasks.map { goldenRecordTaskStateMachine.doReserve(it) }
+        val pendingTimeout = reservedTasks.minOfOrNull { calculateTaskPendingTimeout(it) } ?: now
+
+        return reservedTasks
+            .map { task ->
+                TaskStepReservationEntryDto(
+                    task.uuid.toString(),
+                    task.gateRecord.publicId.toString(),
+                    toBusinessPartnerResult(task.businessPartner)
+                )
+            }
+            .let { reservations -> TaskStepReservationResponse(reservations, pendingTimeout) }
+    }
+
+    private fun calculateTaskPendingTimeout(task: GoldenRecordTaskDb) =
+        task.createdAt.instant.plus(taskConfigProperties.taskPendingTimeout)
+
+    @Transactional
+    fun resolveStepResults(resultRequest: TaskStepResultRequest) {
+        logger.debug { "Step results for reserved golden record tasks: executing resolveStepResults() with parameters $resultRequest" }
+        val uuids = resultRequest.results.map { toUUID(it.taskId) }
+        val foundTasks = taskRepository.findByUuidIn(uuids.toSet()).also { taskRepository.fetchBusinessPartnerData(it) }
+        val foundTasksByUuid = foundTasks.associateBy { it.uuid.toString() }
+
+        resultRequest.results
+            .map { resultEntry -> Pair(foundTasksByUuid[resultEntry.taskId] ?: throw BpdmTaskNotFoundException(resultEntry.taskId), resultEntry) }
+            .filterNot { (task, _) -> task.processingState.resultState == GoldenRecordTaskDb.ResultState.Aborted }
+            .forEach { (task, resultEntry) ->
+                val step = resultRequest.step
+                val errors = resultEntry.errors
+                val resultBusinessPartner = resultEntry.businessPartner
+
+                when{
+                    errors.isNotEmpty() -> goldenRecordTaskStateMachine.doResolveTaskToError(task, step, errors)
+                    else ->  resolveTaskStepToSuccess(task, step, resultBusinessPartner)
+                }
+            }
+    }
+
+    fun resolveTaskStepToSuccess(
+        task: GoldenRecordTaskDb,
+        step: TaskStep,
+        resultBusinessPartner: BusinessPartner
+    ): GoldenRecordTaskDb {
+        logger.debug { "Executing doResolveTaskToSuccess() with parameters $task // $step and $resultBusinessPartner" }
+        val state = task.processingState
+
+        if (!isResolvableForStep(state, step)) {
+            if(hasAlreadyResolvedStep(state, step))
+            {
+                logger.debug { "Task ${task.uuid} has already been processed for step $step. Result is ignored" }
+                return task
+            }else{
+                throw BpdmIllegalStateException(task.uuid, state)
+            }
+        }
+
+        val nextStep = getNextStep(state.mode, state.step)
+
+        if (nextStep != null) {
+            // still steps left to process -> queued for next step
+            task.processingState.toStep(nextStep)
+        } else {
+            // last step finished -> set resultState and stepState to success
+            task.processingState.toSuccess()
+        }
+
+        task.updateBusinessPartner(requestedToBusinessPartner(resultBusinessPartner))
+        task.updatedAt =  DbTimestamp(Instant.now())
+
+        return taskRepository.save(task)
+    }
+
+    private fun isResolvableForStep(state: GoldenRecordTaskDb.ProcessingState, step: TaskStep): Boolean{
+        return state.resultState == GoldenRecordTaskDb.ResultState.Pending
+                && state.stepState == GoldenRecordTaskDb.StepState.Reserved
+                && state.step == step
+    }
+
+    private fun hasAlreadyResolvedStep(state: GoldenRecordTaskDb.ProcessingState, step: TaskStep): Boolean{
+        if(state.step == step) return state.stepState != GoldenRecordTaskDb.StepState.Reserved
+        return isStepBefore(step, state.step, state.mode)
+    }
+
+    private fun isStepBefore(stepBefore: TaskStep, stepAfter: TaskStep, mode: TaskMode): Boolean{
+        val modeSteps = stateMachineConfigProperties.modeSteps[mode]!!
+        return modeSteps.contains(stepBefore) && modeSteps.indexOf(stepBefore) <= modeSteps.indexOf(stepAfter)
+    }
+
+    private fun getNextStep(mode: TaskMode, currentStep: TaskStep): TaskStep? {
+        return stateMachineConfigProperties.modeSteps[mode]!!
+            .dropWhile { it != currentStep }        // drop steps before currentStep
+            .drop(1)                             // then drop currentStep
+            .firstOrNull()                          // return next step
+    }
+
+    private fun GoldenRecordTaskDb.ProcessingState.toStep(nextStep: TaskStep) {
+        step = nextStep
+        stepState = GoldenRecordTaskDb.StepState.Queued
+    }
+
+    private fun GoldenRecordTaskDb.ProcessingState.toSuccess() {
+        resultState = GoldenRecordTaskDb.ResultState.Success
+        stepState = GoldenRecordTaskDb.StepState.Success
+        pendingTimeout = null
+        retentionTimeout = Instant.now().plus(taskConfigProperties.taskRetentionTimeout).toTimestamp()
+
+    }
+
+    fun searchTaskStates(stateRequest: TaskStateRequest): TaskStateResponse {
+        logger.debug { "Search for the state of golden record task: executing searchTaskStates() with parameters $stateRequest" }
+        val requestsByTaskId = stateRequest.entries.associateBy { it.taskId }
+
+        return stateRequest.entries.map { toUUID(it.taskId) }
+            .let { uuids -> taskRepository.findByUuidIn(uuids.toSet()) }
+            .also { tasks -> taskRepository.fetchBusinessPartnerData(tasks) }
+            .filter { task -> requestsByTaskId[task.uuid.toString()]?.recordId == task.gateRecord.privateId.toString() }
+            .map { task -> responseToClientState(task, calculateTaskRetentionTimeout(task)) }
+            .let { TaskStateResponse(tasks = it) }
+    }
+}

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/RequestMapper.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/RequestMapper.kt
@@ -40,7 +40,7 @@ class RequestMapper {
                 siteExists = site != null,
                 siteName = site?.siteName,
                 legalForm = legalEntity.legalForm,
-                isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+                isCatenaXMemberData = legalEntity.isParticipantData,
                 owningCompany = owningCompany,
                 legalEntityHasChanged = legalEntity.hasChanged,
                 siteHasChanged = site?.hasChanged

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/ResponseMapper.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/ResponseMapper.kt
@@ -88,7 +88,7 @@ class ResponseMapper {
                 identifiers = toIdentifiers(businessPartner, IdentifierDb.Scope.LegalEntity),
                 states = toStates(businessPartner, BusinessStateDb.Scope.LegalEntity),
                 confidenceCriteria = toConfidence(businessPartner, ConfidenceCriteriaDb.Scope.LegalEntity),
-                isCatenaXMemberData = isCatenaXMemberData,
+                isParticipantData = isCatenaXMemberData,
                 hasChanged = legalEntityHasChanged,
                 legalAddress = toPostalAddressOrEmpty(businessPartner, PostalAddressDb.Scope.LegalAddress)!!
             )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/ApiCommons.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/ApiCommons.kt
@@ -40,10 +40,10 @@ object ApiCommons {
     const val MEMBERS_ADDRESSES_SEARCH_PATH_V6 = "${BASE_PATH_V6}/members/addresses${CommonApiPathNames.SUBPATH_SEARCH}"
     const val MEMBERS_CHANGELOG_SEARCH_PATH_V6 = "${BASE_PATH_V6}/members/changelog${CommonApiPathNames.SUBPATH_SEARCH}"
 
-    const val MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/legal-entities${CommonApiPathNames.SUBPATH_SEARCH}"
-    const val MEMBERS_SITES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/sites${CommonApiPathNames.SUBPATH_SEARCH}"
-    const val MEMBERS_ADDRESSES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/addresses${CommonApiPathNames.SUBPATH_SEARCH}"
-    const val MEMBERS_CHANGELOG_SEARCH_PATH_V7 = "${BASE_PATH_V7}/members/changelog${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/participants/legal-entities${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_SITES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/participants/sites${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_ADDRESSES_SEARCH_PATH_V7 = "${BASE_PATH_V7}/participants/addresses${CommonApiPathNames.SUBPATH_SEARCH}"
+    const val MEMBERS_CHANGELOG_SEARCH_PATH_V7 = "${BASE_PATH_V7}/participants/changelog${CommonApiPathNames.SUBPATH_SEARCH}"
 
     const val CHANGELOG_BASE_PATH_V6 = "${BASE_PATH_V6}/business-partners/changelog"
     const val CHANGELOG_BASE_PATH_V7 = "${BASE_PATH_V7}/business-partners/changelog"
@@ -52,7 +52,7 @@ object ApiCommons {
     const val BPN_BASE_PATH_V7 = "${BASE_PATH_V7}/bpn"
 
     const val MEMBERSHIP_BASE_PATH_V6 = "${BASE_PATH_V6}/cx-memberships"
-    const val MEMBERSHIP_BASE_PATH_V7 = "${BASE_PATH_V7}/cx-memberships"
+    const val MEMBERSHIP_BASE_PATH_V7 = "${BASE_PATH_V7}/data-space-participants"
 
     const val LEGAL_ENTITIES_NAME = "Legal Entity Controller"
     const val LEGAL_ENTITIES_DESCRIPTION = "Read, create and update business partner of type legal entity"

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolAddressApi.kt
@@ -55,7 +55,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @GetMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6, ApiCommons.ADDRESS_BASE_PATH_V7])
+    @GetMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V7])
     fun getAddresses(
         @ParameterObject addressSearchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -73,7 +73,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @GetMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V6}/{bpna}", "${ApiCommons.ADDRESS_BASE_PATH_V7}/{bpna}"])
+    @GetMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V7}/{bpna}"])
     fun getAddress(
         @Parameter(description = "BPNA value") @PathVariable bpna: String
     ): LogisticAddressVerboseDto
@@ -89,7 +89,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PostMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V6}${CommonApiPathNames.SUBPATH_SEARCH}", "${ApiCommons.ADDRESS_BASE_PATH_V7}${CommonApiPathNames.SUBPATH_SEARCH}"])
+    @PostMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V7}${CommonApiPathNames.SUBPATH_SEARCH}"])
     fun searchAddresses(
         @RequestBody searchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -109,7 +109,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PostMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6, ApiCommons.ADDRESS_BASE_PATH_V7])
+    @PostMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V7])
     fun createAddresses(
         @RequestBody
         requests: Collection<AddressPartnerCreateRequest>
@@ -127,7 +127,7 @@ interface PoolAddressApi {
         ]
     )
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PutMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6, ApiCommons.ADDRESS_BASE_PATH_V7])
+    @PutMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V7])
     fun updateAddresses(
         @RequestBody
         requests: Collection<AddressPartnerUpdateRequest>

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolDataSpaceParticipantsApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolDataSpaceParticipantsApi.kt
@@ -21,9 +21,9 @@ package org.eclipse.tractusx.bpdm.pool.api
 
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.CxMembershipDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.DataSpaceParticipantDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantUpdateRequest
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -32,15 +32,15 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 
 @RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
-interface PoolCxMembershipApi {
+interface PoolDataSpaceParticipantsApi {
 
-    @GetMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V6, ApiCommons.MEMBERSHIP_BASE_PATH_V7])
+    @GetMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V7])
     fun get(
-        @ParameterObject searchRequest: CxMembershipSearchRequest,
+        @ParameterObject searchRequest: DataSpaceParticipantSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
-    ): PageDto<CxMembershipDto>
+    ): PageDto<DataSpaceParticipantDto>
 
 
-    @PutMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V6, ApiCommons.MEMBERSHIP_BASE_PATH_V7])
-    fun put(@RequestBody updateRequest: CxMembershipUpdateRequest)
+    @PutMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V7])
+    fun put(@RequestBody updateRequest: DataSpaceParticipantUpdateRequest)
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolLegalEntityApi.kt
@@ -56,7 +56,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6, ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
+    @GetMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
     fun getLegalEntities(
         @ParameterObject searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -82,7 +82,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{idValue}", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{idValue}"])
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{idValue}"])
     fun getLegalEntity(
         @Parameter(description = "Identifier value") @PathVariable("idValue") idValue: String,
         @Parameter(description = "Type of identifier to use, defaults to BPN when omitted", schema = Schema(defaultValue = "BPN"))
@@ -106,7 +106,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/search", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/search"])
+    @PostMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/search"])
     fun postLegalEntitySearch(
         @RequestBody searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -124,7 +124,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{bpnl}/sites", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/sites"])
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/sites"])
     fun getSites(
         @Parameter(description = "BPNL value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
@@ -142,7 +142,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{bpnl}/addresses", "${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/addresses"])
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V7}/{bpnl}/addresses"])
     fun getAddresses(
         @Parameter(description = "BPNL value") @PathVariable bpnl: String,
         @ParameterObject paginationRequest: PaginationRequest
@@ -161,7 +161,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6, ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
+    @PostMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
     fun createBusinessPartners(
         @RequestBody
         businessPartners: Collection<LegalEntityPartnerCreateRequest>
@@ -180,7 +180,7 @@ interface PoolLegalEntityApi {
         ]
     )
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PutMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6, ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
+    @PutMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V7])
     fun updateBusinessPartners(
         @RequestBody
         businessPartners: Collection<LegalEntityPartnerUpdateRequest>

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMembersApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMembersApi.kt
@@ -41,28 +41,28 @@ import org.springframework.web.bind.annotation.RequestMapping
 interface PoolMembersApi {
 
     @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
-    @PostMapping(value = [ApiCommons.MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V6, ApiCommons.MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V7])
+    @PostMapping(value = [ApiCommons.MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V7])
     fun searchLegalEntities(
         @RequestBody searchRequest: LegalEntitySearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LegalEntityWithLegalAddressVerboseDto>
 
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping(value = [ApiCommons.MEMBERS_SITES_SEARCH_PATH_V6, ApiCommons.MEMBERS_SITES_SEARCH_PATH_V7])
+    @PostMapping(value = [ApiCommons.MEMBERS_SITES_SEARCH_PATH_V7])
     fun postSiteSearch(
         @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<SiteWithMainAddressVerboseDto>
 
     @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
-    @PostMapping(value = [ApiCommons.MEMBERS_ADDRESSES_SEARCH_PATH_V6, ApiCommons.MEMBERS_ADDRESSES_SEARCH_PATH_V7])
+    @PostMapping(value = [ApiCommons.MEMBERS_ADDRESSES_SEARCH_PATH_V7])
     fun searchAddresses(
         @RequestBody searchRequest: AddressSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageDto<LogisticAddressVerboseDto>
 
     @Tag(name = ApiCommons.CHANGELOG_NAME, description = ApiCommons.CHANGELOG_DESCRIPTION)
-    @PostMapping(value = [ApiCommons.MEMBERS_CHANGELOG_SEARCH_PATH_V6, ApiCommons.MEMBERS_CHANGELOG_SEARCH_PATH_V7])
+    @PostMapping(value = [ApiCommons.MEMBERS_CHANGELOG_SEARCH_PATH_V7])
     fun searchChangelogEntries(
         @RequestBody changelogSearchRequest: ChangelogSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolMetadataApi.kt
@@ -60,7 +60,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/identifier-types", "${ApiCommons.BASE_PATH_V7}/identifier-types"])
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7}/identifier-types"])
     fun createIdentifierType(@RequestBody identifierType: IdentifierTypeDto): IdentifierTypeDto
 
     @Operation(
@@ -74,7 +74,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/identifier-types", "${ApiCommons.BASE_PATH_V7}/identifier-types"])
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V7}/identifier-types"])
     fun getIdentifierTypes(
         @ParameterObject paginationRequest: PaginationRequest,
         @Parameter businessPartnerType: IdentifierBusinessPartnerType,
@@ -96,7 +96,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/legal-forms", "${ApiCommons.BASE_PATH_V7}/legal-forms"])
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V7}/legal-forms"])
     fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormDto
 
     @Operation(
@@ -110,7 +110,7 @@ interface PoolMetadataApi {
         ]
     )
     @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
-    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/legal-forms", "${ApiCommons.BASE_PATH_V7}/legal-forms"])
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V7}/legal-forms"])
     fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageDto<LegalFormDto>
 
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/PoolSiteApi.kt
@@ -54,7 +54,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @GetMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/{bpns}", "${ApiCommons.SITE_BASE_PATH_V7}/{bpns}"])
+    @GetMapping(value = ["${ApiCommons.SITE_BASE_PATH_V7}/{bpns}"])
     fun getSite(
         @Parameter(description = "BPNS value") @PathVariable bpns: String
     ): SiteWithMainAddressVerboseDto
@@ -70,7 +70,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/search", "${ApiCommons.SITE_BASE_PATH_V7}/search"])
+    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V7}/search"])
     fun postSiteSearch(
         @RequestBody searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -89,7 +89,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping(value = [ApiCommons.SITE_BASE_PATH_V6, ApiCommons.SITE_BASE_PATH_V7])
+    @PostMapping(value = [ApiCommons.SITE_BASE_PATH_V7])
     fun createSite(
         @RequestBody
         requests: Collection<SitePartnerCreateRequest>
@@ -107,7 +107,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PutMapping(value = [ApiCommons.SITE_BASE_PATH_V6, ApiCommons.SITE_BASE_PATH_V7])
+    @PutMapping(value = [ApiCommons.SITE_BASE_PATH_V7])
     fun updateSite(
         @RequestBody
         requests: Collection<SitePartnerUpdateRequest>
@@ -124,7 +124,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @GetMapping(value = [ApiCommons.SITE_BASE_PATH_V6, ApiCommons.SITE_BASE_PATH_V7])
+    @GetMapping(value = [ApiCommons.SITE_BASE_PATH_V7])
     fun getSites(
         @ParameterObject searchRequest: SiteSearchRequest,
         @ParameterObject paginationRequest: PaginationRequest
@@ -142,7 +142,7 @@ interface PoolSiteApi {
         ]
     )
     @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
-    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/legal-main-sites", "${ApiCommons.SITE_BASE_PATH_V7}/legal-main-sites"])
+    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V7}/legal-main-sites"])
     fun createSiteWithLegalReference(
         @RequestBody request: Collection<SiteCreateRequestWithLegalAddressAsMain>
     ): SitePartnerCreateResponseWrapper

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/DataSpaceParticipantsApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/DataSpaceParticipantsApiClient.kt
@@ -22,10 +22,10 @@ package org.eclipse.tractusx.bpdm.pool.api.client
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
-import org.eclipse.tractusx.bpdm.pool.api.PoolCxMembershipApi
-import org.eclipse.tractusx.bpdm.pool.api.model.CxMembershipDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.PoolDataSpaceParticipantsApi
+import org.eclipse.tractusx.bpdm.pool.api.model.DataSpaceParticipantDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantUpdateRequest
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.GetExchange
@@ -33,12 +33,12 @@ import org.springframework.web.service.annotation.HttpExchange
 import org.springframework.web.service.annotation.PutExchange
 
 @HttpExchange
-interface CxMembershipApiClient: PoolCxMembershipApi {
+interface DataSpaceParticipantsApiClient: PoolDataSpaceParticipantsApi {
 
     @GetExchange(value = ApiCommons.MEMBERSHIP_BASE_PATH_V7)
-    override fun get(@ParameterObject searchRequest: CxMembershipSearchRequest, @ParameterObject paginationRequest: PaginationRequest): PageDto<CxMembershipDto>
+    override fun get(@ParameterObject searchRequest: DataSpaceParticipantSearchRequest, @ParameterObject paginationRequest: PaginationRequest): PageDto<DataSpaceParticipantDto>
 
     @PutExchange(value = ApiCommons.MEMBERSHIP_BASE_PATH_V7)
-    override fun put(@RequestBody updateRequest: CxMembershipUpdateRequest)
+    override fun put(@RequestBody updateRequest: DataSpaceParticipantUpdateRequest)
 
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolApiClient.kt
@@ -35,5 +35,5 @@ interface PoolApiClient {
 
     val members: MembersApiClient
 
-    val memberships: CxMembershipApiClient
+    val participants: DataSpaceParticipantsApiClient
 }

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/client/PoolClientImpl.kt
@@ -55,7 +55,7 @@ class PoolClientImpl(
 
     override val members by lazy { createClient<MembersApiClient>() }
 
-    override val memberships by lazy { createClient<CxMembershipApiClient>() }
+    override val participants by lazy { createClient<DataSpaceParticipantsApiClient>() }
 
     private inline fun <reified T> createClient() =
         httpServiceProxyFactory.createClient(T::class.java)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/DataSpaceParticipantDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/DataSpaceParticipantDto.kt
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.model
+
+data class DataSpaceParticipantDto (
+    val bpnL: String,
+    val isDataSpaceParticipant: Boolean
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityDto.kt
@@ -34,6 +34,8 @@ data class LegalEntityDto(
     override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
     override val states: Collection<LegalEntityStateDto> = emptyList(),
     override val confidenceCriteria: ConfidenceCriteriaDto,
-    override val isCatenaXMemberData: Boolean
+
+    @get:Schema(description = "Indicates whether the legal entity is owned and thus provided by a Data Space Participant.")
+    val isParticipantData: Boolean
 
 ) : IBaseLegalEntityDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalEntityVerboseDto.kt
@@ -54,7 +54,8 @@ data class LegalEntityVerboseDto(
 
     override val confidenceCriteria: ConfidenceCriteriaDto,
 
-    override val isCatenaXMemberData: Boolean,
+    @get:Schema(description = "Indicates whether the legal entity is owned and thus provided by a Data Space Participant.")
+    val isParticipantData: Boolean,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,
@@ -62,7 +63,7 @@ data class LegalEntityVerboseDto(
     @get:Schema(description = CommonDescription.updatedAt)
     val updatedAt: Instant,
 
-) : IBaseLegalEntityDto {
+    ) : IBaseLegalEntityDto {
 
     @get:JsonIgnore
     override val legalForm: String?

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalFormDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LegalFormDto.kt
@@ -36,7 +36,7 @@ data class LegalFormDto(
     val transliteratedName: String?,
 
     @get:Schema(description = LegalFormDescription.abbreviation)
-    val abbreviation: String? = null,
+    val abbreviations: String? = null,
 
     val country: CountryCode?,
 

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/LogisticAddressVerboseDto.kt
@@ -46,8 +46,8 @@ data class LogisticAddressVerboseDto(
     @get:Schema(description = LogisticAddressDescription.bpnSite)
     val bpnSite: String?,
 
-    @get:Schema(description = "Indicates whether the address is owned and thus provided by a Catena-X Member.")
-    val isCatenaXMemberData: Boolean,
+    @get:Schema(description = "Indicates whether the address is owned and thus provided by a Data Space Participant.")
+    val isParticipantData: Boolean,
 
     @get:Schema(description = CommonDescription.createdAt)
     val createdAt: Instant,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteVerboseDto.kt
@@ -34,8 +34,8 @@ data class SiteVerboseDto(
     override val name: String,
     override val states: Collection<SiteStateVerboseDto> = emptyList(),
 
-    @get:Schema(description = "Indicates whether the site is owned and thus provided by a Catena-X Member.")
-    val isCatenaXMemberData: Boolean,
+    @get:Schema(description = "Indicates whether the site is owned and thus provided by a Data Space Participant.")
+    val isParticipantData: Boolean,
 
     @get:Schema(description = SiteDescription.bpnLegalEntity)
     val bpnLegalEntity: String,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/DataSpaceParticipantSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/DataSpaceParticipantSearchRequest.kt
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.model.request
+
+data class DataSpaceParticipantSearchRequest(
+    val bpnLs: List<String>? = null,
+    val isDataSpaceParticipant: Boolean? = null
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/DataSpaceParticipantUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/DataSpaceParticipantUpdateRequest.kt
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.model.request
+
+import org.eclipse.tractusx.bpdm.pool.api.model.DataSpaceParticipantDto
+
+data class DataSpaceParticipantUpdateRequest(
+    val participants: List<DataSpaceParticipantDto>
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalFormRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/request/LegalFormRequest.kt
@@ -35,7 +35,7 @@ data class LegalFormRequest(
     val transliteratedName: String?,
 
     @Schema(description = "Comma separed list of abbreviations of the legal form name")
-    val abbreviation: String?,
+    val abbreviations: String?,
 
     @Schema(description = "Transliterated abbreviations of the legal form abbreviations")
     val transliteratedAbbreviations: String?,

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolAddressApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolAddressApi.kt
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.util.CommonApiPathNames
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerUpdateResponseWrapper
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.*
+
+
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+interface PoolAddressApi {
+
+    @Operation(
+        summary = "Returns addresses by different search parameters",
+        description = "This endpoint tries to find matches among all existing business partners of type address, " +
+                "filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. " +
+                "The match of a partner is better the higher its relevancy score. "
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of addresses matching the search criteria, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed search or pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
+    @GetMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6])
+    fun getAddresses(
+        @ParameterObject addressSearchRequest: AddressSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto>
+
+    @Operation(
+        summary = "Returns an address by its BPNA",
+        description = "Get business partners of type address by BPNA ignoring case."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Found address with specified BPNA"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "No address found under specified BPNA", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
+    @GetMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V6}/{bpna}"])
+    fun getAddress(
+        @Parameter(description = "BPNA value") @PathVariable bpna: String
+    ): LogisticAddressVerboseDto
+
+    @Operation(
+        summary = "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
+        description = "Search business partners of type address by their BPNA or their parents' BPNL or BPNS."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Found sites for the specified sites and legal entities"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
+    @PostMapping(value = ["${ApiCommons.ADDRESS_BASE_PATH_V6}${CommonApiPathNames.SUBPATH_SEARCH}"])
+    fun searchAddresses(
+        @RequestBody searchRequest: AddressSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto>
+
+    @Operation(
+        summary = "Creates a new address",
+        description = "Create new business partners of type address by specifying the BPN of the parent each address belongs to. " +
+                "A parent can be either a site or legal entity business partner. " +
+                "If the parent cannot be found, the record is ignored." +
+                "For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New business partner record successfully created, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed requests", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
+    @PostMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6])
+    fun createAddresses(
+        @RequestBody
+        requests: Collection<AddressPartnerCreateRequest>
+    ): AddressPartnerCreateResponseWrapper
+
+    @Operation(
+        summary = "Updates an existing address",
+        description = "Update existing business partner records of type address referenced via BPNA. " +
+                "The endpoint expects to receive the full updated record, including values that didn't change."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "The successfully updated records, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed requests", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
+    @PutMapping(value = [ApiCommons.ADDRESS_BASE_PATH_V6])
+    fun updateAddresses(
+        @RequestBody
+        requests: Collection<AddressPartnerUpdateRequest>
+    ): AddressPartnerUpdateResponseWrapper
+
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolCxMembershipApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolCxMembershipApi.kt
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6
+
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.CxMembershipDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.CxMembershipSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.CxMembershipUpdateRequest
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+interface PoolCxMembershipApi {
+
+    @GetMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V6])
+    fun get(
+        @ParameterObject searchRequest: CxMembershipSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<CxMembershipDto>
+
+
+    @PutMapping(value = [ApiCommons.MEMBERSHIP_BASE_PATH_V6])
+    fun put(@RequestBody updateRequest: CxMembershipUpdateRequest)
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolLegalEntityApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolLegalEntityApi.kt
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6
+
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.SiteVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalEntityPartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalEntityPartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.*
+
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+interface PoolLegalEntityApi {
+
+    @Operation(
+        summary = "Returns legal entities by different search parameters",
+        description = "This endpoint tries to find matches among all existing business partners of type legal entity, " +
+                "filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. "
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of business partners matching the search criteria, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed search or pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @GetMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6])
+    fun getLegalEntities(
+        @ParameterObject searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
+
+    @Operation(
+        summary = "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
+        description = "This endpoint tries to find a business partner by the specified identifier. " +
+                "The identifier value is case insensitively compared but needs to be given exactly. " +
+                "By default the value given is interpreted as a BPN. " +
+                "By specifying the technical key of another identifier type" +
+                "the value is matched against the identifiers of that given type."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Found business partner with specified identifier"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+            ApiResponse(
+                responseCode = "404",
+                description = "No business partner found under specified identifier or specified identifier type not found",
+                content = [Content()]
+            )
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{idValue}"])
+    fun getLegalEntity(
+        @Parameter(description = "Identifier value") @PathVariable("idValue") idValue: String,
+        @Parameter(description = "Type of identifier to use, defaults to BPN when omitted", schema = Schema(defaultValue = "BPN"))
+        @RequestParam idType: String? = "BPN"
+    ): LegalEntityWithLegalAddressVerboseDto
+
+    @Operation(
+        summary = "Returns legal entities by different search parameters",
+        description = "Search legal entity partners by their BPNLs. " +
+                "The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. " +
+                "For a single request, the maximum number of BPNLs to search for is limited to \${bpdm.bpn.search-request-limit} entries."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Found legal entites"),
+            ApiResponse(
+                responseCode = "400",
+                description = "On malformed request parameters or if number of requested bpns exceeds limit",
+                content = [Content()]
+            )
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @PostMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/search"])
+    fun postLegalEntitySearch(
+        @RequestBody searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
+
+    @Operation(
+        summary = "Returns all sites of a legal entity with a specific BPNL",
+        description = "Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "The sites for the specified bpnl"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "No business partner found for specified bpnl", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{bpnl}/sites"])
+    fun getSites(
+        @Parameter(description = "BPNL value") @PathVariable bpnl: String,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<SiteVerboseDto>
+
+    @Operation(
+        summary = "Returns all addresses of a legal entity with a specific BPNL",
+        description = "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "The addresses for the specified BPNL"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "No business partner found for specified BPNL", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @GetMapping(value = ["${ApiCommons.LEGAL_ENTITY_BASE_PATH_V6}/{bpnl}/addresses"])
+    fun getAddresses(
+        @Parameter(description = "BPNL value") @PathVariable bpnl: String,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto>
+
+    @Operation(
+        summary = "Creates a new legal entity",
+        description = "Create new business partners of type legal entity. " +
+                "The given additional identifiers of a record need to be unique, otherwise they are ignored. " +
+                "For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New legal entities request was processed successfully, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed requests", content = [Content()]),
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @PostMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6])
+    fun createBusinessPartners(
+        @RequestBody
+        businessPartners: Collection<LegalEntityPartnerCreateRequest>
+    ): LegalEntityPartnerCreateResponseWrapper
+
+
+    @Operation(
+        summary = "Updates an existing legal entity",
+        description = "Update existing business partner records of type legal entity referenced via BPNL. " +
+                "The endpoint expects to receive the full updated record, including values that didn't change."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Update legal entities request was processed successfully, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed requests", content = [Content()]),
+        ]
+    )
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @PutMapping(value = [ApiCommons.LEGAL_ENTITY_BASE_PATH_V6])
+    fun updateBusinessPartners(
+        @RequestBody
+        businessPartners: Collection<LegalEntityPartnerUpdateRequest>
+    ): LegalEntityPartnerUpdateResponseWrapper
+
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolMembersApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolMembersApi.kt
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SiteWithMainAddressVerboseDto
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+interface PoolMembersApi {
+
+    @Tag(name = ApiCommons.LEGAL_ENTITIES_NAME, description = ApiCommons.LEGAL_ENTITIES_DESCRIPTION)
+    @PostMapping(value = [ApiCommons.MEMBERS_LEGAL_ENTITIES_SEARCH_PATH_V6])
+    fun searchLegalEntities(
+        @RequestBody searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto>
+
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @PostMapping(value = [ApiCommons.MEMBERS_SITES_SEARCH_PATH_V6])
+    fun postSiteSearch(
+        @RequestBody searchRequest: SiteSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<SiteWithMainAddressVerboseDto>
+
+    @Tag(name = ApiCommons.ADDRESS_NAME, description = ApiCommons.ADDRESS_DESCRIPTION)
+    @PostMapping(value = [ApiCommons.MEMBERS_ADDRESSES_SEARCH_PATH_V6])
+    fun searchAddresses(
+        @RequestBody searchRequest: AddressSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto>
+
+    @Tag(name = ApiCommons.CHANGELOG_NAME, description = ApiCommons.CHANGELOG_DESCRIPTION)
+    @PostMapping(value = [ApiCommons.MEMBERS_CHANGELOG_SEARCH_PATH_V6])
+    fun searchChangelogEntries(
+        @RequestBody changelogSearchRequest: ChangelogSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<ChangelogEntryVerboseDto>
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolMetadataApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolMetadataApi.kt
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6
+
+import com.neovisionaries.i18n.CountryCode
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.IdentifierTypeDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalFormRequest
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.*
+
+
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+interface PoolMetadataApi {
+
+    companion object DescriptionObject {
+        const val technicalKeyDisclaimer =
+            "The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. " +
+                    "A recommendation for technical keys: They should be short, descriptive and " +
+                    "use a restricted common character set in order to ensure compatibility with older systems."
+    }
+
+    @Operation(
+        summary = "Creates a new identifier type",
+        description = "Create a new identifier type (including validity details) which can be referenced by business partner records. " +
+                "Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. " +
+                "The actual name of the identifier type is free to choose and doesn't need to be unique. $technicalKeyDisclaimer"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New identifier type successfully created"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+            ApiResponse(responseCode = "409", description = "Identifier type with specified technical key already exists", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/identifier-types"])
+    fun createIdentifierType(@RequestBody identifierType: IdentifierTypeDto): IdentifierTypeDto
+
+    @Operation(
+        summary = "Returns all identifier types filtered by business partner type and country.",
+        description = "Lists all matching identifier types including validity details in a paginated result"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of existing identifier types, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/identifier-types"])
+    fun getIdentifierTypes(
+        @ParameterObject paginationRequest: PaginationRequest,
+        @Parameter businessPartnerType: IdentifierBusinessPartnerType,
+        @Parameter country: CountryCode?
+    ):
+            PageDto<IdentifierTypeDto>
+
+
+    @Operation(
+        summary = "Creates a new legal form",
+        description = "Create a new legal form which can be referenced by business partner records. " +
+                "The actual name of the legal form is free to choose and doesn't need to be unique. " + technicalKeyDisclaimer
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New legal form successfully created"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+            ApiResponse(responseCode = "409", description = "Legal form with specified technical key already exists", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
+    @PostMapping(value = ["${ApiCommons.BASE_PATH_V6}/legal-forms"])
+    fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormDto
+
+    @Operation(
+        summary = "Returns all legal forms",
+        description = "Lists all currently known legal forms in a paginated result"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of existing legal forms, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.METADATA_NAME, description = ApiCommons.METADATA_DESCRIPTION)
+    @GetMapping(value = ["${ApiCommons.BASE_PATH_V6}/legal-forms"])
+    fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageDto<LegalFormDto>
+
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolSiteApi.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/PoolSiteApi.kt
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6
+
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SiteWithMainAddressVerboseDto
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.*
+
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+interface PoolSiteApi {
+
+    @Operation(
+        summary = "Returns a site by its BPNS",
+        description = "Get business partners of type site by BPNS ignoring case."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Found site with specified BPNS"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()]),
+            ApiResponse(responseCode = "404", description = "No site found under specified BPNS", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @GetMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/{bpns}"])
+    fun getSite(
+        @Parameter(description = "BPNS value") @PathVariable bpns: String
+    ): SiteWithMainAddressVerboseDto
+
+    @Operation(
+        summary = "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
+        description = "Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Found sites that belong to specified legal entites"),
+            ApiResponse(responseCode = "400", description = "On malformed request parameters", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/search"])
+    fun postSiteSearch(
+        @RequestBody searchRequest: SiteSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<SiteWithMainAddressVerboseDto>
+
+    @Operation(
+        summary = "Creates a new site",
+        description = "Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. " +
+                "If the legal entitiy cannot be found, the record is ignored." +
+                "For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New sites request was processed successfully, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed requests", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @PostMapping(value = [ApiCommons.SITE_BASE_PATH_V6])
+    fun createSite(
+        @RequestBody
+        requests: Collection<SitePartnerCreateRequest>
+    ): SitePartnerCreateResponseWrapper
+
+    @Operation(
+        summary = "Updates an existing site",
+        description = "Update existing business partner records of type site referenced via BPNS. " +
+                "The endpoint expects to receive the full updated record, including values that didn't change."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Update sites request was processed successfully, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed requests", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @PutMapping(value = [ApiCommons.SITE_BASE_PATH_V6])
+    fun updateSite(
+        @RequestBody
+        requests: Collection<SitePartnerUpdateRequest>
+    ): SitePartnerUpdateResponseWrapper
+
+    @Operation(
+        summary = "Get page of sites matching the pagination search criteria",
+        description = "This endpoint retrieves all existing business partners of type sites."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Page of business partners matching the search criteria, may be empty"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @GetMapping(value = [ApiCommons.SITE_BASE_PATH_V6])
+    fun getSites(
+        @ParameterObject searchRequest: SiteSearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<SiteWithMainAddressVerboseDto>
+
+    @Operation(
+        summary = "Create a new site with legal entity reference",
+        description = "Create a business partner site with the given legal entity reference. " +
+                "It will designate the address information as both legal and site main address."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "New sites request was processed successfully, possible errors are returned"),
+            ApiResponse(responseCode = "400", description = "On malformed pagination request", content = [Content()])
+        ]
+    )
+    @Tag(name = ApiCommons.SITE_NAME, description = ApiCommons.SITE_DESCRIPTION)
+    @PostMapping(value = ["${ApiCommons.SITE_BASE_PATH_V6}/legal-main-sites"])
+    fun createSiteWithLegalReference(
+        @RequestBody request: Collection<SiteCreateRequestWithLegalAddressAsMain>
+    ): SitePartnerCreateResponseWrapper
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/CxMembershipDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/CxMembershipDto.kt
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model
+
+data class CxMembershipDto (
+    val bpnL: String,
+    val isCatenaXMember: Boolean
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/IdentifierTypeDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/IdentifierTypeDto.kt
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.IdentifierTypeDescription
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDetailDto
+
+@Schema(description = IdentifierTypeDescription.header)
+data class IdentifierTypeDto(
+
+    @get:Schema(description = IdentifierTypeDescription.technicalKey)
+    val technicalKey: String,
+
+    @get:Schema(description = IdentifierTypeDescription.businessPartnerType)
+    val businessPartnerType: IdentifierBusinessPartnerType,
+
+    @get:Schema(description = IdentifierTypeDescription.name)
+    val name: String,
+
+    @get:Schema(description = IdentifierTypeDescription.abbreviation)
+    val abbreviation: String?,
+
+    @get:Schema(description = IdentifierTypeDescription.transliteratedName)
+    val transliteratedName: String?,
+
+    @get:Schema(description = IdentifierTypeDescription.transliteratedAbbreviation)
+    val transliteratedAbbreviation: String?,
+
+    @get:Schema(description = IdentifierTypeDescription.details)
+    val details: Collection<IdentifierTypeDetailDto> = listOf()
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LegalEntityDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LegalEntityDto.kt
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.pool.api.model.ConfidenceCriteriaDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityIdentifierDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityStateDto
+
+@Schema(description = LegalEntityDescription.header)
+data class LegalEntityDto(
+
+    @get:Schema(description = LegalEntityDescription.legalName)
+    val legalName: String,
+
+    override val legalShortName: String?,
+    override val legalForm: String? = null,
+    override val identifiers: Collection<LegalEntityIdentifierDto> = emptyList(),
+    override val states: Collection<LegalEntityStateDto> = emptyList(),
+    override val confidenceCriteria: ConfidenceCriteriaDto,
+
+    @get:Schema(description = "Indicates whether the legal entity is owned and thus provided by a Catena-X Member.")
+    val isCatenaXMemberData: Boolean
+
+) : IBaseLegalEntityDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LegalEntityVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LegalEntityVerboseDto.kt
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.pool.api.model.*
+import java.time.Instant
+
+@Schema(description = LegalEntityDescription.header)
+data class LegalEntityVerboseDto(
+
+    @get:Schema(description = LegalEntityDescription.bpnl)
+    val bpnl: String,
+
+    @get:Schema(description = LegalEntityDescription.legalName)
+    val legalName: String,
+
+    override val legalShortName: String? = null,
+
+    @field:JsonProperty("legalForm")
+    @get:Schema(description = LegalEntityDescription.legalForm)
+    val legalFormVerbose: LegalFormDto? = null,
+
+    override val identifiers: Collection<LegalEntityIdentifierVerboseDto> = emptyList(),
+    override val states: Collection<LegalEntityStateVerboseDto> = emptyList(),
+
+    @get:ArraySchema(arraySchema = Schema(description = LegalEntityDescription.relations))
+    val relations: Collection<RelationVerboseDto> = emptyList(),
+
+    @get:Schema(description = LegalEntityDescription.currentness)
+    val currentness: Instant,
+
+    override val confidenceCriteria: ConfidenceCriteriaDto,
+
+    @get:Schema(description = "Indicates whether the legal entity is owned and thus provided by a Catena-X Member.")
+    val isCatenaXMemberData: Boolean,
+
+    @get:Schema(description = CommonDescription.createdAt)
+    val createdAt: Instant,
+
+    @get:Schema(description = CommonDescription.updatedAt)
+    val updatedAt: Instant,
+
+) : IBaseLegalEntityDto {
+
+    @get:JsonIgnore
+    override val legalForm: String?
+        get() = legalFormVerbose?.technicalKey
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LegalFormDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LegalFormDto.kt
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model
+
+import com.neovisionaries.i18n.CountryCode
+import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalFormDescription
+
+@Schema(description = LegalFormDescription.header)
+data class LegalFormDto(
+
+    @get:Schema(description = LegalFormDescription.technicalKey)
+    val technicalKey: String,
+
+    @get:Schema(description = LegalFormDescription.name)
+    val name: String,
+
+    val transliteratedName: String?,
+
+    @get:Schema(description = LegalFormDescription.abbreviation)
+    val abbreviation: String? = null,
+
+    val country: CountryCode?,
+
+    val language: LanguageCode?,
+
+    val administrativeAreaLevel1: String?,
+
+    val transliteratedAbbreviations: String?,
+
+    val isActive: Boolean
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LogisticAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/LogisticAddressVerboseDto.kt
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
+import org.eclipse.tractusx.bpdm.pool.api.model.*
+import java.time.Instant
+
+@Schema(description = LogisticAddressDescription.header)
+data class LogisticAddressVerboseDto(
+
+    @get:Schema(description = LogisticAddressDescription.bpna)
+    val bpna: String,
+
+    @get:Schema(description = LogisticAddressDescription.name)
+    val name: String? = null,
+
+    override val states: Collection<AddressStateVerboseDto> = emptyList(),
+    override val identifiers: Collection<AddressIdentifierVerboseDto> = emptyList(),
+    override val physicalPostalAddress: PhysicalPostalAddressVerboseDto,
+    override val alternativePostalAddress: AlternativePostalAddressVerboseDto? = null,
+
+    @get:Schema(description = LogisticAddressDescription.bpnLegalEntity)
+    val bpnLegalEntity: String?,
+
+    @get:Schema(description = LogisticAddressDescription.bpnSite)
+    val bpnSite: String?,
+
+    @get:Schema(description = "Indicates whether the address is owned and thus provided by a Catena-X Member.")
+    val isCatenaXMemberData: Boolean,
+
+    @get:Schema(description = CommonDescription.createdAt)
+    val createdAt: Instant,
+
+    @get:Schema(description = CommonDescription.updatedAt)
+    val updatedAt: Instant,
+
+    override val confidenceCriteria: ConfidenceCriteriaDto,
+
+    @get:Schema(name = "addressType", description = LogisticAddressDescription.addressType)
+    val addressType: AddressType? = null,
+) : IBaseLogisticAddressDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/SiteVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/SiteVerboseDto.kt
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.pool.api.model.ConfidenceCriteriaDto
+import org.eclipse.tractusx.bpdm.pool.api.model.SiteStateVerboseDto
+import java.time.Instant
+
+@Schema(description = SiteDescription.header)
+data class SiteVerboseDto(
+
+    @get:Schema(description = SiteDescription.bpns)
+    val bpns: String,
+
+    override val name: String,
+    override val states: Collection<SiteStateVerboseDto> = emptyList(),
+
+    @get:Schema(description = "Indicates whether the site is owned and thus provided by a Catena-X Member.")
+    val isCatenaXMemberData: Boolean,
+
+    @get:Schema(description = SiteDescription.bpnLegalEntity)
+    val bpnLegalEntity: String,
+
+    @get:Schema(description = CommonDescription.createdAt)
+    val createdAt: Instant,
+
+    @get:Schema(description = CommonDescription.updatedAt)
+    val updatedAt: Instant,
+
+    override val confidenceCriteria: ConfidenceCriteriaDto
+
+) : IBaseSiteDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/CxMembershipSearchRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/CxMembershipSearchRequest.kt
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.request
+
+data class CxMembershipSearchRequest(
+    val bpnLs: List<String>? = null,
+    val isCatenaXMember: Boolean? = null
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/CxMembershipUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/CxMembershipUpdateRequest.kt
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.request
+
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.CxMembershipDto
+
+data class CxMembershipUpdateRequest(
+    val memberships: List<CxMembershipDto>
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/LegalEntityPartnerCreateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/LegalEntityPartnerCreateRequest.kt
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.request
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.RequestWithKey
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalEntityDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressDto
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = LegalEntityDescription.headerCreateRequest)
+data class LegalEntityPartnerCreateRequest(
+
+    @field:JsonUnwrapped
+    val legalEntity: LegalEntityDto,
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
+    val legalAddress: LogisticAddressDto,
+
+    @get:Schema(description = CommonDescription.index)
+    val index: String?
+
+): RequestWithKey {
+    override fun getRequestKey(): String? {
+        return index
+    }
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/LegalEntityPartnerUpdateRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/LegalEntityPartnerUpdateRequest.kt
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.request
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.RequestWithKey
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalEntityDto
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressDto
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = LegalEntityDescription.headerUpdateRequest)
+data class LegalEntityPartnerUpdateRequest(
+
+    @get:Schema(description = LegalEntityDescription.bpnl)
+    val bpnl: String,
+
+    @field:JsonUnwrapped
+    val legalEntity: LegalEntityDto,
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
+    val legalAddress: LogisticAddressDto
+
+): RequestWithKey {
+
+    override fun getRequestKey(): String {
+        return bpnl
+    }
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/LegalFormRequest.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/request/LegalFormRequest.kt
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.request
+
+import com.neovisionaries.i18n.CountryCode
+import com.neovisionaries.i18n.LanguageCode
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "LegalFormRequest", description = "New legal form record to be referenced by business partners")
+data class LegalFormRequest(
+    @Schema(description = "Unique key to be used for reference")
+    val technicalKey: String,
+
+    @Schema(description = "Full name of the legal form")
+    val name: String,
+
+    @Schema(description = "Transliterated name of the legal form")
+    val transliteratedName: String?,
+
+    @Schema(description = "Comma separed list of abbreviations of the legal form name")
+    val abbreviation: String?,
+
+    @Schema(description = "Transliterated abbreviations of the legal form abbreviations")
+    val transliteratedAbbreviations: String?,
+
+    @Schema(description = "The country to which this legal form belongs to")
+    val country: CountryCode?,
+
+    @Schema(description = "The language of the legal form's name")
+    val language: LanguageCode?,
+
+    @Schema(description = "The administrative area level 1 this legal form belongs to")
+    val administrativeAreaLevel1: String?,
+
+    @Schema(description = "Whether this legal form is considered as active according to GLEIF")
+    val isActive: Boolean
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/AddressPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/AddressPartnerCreateVerboseDto.kt
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.response
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LogisticAddressDescription
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = LogisticAddressDescription.headerCreateResponse)
+data class AddressPartnerCreateVerboseDto(
+
+    @field:JsonUnwrapped
+    val address: LogisticAddressVerboseDto,
+
+    @Schema(description = CommonDescription.index)
+    val index: String?
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/EntitiesWithErrors.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/EntitiesWithErrors.kt
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorCode
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityCreateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityUpdateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteCreateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteUpdateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressCreateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressUpdateError
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+
+open class EntitiesWithErrors<ENTITY, out ERROR : ErrorCode>(
+
+    @Schema(description = "Successfully created entities")
+    open val entities: Collection<ENTITY>,
+    @Schema(description = "Errors for not created entities")
+    open val errors: Collection<ErrorInfo<ERROR>>
+) {
+    val entityCount: Int
+        get() = entities.size
+    val errorCount: Int
+        get() = errors.size
+}
+
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
+data class LegalEntityPartnerCreateResponseWrapper(
+    override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
+    override val errors: Collection<ErrorInfo<LegalEntityCreateError>>
+) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityCreateError>(entities, errors)
+
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
+data class LegalEntityPartnerUpdateResponseWrapper(
+    override val entities: Collection<LegalEntityPartnerCreateVerboseDto>,
+    override val errors: Collection<ErrorInfo<LegalEntityUpdateError>>
+) : EntitiesWithErrors<LegalEntityPartnerCreateVerboseDto, LegalEntityUpdateError>(entities, errors)
+
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
+data class SitePartnerCreateResponseWrapper(
+    override val entities: Collection<SitePartnerCreateVerboseDto>,
+    override val errors: Collection<ErrorInfo<SiteCreateError>>
+) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteCreateError>(entities, errors)
+
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
+data class SitePartnerUpdateResponseWrapper(
+    override val entities: Collection<SitePartnerCreateVerboseDto>,
+    override val errors: Collection<ErrorInfo<SiteUpdateError>>
+) : EntitiesWithErrors<SitePartnerCreateVerboseDto, SiteUpdateError>(entities, errors)
+
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
+data class AddressPartnerCreateResponseWrapper(
+    override val entities: Collection<AddressPartnerCreateVerboseDto>,
+    override val errors: Collection<ErrorInfo<AddressCreateError>>
+) : EntitiesWithErrors<AddressPartnerCreateVerboseDto, AddressCreateError>(entities, errors)
+
+@Schema(description = CommonDescription.headerEntityWithErrorsWrapper)
+data class AddressPartnerUpdateResponseWrapper(
+    override val entities: Collection<LogisticAddressVerboseDto>,
+    override val errors: Collection<ErrorInfo<AddressUpdateError>>
+) : EntitiesWithErrors<LogisticAddressVerboseDto, AddressUpdateError>(entities, errors)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/LegalEntityPartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/LegalEntityPartnerCreateVerboseDto.kt
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.response
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = LegalEntityDescription.headerUpsertResponse)
+data class LegalEntityPartnerCreateVerboseDto(
+
+    @field:JsonUnwrapped
+    val legalEntity: LegalEntityVerboseDto,
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
+    val legalAddress: LogisticAddressVerboseDto,
+
+    @get:Schema(description = CommonDescription.index)
+    val index: String?
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/LegalEntityWithLegalAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/LegalEntityWithLegalAddressVerboseDto.kt
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.response
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.LegalEntityDescription
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = LegalEntityDescription.header)
+data class LegalEntityWithLegalAddressVerboseDto(
+
+    @field:JsonUnwrapped
+    val legalEntity: LegalEntityVerboseDto,
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = LegalEntityDescription.legalAddress)
+    val legalAddress: LogisticAddressVerboseDto,
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/SitePartnerCreateVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/SitePartnerCreateVerboseDto.kt
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.response
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.CommonDescription
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.SiteVerboseDto
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = SiteDescription.headerUpsertResponse)
+data class SitePartnerCreateVerboseDto(
+
+    @field:JsonUnwrapped
+    val site: SiteVerboseDto,
+
+    // TODO OpenAPI description for complex field does not work!!
+    @get:Schema(description = SiteDescription.mainAddress)
+    val mainAddress: LogisticAddressVerboseDto,
+
+    @get:Schema(description = CommonDescription.index)
+    val index: String?
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/SiteWithMainAddressVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/model/response/SiteWithMainAddressVerboseDto.kt
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.model.response
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.swagger.v3.oas.annotations.media.Schema
+import org.eclipse.tractusx.bpdm.common.dto.openapidescription.SiteDescription
+import org.eclipse.tractusx.bpdm.common.service.DataClassUnwrappedJsonDeserializer
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.SiteVerboseDto
+
+@JsonDeserialize(using = DataClassUnwrappedJsonDeserializer::class)
+@Schema(description = SiteDescription.header)
+data class SiteWithMainAddressVerboseDto(
+
+    @field:JsonUnwrapped
+    val site: SiteVerboseDto,
+
+    // TODO OpenAPI description for complex field does not work!!
+    @Schema(description = SiteDescription.mainAddress)
+    val mainAddress: LogisticAddressVerboseDto,
+)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/DataSpaceParticipantsController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/DataSpaceParticipantsController.kt
@@ -21,27 +21,27 @@ package org.eclipse.tractusx.bpdm.pool.controller
 
 import org.eclipse.tractusx.bpdm.common.dto.PageDto
 import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
-import org.eclipse.tractusx.bpdm.pool.api.PoolCxMembershipApi
-import org.eclipse.tractusx.bpdm.pool.api.model.CxMembershipDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.PoolDataSpaceParticipantsApi
+import org.eclipse.tractusx.bpdm.pool.api.model.DataSpaceParticipantDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
-import org.eclipse.tractusx.bpdm.pool.service.CxMembershipService
+import org.eclipse.tractusx.bpdm.pool.service.DataSpaceParticipantsService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class CxMembershipController(
-    private val cxMembershipService: CxMembershipService
-): PoolCxMembershipApi {
+class DataSpaceParticipantsController(
+    private val dataSpaceParticipantsService: DataSpaceParticipantsService
+): PoolDataSpaceParticipantsApi {
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
-    override fun get(searchRequest: CxMembershipSearchRequest, paginationRequest: PaginationRequest): PageDto<CxMembershipDto> {
-       return cxMembershipService.searchMemberships(searchRequest, paginationRequest)
+    override fun get(searchRequest: DataSpaceParticipantSearchRequest, paginationRequest: PaginationRequest): PageDto<DataSpaceParticipantDto> {
+       return dataSpaceParticipantsService.searchMemberships(searchRequest, paginationRequest)
     }
 
     @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
-    override fun put(updateRequest: CxMembershipUpdateRequest) {
-        return cxMembershipService.updateMemberships(updateRequest)
+    override fun put(updateRequest: DataSpaceParticipantUpdateRequest) {
+        return dataSpaceParticipantsService.updateMemberships(updateRequest)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/AddressController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/AddressController.kt
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.PoolAddressApi
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("AddressControllerLegacy")
+class AddressController(
+    private val addressLegacyServiceMapper: AddressLegacyServiceMapper
+) : PoolAddressApi {
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun getAddresses(addressSearchRequest: AddressSearchRequest, paginationRequest: PaginationRequest): PageDto<LogisticAddressVerboseDto> {
+        return searchAddresses(addressSearchRequest, paginationRequest)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun getAddress(
+        bpna: String
+    ): LogisticAddressVerboseDto {
+        return addressLegacyServiceMapper.findByBpn(bpna.uppercase())
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun searchAddresses(
+        searchRequest: AddressSearchRequest,
+        paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto> {
+        return addressLegacyServiceMapper.searchAddresses(
+            AddressLegacyServiceMapper.AddressSearchRequest(
+                addressBpns = searchRequest.addressBpns,
+                siteBpns = searchRequest.siteBpns,
+                legalEntityBpns = searchRequest.legalEntityBpns,
+                name = searchRequest.name,
+                isCatenaXMemberData = null
+            ),
+            paginationRequest
+        )
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun createAddresses(
+        requests: Collection<AddressPartnerCreateRequest>
+    ): AddressPartnerCreateResponseWrapper {
+        return addressLegacyServiceMapper.createAddresses(requests)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun updateAddresses(
+        requests: Collection<AddressPartnerUpdateRequest>
+    ): AddressPartnerUpdateResponseWrapper {
+        return addressLegacyServiceMapper.updateAddresses(requests)
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/AddressLegacyServiceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/AddressLegacyServiceMapper.kt
@@ -1,0 +1,477 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
+import org.eclipse.tractusx.bpdm.common.service.toPageRequest
+import org.eclipse.tractusx.bpdm.common.util.findDuplicates
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressPartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressCreateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressUpdateError
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorCode
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.dto.AddressMetadataDto
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
+import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
+import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddressDb
+import org.eclipse.tractusx.bpdm.pool.entity.SiteDb
+import org.eclipse.tractusx.bpdm.pool.repository.AddressIdentifierRepository
+import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
+import org.eclipse.tractusx.bpdm.pool.repository.LogisticAddressRepository
+import org.eclipse.tractusx.bpdm.pool.repository.SiteRepository
+import org.eclipse.tractusx.bpdm.pool.service.*
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.AddressMetadataMapping
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createAlternativeAddress
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createConfidenceCriteria
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createPhysicalAddress
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toAddressIdentifier
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toAddressState
+import org.eclipse.tractusx.bpdm.pool.service.RequestValidationService.IdentifierCandidate
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AddressLegacyServiceMapper(
+    private val logisticAddressRepository: LogisticAddressRepository,
+    private val legalEntityRepository: LegalEntityRepository,
+    private val bpnIssuingService: BpnIssuingService,
+    private val metadataService: MetadataService,
+    private val changelogService: PartnerChangelogService,
+    private val addressIdentifierRepository: AddressIdentifierRepository,
+    private val siteRepository: SiteRepository,
+    private val businessPartnerFetchService: BusinessPartnerFetchService,
+    private val addressRepository: LogisticAddressRepository,
+    private val businessPartnerEquivalenceMapper: BusinessPartnerEquivalenceMapper
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    fun findByBpn(bpn: String): LogisticAddressVerboseDto {
+        val address = findAddressByBpn(bpn) ?: throw BpdmNotFoundException("Address", bpn)
+        return address.toDto()
+    }
+
+    fun findAddressByBpn(bpn: String): LogisticAddressDb? {
+        logger.debug { "Executing findAddressByBpn() with parameters $bpn" }
+        return logisticAddressRepository.findByBpn(bpn)
+    }
+
+    fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
+        return LogisticAddressVerboseDto(
+            bpna = bpn,
+            bpnLegalEntity = legalEntity?.bpn,
+            bpnSite = site?.bpn,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            name = name,
+            states = states.map { it.toDto() },
+            identifiers = identifiers.map { it.toDto() },
+            physicalPostalAddress = physicalPostalAddress.toDto(),
+            alternativePostalAddress = alternativePostalAddress?.toDto(),
+            confidenceCriteria = confidenceCriteria.toDto(),
+            isCatenaXMemberData = legalEntity?.isCatenaXMemberData ?: site?.legalEntity?.isCatenaXMemberData ?: false,
+            addressType = getAddressType(this)
+        )
+    }
+
+    /**
+     * Search addresses per page for [searchRequest] and [paginationRequest]
+     */
+    @Transactional
+    fun searchAddresses(searchRequest: AddressSearchRequest, paginationRequest: PaginationRequest): PageDto<LogisticAddressVerboseDto> {
+
+        val spec = Specification.allOf(
+            LogisticAddressRepository.byBpns(searchRequest.addressBpns),
+            LogisticAddressRepository.bySiteBpns(searchRequest.siteBpns),
+            LogisticAddressRepository.byLegalEntityBpns(searchRequest.legalEntityBpns),
+            LogisticAddressRepository.byName(searchRequest.name),
+            LogisticAddressRepository.byIsMember(searchRequest.isCatenaXMemberData)
+        )
+        val addressPage = logisticAddressRepository.findAll(spec, paginationRequest.toPageRequest())
+
+        return addressPage.toDto { it.toDto() }
+    }
+
+    data class AddressSearchRequest(
+        val addressBpns: List<String>?,
+        val siteBpns: List<String>?,
+        val legalEntityBpns: List<String>?,
+        val name: String?,
+        val isCatenaXMemberData: Boolean?
+    )
+
+    @Transactional
+    fun createAddresses(requests: Collection<AddressPartnerCreateRequest>): AddressPartnerCreateResponseWrapper {
+        logger.info { "Create ${requests.size} new addresses" }
+
+        val errorsByRequest = validateAddressesToCreateFromController(requests)
+        val errors = errorsByRequest.flatMap { it.value }
+        val validRequests = requests.filterNot { errorsByRequest.containsKey(it) }
+
+        fun isLegalEntityRequest(request: AddressPartnerCreateRequest) =
+            bpnIssuingService.translateToBusinessPartnerType(request.bpnParent) == BusinessPartnerType.LEGAL_ENTITY
+
+        fun isSiteRequest(request: AddressPartnerCreateRequest) =
+            bpnIssuingService.translateToBusinessPartnerType(request.bpnParent) == BusinessPartnerType.SITE
+
+        val legalEntityRequests = validRequests.filter { isLegalEntityRequest(it) }
+        val siteRequests = validRequests.filter { isSiteRequest(it) }
+
+        val metadataMap = metadataService.getMetadata(validRequests.map { it.address }).toMapping()
+
+        val addressResponses = createAddressesForSite(siteRequests, metadataMap)
+            .plus(createAddressesForLegalEntity(legalEntityRequests, metadataMap))
+
+        changelogService.createChangelogEntries(addressResponses.map {
+            ChangelogEntryCreateRequest(it.address.bpna, ChangelogType.CREATE, BusinessPartnerType.ADDRESS)
+        })
+
+        return AddressPartnerCreateResponseWrapper(addressResponses, errors)
+    }
+
+
+
+    fun validateAddressesToCreateFromController(
+        addressRequests: Collection<AddressPartnerCreateRequest>
+    ): Map<AddressPartnerCreateRequest, Collection<ErrorInfo<AddressCreateError>>> {
+
+        val addressDtos = addressRequests.map { it.address }
+        val regionValidator = ValidateAdministrativeAreaLevel1Exists(addressDtos, AddressCreateError.RegionNotFound)
+        val identifiersValidator = ValidateIdentifierTypesExists(addressDtos, AddressCreateError.IdentifierNotFound)
+        val identifiersDuplicateValidator = ValidateAddressIdentifiersDuplicated(addressDtos, AddressCreateError.AddressDuplicateIdentifier)
+        val parentValidator = ValidateAddressParent(addressRequests)
+
+        return addressRequests.associateWith { request ->
+            val address = request.address
+
+            val validationErrors =
+                regionValidator.validate(address, request) +
+                        identifiersValidator.validate(address, request) +
+                        identifiersDuplicateValidator.validate(address, request, bpn = null) +
+                        parentValidator.validate(request.bpnParent, request)
+
+            validationErrors
+        }.filterValues { it.isNotEmpty() }
+    }
+
+    inner class ValidateAdministrativeAreaLevel1Exists<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+
+        private val existingRegions = metadataService.getRegions(addressDtos).map { it.regionCode }.toSet()
+        fun validate(address: IBaseLogisticAddressDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+
+            val requestedAdminLevels = listOfNotNull(
+                address.physicalPostalAddress?.administrativeAreaLevel1,
+                address.alternativePostalAddress?.administrativeAreaLevel1
+            )
+            val missingAdminLevels = requestedAdminLevels - existingRegions
+            return missingAdminLevels.map {
+                ErrorInfo(
+                    errorCode,
+                    "Address administrative area level1 '$it' does not exist",
+                    entityKey.getRequestKey()
+                )
+            }
+        }
+    }
+
+    inner class ValidateIdentifierTypesExists<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+        private val existingTypes = metadataService.getIdentifiers(addressDtos).map { it.technicalKey }.toSet()
+
+        fun validate(addressDto: IBaseLogisticAddressDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+            val requestedTypes = addressDto.identifiers.map { it.type }
+            val missingTypes = requestedTypes - existingTypes
+
+            return missingTypes.map {
+                ErrorInfo(
+                    errorCode,
+                    "Address Identifier Type '$it' does not exist",
+                    entityKey.getRequestKey()
+                )
+            }
+        }
+    }
+
+    private inner class ValidateAddressIdentifiersDuplicated<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+
+        val existingIdentifiers = getAddressDuplicateIdentifierCandidates(addressDtos)
+
+        fun validate(address: IBaseLogisticAddressDto, entityKey: RequestWithKey, bpn: String?): Collection<ErrorInfo<ERROR>> {
+
+            return address.identifiers.mapNotNull {
+                val identifierPair = IdentifierCandidateKey(type = it.type, value = it.value)
+                existingIdentifiers[identifierPair]?.let { candidate ->
+                    if (candidate.bpn === null || candidate.bpn != bpn)
+                        ErrorInfo(errorCode, "Duplicate Address Identifier: Value '${it.value}' of type '${it.type}'", entityKey.getRequestKey())
+                    else
+                        null
+                }
+            }
+        }
+
+        private fun getAddressDuplicateIdentifierCandidates(addressDtos: Collection<IBaseLogisticAddressDto>)
+                : Map<IdentifierCandidateKey, IdentifierCandidate> {
+
+            val identifiers = addressDtos.flatMap { it.identifiers }
+            val idValues = identifiers.map { it.value }
+            val duplicatesFromRequest = identifiers
+                .map { IdentifierCandidateKey(it.type, it.value) }
+                .findDuplicates()
+                .associateWith { IdentifierCandidate(bpn = null, type = it.type, value = it.value) }
+            val duplicatesFromDb = addressIdentifierRepository.findByValueIn(idValues)
+                .map { IdentifierCandidate(bpn = it.address.bpn, type = it.type.technicalKey, value = it.value) }
+                .associateBy { IdentifierCandidateKey(it.type, it.value) }
+            return duplicatesFromRequest.plus(duplicatesFromDb)
+        }
+
+    }
+
+    private data class IdentifierCandidateKey(
+        val type: String,
+        val value: String
+    )
+
+    private inner class ValidateAddressParent(requests: Collection<AddressPartnerCreateRequest>) {
+
+        val requestsByParentType = requests.groupBy { bpnIssuingService.translateToBusinessPartnerType(it.bpnParent) }
+        val legalEntityParentBpns = requestsByParentType[BusinessPartnerType.LEGAL_ENTITY]?.map { it.bpnParent } ?: emptyList()
+        val existingLegalEntities = legalEntityRepository.findDistinctByBpnIn(legalEntityParentBpns).map { it.bpn }.toSet()
+
+        val siteParentBpns = requestsByParentType[BusinessPartnerType.SITE]?.map { it.bpnParent } ?: emptyList()
+        val existingSites = siteRepository.findDistinctByBpnIn(siteParentBpns).map { it.bpn }.toSet()
+
+        fun validate(bpnParent: String, entityKey: RequestWithKey): Collection<ErrorInfo<AddressCreateError>> {
+            val type = bpnIssuingService.translateToBusinessPartnerType(bpnParent)
+            return when (type) {
+                BusinessPartnerType.LEGAL_ENTITY -> validateParentBpnExists(
+                    bpnParent,
+                    entityKey.getRequestKey(),
+                    existingLegalEntities,
+                    AddressCreateError.LegalEntityNotFound
+                )
+
+                BusinessPartnerType.SITE -> validateParentBpnExists(bpnParent, entityKey.getRequestKey(), existingSites, AddressCreateError.SiteNotFound)
+                else -> listOf(ErrorInfo(AddressCreateError.BpnNotValid, "Parent '${bpnParent}' is not a valid BPNL/BPNS", entityKey.getRequestKey()))
+
+            }
+        }
+    }
+
+    private fun <ERROR : ErrorCode> validateParentBpnExists(parentBpn: String, entityKey: String?, existingParentBpns: Set<String>, errorCode: ERROR)
+            : Collection<ErrorInfo<ERROR>> {
+        return if (!existingParentBpns.contains(parentBpn))
+            listOf(ErrorInfo(errorCode, "Parent with BPN '$parentBpn'not found", entityKey))
+        else
+            emptyList()
+    }
+
+    private fun AddressMetadataDto.toMapping() =
+        AddressMetadataMapping(
+            idTypes = idTypes.associateBy { it.technicalKey },
+            regions = regions.associateBy { it.regionCode }
+        )
+
+    private fun createAddressesForSite(
+        validRequests: Collection<AddressPartnerCreateRequest>,
+        metadataMap: AddressMetadataMapping
+    ): List<AddressPartnerCreateVerboseDto> {
+
+        val bpnsToFetch = validRequests.map { it.bpnParent }
+        val siteParents = siteRepository.findDistinctByBpnIn(bpnsToFetch)
+        val siteParentsByBpn = siteParents.associateBy { it.bpn }
+
+        val bpnAs = bpnIssuingService.issueAddressBpns(validRequests.size)
+        val addressesWithIndex = validRequests
+            .mapIndexed { i, request ->
+                val site = siteParentsByBpn[request.bpnParent]!!
+                val address = createLogisticAddress(request.address, bpnAs[i], site.legalEntity, site, metadataMap)
+                Pair(address, request.index)
+            }
+
+        logisticAddressRepository.saveAll(addressesWithIndex.map { (address, _) -> address })
+        return addressesWithIndex.map { (address, index) ->
+            address.toCreateResponse(index).also { logger.info { "Address ${address.bpn} was created" } }
+        }
+    }
+
+    fun LogisticAddressDb.toCreateResponse(index: String?): AddressPartnerCreateVerboseDto {
+        return AddressPartnerCreateVerboseDto(
+            address = toDto(),
+            index = index
+        )
+    }
+
+    private fun createLogisticAddress(
+        dto: LogisticAddressDto,
+        bpn: String,
+        legalEntity: LegalEntityDb,
+        site: SiteDb?,
+        metadataMap: AddressMetadataMapping
+    ) = createLogisticAddressInternal(dto, bpn, metadataMap)
+        .apply {
+            this.legalEntity = legalEntity
+            this.site = site
+        }
+
+    private fun createLogisticAddressInternal(
+        dto: LogisticAddressDto,
+        bpn: String,
+        metadataMap: AddressMetadataMapping
+    ): LogisticAddressDb {
+        val address = LogisticAddressDb(
+            bpn = bpn,
+            legalEntity = null,
+            site = null,
+            physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap.regions),
+            alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap.regions) },
+            name = dto.name,
+            confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
+        )
+
+        updateLogisticAddress(address, dto, metadataMap)
+
+        return address
+    }
+
+    private fun updateLogisticAddress(address: LogisticAddressDb, dto: LogisticAddressDto, metadataMap: AddressMetadataMapping) {
+        address.name = dto.name
+        address.physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap.regions)
+        address.alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap.regions) }
+
+        address.identifiers.apply {
+            clear()
+            addAll(dto.identifiers.map { toAddressIdentifier(it, metadataMap.idTypes, address) })
+        }
+        address.states.apply {
+            clear()
+            addAll(dto.states.map { toAddressState(it, address) })
+        }
+
+        address.confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
+    }
+
+    private fun createAddressesForLegalEntity(
+        validRequests: Collection<AddressPartnerCreateRequest>,
+        metadataMap: AddressMetadataMapping
+    ): Collection<AddressPartnerCreateVerboseDto> {
+
+        val bpnLsToFetch = validRequests.map { it.bpnParent }
+        val parentLegalEntities = businessPartnerFetchService.fetchByBpns(bpnLsToFetch)
+        val parentLegalEntitiesByBpn = parentLegalEntities.associateBy { it.bpn }
+
+        val bpnAs = bpnIssuingService.issueAddressBpns(validRequests.size)
+        val addressesWithIndex = validRequests
+            .mapIndexed { i, request ->
+                val legalEntity = parentLegalEntitiesByBpn[request.bpnParent]!!
+                val address = createLogisticAddress(request.address, bpnAs[i], legalEntity, null, metadataMap)
+                Pair(address, request.index)
+            }
+
+        logisticAddressRepository.saveAll(addressesWithIndex.map { (address, _) -> address })
+        return addressesWithIndex.map { (address, index) -> address.toCreateResponse(index) }
+    }
+
+    fun updateAddresses(requests: Collection<AddressPartnerUpdateRequest>): AddressPartnerUpdateResponseWrapper {
+        logger.info { "Update ${requests.size} business partner addresses" }
+
+        val errorsByRequest = validateAddressesToUpdateFromController(requests)
+        val errors = errorsByRequest.flatMap { it.value }
+        val validRequests = requests.filterNot { errorsByRequest.containsKey(it) }
+
+        val addresses = logisticAddressRepository.findDistinctByBpnIn(validRequests.map { it.bpna })
+        val metadataMap = metadataService.getMetadata(validRequests.map { it.address }).toMapping()
+
+        val addressRequestPairs = addresses.sortedBy { it.bpn }.zip(requests.sortedBy { it.bpna })
+        addressRequestPairs.forEach { (address, request) ->
+            val addressBeforeUpdate = businessPartnerEquivalenceMapper.toEquivalenceDto(address)
+            updateLogisticAddress(address, request.address, metadataMap)
+            val addressAfterUpdate = businessPartnerEquivalenceMapper.toEquivalenceDto(address)
+
+            if (addressBeforeUpdate != addressAfterUpdate) {
+                logger.info { "Address ${address.bpn} was updated" }
+
+                logisticAddressRepository.save(address)
+
+                changelogService.createChangelogEntries(listOf(ChangelogEntryCreateRequest(address.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS)))
+            }
+        }
+
+        val addressResponses = addresses.map { it.toDto() }
+
+        return AddressPartnerUpdateResponseWrapper(addressResponses, errors)
+    }
+
+    fun validateAddressesToUpdateFromController(
+        addressRequests: Collection<AddressPartnerUpdateRequest>
+    ): Map<AddressPartnerUpdateRequest, Collection<ErrorInfo<AddressUpdateError>>> {
+
+        val addressDtos = addressRequests.map { it.address }
+        val requestedAddressBpns = addressRequests.map { it.bpna }
+        val existingAddressBpns = addressRepository.findDistinctByBpnIn(requestedAddressBpns).map { it.bpn }.toSet()
+
+        val regionValidator = ValidateAdministrativeAreaLevel1Exists(addressDtos, AddressUpdateError.RegionNotFound)
+        val identifiersValidator = ValidateIdentifierTypesExists(addressDtos, AddressUpdateError.IdentifierNotFound)
+        val identifiersDuplicateValidator = ValidateAddressIdentifiersDuplicated(addressDtos, AddressUpdateError.AddressDuplicateIdentifier)
+        val existingBpnValidator = ValidateUpdateBpnExists(existingAddressBpns, AddressUpdateError.AddressNotFound)
+
+        return addressRequests.associateWith { request ->
+            val address = request.address
+
+            val validationErrors = regionValidator.validate(address, request) +
+                    identifiersValidator.validate(address, request) +
+                    identifiersDuplicateValidator.validate(address, request, request.bpna) +
+                    existingBpnValidator.validate(request.bpna)
+            validationErrors
+        }.filterValues { it.isNotEmpty() }
+    }
+
+    inner class ValidateUpdateBpnExists<ERROR : ErrorCode>(
+        private val existingBpns: Set<String>,
+        private val errorCode: ERROR
+    ) {
+
+        fun validate(bpnToUpdate: String?): Collection<ErrorInfo<ERROR>> {
+            return if (bpnToUpdate != null && !existingBpns.contains(bpnToUpdate))
+                listOf(ErrorInfo(errorCode, "Business Partner with BPN '$bpnToUpdate' can't be updated as it doesn't exist", bpnToUpdate))
+            else
+                emptyList()
+        }
+    }
+
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/CxMembershipController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/CxMembershipController.kt
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.PoolCxMembershipApi
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.CxMembershipDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.CxMembershipSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.CxMembershipUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("CxMembershipControllerLegacy")
+class CxMembershipController(
+    private val cxMembershipLegacyServiceMapper: CxMembershipLegacyServiceMapper
+): PoolCxMembershipApi {
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun get(searchRequest: CxMembershipSearchRequest, paginationRequest: PaginationRequest): PageDto<CxMembershipDto> {
+       return cxMembershipLegacyServiceMapper.searchMemberships(searchRequest, paginationRequest)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun put(updateRequest: CxMembershipUpdateRequest) {
+        return cxMembershipLegacyServiceMapper.updateMemberships(updateRequest)
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/CxMembershipLegacyServiceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/CxMembershipLegacyServiceMapper.kt
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.exception.BpdmMultipleNotFoundException
+import org.eclipse.tractusx.bpdm.common.mapping.ValidationContext.Companion.fromRoot
+import org.eclipse.tractusx.bpdm.common.mapping.types.BpnLString
+import org.eclipse.tractusx.bpdm.common.service.toPageDto
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.CxMembershipUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.CxMembershipDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.CxMembershipSearchRequest
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
+import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
+import org.eclipse.tractusx.bpdm.pool.service.PartnerChangelogService
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CxMembershipLegacyServiceMapper(
+    private val legalEntityRepository: LegalEntityRepository,
+    private val changelogService: PartnerChangelogService
+) {
+
+    fun searchMemberships(searchRequest: CxMembershipSearchRequest, paginationRequest: PaginationRequest): PageDto<CxMembershipDto> {
+        searchRequest.bpnLs?.let { BpnLString.assert(it, fromRoot(CxMembershipSearchRequest::class, "searchRequest", CxMembershipSearchRequest::bpnLs)) }
+
+        val spec = Specification.allOf(
+            LegalEntityRepository.byBpns(searchRequest.bpnLs),
+            LegalEntityRepository.byIsMember(searchRequest.isCatenaXMember)
+        )
+        val legalEntityPage = legalEntityRepository.findAll(spec, PageRequest.of(paginationRequest.page, paginationRequest.size))
+
+        return legalEntityPage.toPageDto { CxMembershipDto(it.bpn, it.isCatenaXMemberData) }
+    }
+
+    @Transactional
+    fun updateMemberships(updateRequest: CxMembershipUpdateRequest){
+        BpnLString.assert(
+            updateRequest.memberships.map { it.bpnL },
+            fromRoot(CxMembershipUpdateRequest::class, "updateRequest", CxMembershipUpdateRequest::memberships, CxMembershipDto::bpnL)
+        )
+
+        val updatesByBpnL = updateRequest.memberships.associate { Pair(it.bpnL, it.isCatenaXMember) }
+
+        val foundLegalEntities = legalEntityRepository.findDistinctByBpnIn(updatesByBpnL.keys)
+
+        val notFoundBpnLs = updatesByBpnL.keys.minus( foundLegalEntities.map { it.bpn }.toSet())
+        if(notFoundBpnLs.isNotEmpty())
+            throw BpdmMultipleNotFoundException("Legal Entities", notFoundBpnLs)
+
+        foundLegalEntities.forEach { legalEntity ->
+            val updateValue = updatesByBpnL[legalEntity.bpn]!!
+            if(legalEntity.isCatenaXMemberData != updateValue){
+                legalEntity.isCatenaXMemberData = updateValue
+                legalEntityRepository.save(legalEntity)
+
+                changelogService.createChangelogEntry(
+                    ChangelogEntryCreateRequest(
+                    legalEntity.bpn, ChangelogType.UPDATE, BusinessPartnerType.LEGAL_ENTITY
+                )
+                )
+            }
+        }
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/LegalEntityController.kt
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.PoolLegalEntityApi
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.SiteVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalEntityPartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalEntityPartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.config.BpnConfigProperties
+import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("LegalEntityControllerLegacy")
+class LegalEntityController(
+    val legalEntityLegacyServiceMapper: LegalEntityLegacyServiceMapper,
+    val bpnConfigProperties: BpnConfigProperties,
+) : PoolLegalEntityApi {
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun getLegalEntities(
+        @ParameterObject searchRequest: LegalEntitySearchRequest,
+        @ParameterObject paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto> {
+        return legalEntityLegacyServiceMapper.searchLegalEntities(
+            LegalEntityLegacyServiceMapper.LegalEntitySearchRequest(
+                bpnLs = searchRequest.bpnLs,
+                legalName = searchRequest.legalName,
+                isCatenaXMemberData = null
+            ),
+            paginationRequest
+        )
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun getLegalEntity(idValue: String, idType: String?): LegalEntityWithLegalAddressVerboseDto {
+        val actualType = idType ?: bpnConfigProperties.id
+        return if (actualType == bpnConfigProperties.id) legalEntityLegacyServiceMapper.findLegalEntityIgnoreCase(idValue.uppercase())
+        else legalEntityLegacyServiceMapper.findLegalEntityIgnoreCase(actualType, idValue)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun postLegalEntitySearch(
+        searchRequest: LegalEntitySearchRequest,
+        paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto> {
+        return legalEntityLegacyServiceMapper.searchLegalEntities(
+            LegalEntityLegacyServiceMapper.LegalEntitySearchRequest(
+                searchRequest.bpnLs,
+                searchRequest.legalName,
+                isCatenaXMemberData = null
+            ),
+            paginationRequest
+        )
+    }
+
+
+    override fun getSites(
+        bpnl: String,
+        paginationRequest: PaginationRequest
+    ): PageDto<SiteVerboseDto> {
+        return legalEntityLegacyServiceMapper.findByParentBpn(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun getAddresses(
+        bpnl: String,
+        paginationRequest: PaginationRequest
+    ): PageDto<LogisticAddressVerboseDto> {
+        return legalEntityLegacyServiceMapper.findNonSiteAddressesOfLegalEntity(bpnl.uppercase(), paginationRequest.page, paginationRequest.size)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun createBusinessPartners(
+        businessPartners: Collection<LegalEntityPartnerCreateRequest>
+    ): LegalEntityPartnerCreateResponseWrapper {
+        return legalEntityLegacyServiceMapper.createLegalEntities(businessPartners)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun updateBusinessPartners(
+        businessPartners: Collection<LegalEntityPartnerUpdateRequest>
+    ): LegalEntityPartnerUpdateResponseWrapper {
+        return legalEntityLegacyServiceMapper.updateLegalEntities(businessPartners)
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/LegalEntityLegacyServiceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/LegalEntityLegacyServiceMapper.kt
@@ -1,0 +1,767 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLegalEntityDto
+import org.eclipse.tractusx.bpdm.common.dto.IBaseLogisticAddressDto
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.common.dto.RequestWithKey
+import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
+import org.eclipse.tractusx.bpdm.common.util.findDuplicates
+import org.eclipse.tractusx.bpdm.common.util.mergeMapsWithCollectionInValue
+import org.eclipse.tractusx.bpdm.common.util.replace
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalEntityPartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalEntityPartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorCode
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityCreateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityUpdateError
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalEntityVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.SiteVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalEntityDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.dto.AddressMetadataDto
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
+import org.eclipse.tractusx.bpdm.pool.dto.LegalEntityMetadataDto
+import org.eclipse.tractusx.bpdm.pool.entity.*
+import org.eclipse.tractusx.bpdm.pool.repository.*
+import org.eclipse.tractusx.bpdm.pool.service.AddressService
+import org.eclipse.tractusx.bpdm.pool.service.BpnIssuingService
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.AddressMetadataMapping
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createAlternativeAddress
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createConfidenceCriteria
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createCurrentnessTimestamp
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createPhysicalAddress
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toAddressIdentifier
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toAddressState
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toLegalEntityIdentifier
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toLegalEntityState
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.LegalEntityMetadataMapping
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerEquivalenceMapper
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerFetchService
+import org.eclipse.tractusx.bpdm.pool.service.MetadataService
+import org.eclipse.tractusx.bpdm.pool.service.PartnerChangelogService
+import org.eclipse.tractusx.bpdm.pool.service.RequestValidationService.AddressBridge
+import org.eclipse.tractusx.bpdm.pool.service.RequestValidationService.IdentifierCandidate
+import org.eclipse.tractusx.bpdm.pool.service.RequestValidationService.LegalEntityBridge
+import org.eclipse.tractusx.bpdm.pool.service.RequestValidationService.ValidatorErrorCodes
+import org.eclipse.tractusx.bpdm.pool.service.getAddressType
+import org.eclipse.tractusx.bpdm.pool.service.toDto
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.collections.associateBy
+import kotlin.collections.plus
+
+@Service
+class LegalEntityLegacyServiceMapper(
+    private val legalEntityRepository: LegalEntityRepository,
+    private val identifierTypeRepository: IdentifierTypeRepository,
+    private val siteRepository: SiteRepository,
+    private val logisticAddressRepository: LogisticAddressRepository,
+    private val legalEntityIdentifierRepository: LegalEntityIdentifierRepository,
+    private val addressIdentifierRepository: AddressIdentifierRepository,
+    private val addressService: AddressService,
+    private val businessPartnerFetchService: BusinessPartnerFetchService,
+    private val metadataService: MetadataService,
+    private val changelogService: PartnerChangelogService,
+    private val bpnIssuingService: BpnIssuingService,
+    private val businessPartnerEquivalenceMapper: BusinessPartnerEquivalenceMapper
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    /**
+     * Search legal entities per page for [searchRequest] and [paginationRequest]
+     */
+    @Transactional
+    fun searchLegalEntities(searchRequest: LegalEntitySearchRequest, paginationRequest: PaginationRequest): PageDto<LegalEntityWithLegalAddressVerboseDto> {
+        val spec = Specification.allOf(
+            LegalEntityRepository.byBpns(searchRequest.bpnLs),
+            LegalEntityRepository.byLegalName(searchRequest.legalName),
+            LegalEntityRepository.byIsMember(searchRequest.isCatenaXMemberData)
+        )
+
+        val legalEntityPage = legalEntityRepository.findAll(spec, PageRequest.of(paginationRequest.page, paginationRequest.size))
+
+        return legalEntityPage.toDto(::toLegalEntityWithLegalAddress)
+    }
+
+    /**
+     * Fetch a business partner by [bpn] and return as [LegalEntityWithLegalAddressVerboseDto]
+     */
+    fun findLegalEntityIgnoreCase(bpn: String): LegalEntityWithLegalAddressVerboseDto {
+        logger.debug { "Executing findLegalEntityIgnoreCase() with parameters $bpn" }
+        val legalEntity = findLegalEntityOrThrow(bpn)
+        return toLegalEntityWithLegalAddress(legalEntity)
+    }
+
+    /**
+     * Fetch a business partner by [identifierValue] (ignoring case) of [identifierType] and return as [LegalEntityWithLegalAddressVerboseDto]
+     */
+    @Transactional
+    fun findLegalEntityIgnoreCase(identifierType: String, identifierValue: String): LegalEntityWithLegalAddressVerboseDto {
+        logger.debug { "Executing findLegalEntityIgnoreCase() with parameters $identifierType and $identifierValue" }
+        val legalEntity = findLegalEntityOrThrow(identifierType, identifierValue)
+        return toLegalEntityWithLegalAddress(legalEntity)
+    }
+
+    private fun findLegalEntityOrThrow(bpn: String): LegalEntityDb {
+        return legalEntityRepository.findByBpnIgnoreCase(bpn) ?: throw BpdmNotFoundException(LegalEntityDb::class.simpleName!!, bpn)
+    }
+
+    fun findLegalEntityOrThrow(identifierTypeKey: String, identifierValue: String): LegalEntityDb {
+        val identifierType = findIdentifierTypeOrThrow(identifierTypeKey, IdentifierBusinessPartnerType.LEGAL_ENTITY)
+        return legalEntityRepository.findByIdentifierTypeAndValueIgnoreCase(identifierType, identifierValue)
+            ?: throw BpdmNotFoundException("Identifier Value", identifierValue)
+    }
+
+    private fun findIdentifierTypeOrThrow(identifierTypeKey: String, businessPartnerType: IdentifierBusinessPartnerType) =
+        identifierTypeRepository.findByBusinessPartnerTypeAndTechnicalKey(businessPartnerType, identifierTypeKey)
+            ?: throw BpdmNotFoundException(IdentifierTypeDb::class, "$identifierTypeKey/$businessPartnerType")
+
+
+    fun toLegalEntityWithLegalAddress(entity: LegalEntityDb): LegalEntityWithLegalAddressVerboseDto {
+        return LegalEntityWithLegalAddressVerboseDto(
+            legalAddress = entity.legalAddress.toDto(),
+            legalEntity = entity.toDto()
+        )
+    }
+
+    fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
+        return LogisticAddressVerboseDto(
+            bpna = bpn,
+            bpnLegalEntity = legalEntity?.bpn,
+            bpnSite = site?.bpn,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            name = name,
+            states = states.map { it.toDto() },
+            identifiers = identifiers.map { it.toDto() },
+            physicalPostalAddress = physicalPostalAddress.toDto(),
+            alternativePostalAddress = alternativePostalAddress?.toDto(),
+            confidenceCriteria = confidenceCriteria.toDto(),
+            isCatenaXMemberData = legalEntity?.isCatenaXMemberData ?: site?.legalEntity?.isCatenaXMemberData ?: false,
+            addressType = getAddressType(this)
+        )
+    }
+
+    fun LegalEntityDb.toDto(): LegalEntityVerboseDto {
+        return LegalEntityVerboseDto(
+            bpnl = bpn,
+            legalName = legalName.value,
+            legalShortName = legalName.shortName,
+            legalFormVerbose = legalForm?.toDto(),
+            identifiers = identifiers.map { it.toDto() },
+            states = states.map { it.toDto() },
+            relations = startNodeRelations.plus(endNodeRelations).map { it.toDto() },
+            currentness = currentness,
+            confidenceCriteria = confidenceCriteria.toDto(),
+            isCatenaXMemberData = isCatenaXMemberData,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+    }
+
+    fun LegalFormDb.toDto(): LegalFormDto {
+        return LegalFormDto(
+            technicalKey = technicalKey,
+            name = name,
+            transliteratedName = transliteratedName,
+            abbreviation = abbreviation,
+            transliteratedAbbreviations = transliteratedAbbreviations,
+            country = countryCode,
+            language = languageCode,
+            administrativeAreaLevel1 = administrativeArea?.regionCode,
+            isActive = isActive
+        )
+    }
+
+    data class LegalEntitySearchRequest(
+        val bpnLs: List<String>?,
+        val legalName: String?,
+        val isCatenaXMemberData: Boolean?
+    )
+
+    fun findByParentBpn(bpn: String, pageIndex: Int, pageSize: Int): PageDto<SiteVerboseDto> {
+        logger.debug { "Executing findByPartnerBpn() with parameters $bpn // $pageIndex // $pageSize" }
+        val legalEntity = legalEntityRepository.findByBpnIgnoreCase(bpn) ?: throw BpdmNotFoundException("Business Partner", bpn)
+
+        val page = siteRepository.findByLegalEntity(legalEntity, PageRequest.of(pageIndex, pageSize))
+        fetchSiteDependencies(page.toSet())
+        return page.toDto(page.content.map { it.toDto() })
+    }
+
+    private fun fetchSiteDependencies(sites: Set<SiteDb>) {
+        siteRepository.joinAddresses(sites)
+        siteRepository.joinStates(sites)
+        val addresses = sites.flatMap { it.addresses }.toSet()
+        addressService.fetchLogisticAddressDependencies(addresses)
+    }
+
+    fun SiteDb.toDto(): SiteVerboseDto {
+        return SiteVerboseDto(
+            bpn,
+            name,
+            states = states.map { it.toDto() },
+            bpnLegalEntity = legalEntity.bpn,
+            confidenceCriteria = confidenceCriteria.toDto(),
+            isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+    }
+
+    /**
+     * Find Addresses which directly belong to a Legal Entity
+     */
+    fun findNonSiteAddressesOfLegalEntity(bpnl: String, pageIndex: Int, pageSize: Int): PageDto<LogisticAddressVerboseDto> {
+        logger.debug { "Executing findByPartnerBpn() with parameters $bpnl // $pageIndex // $pageSize" }
+        val legalEntity = legalEntityRepository.findByBpnIgnoreCase(bpnl) ?:  throw BpdmNotFoundException("Business Partner", bpnl)
+
+        val page = logisticAddressRepository.findByLegalEntityAndSiteIsNull(legalEntity, PageRequest.of(pageIndex, pageSize))
+        addressService.fetchLogisticAddressDependencies(page.map { it }.toSet())
+        return page.toDto(page.content.map { it.toDto() })
+    }
+
+    /**
+     * Create new business partner records from [requests]
+     */
+    @Transactional
+    fun createLegalEntities(requests: Collection<LegalEntityPartnerCreateRequest>): LegalEntityPartnerCreateResponseWrapper {
+        logger.info { "Create ${requests.size} new legal entities" }
+
+        val errorsByRequest = validateLegalEntitiesToCreateFromController(requests)
+        val errors = errorsByRequest.flatMap { it.value }
+        val validRequests = requests.filterNot { errorsByRequest.containsKey(it) }
+
+        val legalEntityMetadataMap = metadataService.getMetadata(requests.map { it.legalEntity }).toMapping()
+        val addressMetadataMap = metadataService.getMetadata(requests.map { it.legalAddress }).toMapping()
+
+        val bpnLs = bpnIssuingService.issueLegalEntityBpns(validRequests.size)
+        val bpnAs = bpnIssuingService.issueAddressBpns(validRequests.size)
+
+        val requestsByLegalEntities = validRequests
+            .mapIndexed { bpnIndex, request ->
+                val legalEntity = createLegalEntity(request.legalEntity, bpnLs[bpnIndex], legalEntityMetadataMap)
+                val legalAddress = createLogisticAddress(request.legalAddress, bpnAs[bpnIndex], legalEntity, null, addressMetadataMap)
+                legalEntity.legalAddress = legalAddress
+                Pair(legalEntity, request)
+            }
+            .toMap()
+
+        val legalEntities = requestsByLegalEntities.keys
+
+        changelogService.createChangelogEntries(legalEntities.map {
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.CREATE, BusinessPartnerType.LEGAL_ENTITY)
+        })
+        changelogService.createChangelogEntries(legalEntities.map {
+            ChangelogEntryCreateRequest(it.legalAddress.bpn, ChangelogType.CREATE, BusinessPartnerType.ADDRESS)
+        })
+
+        legalEntities.map {
+
+            logger.info { logger.info { "Legal Entity ${it.bpn} was created" } }
+
+        }
+        legalEntityRepository.saveAll(legalEntities)
+
+        val legalEntityResponse = legalEntities.map { it.toUpsertDto(requestsByLegalEntities[it]!!.index) }
+
+        return LegalEntityPartnerCreateResponseWrapper(legalEntityResponse, errors)
+    }
+
+    fun validateLegalEntitiesToCreateFromController(leCreateRequests: Collection<LegalEntityPartnerCreateRequest>): Map<RequestWithKey, Collection<ErrorInfo<LegalEntityCreateError>>> {
+
+        val leErrorsByRequest = validateLegalEntitiesToCreate(leCreateRequests.map {
+            LegalEntityBridge(legalEntity = it.legalEntity, request = it, bpnL = null)
+        })
+        val legalAddressBridges = leCreateRequests.map {
+            AddressBridge(address = it.legalAddress, request = it, bpnA = null)
+        }
+
+        val addressErrorsByRequest = validateAddresses(legalAddressBridges, leCreateMessages)
+        return mergeMapsWithCollectionInValue(leErrorsByRequest, addressErrorsByRequest)
+    }
+
+    private fun validateLegalEntitiesToCreate(
+        requestBridges: List<LegalEntityBridge>
+    ): Map<RequestWithKey, List<ErrorInfo<LegalEntityCreateError>>> {
+
+        val legalEntityDtos = requestBridges.map { it.legalEntity }
+        val duplicatesValidator = ValidateLegalEntityIdentifiersDuplicated(legalEntityDtos, LegalEntityCreateError.LegalEntityDuplicateIdentifier)
+        val legalFormValidator = ValidateLegalFormExists(legalEntityDtos, LegalEntityCreateError.LegalFormNotFound)
+        val identifierValidator = ValidateIdentifierLeTypesExists(legalEntityDtos, LegalEntityCreateError.LegalEntityIdentifierNotFound)
+
+        return requestBridges.associate {
+            val legalEntityDto = it.legalEntity
+            val request = it.request
+
+            val validationErrors =
+                legalFormValidator.validate(legalEntityDto, request) +
+                        identifierValidator.validate(legalEntityDto, request) +
+                        duplicatesValidator.validate(legalEntityDto, request, bpn = null)
+            request to validationErrors
+        }.filterValues { it.isNotEmpty() }
+    }
+
+    private inner class ValidateLegalEntityIdentifiersDuplicated<ERROR : ErrorCode>(
+        legalEntityDtos: Collection<IBaseLegalEntityDto>,
+        private val errorCode: ERROR
+    ) {
+
+        val existingIdentifiers = getLegalEntityDuplicateIdentifierCandidates(legalEntityDtos)
+
+        fun validate(legalEntity: IBaseLegalEntityDto, entityKey: RequestWithKey, bpn: String?): Collection<ErrorInfo<ERROR>> {
+
+            return legalEntity.identifiers.mapNotNull {
+                val identifierPair = IdentifierCandidateKey(type = it.type, value = it.value)
+                existingIdentifiers[identifierPair]?.let { candidate ->
+                    if (candidate.bpn === null || candidate.bpn != bpn)
+                        ErrorInfo(errorCode, "Duplicate Legal Entity Identifier: Value '${it.value}' of type '${it.type}'", entityKey.getRequestKey())
+                    else
+                        null
+                }
+            }
+        }
+
+        private fun getLegalEntityDuplicateIdentifierCandidates(legalEntityDtos: Collection<IBaseLegalEntityDto>)
+                : Map<IdentifierCandidateKey, IdentifierCandidate> {
+
+            val identifiers = legalEntityDtos.flatMap { it.identifiers }
+            val idValues = identifiers.map { it.value }
+            val duplicatesFromRequest = identifiers
+                .map { IdentifierCandidateKey(it.type, it.value) }
+                .findDuplicates()
+                .associateWith { IdentifierCandidate(bpn = null, type = it.type, value = it.value) }
+            val duplicatesFromDb = legalEntityIdentifierRepository.findByValueIn(idValues)
+                .map { IdentifierCandidate(bpn = it.legalEntity.bpn, type = it.type.technicalKey, value = it.value) }
+                .associateBy { IdentifierCandidateKey(it.type, it.value) }
+            return duplicatesFromRequest.plus(duplicatesFromDb)
+        }
+    }
+
+    private data class IdentifierCandidateKey(
+        val type: String,
+        val value: String
+    )
+
+    inner class ValidateLegalFormExists<ERROR : ErrorCode>(
+        leDtos: Collection<IBaseLegalEntityDto>,
+        private val errorCode: ERROR
+    ) {
+
+        val existingLegalForms: Set<String> = metadataService.getMetadata(leDtos).toKeys().legalForms
+        fun validate(legalEntity: IBaseLegalEntityDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+            if (legalEntity.legalForm != null) {
+                if (!existingLegalForms.contains(legalEntity.legalForm)) {
+                    return listOf(ErrorInfo(errorCode, "Legal Form '${legalEntity.legalForm}' does not exist", entityKey.getRequestKey()))
+                }
+            }
+            return emptyList()
+        }
+    }
+
+    inner class ValidateIdentifierLeTypesExists<ERROR : ErrorCode>(
+        leDtos: Collection<IBaseLegalEntityDto>,
+        private val errorCode: ERROR
+    ) {
+
+        private val existingTypes: Set<String> = metadataService.getMetadata(leDtos).toKeys().idTypes
+        fun validate(legalEntity: IBaseLegalEntityDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+            val requestedTypes = legalEntity.identifiers.map { it.type }
+            val missingTypes = requestedTypes - existingTypes
+
+            return missingTypes.map {
+                ErrorInfo(
+                    errorCode,
+                    "Legal Entity Identifier Type '$it' does not exist",
+                    entityKey.getRequestKey()
+                )
+            }
+        }
+    }
+
+    fun <ERROR : ErrorCode> validateAddresses(
+        addressBridges: Collection<AddressBridge>, messages: ValidatorErrorCodes<ERROR>
+    ): Map<RequestWithKey, List<ErrorInfo<ERROR>>> {
+
+        val addressDtos = addressBridges.map { it.address }
+        val regionValidator = ValidateAdministrativeAreaLevel1Exists(addressDtos, messages.regionNotFound)
+        val identifiersValidator = ValidateIdentifierTypesExists(addressDtos, messages.identifierNotFound)
+        val identifiersDuplicateValidator = ValidateAddressIdentifiersDuplicated(addressDtos, messages.duplicateIdentifier)
+
+        val result: MutableMap<RequestWithKey, List<ErrorInfo<ERROR>>> = mutableMapOf()
+        // there could be second bridge for the same request, e.g. main address and additional address
+        addressBridges.forEach { bridge ->
+            val legalAddressDto = bridge.address
+            val request: RequestWithKey = bridge.request
+            val validationErrors =
+                regionValidator.validate(legalAddressDto, request) +
+                        identifiersValidator.validate(legalAddressDto, request) +
+                        identifiersDuplicateValidator.validate(legalAddressDto, request, bridge.bpnA)
+
+            if (validationErrors.isNotEmpty()) {
+                val existing = result[request]
+                if (existing == null) {
+                    result[request] = validationErrors
+                } else {
+                    result[request] = existing + validationErrors
+                }
+            }
+        }
+        return result
+    }
+
+    inner class ValidateAdministrativeAreaLevel1Exists<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+
+        private val existingRegions = metadataService.getRegions(addressDtos).map { it.regionCode }.toSet()
+        fun validate(address: IBaseLogisticAddressDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+
+            val requestedAdminLevels = listOfNotNull(
+                address.physicalPostalAddress?.administrativeAreaLevel1,
+                address.alternativePostalAddress?.administrativeAreaLevel1
+            )
+            val missingAdminLevels = requestedAdminLevels - existingRegions
+            return missingAdminLevels.map {
+                ErrorInfo(
+                    errorCode,
+                    "Address administrative area level1 '$it' does not exist",
+                    entityKey.getRequestKey()
+                )
+            }
+        }
+    }
+
+    inner class ValidateIdentifierTypesExists<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+        private val existingTypes = metadataService.getIdentifiers(addressDtos).map { it.technicalKey }.toSet()
+
+        fun validate(addressDto: IBaseLogisticAddressDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+            val requestedTypes = addressDto.identifiers.map { it.type }
+            val missingTypes = requestedTypes - existingTypes
+
+            return missingTypes.map {
+                ErrorInfo(
+                    errorCode,
+                    "Address Identifier Type '$it' does not exist",
+                    entityKey.getRequestKey()
+                )
+            }
+        }
+    }
+
+    private inner class ValidateAddressIdentifiersDuplicated<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+
+        val existingIdentifiers = getAddressDuplicateIdentifierCandidates(addressDtos)
+
+        fun validate(address: IBaseLogisticAddressDto, entityKey: RequestWithKey, bpn: String?): Collection<ErrorInfo<ERROR>> {
+
+            return address.identifiers.mapNotNull {
+                val identifierPair = IdentifierCandidateKey(type = it.type, value = it.value)
+                existingIdentifiers[identifierPair]?.let { candidate ->
+                    if (candidate.bpn === null || candidate.bpn != bpn)
+                        ErrorInfo(errorCode, "Duplicate Address Identifier: Value '${it.value}' of type '${it.type}'", entityKey.getRequestKey())
+                    else
+                        null
+                }
+            }
+        }
+
+        private fun getAddressDuplicateIdentifierCandidates(addressDtos: Collection<IBaseLogisticAddressDto>)
+                : Map<IdentifierCandidateKey, IdentifierCandidate> {
+
+            val identifiers = addressDtos.flatMap { it.identifiers }
+            val idValues = identifiers.map { it.value }
+            val duplicatesFromRequest = identifiers
+                .map { IdentifierCandidateKey(it.type, it.value) }
+                .findDuplicates()
+                .associateWith { IdentifierCandidate(bpn = null, type = it.type, value = it.value) }
+            val duplicatesFromDb = addressIdentifierRepository.findByValueIn(idValues)
+                .map { IdentifierCandidate(bpn = it.address.bpn, type = it.type.technicalKey, value = it.value) }
+                .associateBy { IdentifierCandidateKey(it.type, it.value) }
+            return duplicatesFromRequest.plus(duplicatesFromDb)
+        }
+
+    }
+
+    val leCreateMessages = ValidatorErrorCodes(
+        regionNotFound = LegalEntityCreateError.LegalAddressRegionNotFound,
+        identifierNotFound = LegalEntityCreateError.LegalAddressIdentifierNotFound,
+        duplicateIdentifier = LegalEntityCreateError.LegalAddressDuplicateIdentifier
+    )
+
+    fun LegalEntityDb.toUpsertDto(entryId: String?): LegalEntityPartnerCreateVerboseDto {
+        return LegalEntityPartnerCreateVerboseDto(
+            legalEntity = toDto(),
+            legalAddress = legalAddress.toDto(),
+            index = entryId
+        )
+    }
+
+    fun createLegalEntity(
+        legalEntityDto: LegalEntityDto,
+        bpnL: String,
+        metadataMap: LegalEntityMetadataMapping
+    ): LegalEntityDb {
+        // it has to be validated that the legalForm exits
+        val legalForm = legalEntityDto.legalForm?.let { metadataMap.legalForms[it]!! }
+        val legalName = NameDb(value = legalEntityDto.legalName, shortName = legalEntityDto.legalShortName)
+        val newLegalEntity = LegalEntityDb(
+            bpn = bpnL,
+            legalName = legalName,
+            legalForm = legalForm,
+            currentness = Instant.now().truncatedTo(ChronoUnit.MICROS),
+            confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria),
+            isCatenaXMemberData = legalEntityDto.isCatenaXMemberData
+        )
+        updateLegalEntity(newLegalEntity, legalEntityDto, metadataMap)
+
+        return newLegalEntity
+    }
+
+    fun updateLegalEntity(
+        legalEntity: LegalEntityDb,
+        legalEntityDto: LegalEntityDto,
+        metadataMap: LegalEntityMetadataMapping
+    ) {
+        legalEntity.currentness = createCurrentnessTimestamp()
+
+        legalEntity.legalName = NameDb(value = legalEntityDto.legalName, shortName = legalEntityDto.legalShortName)
+
+        legalEntity.legalForm = legalEntityDto.legalForm?.let { metadataMap.legalForms[it]!! }
+
+        legalEntity.identifiers.replace(legalEntityDto.identifiers.map { toLegalEntityIdentifier(it, metadataMap.idTypes, legalEntity) })
+        legalEntity.states.replace(legalEntityDto.states.map { toLegalEntityState(it, legalEntity) })
+        legalEntity.confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria)
+        legalEntity.isCatenaXMemberData = legalEntityDto.isCatenaXMemberData
+    }
+
+    private fun LegalEntityMetadataDto.toMapping() =
+        LegalEntityMetadataMapping(
+            idTypes = idTypes.associateBy { it.technicalKey },
+            legalForms = legalForms.associateBy { it.technicalKey }
+        )
+
+    private fun AddressMetadataDto.toMapping() =
+        AddressMetadataMapping(
+            idTypes = idTypes.associateBy { it.technicalKey },
+            regions = regions.associateBy { it.regionCode }
+        )
+
+    private fun createLogisticAddress(
+        dto: LogisticAddressDto,
+        bpn: String,
+        legalEntity: LegalEntityDb,
+        site: SiteDb?,
+        metadataMap: AddressMetadataMapping
+    ) = createLogisticAddressInternal(dto, bpn, metadataMap)
+        .apply {
+            this.legalEntity = legalEntity
+            this.site = site
+        }
+
+    private fun createLogisticAddressInternal(
+        dto: LogisticAddressDto,
+        bpn: String,
+        metadataMap: AddressMetadataMapping
+    ): LogisticAddressDb {
+        val address = LogisticAddressDb(
+            bpn = bpn,
+            legalEntity = null,
+            site = null,
+            physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap.regions),
+            alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap.regions) },
+            name = dto.name,
+            confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
+        )
+
+        updateLogisticAddress(address, dto, metadataMap)
+
+        return address
+    }
+
+    private fun updateLogisticAddress(address: LogisticAddressDb, dto: LogisticAddressDto, metadataMap: AddressMetadataMapping) {
+        address.name = dto.name
+        address.physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap.regions)
+        address.alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap.regions) }
+
+        address.identifiers.apply {
+            clear()
+            addAll(dto.identifiers.map { toAddressIdentifier(it, metadataMap.idTypes, address) })
+        }
+        address.states.apply {
+            clear()
+            addAll(dto.states.map { toAddressState(it, address) })
+        }
+
+        address.confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
+    }
+
+    private fun LegalEntityMetadataDto.toKeys(): LegalEntityMetadataKeys {
+        return LegalEntityMetadataKeys(
+            idTypes = idTypes.map { it.technicalKey }.toSet(),
+            legalForms = legalForms.map { it.technicalKey }.toSet()
+        )
+    }
+
+    private data class LegalEntityMetadataKeys(
+        val idTypes: Set<String>,
+        val legalForms: Set<String>
+    )
+
+    /**
+     * Update existing records with [requests]
+     */
+    @Transactional
+    fun updateLegalEntities(requests: Collection<LegalEntityPartnerUpdateRequest>): LegalEntityPartnerUpdateResponseWrapper {
+        logger.info { "Update ${requests.size} legal entities" }
+
+        val errorsByRequest = validateLegalEntitiesToUpdateFromController(requests)
+        val errors = errorsByRequest.flatMap { it.value }
+        val validRequests = requests.filterNot { errorsByRequest.containsKey(it) }
+
+        val legalEntityMetadataMap = metadataService.getMetadata(validRequests.map { it.legalEntity }).toMapping()
+        val addressMetadataMap = metadataService.getMetadata(validRequests.map { it.legalAddress }).toMapping()
+
+        val bpnsToFetch = validRequests.map { it.bpnl }
+        val legalEntities = legalEntityRepository.findDistinctByBpnIn(bpnsToFetch)
+        businessPartnerFetchService.fetchDependenciesWithLegalAddress(legalEntities)
+        val requestsByBpn = validRequests.associateBy { it.bpnl }
+
+        val legalEntityRequestPairs = legalEntities.map { legalEntity -> Pair(legalEntity, requestsByBpn[legalEntity.bpn]!!) }
+        legalEntityRequestPairs.forEach { (legalEntity, request) ->
+            val legalEntityBeforeUpdate = businessPartnerEquivalenceMapper.toEquivalenceDto(legalEntity)
+            updateLegalEntity(legalEntity, request.legalEntity, legalEntityMetadataMap)
+            updateLogisticAddress(legalEntity.legalAddress, request.legalAddress, addressMetadataMap)
+            val legalEntityAfterUpdate = businessPartnerEquivalenceMapper.toEquivalenceDto(legalEntity)
+
+            if (legalEntityBeforeUpdate != legalEntityAfterUpdate) {
+                logger.info { "Legal Entity ${legalEntity.bpn} was updated" }
+
+                legalEntityRepository.save(legalEntity)
+
+                changelogService.createChangelogEntries(
+                    listOf(
+                        ChangelogEntryCreateRequest(
+                            legalEntity.bpn,
+                            ChangelogType.UPDATE,
+                            BusinessPartnerType.LEGAL_ENTITY
+                        )
+                    )
+                )
+                changelogService.createChangelogEntries(
+                    listOf(
+                        ChangelogEntryCreateRequest(
+                            legalEntity.legalAddress.bpn,
+                            ChangelogType.UPDATE,
+                            BusinessPartnerType.ADDRESS
+                        )
+                    )
+                )
+            }
+        }
+
+        val legalEntityResponses = legalEntityRequestPairs.map { (legalEntity, request) -> legalEntity.toUpsertDto(request.bpnl) }
+
+        return LegalEntityPartnerUpdateResponseWrapper(legalEntityResponses, errors)
+    }
+
+    fun validateLegalEntitiesToUpdateFromController(
+        leRequests: Collection<LegalEntityPartnerUpdateRequest>
+    ): Map<RequestWithKey, Collection<ErrorInfo<LegalEntityUpdateError>>> {
+
+        val leErrorsByRequest = validateLegalEntitiesToUpdate(leRequests.map {
+            LegalEntityBridge(legalEntity = it.legalEntity, request = it, bpnL = it.bpnl)
+        })
+
+        val addressBpnByLegalEntityBpnL = legalEntityRepository.findDistinctByBpnIn(leRequests.map { it.bpnl }).associate { it.bpn to it.legalAddress.bpn }
+        val legalAddressBridges = leRequests.map {
+            AddressBridge(address = it.legalAddress, request = it, bpnA = addressBpnByLegalEntityBpnL[it.bpnl])
+        }
+        val addressErrorsByRequest = validateAddresses(legalAddressBridges, leUpdateMessages)
+        return mergeMapsWithCollectionInValue(leErrorsByRequest, addressErrorsByRequest)
+    }
+
+    fun validateLegalEntitiesToUpdate(
+        requestBridges: Collection<LegalEntityBridge>
+    ): Map<RequestWithKey, Collection<ErrorInfo<LegalEntityUpdateError>>> {
+
+        val legalEntityDtos = requestBridges.map { it.legalEntity }
+        val duplicatesValidator = ValidateLegalEntityIdentifiersDuplicated(legalEntityDtos, LegalEntityUpdateError.LegalEntityDuplicateIdentifier)
+        val existingLegalEntityBpns = legalEntityRepository.findDistinctByBpnIn(requestBridges.mapNotNull { it.bpnL }).map { it.bpn }.toSet()
+        val existingBpnValidator = ValidateUpdateBpnExists(existingLegalEntityBpns, LegalEntityUpdateError.LegalEntityNotFound)
+        val legalFormValidator = ValidateLegalFormExists(legalEntityDtos, LegalEntityUpdateError.LegalFormNotFound)
+        val identifierValidator = ValidateIdentifierLeTypesExists(legalEntityDtos, LegalEntityUpdateError.LegalEntityIdentifierNotFound)
+
+        return requestBridges.associate { requestBridge ->
+            val legalEntity = requestBridge.legalEntity
+
+            val validationErrors =
+                legalFormValidator.validate(legalEntity, requestBridge.request) +
+                        identifierValidator.validate(legalEntity, requestBridge.request) +
+                        duplicatesValidator.validate(legalEntity, requestBridge.request, requestBridge.bpnL) +
+                        existingBpnValidator.validate(requestBridge.bpnL)
+            requestBridge.request to validationErrors
+        }.filterValues { it.isNotEmpty() }
+    }
+
+    inner class ValidateUpdateBpnExists<ERROR : ErrorCode>(
+        private val existingBpns: Set<String>,
+        private val errorCode: ERROR
+    ) {
+
+        fun validate(bpnToUpdate: String?): Collection<ErrorInfo<ERROR>> {
+            return if (bpnToUpdate != null && !existingBpns.contains(bpnToUpdate))
+                listOf(ErrorInfo(errorCode, "Business Partner with BPN '$bpnToUpdate' can't be updated as it doesn't exist", bpnToUpdate))
+            else
+                emptyList()
+        }
+    }
+
+    val leUpdateMessages = ValidatorErrorCodes(
+        regionNotFound = LegalEntityUpdateError.LegalAddressRegionNotFound,
+        identifierNotFound = LegalEntityUpdateError.LegalAddressIdentifierNotFound,
+        duplicateIdentifier = LegalEntityUpdateError.LegalAddressDuplicateIdentifier
+    )
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/MemberController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/MemberController.kt
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.PoolMembersApi
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.AddressSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.ChangelogSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ChangelogEntryVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SiteWithMainAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.config.ControllerConfigProperties
+import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.eclipse.tractusx.bpdm.pool.exception.BpdmRequestSizeException
+import org.eclipse.tractusx.bpdm.pool.service.PartnerChangelogService
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("MemberControllerLegacy")
+class MemberController(
+    private val changelogService: PartnerChangelogService,
+    private val controllerConfigProperties: ControllerConfigProperties,
+    private val legalEntityLegacyServiceMapper: LegalEntityLegacyServiceMapper,
+    private val siteLegacyServiceMapper: SiteLegacyServiceMapper,
+    private val addressLegacyServiceMapper: AddressLegacyServiceMapper
+) : PoolMembersApi {
+
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
+    override fun searchLegalEntities(
+        searchRequest: LegalEntitySearchRequest,
+        paginationRequest: PaginationRequest
+    ): PageDto<LegalEntityWithLegalAddressVerboseDto> {
+        return legalEntityLegacyServiceMapper.searchLegalEntities(
+            LegalEntityLegacyServiceMapper.LegalEntitySearchRequest(
+                bpnLs = searchRequest.bpnLs,
+                legalName = searchRequest.legalName,
+                isCatenaXMemberData = true
+            ),
+            paginationRequest
+        )
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
+    override fun postSiteSearch(searchRequest: SiteSearchRequest, paginationRequest: PaginationRequest): PageDto<SiteWithMainAddressVerboseDto> {
+        return siteLegacyServiceMapper.searchSites(
+            SiteLegacyServiceMapper.SiteSearchRequest(
+                siteBpns =  searchRequest.siteBpns,
+                legalEntityBpns = searchRequest.legalEntityBpns,
+                name = searchRequest.name,
+                isCatenaXMemberData = true
+            ),
+            paginationRequest
+        )
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_PARTNER})")
+    override fun searchAddresses(searchRequest: AddressSearchRequest, paginationRequest: PaginationRequest): PageDto<LogisticAddressVerboseDto> {
+        return addressLegacyServiceMapper.searchAddresses(
+            AddressLegacyServiceMapper.AddressSearchRequest(
+                addressBpns = searchRequest.addressBpns,
+                siteBpns = searchRequest.siteBpns,
+                legalEntityBpns = searchRequest.legalEntityBpns,
+                name = searchRequest.name,
+                isCatenaXMemberData = true
+            ),
+            paginationRequest
+        )
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_MEMBER_CHANGELOG})")
+    override fun searchChangelogEntries(
+        changelogSearchRequest: ChangelogSearchRequest,
+        paginationRequest: PaginationRequest
+    ): PageDto<ChangelogEntryVerboseDto> {
+        changelogSearchRequest.bpns?.let { bpns ->
+            if (bpns.size > controllerConfigProperties.searchRequestLimit) {
+                throw BpdmRequestSizeException(bpns.size, controllerConfigProperties.searchRequestLimit)
+            }
+        }
+
+        return changelogService.getChangeLogEntries(
+            bpns = changelogSearchRequest.bpns,
+            businessPartnerTypes = changelogSearchRequest.businessPartnerTypes,
+            fromTime = changelogSearchRequest.timestampAfter,
+            isCatenaXMemberData = true,
+            pageIndex = paginationRequest.page,
+            pageSize = paginationRequest.size
+        )
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/MetadataController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/MetadataController.kt
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.v6.PoolMetadataApi
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalFormRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.IdentifierTypeDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.springframework.data.domain.PageRequest
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("MetadataControllerLegacy")
+class MetadataController(
+    val metadataLegacyServiceMapper: MetadataLegacyServiceMapper
+) : PoolMetadataApi {
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_METADATA})")
+    override fun createIdentifierType(identifierType: IdentifierTypeDto): IdentifierTypeDto {
+        return metadataLegacyServiceMapper.createIdentifierType(identifierType)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_METADATA})")
+    override fun getIdentifierTypes(
+        paginationRequest: PaginationRequest,
+        businessPartnerType: IdentifierBusinessPartnerType,
+        country: CountryCode?
+    ): PageDto<IdentifierTypeDto> {
+        return metadataLegacyServiceMapper.getIdentifierTypes(PageRequest.of(paginationRequest.page, paginationRequest.size), businessPartnerType, country)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_METADATA})")
+    override fun createLegalForm(type: LegalFormRequest): LegalFormDto {
+        return metadataLegacyServiceMapper.createLegalForm(type)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_METADATA})")
+    override fun getLegalForms(paginationRequest: PaginationRequest): PageDto<LegalFormDto> {
+        return metadataLegacyServiceMapper.getLegalForms(PageRequest.of(paginationRequest.page, paginationRequest.size))
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/MetadataLegacyServiceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/MetadataLegacyServiceMapper.kt
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import com.neovisionaries.i18n.CountryCode
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDetailDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalFormRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.IdentifierTypeDto
+import org.eclipse.tractusx.bpdm.pool.entity.IdentifierTypeDb
+import org.eclipse.tractusx.bpdm.pool.entity.IdentifierTypeDetailDb
+import org.eclipse.tractusx.bpdm.pool.entity.LegalFormDb
+import org.eclipse.tractusx.bpdm.pool.exception.BpdmAlreadyExists
+import org.eclipse.tractusx.bpdm.pool.repository.IdentifierTypeRepository
+import org.eclipse.tractusx.bpdm.pool.repository.LegalFormRepository
+import org.eclipse.tractusx.bpdm.pool.repository.RegionRepository
+import org.eclipse.tractusx.bpdm.pool.service.toDto
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MetadataLegacyServiceMapper(
+    private val identifierTypeRepository: IdentifierTypeRepository,
+    private val legalFormRepository: LegalFormRepository,
+    private val regionRepository: RegionRepository
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    @Transactional
+    fun createIdentifierType(type: IdentifierTypeDto): IdentifierTypeDto {
+        if (identifierTypeRepository.findByBusinessPartnerTypeAndTechnicalKey(type.businessPartnerType, type.technicalKey) != null)
+            throw BpdmAlreadyExists(IdentifierTypeDb::class.simpleName!!, "${type.technicalKey}/${type.businessPartnerType}")
+
+        logger.info { "Create new Identifier-Type with key ${type.technicalKey}, businessPartnerType ${type.businessPartnerType} and name ${type.name}" }
+        val entity = IdentifierTypeDb(
+            technicalKey = type.technicalKey,
+            businessPartnerType = type.businessPartnerType,
+            name = type.name,
+            abbreviation = type.abbreviation,
+            transliteratedName = type.transliteratedName,
+            transliteratedAbbreviation = type.transliteratedAbbreviation
+        )
+        entity.details.addAll(
+            type.details.map { IdentifierTypeDetailDb(entity, it.country, it.mandatory) }.toSet()
+        )
+        return identifierTypeRepository.save(entity).toDto()
+    }
+
+    fun IdentifierTypeDb.toDto(): IdentifierTypeDto {
+        return IdentifierTypeDto(
+            technicalKey, businessPartnerType, name, abbreviation, transliteratedName, transliteratedAbbreviation,
+            details.map { IdentifierTypeDetailDto(it.countryCode, it.mandatory) })
+    }
+
+    fun getIdentifierTypes(
+        pageRequest: Pageable,
+        businessPartnerType: IdentifierBusinessPartnerType,
+        country: CountryCode? = null
+    ): PageDto<IdentifierTypeDto> {
+        val spec = Specification.allOf(
+            IdentifierTypeRepository.Specs.byBusinessPartnerType(businessPartnerType),
+            IdentifierTypeRepository.Specs.byCountry(country)
+        )
+        val page = identifierTypeRepository.findAll(spec, pageRequest)
+        return page.toDto(page.content.map { it.toDto() })
+    }
+
+    @Transactional
+    fun createLegalForm(request: LegalFormRequest): LegalFormDto {
+        if (legalFormRepository.findByTechnicalKey(request.technicalKey) != null)
+            throw BpdmAlreadyExists(LegalFormDb::class.simpleName!!, request.technicalKey)
+
+        logger.info { "Create new Legal-Form with key ${request.technicalKey} and name ${request.name}" }
+
+        val region = request.administrativeAreaLevel1?.let { regionRepository.findByRegionCodeIn(setOf(it)) }?.firstOrNull()
+
+        val legalForm = LegalFormDb(
+            technicalKey = request.technicalKey,
+            name = request.name,
+            transliteratedName = request.transliteratedName,
+            abbreviation = request.abbreviation,
+            transliteratedAbbreviations = request.transliteratedAbbreviations,
+            countryCode = request.country,
+            languageCode = request.language,
+            administrativeArea = region,
+            isActive = request.isActive
+        )
+
+        return legalFormRepository.save(legalForm).toDto()
+    }
+
+    fun LegalFormDb.toDto(): LegalFormDto {
+        return LegalFormDto(
+            technicalKey = technicalKey,
+            name = name,
+            transliteratedName = transliteratedName,
+            abbreviation = abbreviation,
+            transliteratedAbbreviations = transliteratedAbbreviations,
+            country = countryCode,
+            language = languageCode,
+            administrativeAreaLevel1 = administrativeArea?.regionCode,
+            isActive = isActive
+        )
+    }
+
+    fun getLegalForms(pageRequest: Pageable): PageDto<LegalFormDto> {
+        val page = legalFormRepository.findAll(pageRequest)
+        return page.toDto(page.content.map { it.toDto() })
+    }
+
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/SiteController.kt
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.PoolSiteApi
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SiteWithMainAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.config.PermissionConfigProperties
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("SiteControllerLegacy")
+class SiteController(
+    private val siteLegacyServiceMapper: SiteLegacyServiceMapper
+) : PoolSiteApi {
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun getSite(
+        bpns: String
+    ): SiteWithMainAddressVerboseDto {
+        return siteLegacyServiceMapper.findByBpn(bpns.uppercase())
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun postSiteSearch(
+        searchRequest: SiteSearchRequest,
+        paginationRequest: PaginationRequest
+    ): PageDto<SiteWithMainAddressVerboseDto> {
+        return siteLegacyServiceMapper.searchSites(
+            SiteLegacyServiceMapper.SiteSearchRequest(
+                siteBpns = searchRequest.siteBpns,
+                legalEntityBpns = searchRequest.legalEntityBpns,
+                name = searchRequest.name,
+                isCatenaXMemberData = null
+            ),
+            paginationRequest
+        )
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun createSite(
+        requests: Collection<SitePartnerCreateRequest>
+    ): SitePartnerCreateResponseWrapper {
+        return siteLegacyServiceMapper.createSitesWithMainAddress(requests)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun updateSite(
+        requests: Collection<SitePartnerUpdateRequest>
+    ): SitePartnerUpdateResponseWrapper {
+        return siteLegacyServiceMapper.updateSites(requests)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
+    override fun getSites(
+        searchRequest: SiteSearchRequest,
+        paginationRequest: PaginationRequest
+    ): PageDto<SiteWithMainAddressVerboseDto> {
+        return postSiteSearch(searchRequest, paginationRequest)
+    }
+
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.WRITE_PARTNER})")
+    override fun createSiteWithLegalReference(
+        request: Collection<SiteCreateRequestWithLegalAddressAsMain>
+    ): SitePartnerCreateResponseWrapper {
+        return siteLegacyServiceMapper.createSitesWithLegalAddressAsMain(request)
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/SiteLegacyServiceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/SiteLegacyServiceMapper.kt
@@ -1,0 +1,562 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.controller.v6
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.*
+import org.eclipse.tractusx.bpdm.common.exception.BpdmNotFoundException
+import org.eclipse.tractusx.bpdm.common.util.findDuplicates
+import org.eclipse.tractusx.bpdm.common.util.mergeMapsWithCollectionInValue
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.pool.api.model.LogisticAddressDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteCreateRequestWithLegalAddressAsMain
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerCreateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.SitePartnerUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorCode
+import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteCreateError
+import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteUpdateError
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.SiteVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SiteWithMainAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.dto.AddressMetadataDto
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
+import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
+import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddressDb
+import org.eclipse.tractusx.bpdm.pool.entity.SiteDb
+import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
+import org.eclipse.tractusx.bpdm.pool.repository.AddressIdentifierRepository
+import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
+import org.eclipse.tractusx.bpdm.pool.repository.SiteRepository
+import org.eclipse.tractusx.bpdm.pool.service.*
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.AddressMetadataMapping
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createAlternativeAddress
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createConfidenceCriteria
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createPhysicalAddress
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.createSite
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toAddressIdentifier
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.toAddressState
+import org.eclipse.tractusx.bpdm.pool.service.BusinessPartnerBuildService.Companion.updateSite
+import org.eclipse.tractusx.bpdm.pool.service.RequestValidationService.*
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SiteLegacyServiceMapper(
+    private val siteRepository: SiteRepository,
+    private val legalEntityRepository: LegalEntityRepository,
+    private val addressService: AddressService,
+    private val metadataService: MetadataService,
+    private val addressIdentifierRepository: AddressIdentifierRepository,
+    private val bpnIssuingService: BpnIssuingService,
+    private val changelogService: PartnerChangelogService,
+    private val businessPartnerEquivalenceMapper: BusinessPartnerEquivalenceMapper
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    fun findByBpn(bpn: String): SiteWithMainAddressVerboseDto {
+        logger.debug { "Executing findByBpn() with parameters $bpn " }
+        val site = siteRepository.findByBpn(bpn) ?: throw BpdmNotFoundException("Site", bpn)
+        return toPoolDto(site)
+    }
+
+    fun toPoolDto(entity: SiteDb): SiteWithMainAddressVerboseDto {
+        return SiteWithMainAddressVerboseDto(
+
+            site = SiteVerboseDto(
+                entity.bpn,
+                entity.name,
+                states = entity.states.map { it.toDto() },
+                bpnLegalEntity = entity.legalEntity.bpn,
+                confidenceCriteria = entity.confidenceCriteria.toDto(),
+                isCatenaXMemberData = entity.legalEntity.isCatenaXMemberData,
+                createdAt = entity.createdAt,
+                updatedAt = entity.updatedAt,
+            ),
+            mainAddress = entity.mainAddress.toDto()
+        )
+    }
+
+    fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
+        return LogisticAddressVerboseDto(
+            bpna = bpn,
+            bpnLegalEntity = legalEntity?.bpn,
+            bpnSite = site?.bpn,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            name = name,
+            states = states.map { it.toDto() },
+            identifiers = identifiers.map { it.toDto() },
+            physicalPostalAddress = physicalPostalAddress.toDto(),
+            alternativePostalAddress = alternativePostalAddress?.toDto(),
+            confidenceCriteria = confidenceCriteria.toDto(),
+            isCatenaXMemberData = legalEntity?.isCatenaXMemberData ?: site?.legalEntity?.isCatenaXMemberData ?: false,
+            addressType = getAddressType(this)
+        )
+    }
+
+    /**
+     * Search sites per page for [searchRequest] and [paginationRequest]
+     */
+    @Transactional
+    fun searchSites(searchRequest: SiteSearchRequest, paginationRequest: PaginationRequest): PageDto<SiteWithMainAddressVerboseDto> {
+        logger.debug { "Executing site search with request: $searchRequest" }
+        val spec = Specification.allOf(
+            SiteRepository.byBpns(searchRequest.siteBpns),
+            SiteRepository.byParentBpns(searchRequest.legalEntityBpns),
+            SiteRepository.byName(searchRequest.name),
+            SiteRepository.byIsMember(searchRequest.isCatenaXMemberData)
+        )
+
+        val sitePage = siteRepository.findAll(spec, PageRequest.of(paginationRequest.page, paginationRequest.size))
+
+        fetchSiteDependencies(sitePage.toSet())
+
+        return sitePage.toDto(::toPoolDto)
+    }
+
+    private fun fetchSiteDependencies(sites: Set<SiteDb>) {
+        siteRepository.joinAddresses(sites)
+        siteRepository.joinStates(sites)
+        val addresses = sites.flatMap { it.addresses }.toSet()
+        addressService.fetchLogisticAddressDependencies(addresses)
+    }
+
+    data class SiteSearchRequest(
+        val siteBpns: List<String>?,
+        val legalEntityBpns: List<String>?,
+        val name: String?,
+        val isCatenaXMemberData: Boolean?
+    )
+
+    @Transactional
+    fun createSitesWithMainAddress(requests: Collection<SitePartnerCreateRequest>): SitePartnerCreateResponseWrapper {
+        logger.info { "Create ${requests.size} new sites" }
+
+        val errorsByRequest = validateSitesToCreateFromController(requests)
+        val errors = errorsByRequest.flatMap { it.value }
+        val validRequests = requests.filterNot { errorsByRequest.containsKey(it) }
+
+        val validMainAddresses = validRequests.map { it.site.mainAddress }
+        val addressMetadataMap = metadataService.getMetadata(validMainAddresses).toMapping()
+
+        val legalEntities = legalEntityRepository.findDistinctByBpnIn(validRequests.map { it.bpnlParent })
+        val legalEntitiesByBpn = legalEntities.associateBy { it.bpn }
+
+        val bpnSs = bpnIssuingService.issueSiteBpns(validRequests.size)
+        val bpnAs = bpnIssuingService.issueAddressBpns(validRequests.size)
+
+        fun createSiteWithMainAddress(bpnIndex: Int, request: SitePartnerCreateRequest) =
+            createSite(request.site, bpnSs[bpnIndex], legalEntitiesByBpn[request.bpnlParent]!!)
+                .apply { mainAddress = createLogisticAddress(request.site.mainAddress, bpnAs[bpnIndex], this.legalEntity, this, addressMetadataMap) }
+                .let { site -> Pair(site, request) }
+
+        val requestsBySites = validRequests
+            .mapIndexed { i, request -> createSiteWithMainAddress(i, request) }
+            .toMap()
+
+        val siteResponse = createChangeLogAndSaveSiteInformation(requestsBySites).map { it.toUpsertDto(requestsBySites[it]!!.index) }
+
+        return SitePartnerCreateResponseWrapper(siteResponse, errors)
+    }
+
+    fun SiteDb.toUpsertDto(entryId: String?): SitePartnerCreateVerboseDto {
+        return SitePartnerCreateVerboseDto(
+            site = toDto(),
+            mainAddress = mainAddress.toDto(),
+            index = entryId
+        )
+    }
+
+    fun SiteDb.toDto(): SiteVerboseDto {
+        return SiteVerboseDto(
+            bpn,
+            name,
+            states = states.map { it.toDto() },
+            bpnLegalEntity = legalEntity.bpn,
+            confidenceCriteria = confidenceCriteria.toDto(),
+            isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+    }
+
+    fun validateSitesToCreateFromController(
+        siteRequests: Collection<SitePartnerCreateRequest>,
+    ): Map<RequestWithKey, Collection<ErrorInfo<SiteCreateError>>> {
+
+        val siteErrorsByRequest = validateSitesToCreate(siteRequests)
+        val addressErrorsByRequest = validateAddresses(siteRequests.map {
+            AddressBridge(address = it.site.mainAddress, request = it, bpnA = null)
+        }, siteCreateMessages)
+        return mergeMapsWithCollectionInValue(siteErrorsByRequest, addressErrorsByRequest)
+    }
+
+    fun validateSitesToCreate(
+        requests: Collection<SitePartnerCreateRequest>,
+    ): Map<RequestWithKey, Collection<ErrorInfo<SiteCreateError>>> {
+
+        val requestedParentBpns = requests.map { it.bpnlParent }
+        val existingParentBpns = legalEntityRepository.findDistinctByBpnIn(requestedParentBpns).map { it.bpn }.toSet()
+
+        return requests.associate { request ->
+            val validationErrors =
+                validateParentBpnExists(request.bpnlParent, request.getRequestKey(), existingParentBpns, SiteCreateError.LegalEntityNotFound)
+            request to validationErrors
+        }.filterValues { it.isNotEmpty() }
+    }
+
+    private fun <ERROR : ErrorCode> validateParentBpnExists(parentBpn: String, entityKey: String?, existingParentBpns: Set<String>, errorCode: ERROR)
+            : Collection<ErrorInfo<ERROR>> {
+        return if (!existingParentBpns.contains(parentBpn))
+            listOf(ErrorInfo(errorCode, "Parent with BPN '$parentBpn'not found", entityKey))
+        else
+            emptyList()
+    }
+
+    fun <ERROR : ErrorCode> validateAddresses(
+        addressBridges: Collection<AddressBridge>, messages: ValidatorErrorCodes<ERROR>
+    ): Map<RequestWithKey, List<ErrorInfo<ERROR>>> {
+
+        val addressDtos = addressBridges.map { it.address }
+        val regionValidator = ValidateAdministrativeAreaLevel1Exists(addressDtos, messages.regionNotFound)
+        val identifiersValidator = ValidateIdentifierTypesExists(addressDtos, messages.identifierNotFound)
+        val identifiersDuplicateValidator = ValidateAddressIdentifiersDuplicated(addressDtos, messages.duplicateIdentifier)
+
+        val result: MutableMap<RequestWithKey, List<ErrorInfo<ERROR>>> = mutableMapOf()
+        // there could be second bridge for the same request, e.g. main address and additional address
+        addressBridges.forEach { bridge ->
+            val legalAddressDto = bridge.address
+            val request: RequestWithKey = bridge.request
+            val validationErrors =
+                regionValidator.validate(legalAddressDto, request) +
+                        identifiersValidator.validate(legalAddressDto, request) +
+                        identifiersDuplicateValidator.validate(legalAddressDto, request, bridge.bpnA)
+
+            if (validationErrors.isNotEmpty()) {
+                val existing = result[request]
+                if (existing == null) {
+                    result[request] = validationErrors
+                } else {
+                    result[request] = existing + validationErrors
+                }
+            }
+        }
+        return result
+    }
+
+    inner class ValidateAdministrativeAreaLevel1Exists<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+
+        private val existingRegions = metadataService.getRegions(addressDtos).map { it.regionCode }.toSet()
+        fun validate(address: IBaseLogisticAddressDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+
+            val requestedAdminLevels = listOfNotNull(
+                address.physicalPostalAddress?.administrativeAreaLevel1,
+                address.alternativePostalAddress?.administrativeAreaLevel1
+            )
+            val missingAdminLevels = requestedAdminLevels - existingRegions
+            return missingAdminLevels.map {
+                ErrorInfo(
+                    errorCode,
+                    "Address administrative area level1 '$it' does not exist",
+                    entityKey.getRequestKey()
+                )
+            }
+        }
+    }
+
+    inner class ValidateIdentifierTypesExists<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+        private val existingTypes = metadataService.getIdentifiers(addressDtos).map { it.technicalKey }.toSet()
+
+        fun validate(addressDto: IBaseLogisticAddressDto, entityKey: RequestWithKey): Collection<ErrorInfo<ERROR>> {
+            val requestedTypes = addressDto.identifiers.map { it.type }
+            val missingTypes = requestedTypes - existingTypes
+
+            return missingTypes.map {
+                ErrorInfo(
+                    errorCode,
+                    "Address Identifier Type '$it' does not exist",
+                    entityKey.getRequestKey()
+                )
+            }
+        }
+    }
+
+    private inner class ValidateAddressIdentifiersDuplicated<ERROR : ErrorCode>(
+        addressDtos: Collection<IBaseLogisticAddressDto>,
+        private val errorCode: ERROR
+    ) {
+
+        val existingIdentifiers = getAddressDuplicateIdentifierCandidates(addressDtos)
+
+        fun validate(address: IBaseLogisticAddressDto, entityKey: RequestWithKey, bpn: String?): Collection<ErrorInfo<ERROR>> {
+
+            return address.identifiers.mapNotNull {
+                val identifierPair = IdentifierCandidateKey(type = it.type, value = it.value)
+                existingIdentifiers[identifierPair]?.let { candidate ->
+                    if (candidate.bpn === null || candidate.bpn != bpn)
+                        ErrorInfo(errorCode, "Duplicate Address Identifier: Value '${it.value}' of type '${it.type}'", entityKey.getRequestKey())
+                    else
+                        null
+                }
+            }
+        }
+
+        private fun getAddressDuplicateIdentifierCandidates(addressDtos: Collection<IBaseLogisticAddressDto>)
+                : Map<IdentifierCandidateKey, IdentifierCandidate> {
+
+            val identifiers = addressDtos.flatMap { it.identifiers }
+            val idValues = identifiers.map { it.value }
+            val duplicatesFromRequest = identifiers
+                .map { IdentifierCandidateKey(it.type, it.value) }
+                .findDuplicates()
+                .associateWith { IdentifierCandidate(bpn = null, type = it.type, value = it.value) }
+            val duplicatesFromDb = addressIdentifierRepository.findByValueIn(idValues)
+                .map { IdentifierCandidate(bpn = it.address.bpn, type = it.type.technicalKey, value = it.value) }
+                .associateBy { IdentifierCandidateKey(it.type, it.value) }
+            return duplicatesFromRequest.plus(duplicatesFromDb)
+        }
+
+    }
+
+    private data class IdentifierCandidateKey(
+        val type: String,
+        val value: String
+    )
+
+    private fun AddressMetadataDto.toMapping() =
+        AddressMetadataMapping(
+            idTypes = idTypes.associateBy { it.technicalKey },
+            regions = regions.associateBy { it.regionCode }
+        )
+
+    private fun createLogisticAddress(
+        dto: LogisticAddressDto,
+        bpn: String,
+        legalEntity: LegalEntityDb,
+        site: SiteDb?,
+        metadataMap: AddressMetadataMapping
+    ) = createLogisticAddressInternal(dto, bpn, metadataMap)
+        .apply {
+            this.legalEntity = legalEntity
+            this.site = site
+        }
+
+    private fun createLogisticAddressInternal(
+        dto: LogisticAddressDto,
+        bpn: String,
+        metadataMap: AddressMetadataMapping
+    ): LogisticAddressDb {
+        val address = LogisticAddressDb(
+            bpn = bpn,
+            legalEntity = null,
+            site = null,
+            physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap.regions),
+            alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap.regions) },
+            name = dto.name,
+            confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
+        )
+
+        updateLogisticAddress(address, dto, metadataMap)
+
+        return address
+    }
+
+    private fun updateLogisticAddress(address: LogisticAddressDb, dto: LogisticAddressDto, metadataMap: AddressMetadataMapping) {
+        address.name = dto.name
+        address.physicalPostalAddress = createPhysicalAddress(dto.physicalPostalAddress, metadataMap.regions)
+        address.alternativePostalAddress = dto.alternativePostalAddress?.let { createAlternativeAddress(it, metadataMap.regions) }
+
+        address.identifiers.apply {
+            clear()
+            addAll(dto.identifiers.map { toAddressIdentifier(it, metadataMap.idTypes, address) })
+        }
+        address.states.apply {
+            clear()
+            addAll(dto.states.map { toAddressState(it, address) })
+        }
+
+        address.confidenceCriteria = createConfidenceCriteria(dto.confidenceCriteria)
+    }
+
+    private fun createChangeLogAndSaveSiteInformation(requestsBySites: Map<SiteDb, SitePartnerCreateRequest>): Set<SiteDb> {
+        val sites = requestsBySites.keys
+
+        changelogService.createChangelogEntries(sites.map {
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.CREATE, BusinessPartnerType.SITE)
+        })
+        changelogService.createChangelogEntries(sites.map {
+            ChangelogEntryCreateRequest(it.mainAddress.bpn, ChangelogType.CREATE, BusinessPartnerType.ADDRESS)
+        })
+
+        sites.map {
+
+            logger.info { "Site ${it.bpn} was created" }
+
+        }
+
+        siteRepository.saveAll(sites)
+        return sites
+    }
+
+    val siteCreateMessages = ValidatorErrorCodes(
+        regionNotFound = SiteCreateError.MainAddressRegionNotFound,
+        identifierNotFound = SiteCreateError.MainAddressIdentifierNotFound,
+        duplicateIdentifier = SiteCreateError.MainAddressDuplicateIdentifier
+    )
+
+    @Transactional
+    fun updateSites(requests: Collection<SitePartnerUpdateRequest>): SitePartnerUpdateResponseWrapper {
+        logger.info { "Update ${requests.size} sites" }
+
+        val errorsByRequest = validateSitesToUpdateFromController(requests)
+        val errors = errorsByRequest.flatMap { it.value }
+        val validRequests = requests.filterNot { errorsByRequest.containsKey(it) }
+
+        val addressMetadataMap = metadataService.getMetadata(requests.map { it.site.mainAddress }).toMapping()
+
+        val bpnsToFetch = validRequests.map { it.bpns }
+        val sites = siteRepository.findDistinctByBpnIn(bpnsToFetch)
+        val requestByBpnMap = validRequests.associateBy { it.bpns }
+
+        val siteRequestPairs = sites.map { site -> Pair(site, requestByBpnMap[site.bpn]!!) }
+        siteRequestPairs.forEach { (site, request) ->
+            val siteBeforeUpdate = businessPartnerEquivalenceMapper.toEquivalenceDto(site)
+            updateSite(site, request.site)
+            updateLogisticAddress(site.mainAddress, request.site.mainAddress, addressMetadataMap)
+            val siteAfterUpdate = businessPartnerEquivalenceMapper.toEquivalenceDto(site)
+
+            if (siteBeforeUpdate != siteAfterUpdate) {
+                logger.info { "Site ${site.bpn} was updated" }
+
+                siteRepository.save(site)
+
+                changelogService.createChangelogEntries(listOf(ChangelogEntryCreateRequest(site.bpn, ChangelogType.UPDATE, BusinessPartnerType.SITE)))
+                changelogService.createChangelogEntries(
+                    listOf(
+                        ChangelogEntryCreateRequest(
+                            site.mainAddress.bpn,
+                            ChangelogType.UPDATE,
+                            BusinessPartnerType.ADDRESS
+                        )
+                    )
+                )
+            }
+        }
+
+        val siteResponses = siteRequestPairs.map { (site, request) -> site.toUpsertDto(request.bpns) }
+
+        return SitePartnerUpdateResponseWrapper(siteResponses, errors)
+    }
+
+    fun validateSitesToUpdateFromController(
+        siteRequests: Collection<SitePartnerUpdateRequest>,
+    ): Map<RequestWithKey, Collection<ErrorInfo<SiteUpdateError>>> {
+
+        val siteErrorsByRequest = validateSitesToUpdate(siteRequests.map {
+            SiteUpdateBridge(request = it, bpnS = it.bpns)
+        })
+
+        val addressBpnBySiteBpnS = siteRepository.findDistinctByBpnIn(siteRequests.map { it.bpns }).associate { it.bpn to it.mainAddress.bpn }
+        val addressErrorsByRequest = validateAddresses(siteRequests.map {
+            AddressBridge(address = it.site.mainAddress, request = it, bpnA = addressBpnBySiteBpnS[it.bpns])
+        }, siteUpdateMessages)
+        return mergeMapsWithCollectionInValue(siteErrorsByRequest, addressErrorsByRequest)
+    }
+
+    fun validateSitesToUpdate(
+        requestBridges: Collection<SiteUpdateBridge>,
+    ): Map<RequestWithKey, Collection<ErrorInfo<SiteUpdateError>>> {
+
+        val requestedSiteBpns = requestBridges.map { it.bpnS }
+        val existingSiteBpns = siteRepository.findDistinctByBpnIn(requestedSiteBpns).map { it.bpn }.toSet()
+        val existingBpnValidator = ValidateUpdateBpnExists(existingSiteBpns, SiteUpdateError.SiteNotFound)
+
+        return requestBridges.associate { bridge ->
+            val validationErrors = existingBpnValidator.validate(bridge.bpnS)
+            bridge.request to validationErrors
+        }.filterValues { it.isNotEmpty() }
+    }
+
+    inner class ValidateUpdateBpnExists<ERROR : ErrorCode>(
+        private val existingBpns: Set<String>,
+        private val errorCode: ERROR
+    ) {
+
+        fun validate(bpnToUpdate: String?): Collection<ErrorInfo<ERROR>> {
+            return if (bpnToUpdate != null && !existingBpns.contains(bpnToUpdate))
+                listOf(ErrorInfo(errorCode, "Business Partner with BPN '$bpnToUpdate' can't be updated as it doesn't exist", bpnToUpdate))
+            else
+                emptyList()
+        }
+    }
+
+
+    val siteUpdateMessages = ValidatorErrorCodes(
+        regionNotFound = SiteUpdateError.MainAddressRegionNotFound,
+        identifierNotFound = SiteUpdateError.MainAddressIdentifierNotFound,
+        duplicateIdentifier = SiteUpdateError.MainAddressDuplicateIdentifier
+    )
+
+    fun createSitesWithLegalAddressAsMain(requests: Collection<SiteCreateRequestWithLegalAddressAsMain>): SitePartnerCreateResponseWrapper {
+        logger.info { "Create ${requests.size} new sites with legal address as site main address" }
+
+        val legalEntities = legalEntityRepository.findDistinctByBpnIn(requests.map { it.bpnLParent })
+        val legalEntitiesByBpn = legalEntities.associateBy { it.bpn }
+
+        val bpnSs = bpnIssuingService.issueSiteBpns(requests.size)
+
+        val createdSites = requests.zip(bpnSs).map { (siteRequest, bpnS) ->
+            val legalEntityParent =
+                legalEntitiesByBpn[siteRequest.bpnLParent] ?: throw BpdmValidationException("Parent ${siteRequest.bpnLParent} not found for site to create")
+
+            if(legalEntityParent.legalAddress.site != null)
+                throw BpdmValidationException("Can't create site for legal entity ${siteRequest.bpnLParent} with legal address as site main address: Legal address already belongs to site ${legalEntityParent.legalAddress.site!!.bpn}")
+
+            createSite(siteRequest, bpnS, legalEntityParent)
+                .apply { mainAddress = legalEntityParent.legalAddress }
+                .apply { mainAddress.site = this }
+        }
+
+        siteRepository.saveAll(createdSites)
+
+        changelogService.createChangelogEntries(createdSites.map {
+            ChangelogEntryCreateRequest(it.bpn, ChangelogType.CREATE, BusinessPartnerType.SITE)
+        })
+
+        val siteResponse = createdSites.mapIndexed { index, site -> site.toUpsertDto(index.toString()) }
+
+        return SitePartnerCreateResponseWrapper(siteResponse, emptyList())
+
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -630,7 +630,7 @@ class BusinessPartnerBuildService(
                 legalForm = legalForm,
                 currentness = Instant.now().truncatedTo(ChronoUnit.MICROS),
                 confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria),
-                isCatenaXMemberData = legalEntityDto.isCatenaXMemberData
+                isCatenaXMemberData = legalEntityDto.isParticipantData
             )
             updateLegalEntity(newLegalEntity, legalEntityDto, metadataMap)
 
@@ -650,7 +650,7 @@ class BusinessPartnerBuildService(
             legalEntity.identifiers.replace(legalEntityDto.identifiers.map { toLegalEntityIdentifier(it, metadataMap.idTypes, legalEntity) })
             legalEntity.states.replace(legalEntityDto.states.map { toLegalEntityState(it, legalEntity) })
             legalEntity.confidenceCriteria = createConfidenceCriteria(legalEntityDto.confidenceCriteria)
-            legalEntity.isCatenaXMemberData = legalEntityDto.isCatenaXMemberData
+            legalEntity.isCatenaXMemberData = legalEntityDto.isParticipantData
         }
 
         fun createPhysicalAddress(physicalAddress: IBasePhysicalPostalAddressDto, regions: Map<String, RegionDb>): PhysicalPostalAddressDb {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
@@ -147,7 +147,7 @@ class BusinessPartnerEquivalenceMapper {
         override val states: SortedSet<StateEquivalenceDto>,
         override val confidenceCriteria: ConfidenceCriteriaEquivalenceDto?,
         val legalAddress: LogisticAddressEquivalenceDto?,
-        override val isCatenaXMemberData: Boolean
+        val isCatenaXMemberData: Boolean
     ) : IBaseLegalEntityDto
 
     data class SiteEquivalenceDto(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/DataSpaceParticipantsService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/DataSpaceParticipantsService.kt
@@ -27,9 +27,9 @@ import org.eclipse.tractusx.bpdm.common.mapping.ValidationContext.Companion.from
 import org.eclipse.tractusx.bpdm.common.mapping.types.BpnLString
 import org.eclipse.tractusx.bpdm.common.service.toPageDto
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
-import org.eclipse.tractusx.bpdm.pool.api.model.CxMembershipDto
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipSearchRequest
-import org.eclipse.tractusx.bpdm.pool.api.model.request.CxMembershipUpdateRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.DataSpaceParticipantDto
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantSearchRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.request.DataSpaceParticipantUpdateRequest
 import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
 import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
 import org.springframework.data.domain.PageRequest
@@ -38,30 +38,30 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class CxMembershipService(
+class DataSpaceParticipantsService(
     private val legalEntityRepository: LegalEntityRepository,
     private val changelogService: PartnerChangelogService
 ) {
-    fun searchMemberships(searchRequest: CxMembershipSearchRequest, paginationRequest: PaginationRequest): PageDto<CxMembershipDto>{
-        searchRequest.bpnLs?.let { BpnLString.assert(it, fromRoot(CxMembershipSearchRequest::class, "searchRequest", CxMembershipSearchRequest::bpnLs)) }
+    fun searchMemberships(searchRequest: DataSpaceParticipantSearchRequest, paginationRequest: PaginationRequest): PageDto<DataSpaceParticipantDto>{
+        searchRequest.bpnLs?.let { BpnLString.assert(it, fromRoot(DataSpaceParticipantSearchRequest::class, "searchRequest", DataSpaceParticipantSearchRequest::bpnLs)) }
 
         val spec = Specification.allOf(
             LegalEntityRepository.byBpns(searchRequest.bpnLs),
-            LegalEntityRepository.byIsMember(searchRequest.isCatenaXMember)
+            LegalEntityRepository.byIsMember(searchRequest.isDataSpaceParticipant)
         )
         val legalEntityPage = legalEntityRepository.findAll(spec, PageRequest.of(paginationRequest.page, paginationRequest.size))
 
-        return legalEntityPage.toPageDto { CxMembershipDto(it.bpn, it.isCatenaXMemberData) }
+        return legalEntityPage.toPageDto { DataSpaceParticipantDto(it.bpn, it.isCatenaXMemberData) }
     }
 
     @Transactional
-    fun updateMemberships(updateRequest: CxMembershipUpdateRequest){
+    fun updateMemberships(updateRequest: DataSpaceParticipantUpdateRequest){
         BpnLString.assert(
-            updateRequest.memberships.map { it.bpnL },
-            fromRoot(CxMembershipUpdateRequest::class, "updateRequest", CxMembershipUpdateRequest::memberships, CxMembershipDto::bpnL)
+            updateRequest.participants.map { it.bpnL },
+            fromRoot(DataSpaceParticipantUpdateRequest::class, "updateRequest", DataSpaceParticipantUpdateRequest::participants, DataSpaceParticipantDto::bpnL)
         )
 
-        val updatesByBpnL = updateRequest.memberships.associate { Pair(it.bpnL, it.isCatenaXMember) }
+        val updatesByBpnL = updateRequest.participants.associate { Pair(it.bpnL, it.isDataSpaceParticipant) }
 
         val foundLegalEntities = legalEntityRepository.findDistinctByBpnIn(updatesByBpnL.keys)
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
@@ -100,7 +100,7 @@ class MetadataService(
             technicalKey = request.technicalKey,
             name = request.name,
             transliteratedName = request.transliteratedName,
-            abbreviation = request.abbreviation,
+            abbreviation = request.abbreviations,
             transliteratedAbbreviations = request.transliteratedAbbreviations,
             countryCode = request.country,
             languageCode = request.language,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -73,7 +73,7 @@ fun LegalEntityDb.toDto(): LegalEntityVerboseDto {
         relations = startNodeRelations.plus(endNodeRelations).map { it.toDto() },
         currentness = currentness,
         confidenceCriteria = confidenceCriteria.toDto(),
-        isCatenaXMemberData = isCatenaXMemberData,
+        isParticipantData = isCatenaXMemberData,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )
@@ -101,7 +101,7 @@ fun LegalFormDb.toDto(): LegalFormDto {
         technicalKey = technicalKey,
         name = name,
         transliteratedName = transliteratedName,
-        abbreviation = abbreviation,
+        abbreviations = abbreviation,
         transliteratedAbbreviations = transliteratedAbbreviations,
         country = countryCode,
         language = languageCode,
@@ -135,7 +135,7 @@ fun LogisticAddressDb.toDto(): LogisticAddressVerboseDto {
         physicalPostalAddress = physicalPostalAddress.toDto(),
         alternativePostalAddress = alternativePostalAddress?.toDto(),
         confidenceCriteria = confidenceCriteria.toDto(),
-        isCatenaXMemberData = legalEntity?.isCatenaXMemberData ?: site?.legalEntity?.isCatenaXMemberData ?: false,
+        isParticipantData = legalEntity?.isCatenaXMemberData ?: site?.legalEntity?.isCatenaXMemberData ?: false,
         addressType = getAddressType(this)
     )
 }
@@ -240,7 +240,7 @@ fun SiteDb.toDto(): SiteVerboseDto {
         states = states.map { it.toDto() },
         bpnLegalEntity = legalEntity.bpn,
         confidenceCriteria = confidenceCriteria.toDto(),
-        isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+        isParticipantData = legalEntity.isCatenaXMemberData,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )
@@ -255,7 +255,7 @@ fun SiteDb.toPoolDto(): SiteWithMainAddressVerboseDto {
             states = states.map { it.toDto() },
             bpnLegalEntity = legalEntity.bpn,
             confidenceCriteria = confidenceCriteria.toDto(),
-            isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+            isParticipantData = legalEntity.isCatenaXMemberData,
             createdAt = createdAt,
             updatedAt = updatedAt,
         ),

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionMapper.kt
@@ -37,7 +37,7 @@ class TaskResolutionMapper {
                 identifiers = identifiers.map { Identifier(it.value, it.type, it.issuingBody) },
                 states = states.map { BusinessState(it.validFrom?.toInstant(ZoneOffset.UTC), it.validTo?.toInstant(ZoneOffset.UTC), it.type) },
                 confidenceCriteria = toTaskResult(confidenceCriteria),
-                isCatenaXMemberData = legalEntity.isCatenaXMemberData,
+                isParticipantData = legalEntity.isParticipantData,
                 hasChanged = hasChanged,
                 legalAddress = toTaskResult(legalAddress, hasChanged)
             )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -131,13 +131,13 @@ class TaskStepBuildService(
             throw BpdmValidationException("Legal entity with specified BPNL $bpnL not found")
         }
 
-        val isCatenaXMember = legalEntity.isCatenaXMemberData ?: if(bpnL != null) existingLegalEntityInformation.isCatenaXMemberData else false
+        val isCatenaXMember = legalEntity.isParticipantData ?: if(bpnL != null) existingLegalEntityInformation.isParticipantData else false
 
         val legalEntityResult = if(bpnL != null && legalEntity.hasChanged == false){
             //No need to upsert, just fetch the information
             existingLegalEntityInformation
         }else{
-            upsertLegalEntity(legalEntity.copy(isCatenaXMemberData = isCatenaXMember), taskEntryBpnMapping)
+            upsertLegalEntity(legalEntity.copy(isParticipantData = isCatenaXMember), taskEntryBpnMapping)
         }
 
         return legalEntityResult
@@ -443,7 +443,7 @@ class TaskStepBuildService(
                 identifiers = identifiers.map { assertNotNull(it).let { LegalEntityIdentifierDto(it.value!!, it.type!!, it.issuingBody) } },
                 states = states.map { assertNotNull(it).let { LegalEntityStateDto(it.validFrom.toLocalDateTime(), it.validTo.toLocalDateTime(), it.type!!) }   },
                 confidenceCriteria = toPoolDto(confidenceCriteria, CleaningError.LEGAL_ENTITY_CONFIDENCE_CRITERIA_MISSING),
-                isCatenaXMemberData = isCatenaXMemberData ?: false
+                isParticipantData = isParticipantData ?: false
             )
         }
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthTestBase.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthTestBase.kt
@@ -198,12 +198,12 @@ abstract class AuthTestBase(
 
     @Test
     fun `GET CX Memberships`(){
-        authAssertions.assert(membershipAuthExpectations.getMemberships) { poolApiClient.memberships.get(CxMembershipSearchRequest(), PaginationRequest()) }
+        authAssertions.assert(membershipAuthExpectations.getMemberships) { poolApiClient.participants.get(DataSpaceParticipantSearchRequest(), PaginationRequest()) }
     }
 
     @Test
     fun `PUT CX Memberships`(){
-        authAssertions.assert(membershipAuthExpectations.putMemberships) { poolApiClient.memberships.put(CxMembershipUpdateRequest(listOf())) }
+        authAssertions.assert(membershipAuthExpectations.putMemberships) { poolApiClient.participants.put(DataSpaceParticipantUpdateRequest(listOf())) }
     }
 }
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionServiceTest.kt
@@ -197,7 +197,7 @@ class TaskResolutionServiceTest @Autowired constructor(
         assertThat(createdLegalEntity.legalAddress.bpnLegalEntity).isEqualTo(createdLegalEntity.legalEntity.bpnl)
         assertThat(createdLegalEntity.legalAddress.addressType == AddressType.LegalAddress).isTrue()
         assertThat(createResult[0].businessPartner.legalEntity.bpnReference.referenceValue).isEqualTo(createdLegalEntity.legalEntity.bpnl)
-        compareLegalEntity(createdLegalEntity, createResult[0].businessPartner.legalEntity.copy(isCatenaXMemberData = false))
+        compareLegalEntity(createdLegalEntity, createResult[0].businessPartner.legalEntity.copy(isParticipantData = false))
         val createdAdditionalAddress = poolClient.addresses.getAddress(createResult[0].businessPartner.additionalAddress?.bpnReference?.referenceValue!!)
         assertThat(createdAdditionalAddress.bpnLegalEntity).isEqualTo(createdLegalEntity.legalEntity.bpnl)
         assertThat(createdAdditionalAddress.addressType == AddressType.AdditionalAddress).isTrue()
@@ -456,7 +456,7 @@ class TaskResolutionServiceTest @Autowired constructor(
 
         val updatedLegalEntity = poolClient.legalEntities.getLegalEntity(updateResult[0].businessPartner.legalEntity.bpnReference.referenceValue!!)
         assertThat(updatedLegalEntity.legalEntity.legalName).isEqualTo(updateLegalEntityRequest.legalEntity.legalName)
-        compareLegalEntity(updatedLegalEntity, updateResult[0].businessPartner.legalEntity.copy(isCatenaXMemberData = createLegalEntityRequest.legalEntity.isCatenaXMemberData))
+        compareLegalEntity(updatedLegalEntity, updateResult[0].businessPartner.legalEntity.copy(isParticipantData = createLegalEntityRequest.legalEntity.isParticipantData))
     }
 
     @Test
@@ -485,7 +485,7 @@ class TaskResolutionServiceTest @Autowired constructor(
 
         val updatedLegalEntity = poolClient.legalEntities.getLegalEntity(updateResult[0].businessPartner.legalEntity.bpnReference.referenceValue!!)
         assertThat(updatedLegalEntity.legalEntity.legalName).isEqualTo(updateLegalEntityRequest.legalEntity.legalName)
-        compareLegalEntity(updatedLegalEntity, updateResult[0].businessPartner.legalEntity.copy(isCatenaXMemberData = createLegalEntityRequest.legalEntity.isCatenaXMemberData))
+        compareLegalEntity(updatedLegalEntity, updateResult[0].businessPartner.legalEntity.copy(isParticipantData = createLegalEntityRequest.legalEntity.isParticipantData))
     }
 
     @Test
@@ -941,7 +941,7 @@ class TaskResolutionServiceTest @Autowired constructor(
     }
 
     fun BusinessPartner.withCxMembership(isCatenaXMemberData: Boolean?): BusinessPartner{
-        return copy(legalEntity = legalEntity.copy(isCatenaXMemberData = isCatenaXMemberData))
+        return copy(legalEntity = legalEntity.copy(isParticipantData = isCatenaXMemberData))
     }
 
     private fun minValidLegalEntity(): BusinessPartner {

--- a/docs/api/orchestrator.json
+++ b/docs/api/orchestrator.json
@@ -172,6 +172,39 @@
         }
       }
     },
+    "/v7/business-partners/golden-record-tasks" : {
+      "post" : {
+        "tags" : [ "Task Client" ],
+        "summary" : "Create new golden record tasks for given business partner data",
+        "description" : "Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.",
+        "operationId" : "createTasks_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskCreateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The states of successfully created tasks including the task identifier for tracking purposes.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskCreateResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
     "/v7/business-partners/golden-record-tasks/step-results" : {
       "post" : {
         "tags" : [ "Task Worker" ],
@@ -198,71 +231,12 @@
         }
       }
     },
-    "/v6/golden-record-tasks/step-results" : {
-      "post" : {
-        "tags" : [ "Task Worker" ],
-        "summary" : "Post step results for reserved golden record tasks in the given step queue",
-        "description" : "Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.",
-        "operationId" : "resolveStepResults_2",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/TaskStepResultRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "204" : {
-            "description" : "If the results could be processed"
-          },
-          "400" : {
-            "description" : "On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue"
-          }
-        }
-      }
-    },
-    "/v6/golden-record-tasks/step-reservations" : {
-      "post" : {
-        "tags" : [ "Task Worker" ],
-        "summary" : "Reserve the next golden record tasks waiting in the given step queue",
-        "description" : "Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.",
-        "operationId" : "reserveTasksForStep_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/TaskStepReservationRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "The reserved tasks with their business partner data to process.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TaskStepReservationResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed task create requests or reaching upsert limit"
-          }
-        }
-      }
-    },
     "/v7/business-partners/golden-record-tasks/step-reservations" : {
       "post" : {
         "tags" : [ "Task Worker" ],
         "summary" : "Reserve the next golden record tasks waiting in the given step queue",
         "description" : "Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.",
-        "operationId" : "reserveTasksForStep_2",
+        "operationId" : "reserveTasksForStep_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -296,39 +270,6 @@
         "summary" : "Search for the state of golden record tasks by task identifiers",
         "description" : "Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.",
         "operationId" : "searchTaskStates_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/TaskStateRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "The state of the tasks for the provided task identifiers.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TaskStateResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed task search requests"
-          }
-        }
-      }
-    },
-    "/v6/golden-record-tasks/state/search" : {
-      "post" : {
-        "tags" : [ "Task Client" ],
-        "summary" : "Search for the state of golden record tasks by task identifiers",
-        "description" : "Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.",
-        "operationId" : "searchTaskStates_2",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -420,39 +361,6 @@
         }
       }
     },
-    "/v7/business-partners/golden-record-tasks" : {
-      "post" : {
-        "tags" : [ "Task Client" ],
-        "summary" : "Create new golden record tasks for given business partner data",
-        "description" : "Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.",
-        "operationId" : "createTasks_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/TaskCreateRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "The states of successfully created tasks including the task identifier for tracking purposes.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TaskCreateResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed task create requests or reaching upsert limit"
-          }
-        }
-      }
-    },
     "/v6/golden-record-tasks" : {
       "post" : {
         "tags" : [ "Task Client" ],
@@ -482,6 +390,98 @@
           },
           "400" : {
             "description" : "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
+    "/v6/golden-record-tasks/step-results" : {
+      "post" : {
+        "tags" : [ "Task Worker" ],
+        "summary" : "Post step results for reserved golden record tasks in the given step queue",
+        "description" : "Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.",
+        "operationId" : "resolveStepResults_2",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskStepResultRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "If the results could be processed"
+          },
+          "400" : {
+            "description" : "On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue"
+          }
+        }
+      }
+    },
+    "/v6/golden-record-tasks/step-reservations" : {
+      "post" : {
+        "tags" : [ "Task Worker" ],
+        "summary" : "Reserve the next golden record tasks waiting in the given step queue",
+        "description" : "Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.",
+        "operationId" : "reserveTasksForStep_2",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskStepReservationRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The reserved tasks with their business partner data to process.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskStepReservationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task create requests or reaching upsert limit"
+          }
+        }
+      }
+    },
+    "/v6/golden-record-tasks/state/search" : {
+      "post" : {
+        "tags" : [ "Task Client" ],
+        "summary" : "Search for the state of golden record tasks by task identifiers",
+        "description" : "Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.",
+        "operationId" : "searchTaskStates_2",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TaskStateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The state of the tasks for the provided task identifiers.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TaskStateResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed task search requests"
           }
         }
       }
@@ -944,9 +944,9 @@
           "confidenceCriteria" : {
             "$ref" : "#/components/schemas/ConfidenceCriteria"
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Whether this legal entity is part of the Catena-X network"
+            "description" : "Whether this legal entity is part of the Data Space network"
           },
           "hasChanged" : {
             "type" : "boolean",

--- a/docs/api/orchestrator.yaml
+++ b/docs/api/orchestrator.yaml
@@ -1,7 +1,9 @@
 openapi: 3.1.0
 info:
   title: Business Partner Data Management Orchestrator
-  description: Orchestrator component acts as a passive component and offers for each processing steps individual endpoints
+  description: >-
+    Orchestrator component acts as a passive component and offers for each
+    processing steps individual endpoints
   version: 7.0.0-SNAPSHOT
 servers:
   - url: http://localhost:8085
@@ -14,8 +16,17 @@ paths:
     post:
       tags:
         - Task Client
-      summary: Create new golden record relations tasks for given business partner relationship data
-      description: Create golden record tasks for given business partner relationship data in given mode. The mode decides through which processing steps the given business partner relationship data will go through. The response contains the states of the created tasks in the order of given business partner relationship data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.
+      summary: >-
+        Create new golden record relations tasks for given business partner
+        relationship data
+      description: >-
+        Create golden record tasks for given business partner relationship data
+        in given mode. The mode decides through which processing steps the given
+        business partner relationship data will go through. The response
+        contains the states of the created tasks in the order of given business
+        partner relationship data.If there is an error in the request no tasks
+        are created (all or nothing). For a single request, the maximum number
+        of business partners in the request is limited to 100 entries.
       operationId: createTasks
       requestBody:
         content:
@@ -25,7 +36,9 @@ paths:
         required: true
       responses:
         '200':
-          description: The states of successfully created tasks including the task identifier for tracking purposes.
+          description: >-
+            The states of successfully created tasks including the task
+            identifier for tracking purposes.
           content:
             application/json:
               schema:
@@ -36,8 +49,17 @@ paths:
     post:
       tags:
         - Task Worker
-      summary: Post step results for reserved relations golden record tasks in the given step queue
-      description: Post business partner relations step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.
+      summary: >-
+        Post step results for reserved relations golden record tasks in the
+        given step queue
+      description: >-
+        Post business partner relations step results for the given tasks in the
+        given step queue. In order to post a result for a task it needs to be
+        reserved first, has to currently be in the given step queue and the time
+        limit is not exceeded. The number of results you can post at a time does
+        not need to match the original number of reserved tasks. Results are
+        accepted via strategy 'all or nothing'. For a single request, the
+        maximum number of postable results is limited to 100.
       operationId: resolveStepResults
       requestBody:
         content:
@@ -49,13 +71,22 @@ paths:
         '204':
           description: If the results could be processed
         '400':
-          description: On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue
+          description: >-
+            On malformed requests, reaching upsert limit or posting results for
+            tasks which are missing or in the wrong step queue
   /v7/relations/golden-record-tasks/step-reservations:
     post:
       tags:
         - Task Worker
-      summary: Reserve the next relations golden record tasks waiting in the given step queue
-      description: Reserve up to a given number of relations golden record tasks in the given step queue. The response entries contain the business partner relations data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.
+      summary: >-
+        Reserve the next relations golden record tasks waiting in the given step
+        queue
+      description: >-
+        Reserve up to a given number of relations golden record tasks in the
+        given step queue. The response entries contain the business partner
+        relations data. The reservation has a time limit which is returned. For
+        a single request, the maximum number of reservable tasks is limited to
+        100.
       operationId: reserveTasksForStep
       requestBody:
         content:
@@ -65,7 +96,9 @@ paths:
         required: true
       responses:
         '200':
-          description: The reserved tasks with their business partner relations data to process.
+          description: >-
+            The reserved tasks with their business partner relations data to
+            process.
           content:
             application/json:
               schema:
@@ -76,8 +109,12 @@ paths:
     post:
       tags:
         - Task Client
-      summary: Search for the state of relations golden record tasks by task identifiers
-      description: Returns the state of relations golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.
+      summary: >-
+        Search for the state of relations golden record tasks by task
+        identifiers
+      description: >-
+        Returns the state of relations golden record tasks based on the provided
+        task identifiers. Unknown task identifiers are ignored.
       operationId: searchTaskStates
       requestBody:
         content:
@@ -108,19 +145,61 @@ paths:
         required: true
       responses:
         '200':
-          description: The list of corresponding result states in the same order as has been received. A null indicates that a task could not be found.
+          description: >-
+            The list of corresponding result states in the same order as has
+            been received. A null indicates that a task could not be found.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaskResultStateSearchResponse'
         '400':
           description: On malformed task search requests
+  /v7/business-partners/golden-record-tasks:
+    post:
+      tags:
+        - Task Client
+      summary: Create new golden record tasks for given business partner data
+      description: >-
+        Create golden record tasks for given business partner data in given
+        mode. The mode decides through which processing steps the given business
+        partner data will go through. The response contains the states of the
+        created tasks in the order of given business partner data.If there is an
+        error in the request no tasks are created (all or nothing). For a single
+        request, the maximum number of business partners in the request is
+        limited to 100 entries.
+      operationId: createTasks_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: >-
+            The states of successfully created tasks including the task
+            identifier for tracking purposes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskCreateResponse'
+        '400':
+          description: On malformed task create requests or reaching upsert limit
   /v7/business-partners/golden-record-tasks/step-results:
     post:
       tags:
         - Task Worker
-      summary: Post step results for reserved golden record tasks in the given step queue
-      description: Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.
+      summary: >-
+        Post step results for reserved golden record tasks in the given step
+        queue
+      description: >-
+        Post business partner step results for the given tasks in the given step
+        queue. In order to post a result for a task it needs to be reserved
+        first, has to currently be in the given step queue and the time limit is
+        not exceeded. The number of results you can post at a time does not need
+        to match the original number of reserved tasks. Results are accepted via
+        strategy 'all or nothing'. For a single request, the maximum number of
+        postable results is limited to 100.
       operationId: resolveStepResults_1
       requestBody:
         content:
@@ -132,54 +211,21 @@ paths:
         '204':
           description: If the results could be processed
         '400':
-          description: On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue
-  /v6/golden-record-tasks/step-results:
-    post:
-      tags:
-        - Task Worker
-      summary: Post step results for reserved golden record tasks in the given step queue
-      description: Post business partner step results for the given tasks in the given step queue. In order to post a result for a task it needs to be reserved first, has to currently be in the given step queue and the time limit is not exceeded. The number of results you can post at a time does not need to match the original number of reserved tasks. Results are accepted via strategy 'all or nothing'. For a single request, the maximum number of postable results is limited to 100.
-      operationId: resolveStepResults_2
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TaskStepResultRequest'
-        required: true
-      responses:
-        '204':
-          description: If the results could be processed
-        '400':
-          description: On malformed requests, reaching upsert limit or posting results for tasks which are missing or in the wrong step queue
-  /v6/golden-record-tasks/step-reservations:
-    post:
-      tags:
-        - Task Worker
-      summary: Reserve the next golden record tasks waiting in the given step queue
-      description: Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.
-      operationId: reserveTasksForStep_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TaskStepReservationRequest'
-        required: true
-      responses:
-        '200':
-          description: The reserved tasks with their business partner data to process.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaskStepReservationResponse'
-        '400':
-          description: On malformed task create requests or reaching upsert limit
+          description: >-
+            On malformed requests, reaching upsert limit or posting results for
+            tasks which are missing or in the wrong step queue
   /v7/business-partners/golden-record-tasks/step-reservations:
     post:
       tags:
         - Task Worker
       summary: Reserve the next golden record tasks waiting in the given step queue
-      description: Reserve up to a given number of golden record tasks in the given step queue. The response entries contain the business partner data to process which consists of the generic and L/S/A data. The reservation has a time limit which is returned. For a single request, the maximum number of reservable tasks is limited to 100.
-      operationId: reserveTasksForStep_2
+      description: >-
+        Reserve up to a given number of golden record tasks in the given step
+        queue. The response entries contain the business partner data to process
+        which consists of the generic and L/S/A data. The reservation has a time
+        limit which is returned. For a single request, the maximum number of
+        reservable tasks is limited to 100.
+      operationId: reserveTasksForStep_1
       requestBody:
         content:
           application/json:
@@ -200,30 +246,10 @@ paths:
       tags:
         - Task Client
       summary: Search for the state of golden record tasks by task identifiers
-      description: Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.
+      description: >-
+        Returns the state of golden record tasks based on the provided task
+        identifiers. Unknown task identifiers are ignored.
       operationId: searchTaskStates_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TaskStateRequest'
-        required: true
-      responses:
-        '200':
-          description: The state of the tasks for the provided task identifiers.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaskStateResponse'
-        '400':
-          description: On malformed task search requests
-  /v6/golden-record-tasks/state/search:
-    post:
-      tags:
-        - Task Client
-      summary: Search for the state of golden record tasks by task identifiers
-      description: Returns the state of golden record tasks based on the provided task identifiers. Unknown task identifiers are ignored.
-      operationId: searchTaskStates_2
       requestBody:
         content:
           application/json:
@@ -253,7 +279,9 @@ paths:
         required: true
       responses:
         '200':
-          description: The list of corresponding result states in the same order as has been received. A null indicates that a task could not be found.
+          description: >-
+            The list of corresponding result states in the same order as has
+            been received. A null indicates that a task could not be found.
           content:
             application/json:
               schema:
@@ -274,41 +302,28 @@ paths:
         required: true
       responses:
         '200':
-          description: The list of corresponding result states in the same order as has been received. A null indicates that a task could not be found.
+          description: >-
+            The list of corresponding result states in the same order as has
+            been received. A null indicates that a task could not be found.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaskResultStateSearchResponse'
         '400':
           description: On malformed task search requests
-  /v7/business-partners/golden-record-tasks:
-    post:
-      tags:
-        - Task Client
-      summary: Create new golden record tasks for given business partner data
-      description: Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.
-      operationId: createTasks_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TaskCreateRequest'
-        required: true
-      responses:
-        '200':
-          description: The states of successfully created tasks including the task identifier for tracking purposes.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaskCreateResponse'
-        '400':
-          description: On malformed task create requests or reaching upsert limit
   /v6/golden-record-tasks:
     post:
       tags:
         - Task Client
       summary: Create new golden record tasks for given business partner data
-      description: Create golden record tasks for given business partner data in given mode. The mode decides through which processing steps the given business partner data will go through. The response contains the states of the created tasks in the order of given business partner data.If there is an error in the request no tasks are created (all or nothing). For a single request, the maximum number of business partners in the request is limited to 100 entries.
+      description: >-
+        Create golden record tasks for given business partner data in given
+        mode. The mode decides through which processing steps the given business
+        partner data will go through. The response contains the states of the
+        created tasks in the order of given business partner data.If there is an
+        error in the request no tasks are created (all or nothing). For a single
+        request, the maximum number of business partners in the request is
+        limited to 100 entries.
       operationId: createTasks_2
       requestBody:
         content:
@@ -318,19 +333,107 @@ paths:
         required: true
       responses:
         '200':
-          description: The states of successfully created tasks including the task identifier for tracking purposes.
+          description: >-
+            The states of successfully created tasks including the task
+            identifier for tracking purposes.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaskCreateResponse'
         '400':
           description: On malformed task create requests or reaching upsert limit
+  /v6/golden-record-tasks/step-results:
+    post:
+      tags:
+        - Task Worker
+      summary: >-
+        Post step results for reserved golden record tasks in the given step
+        queue
+      description: >-
+        Post business partner step results for the given tasks in the given step
+        queue. In order to post a result for a task it needs to be reserved
+        first, has to currently be in the given step queue and the time limit is
+        not exceeded. The number of results you can post at a time does not need
+        to match the original number of reserved tasks. Results are accepted via
+        strategy 'all or nothing'. For a single request, the maximum number of
+        postable results is limited to 100.
+      operationId: resolveStepResults_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskStepResultRequest'
+        required: true
+      responses:
+        '204':
+          description: If the results could be processed
+        '400':
+          description: >-
+            On malformed requests, reaching upsert limit or posting results for
+            tasks which are missing or in the wrong step queue
+  /v6/golden-record-tasks/step-reservations:
+    post:
+      tags:
+        - Task Worker
+      summary: Reserve the next golden record tasks waiting in the given step queue
+      description: >-
+        Reserve up to a given number of golden record tasks in the given step
+        queue. The response entries contain the business partner data to process
+        which consists of the generic and L/S/A data. The reservation has a time
+        limit which is returned. For a single request, the maximum number of
+        reservable tasks is limited to 100.
+      operationId: reserveTasksForStep_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskStepReservationRequest'
+        required: true
+      responses:
+        '200':
+          description: The reserved tasks with their business partner data to process.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskStepReservationResponse'
+        '400':
+          description: On malformed task create requests or reaching upsert limit
+  /v6/golden-record-tasks/state/search:
+    post:
+      tags:
+        - Task Client
+      summary: Search for the state of golden record tasks by task identifiers
+      description: >-
+        Returns the state of golden record tasks based on the provided task
+        identifiers. Unknown task identifiers are ignored.
+      operationId: searchTaskStates_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskStateRequest'
+        required: true
+      responses:
+        '200':
+          description: The state of the tasks for the provided task identifiers.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskStateResponse'
+        '400':
+          description: On malformed task search requests
   /v7/relations/golden-record-tasks/finished-events:
     get:
       tags:
         - Task Client
-      summary: Get event log of relations golden record tasks that have finished processing
-      description: 'The event log contains all events of when relations golden record tasks finish processing. These events are helpful for the task creator to check whether created tasks have finished processing. A paginated list of events that happened after a given time is returned. '
+      summary: >-
+        Get event log of relations golden record tasks that have finished
+        processing
+      description: >-
+        The event log contains all events of when relations golden record tasks
+        finish processing. These events are helpful for the task creator to
+        check whether created tasks have finished processing. A paginated list
+        of events that happened after a given time is returned.
       operationId: getRelationsEvents
       parameters:
         - name: timestamp
@@ -368,7 +471,11 @@ paths:
       tags:
         - Task Client
       summary: Get event log of golden record tasks that have finished processing
-      description: 'The event log contains all events of when golden record tasks finish processing. These events are helpful for the task creator to check whether created tasks have finished processing. A paginated list of events that happened after a given time is returned. '
+      description: >-
+        The event log contains all events of when golden record tasks finish
+        processing. These events are helpful for the task creator to check
+        whether created tasks have finished processing. A paginated list of
+        events that happened after a given time is returned.
       operationId: getEvents
       parameters:
         - name: timestamp
@@ -406,7 +513,11 @@ paths:
       tags:
         - Task Client
       summary: Get event log of golden record tasks that have finished processing
-      description: 'The event log contains all events of when golden record tasks finish processing. These events are helpful for the task creator to check whether created tasks have finished processing. A paginated list of events that happened after a given time is returned. '
+      description: >-
+        The event log contains all events of when golden record tasks finish
+        processing. These events are helpful for the task creator to check
+        whether created tasks have finished processing. A paginated list of
+        events that happened after a given time is returned.
       operationId: getEvents_1
       parameters:
         - name: timestamp
@@ -443,47 +554,88 @@ components:
   schemas:
     AlternativeAddress:
       type: object
-      description: An alternative postal address describes an alternative way of delivery for example if the goods are to be picked up somewhere else.
+      description: >-
+        An alternative postal address describes an alternative way of delivery
+        for example if the goods are to be picked up somewhere else.
       properties:
         geographicCoordinates:
           $ref: '#/components/schemas/GeoCoordinate'
         country:
           type: string
-          description: The 2-digit country code of the physical postal address according to ISO 3166-1.
+          description: >-
+            The 2-digit country code of the physical postal address according to
+            ISO 3166-1.
         administrativeAreaLevel1:
           type: string
-          description: The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country.
+          description: >-
+            The 2-digit country subdivision code according to ISO 3166-2, such
+            as a region within a country.
         postalCode:
           type: string
-          description: The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code.
+          description: >-
+            The alphanumeric identifier (sometimes including spaces or
+            punctuation) of the physical postal address for the purpose of
+            sorting mail, synonyms:postcode, post code, PIN or ZIP code.
         city:
           type: string
-          description: 'The name of the city of the physical postal address, synonyms: town, village, municipality.'
+          description: >-
+            The name of the city of the physical postal address, synonyms: town,
+            village, municipality.
         deliveryServiceType:
           type: string
-          description: 'One of the alternative postal address types: P.O. box, private bag, boite postale.'
+          description: >-
+            One of the alternative postal address types: P.O. box, private bag,
+            boite postale.
           enum:
             - PO_BOX
             - PRIVATE_BAG
             - BOITE_POSTALE
         deliveryServiceQualifier:
           type: string
-          description: The qualifier uniquely identifying the delivery service endpoint of the alternative postal address in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number is assigned multiple times in some cities.
+          description: >-
+            The qualifier uniquely identifying the delivery service endpoint of
+            the alternative postal address in conjunction with the delivery
+            service number. In some countries for example, entering a P.O. box
+            number, postal code and city is not sufficient to uniquely identify
+            a P.O. box, because the same P.O. box number is assigned multiple
+            times in some cities.
         deliveryServiceNumber:
           type: string
-          description: The number indicating the delivery service endpoint of the alternative postal address to which the delivery is to be delivered, such as a P.O. box number or a private bag number.
+          description: >-
+            The number indicating the delivery service endpoint of the
+            alternative postal address to which the delivery is to be delivered,
+            such as a P.O. box number or a private bag number.
       required:
         - geographicCoordinates
     BpnReference:
       type: object
-      description: A reference to a BPN for the corresponding business partner data. Either this reference contains an existing BPN or a BPN request identifier. The golden record process makes sure that the each unique BPN request identifier is associated to a unique BPN. For a new BPN request identifier the golden record process creates a new BPN (and golden record) and associates it with the BPN request identifier. Known BPN request identifiers are resolved to the BPN and the corresponding golden record is updated with the business partner data. This makes it possible for duplication check services to reference unique business partners by their own BPN request identifiers instead of needing to rely on BPNs for identification.
+      description: >-
+        A reference to a BPN for the corresponding business partner data. Either
+        this reference contains an existing BPN or a BPN request identifier. The
+        golden record process makes sure that the each unique BPN request
+        identifier is associated to a unique BPN. For a new BPN request
+        identifier the golden record process creates a new BPN (and golden
+        record) and associates it with the BPN request identifier. Known BPN
+        request identifiers are resolved to the BPN and the corresponding golden
+        record is updated with the business partner data. This makes it possible
+        for duplication check services to reference unique business partners by
+        their own BPN request identifiers instead of needing to rely on BPNs for
+        identification.
       properties:
         referenceValue:
           type: string
-          description: The value of the reference, either an existing BPN or a BPN request identifier (which is freely chosen by the duplication check provider)
+          description: >-
+            The value of the reference, either an existing BPN or a BPN request
+            identifier (which is freely chosen by the duplication check
+            provider)
         desiredBpn:
           type: string
-          description: 'The desired BPN when a new golden record has to be created for this business partner data.Requires a BPN request identifier that is not associated with an existing BPN. At this moment the golden record process does not support creating desired BPNs and ignores this field. '
+          description: >-
+            The desired BPN when a new golden record has to be created for this
+            business partner data.Requires a BPN request identifier that is not
+            associated with an existing BPN. At this moment the golden record
+            process does not support creating desired BPNs and ignores this
+            field.
         referenceType:
           type: string
           description: Whether this reference is a BPN or BPN request identifier
@@ -492,16 +644,29 @@ components:
             - BpnRequestIdentifier
     BusinessPartner:
       type: object
-      description: 'Generic business partner data for golden record processing. Typically a sharing member shares incomplete and/or uncategorized business partner data to the golden record process. The golden record process categorizes and completes the data in order to create and update the resulting golden records. The golden records are found in the legalEntity, site and additionalAddress fields. The business partner data needs to contain the full golden record parent relationship. This means, if an additional address is specified in the business partner data, also its legal entity and also its site parent (if a site exists) needs to be specified. '
+      description: >-
+        Generic business partner data for golden record processing. Typically a
+        sharing member shares incomplete and/or uncategorized business partner
+        data to the golden record process. The golden record process categorizes
+        and completes the data in order to create and update the resulting
+        golden records. The golden records are found in the legalEntity, site
+        and additionalAddress fields. The business partner data needs to contain
+        the full golden record parent relationship. This means, if an additional
+        address is specified in the business partner data, also its legal entity
+        and also its site parent (if a site exists) needs to be specified.
       properties:
         nameParts:
           type: array
-          description: Fully categorized and cleaned name parts based on the uncategorized name parts provided
+          description: >-
+            Fully categorized and cleaned name parts based on the uncategorized
+            name parts provided
           items:
             $ref: '#/components/schemas/NamePart'
         owningCompany:
           type: string
-          description: The BPNL of the legal entity to which this business partner data belongs to
+          description: >-
+            The BPNL of the legal entity to which this business partner data
+            belongs to
         uncategorized:
           $ref: '#/components/schemas/UncategorizedProperties'
         legalEntity:
@@ -512,12 +677,23 @@ components:
           $ref: '#/components/schemas/PostalAddress'
         type:
           type: string
-          description: |-
-            The recognized golden record type this business partner data contains.
-            * `Legal Entity`: The business partner data only contains legal entity and legal address information.
-            * `Site`: The business partner data contains site, site main address and its parent legal entity information.
-            * `Additional Address`: The business partner data contains an additional address, (optional) parent site and parent legal entity information.
-            * `Null`: No clear type determined, undecided. The golden record process will not create golden record from this business partner data.
+          description: >-
+            The recognized golden record type this business partner data
+            contains.
+
+            * `Legal Entity`: The business partner data only contains legal
+            entity and legal address information.
+
+            * `Site`: The business partner data contains site, site main address
+            and its parent legal entity information.
+
+            * `Additional Address`: The business partner data contains an
+            additional address, (optional) parent site and parent legal entity
+            information.
+
+            * `Null`: No clear type determined, undecided. The golden record
+            process will not create golden record from this business partner
+            data.
           enum:
             - LegalEntity
             - Site
@@ -565,22 +741,31 @@ components:
             - INACTIVE
     ConfidenceCriteria:
       type: object
-      description: Contains information to evaluate how good or verified the information in the attached business partner data is. This information will be directly written in the matched golden record's confidence criteria.
+      description: >-
+        Contains information to evaluate how good or verified the information in
+        the attached business partner data is. This information will be directly
+        written in the matched golden record's confidence criteria.
       properties:
         sharedByOwner:
           type: boolean
           description: Whether the business partner data is shared by the actual owner
         checkedByExternalDataSource:
           type: boolean
-          description: The corresponding business partner data has been verified by an external data source, like an official register
+          description: >-
+            The corresponding business partner data has been verified by an
+            external data source, like an official register
         numberOfSharingMembers:
           type: integer
           format: int32
-          description: How many sharing members have already shared the matched golden record
+          description: >-
+            How many sharing members have already shared the matched golden
+            record
         lastConfidenceCheckAt:
           type: string
           format: date-time
-          description: Last time the confidence values have been checked (and updated if needed)
+          description: >-
+            Last time the confidence values have been checked (and updated if
+            needed)
         nextConfidenceCheckAt:
           type: string
           format: date-time
@@ -649,7 +834,9 @@ components:
         - totalPages
     GeoCoordinate:
       type: object
-      description: The exact location of the physical postal address in latitude, longitude, and altitude.
+      description: >-
+        The exact location of the physical postal address in latitude,
+        longitude, and altitude.
       properties:
         longitude:
           type: number
@@ -675,7 +862,10 @@ components:
           description: The organisation that issued this identifier
     LegalEntity:
       type: object
-      description: 'Legal entity information for this business partner data. Every business partner either is a legal entity or belongs to a legal entity.There, a legal entity property is not allowed to be ''null''. '
+      description: >-
+        Legal entity information for this business partner data. Every business
+        partner either is a legal entity or belongs to a legal entity.There, a
+        legal entity property is not allowed to be 'null'.
       properties:
         bpnReference:
           $ref: '#/components/schemas/BpnReference'
@@ -700,12 +890,17 @@ components:
             $ref: '#/components/schemas/BusinessState'
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteria'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Whether this legal entity is part of the Catena-X network
+          description: Whether this legal entity is part of the Data Space network
         hasChanged:
           type: boolean
-          description: Whether this legal entity information differs from its golden record counterpart in the Pool. +The Pool will not update the legal entity if it is set to false. However, if this legal entity constitutes a new legal entity golden record, it is still created independent of this flag.
+          description: >-
+            Whether this legal entity information differs from its golden record
+            counterpart in the Pool. +The Pool will not update the legal entity
+            if it is set to false. However, if this legal entity constitutes a
+            new legal entity golden record, it is still created independent of
+            this flag.
         legalAddress:
           $ref: '#/components/schemas/PostalAddress'
       required:
@@ -741,57 +936,90 @@ components:
         - type
     PhysicalAddress:
       type: object
-      description: A physical postal address describes the physical location of an office, warehouse, gate, etc.
+      description: >-
+        A physical postal address describes the physical location of an office,
+        warehouse, gate, etc.
       properties:
         geographicCoordinates:
           $ref: '#/components/schemas/GeoCoordinate'
         country:
           type: string
-          description: The 2-digit country code of the physical postal address according to ISO 3166-1.
+          description: >-
+            The 2-digit country code of the physical postal address according to
+            ISO 3166-1.
         administrativeAreaLevel1:
           type: string
-          description: The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country.
+          description: >-
+            The 2-digit country subdivision code according to ISO 3166-2, such
+            as a region within a country.
         administrativeAreaLevel2:
           type: string
-          description: The name of the locally regulated secondary country subdivision of the physical postal address, such as county within a country.
+          description: >-
+            The name of the locally regulated secondary country subdivision of
+            the physical postal address, such as county within a country.
         administrativeAreaLevel3:
           type: string
-          description: The name of the locally regulated tertiary country subdivision of the physical address, such as townships within a country.
+          description: >-
+            The name of the locally regulated tertiary country subdivision of
+            the physical address, such as townships within a country.
         postalCode:
           type: string
-          description: The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code.
+          description: >-
+            The alphanumeric identifier (sometimes including spaces or
+            punctuation) of the physical postal address for the purpose of
+            sorting mail, synonyms:postcode, post code, PIN or ZIP code.
         city:
           type: string
-          description: 'The name of the city of the physical postal address, synonyms: town, village, municipality.'
+          description: >-
+            The name of the city of the physical postal address, synonyms: town,
+            village, municipality.
         district:
           type: string
-          description: The name of the district of the physical postal address which divides the city in several smaller areas.
+          description: >-
+            The name of the district of the physical postal address which
+            divides the city in several smaller areas.
         street:
           $ref: '#/components/schemas/Street'
         companyPostalCode:
           type: string
-          description: The company postal code of the physical postal address, which is sometimes required for large companies.
+          description: >-
+            The company postal code of the physical postal address, which is
+            sometimes required for large companies.
         industrialZone:
           type: string
-          description: 'The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area.'
+          description: >-
+            The industrial zone of the physical postal address, designating an
+            area for industrial development, synonym: industrial area.
         building:
           type: string
-          description: The alphanumeric identifier of the building addressed by the physical postal address.
+          description: >-
+            The alphanumeric identifier of the building addressed by the
+            physical postal address.
         floor:
           type: string
-          description: 'The number of a floor in the building addressed by the physical postal address, synonym: level.'
+          description: >-
+            The number of a floor in the building addressed by the physical
+            postal address, synonym: level.
         door:
           type: string
-          description: 'The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite.'
+          description: >-
+            The number of a door in the building on the respective floor
+            addressed by the physical postal address, synonyms: room, suite.
         taxJurisdictionCode:
           type: string
-          description: Tax jurisdiction codes are used to identify the specific jurisdiction(s) that a company belong to, particularly in bureaucratic processes such as tax returns and IRS forms.
+          description: >-
+            Tax jurisdiction codes are used to identify the specific
+            jurisdiction(s) that a company belong to, particularly in
+            bureaucratic processes such as tax returns and IRS forms.
       required:
         - geographicCoordinates
         - street
     PostalAddress:
       type: object
-      description: Address information of this business partner data. The address can be either a legal, site main and/or additional address. This can also refer to address information which is unknown to which type it belongs to.
+      description: >-
+        Address information of this business partner data. The address can be
+        either a legal, site main and/or additional address. This can also refer
+        to address information which is unknown to which type it belongs to.
       properties:
         bpnReference:
           $ref: '#/components/schemas/BpnReference'
@@ -817,7 +1045,10 @@ components:
         hasChanged:
           type: boolean
           deprecated: true
-          description: Whether this address information differs from its golden record counterpart in the Pool.Currently deprecated and ignored by the golden record creation and update process.
+          description: >-
+            Whether this address information differs from its golden record
+            counterpart in the Pool.Currently deprecated and ignored by the
+            golden record creation and update process.
       required:
         - bpnReference
         - confidenceCriteria
@@ -826,7 +1057,9 @@ components:
         - states
     Site:
       type: object
-      description: Site information for this business partner data. A site of 'null' means the business partner data has no site.
+      description: >-
+        Site information for this business partner data. A site of 'null' means
+        the business partner data has no site.
       properties:
         bpnReference:
           $ref: '#/components/schemas/BpnReference'
@@ -842,12 +1075,18 @@ components:
           $ref: '#/components/schemas/ConfidenceCriteria'
         hasChanged:
           type: boolean
-          description: Whether this site information differs from its golden record counterpart in the Pool. +The Pool will not update the site if it is set to false. However, if this site constitutes a new site golden record, it is still created independent of this flag.
+          description: >-
+            Whether this site information differs from its golden record
+            counterpart in the Pool. +The Pool will not update the site if it is
+            set to false. However, if this site constitutes a new site golden
+            record, it is still created independent of this flag.
         siteMainAddress:
           $ref: '#/components/schemas/PostalAddress'
         siteMainIsLegalAddress:
           type: boolean
-          description: This site's main address is the legal address of the legal entity. The address information therefore is stored in the legal address.
+          description: >-
+            This site's main address is the legal address of the legal entity.
+            The address information therefore is stored in the legal address.
       required:
         - bpnReference
         - confidenceCriteria
@@ -855,44 +1094,65 @@ components:
         - states
     Street:
       type: object
-      description: 'The street of the physical postal address, synonyms: road, avenue, lane, boulevard, highway'
+      description: >-
+        The street of the physical postal address, synonyms: road, avenue, lane,
+        boulevard, highway
       properties:
         name:
           type: string
           description: The name of the street.
         houseNumber:
           type: string
-          description: The number representing the exact location of a building within the street.
+          description: >-
+            The number representing the exact location of a building within the
+            street.
         houseNumberSupplement:
           type: string
           description: The supplement to the house number
         milestone:
           type: string
-          description: The number representing the exact location of an addressed object within a street without house numbers, such as within long roads.
+          description: >-
+            The number representing the exact location of an addressed object
+            within a street without house numbers, such as within long roads.
         direction:
           type: string
-          description: The cardinal direction describing where the exit to the location of the addressed object on large highways / motorways is located, such as Highway 101 South.
+          description: >-
+            The cardinal direction describing where the exit to the location of
+            the addressed object on large highways / motorways is located, such
+            as Highway 101 South.
         namePrefix:
           type: string
-          description: The street related information, which is usually printed before the official street name on an address label.
+          description: >-
+            The street related information, which is usually printed before the
+            official street name on an address label.
         additionalNamePrefix:
           type: string
-          description: The additional street related information, which is usually printed before the official street name on an address label.
+          description: >-
+            The additional street related information, which is usually printed
+            before the official street name on an address label.
         nameSuffix:
           type: string
-          description: The street related information, which is usually printed after the official street name on an address label.
+          description: >-
+            The street related information, which is usually printed after the
+            official street name on an address label.
         additionalNameSuffix:
           type: string
-          description: The additional street related information, which is usually printed after the official street name on an address label.
+          description: >-
+            The additional street related information, which is usually printed
+            after the official street name on an address label.
     TaskClientRelationsStateDto:
       type: object
-      description: The golden record task's processing state together with optional business partner relationship data in case processing is done
+      description: >-
+        The golden record task's processing state together with optional
+        business partner relationship data in case processing is done
       properties:
         taskId:
           type: string
         recordId:
           type: string
-          description: The identifier of the gate record for which this task has been created
+          description: >-
+            The identifier of the gate record for which this task has been
+            created
         businessPartnerRelationsResult:
           $ref: '#/components/schemas/BusinessPartnerRelations'
         processingState:
@@ -904,13 +1164,17 @@ components:
         - taskId
     TaskClientStateDto:
       type: object
-      description: The golden record task's processing state together with optional business partner data in case processing is done
+      description: >-
+        The golden record task's processing state together with optional
+        business partner data in case processing is done
       properties:
         taskId:
           type: string
         recordId:
           type: string
-          description: The identifier of the gate record for which this task has been created
+          description: >-
+            The identifier of the gate record for which this task has been
+            created
         businessPartnerResult:
           $ref: '#/components/schemas/BusinessPartner'
         processingState:
@@ -922,11 +1186,15 @@ components:
         - taskId
     TaskCreateRelationsRequest:
       type: object
-      description: Request object to specify for which business partner relationship data tasks should be created and in which mode
+      description: >-
+        Request object to specify for which business partner relationship data
+        tasks should be created and in which mode
       properties:
         mode:
           type: string
-          description: The mode affecting which processing steps the business partner relation goes through
+          description: >-
+            The mode affecting which processing steps the business partner
+            relation goes through
           enum:
             - UpdateFromSharingMember
             - UpdateFromPool
@@ -942,7 +1210,9 @@ components:
       properties:
         recordId:
           type: string
-          description: The unique identifier for this record which was previously issued by the Orchestrator
+          description: >-
+            The unique identifier for this record which was previously issued by
+            the Orchestrator
         businessPartnerRelations:
           $ref: '#/components/schemas/BusinessPartnerRelations'
           description: The business partner relationship data to be processed
@@ -960,11 +1230,15 @@ components:
         - createdTasks
     TaskCreateRequest:
       type: object
-      description: Request object to specify for which business partner data tasks should be created and in which mode
+      description: >-
+        Request object to specify for which business partner data tasks should
+        be created and in which mode
       properties:
         mode:
           type: string
-          description: The mode affecting which processing steps the business partner goes through
+          description: >-
+            The mode affecting which processing steps the business partner goes
+            through
           enum:
             - UpdateFromSharingMember
             - UpdateFromPool
@@ -980,7 +1254,9 @@ components:
       properties:
         recordId:
           type: string
-          description: The unique identifier for this record which was previously issued by the Orchestrator
+          description: >-
+            The unique identifier for this record which was previously issued by
+            the Orchestrator
         businessPartner:
           $ref: '#/components/schemas/BusinessPartner'
           description: The business partner data to be processed
@@ -1003,14 +1279,27 @@ components:
       properties:
         type:
           type: string
-          description: |
+          description: >
             The type of error that occurred. 
-            * `NaturalPersonError`: The provided record contains natural person information.
-            * `BpnErrorNotFound`: The provided record can not be matched to a legal entity or an address.
-            * `BpnErrorTooManyOptions`: The provided record can not link to a clear legal entity.
-            * `MandatoryFieldValidationFailed`: The provided record does not fulfill mandatory validation rules.
-            * `BlacklistCountryPresent`: The provided record is part of a country that is not allowed to be processed by the GR process (example: Brazil).
-            * `UnknownSpecialCharacters`: The provided record contains unallowed special characters.
+
+            * `NaturalPersonError`: The provided record contains natural person
+            information.
+
+            * `BpnErrorNotFound`: The provided record can not be matched to a
+            legal entity or an address.
+
+            * `BpnErrorTooManyOptions`: The provided record can not link to a
+            clear legal entity.
+
+            * `MandatoryFieldValidationFailed`: The provided record does not
+            fulfill mandatory validation rules.
+
+            * `BlacklistCountryPresent`: The provided record is part of a
+            country that is not allowed to be processed by the GR process
+            (example: Brazil).
+
+            * `UnknownSpecialCharacters`: The provided record contains unallowed
+            special characters.
           enum:
             - Timeout
             - Unspecified
@@ -1028,7 +1317,9 @@ components:
         - type
     TaskProcessingRelationsStateDto:
       type: object
-      description: Contains detailed information about the current processing state of a relations golden record task
+      description: >-
+        Contains detailed information about the current processing state of a
+        relations golden record task
       properties:
         resultState:
           type: string
@@ -1054,7 +1345,9 @@ components:
             - Error
         errors:
           type: array
-          description: The actual errors that happened during processing if the task has an error result state. The errors refer to the latest step.
+          description: >-
+            The actual errors that happened during processing if the task has an
+            error result state. The errors refer to the latest step.
           items:
             $ref: '#/components/schemas/TaskRelationsErrorDto'
         createdAt:
@@ -1080,7 +1373,9 @@ components:
         - timeout
     TaskProcessingStateDto:
       type: object
-      description: Contains detailed information about the current processing state of a golden record task
+      description: >-
+        Contains detailed information about the current processing state of a
+        golden record task
       properties:
         resultState:
           type: string
@@ -1106,7 +1401,9 @@ components:
             - Error
         errors:
           type: array
-          description: The actual errors that happened during processing if the task has an error result state. The errors refer to the latest step.
+          description: >-
+            The actual errors that happened during processing if the task has an
+            error result state. The errors refer to the latest step.
           items:
             $ref: '#/components/schemas/TaskErrorDto'
         createdAt:
@@ -1166,7 +1463,9 @@ components:
           description: The identifier of the reserved task
         recordId:
           type: string
-          description: The identifier of the gate record for which this task has been created
+          description: >-
+            The identifier of the gate record for which this task has been
+            created
         businessPartnerRelations:
           $ref: '#/components/schemas/BusinessPartnerRelations'
           description: The business partner relations data to process
@@ -1186,7 +1485,9 @@ components:
           type: string
           format: date-time
           deprecated: true
-          description: The timestamp until the reservation is valid and results are accepted
+          description: >-
+            The timestamp until the reservation is valid and results are
+            accepted
       required:
         - reservedTasks
         - timeout
@@ -1199,7 +1500,9 @@ components:
           description: The identifier of the task for which this is a result
         businessPartnerRelations:
           $ref: '#/components/schemas/BusinessPartnerRelations'
-          description: The actual result in form of business partner relations data. Maybe null if an error occurred during processing of this task.
+          description: >-
+            The actual result in form of business partner relations data. Maybe
+            null if an error occurred during processing of this task.
         errors:
           type: array
           items:
@@ -1250,7 +1553,9 @@ components:
         - resultStates
     TaskStateRequest:
       type: object
-      description: Request object for giving a list of task identifiers to search for the state of tasks
+      description: >-
+        Request object for giving a list of task identifiers to search for the
+        state of tasks
       properties:
         entries:
           type: array
@@ -1277,7 +1582,9 @@ components:
           description: The identifier of the reserved task
         recordId:
           type: string
-          description: The identifier of the gate record for which this task has been created
+          description: >-
+            The identifier of the gate record for which this task has been
+            created
         businessPartner:
           $ref: '#/components/schemas/BusinessPartner'
           description: The business partner data to process
@@ -1295,7 +1602,9 @@ components:
         amount:
           type: integer
           format: int32
-          description: The maximum number of tasks to reserve. Can be fewer if queue is not full enough.
+          description: >-
+            The maximum number of tasks to reserve. Can be fewer if queue is not
+            full enough.
         step:
           type: string
           description: The step queue to reserve from
@@ -1318,7 +1627,9 @@ components:
           type: string
           format: date-time
           deprecated: true
-          description: The timestamp until the reservation is valid and results are accepted
+          description: >-
+            The timestamp until the reservation is valid and results are
+            accepted
       required:
         - reservedTasks
         - timeout
@@ -1331,7 +1642,9 @@ components:
           description: The identifier of the task for which this is a result
         businessPartner:
           $ref: '#/components/schemas/BusinessPartner'
-          description: The actual result in form of business partner data. Maybe null if an error occurred during processing of this task.
+          description: >-
+            The actual result in form of business partner data. Maybe null if an
+            error occurred during processing of this task.
         errors:
           type: array
           items:
@@ -1364,22 +1677,30 @@ components:
       properties:
         nameParts:
           type: array
-          description: The plain uncategorized name of the business partner how it appears in the sharing member system
+          description: >-
+            The plain uncategorized name of the business partner how it appears
+            in the sharing member system
           items:
             type: string
         identifiers:
           type: array
-          description: Identifiers for which it is unknown whether they belong to the legal entity, site or any address
+          description: >-
+            Identifiers for which it is unknown whether they belong to the legal
+            entity, site or any address
           items:
             $ref: '#/components/schemas/Identifier'
         states:
           type: array
-          description: Business states for which it is unknown whether they belong to the legal entity, site or any address
+          description: >-
+            Business states for which it is unknown whether they belong to the
+            legal entity, site or any address
           items:
             $ref: '#/components/schemas/BusinessState'
         address:
           $ref: '#/components/schemas/PostalAddress'
-          description: Address information for which it is unknown whether they belong to the legal, site main or additional address
+          description: >-
+            Address information for which it is unknown whether they belong to
+            the legal, site main or additional address
       required:
         - identifiers
         - nameParts
@@ -1389,12 +1710,15 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
+          tokenUrl: >-
+            http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
           scopes: {}
         authorizationCode:
           authorizationUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/auth
-          tokenUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
-          refreshUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
+          tokenUrl: >-
+            http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
+          refreshUrl: >-
+            http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
           scopes: {}
     bearer_scheme:
       type: http

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -172,145 +172,7 @@
         }
       }
     },
-    "/v6/sites" : {
-      "get" : {
-        "tags" : [ "Site Controller" ],
-        "summary" : "Get page of sites matching the pagination search criteria",
-        "description" : "This endpoint retrieves all existing business partners of type sites.",
-        "operationId" : "getSites_1",
-        "parameters" : [ {
-          "name" : "siteBpns",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "legalEntityBpns",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "name",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Page of business partners matching the search criteria, may be empty",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed pagination request"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "Site Controller" ],
-        "summary" : "Updates an existing site",
-        "description" : "Update existing business partner records of type site referenced via BPNS. The endpoint expects to receive the full updated record, including values that didn't change.",
-        "operationId" : "updateSite_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/components/schemas/SitePartnerUpdateRequest"
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Update sites request was processed successfully, possible errors are returned",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SitePartnerUpdateResponseWrapper"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed requests"
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Site Controller" ],
-        "summary" : "Creates a new site",
-        "description" : "Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
-        "operationId" : "createSite_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/components/schemas/SitePartnerCreateRequest"
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "New sites request was processed successfully, possible errors are returned",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SitePartnerCreateResponseWrapper"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed requests"
-          }
-        }
-      }
-    },
-    "/v6/legal-entities" : {
+    "/v7/legal-entities" : {
       "get" : {
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns legal entities by different search parameters",
@@ -438,137 +300,9 @@
         }
       }
     },
-    "/v7/legal-entities" : {
+    "/v7/data-space-participants" : {
       "get" : {
-        "tags" : [ "Legal Entity Controller" ],
-        "summary" : "Returns legal entities by different search parameters",
-        "description" : "This endpoint tries to find matches among all existing business partners of type legal entity, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. ",
-        "operationId" : "getLegalEntities_1",
-        "parameters" : [ {
-          "name" : "bpnLs",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "legalName",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Page of business partners matching the search criteria, may be empty",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed search or pagination request"
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "Legal Entity Controller" ],
-        "summary" : "Updates an existing legal entity",
-        "description" : "Update existing business partner records of type legal entity referenced via BPNL. The endpoint expects to receive the full updated record, including values that didn't change.",
-        "operationId" : "updateBusinessPartners_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/components/schemas/LegalEntityPartnerUpdateRequest"
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Update legal entities request was processed successfully, possible errors are returned",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LegalEntityPartnerUpdateResponseWrapper"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed requests"
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Legal Entity Controller" ],
-        "summary" : "Creates a new legal entity",
-        "description" : "Create new business partners of type legal entity. The given additional identifiers of a record need to be unique, otherwise they are ignored. For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
-        "operationId" : "createBusinessPartners_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/components/schemas/LegalEntityPartnerCreateRequest"
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "New legal entities request was processed successfully, possible errors are returned",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LegalEntityPartnerCreateResponseWrapper"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed requests"
-          }
-        }
-      }
-    },
-    "/v7/cx-memberships" : {
-      "get" : {
-        "tags" : [ "cx-membership-controller" ],
+        "tags" : [ "data-space-participants-controller" ],
         "operationId" : "get",
         "parameters" : [ {
           "name" : "bpnLs",
@@ -606,7 +340,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoCxMembershipDto"
+                  "$ref" : "#/components/schemas/PageDtoDataSpaceParticipantDto"
                 }
               }
             }
@@ -614,13 +348,13 @@
         }
       },
       "put" : {
-        "tags" : [ "cx-membership-controller" ],
+        "tags" : [ "data-space-participants-controller" ],
         "operationId" : "put",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CxMembershipUpdateRequest"
+                "$ref" : "#/components/schemas/DataSpaceParticipantUpdateRequest"
               }
             }
           },
@@ -633,74 +367,7 @@
         }
       }
     },
-    "/v6/cx-memberships" : {
-      "get" : {
-        "tags" : [ "cx-membership-controller" ],
-        "operationId" : "get_1",
-        "parameters" : [ {
-          "name" : "bpnLs",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoCxMembershipDto"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put" : {
-        "tags" : [ "cx-membership-controller" ],
-        "operationId" : "put_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CxMembershipUpdateRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          }
-        }
-      }
-    },
-    "/v6/addresses" : {
+    "/v7/addresses" : {
       "get" : {
         "tags" : [ "Address Controller" ],
         "summary" : "Returns addresses by different search parameters",
@@ -848,7 +515,340 @@
         }
       }
     },
-    "/v7/addresses" : {
+    "/v6/sites" : {
+      "get" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Get page of sites matching the pagination search criteria",
+        "description" : "This endpoint retrieves all existing business partners of type sites.",
+        "operationId" : "getSites_1",
+        "parameters" : [ {
+          "name" : "siteBpns",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "legalEntityBpns",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of business partners matching the search criteria, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Updates an existing site",
+        "description" : "Update existing business partner records of type site referenced via BPNS. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId" : "updateSite_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/SitePartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Update sites request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SitePartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Creates a new site",
+        "description" : "Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId" : "createSite_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/SitePartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New sites request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SitePartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      }
+    },
+    "/v6/legal-entities" : {
+      "get" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns legal entities by different search parameters",
+        "description" : "This endpoint tries to find matches among all existing business partners of type legal entity, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. ",
+        "operationId" : "getLegalEntities_1",
+        "parameters" : [ {
+          "name" : "bpnLs",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "legalName",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of business partners matching the search criteria, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed search or pagination request"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Updates an existing legal entity",
+        "description" : "Update existing business partner records of type legal entity referenced via BPNL. The endpoint expects to receive the full updated record, including values that didn't change.",
+        "operationId" : "updateBusinessPartners_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerUpdateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Update legal entities request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerUpdateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Creates a new legal entity",
+        "description" : "Create new business partners of type legal entity. The given additional identifiers of a record need to be unique, otherwise they are ignored. For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.",
+        "operationId" : "createBusinessPartners_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerCreateRequest"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New legal entities request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalEntityPartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed requests"
+          }
+        }
+      }
+    },
+    "/v6/cx-memberships" : {
+      "get" : {
+        "tags" : [ "cx-membership-controller" ],
+        "operationId" : "get_1",
+        "parameters" : [ {
+          "name" : "bpnLs",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoCxMembershipDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "cx-membership-controller" ],
+        "operationId" : "put_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CxMembershipUpdateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      }
+    },
+    "/v6/addresses" : {
       "get" : {
         "tags" : [ "Address Controller" ],
         "summary" : "Returns addresses by different search parameters",
@@ -996,7 +996,7 @@
         }
       }
     },
-    "/v6/sites/search" : {
+    "/v7/sites/search" : {
       "post" : {
         "tags" : [ "Site Controller" ],
         "summary" : "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
@@ -1049,60 +1049,7 @@
         }
       }
     },
-    "/v7/sites/search" : {
-      "post" : {
-        "tags" : [ "Site Controller" ],
-        "summary" : "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
-        "description" : "Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities",
-        "operationId" : "postSiteSearch_1",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SiteSearchRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Found sites that belong to specified legal entites",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed request parameters"
-          }
-        }
-      }
-    },
-    "/v6/sites/legal-main-sites" : {
+    "/v7/sites/legal-main-sites" : {
       "post" : {
         "tags" : [ "Site Controller" ],
         "summary" : "Create a new site with legal entity reference",
@@ -1138,46 +1085,10 @@
         }
       }
     },
-    "/v7/sites/legal-main-sites" : {
+    "/v7/participants/sites/search" : {
       "post" : {
         "tags" : [ "Site Controller" ],
-        "summary" : "Create a new site with legal entity reference",
-        "description" : "Create a business partner site with the given legal entity reference. It will designate the address information as both legal and site main address.",
-        "operationId" : "createSiteWithLegalReference_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/components/schemas/SiteCreateRequestWithLegalAddressAsMain"
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "New sites request was processed successfully, possible errors are returned",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SitePartnerCreateResponseWrapper"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed pagination request"
-          }
-        }
-      }
-    },
-    "/v7/members/sites/search" : {
-      "post" : {
-        "tags" : [ "Site Controller" ],
-        "operationId" : "postSiteSearch_2",
+        "operationId" : "postSiteSearch_1",
         "parameters" : [ {
           "name" : "page",
           "in" : "query",
@@ -1222,55 +1133,7 @@
         }
       }
     },
-    "/v6/members/sites/search" : {
-      "post" : {
-        "tags" : [ "Site Controller" ],
-        "operationId" : "postSiteSearch_3",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SiteSearchRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v7/members/legal-entities/search" : {
+    "/v7/participants/legal-entities/search" : {
       "post" : {
         "tags" : [ "Legal Entity Controller" ],
         "operationId" : "searchLegalEntities",
@@ -1318,55 +1181,7 @@
         }
       }
     },
-    "/v6/members/legal-entities/search" : {
-      "post" : {
-        "tags" : [ "Legal Entity Controller" ],
-        "operationId" : "searchLegalEntities_1",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/LegalEntitySearchRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v7/members/changelog/search" : {
+    "/v7/participants/changelog/search" : {
       "post" : {
         "tags" : [ "Changelog Controller" ],
         "operationId" : "searchChangelogEntries",
@@ -1414,55 +1229,7 @@
         }
       }
     },
-    "/v6/members/changelog/search" : {
-      "post" : {
-        "tags" : [ "Changelog Controller" ],
-        "operationId" : "searchChangelogEntries_1",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ChangelogSearchRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoChangelogEntryVerboseDto"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v6/members/addresses/search" : {
+    "/v7/participants/addresses/search" : {
       "post" : {
         "tags" : [ "Address Controller" ],
         "operationId" : "searchAddresses",
@@ -1510,55 +1277,7 @@
         }
       }
     },
-    "/v7/members/addresses/search" : {
-      "post" : {
-        "tags" : [ "Address Controller" ],
-        "operationId" : "searchAddresses_1",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AddressSearchRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v6/legal-forms" : {
+    "/v7/legal-forms" : {
       "get" : {
         "tags" : [ "Metadata Controller" ],
         "summary" : "Returns all legal forms",
@@ -1635,142 +1354,12 @@
         }
       }
     },
-    "/v7/legal-forms" : {
-      "get" : {
-        "tags" : [ "Metadata Controller" ],
-        "summary" : "Returns all legal forms",
-        "description" : "Lists all currently known legal forms in a paginated result",
-        "operationId" : "getLegalForms_1",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Page of existing legal forms, may be empty",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoLegalFormDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed request parameters"
-          }
-        }
-      },
-      "post" : {
-        "tags" : [ "Metadata Controller" ],
-        "summary" : "Creates a new legal form",
-        "description" : "Create a new legal form which can be referenced by business partner records. The actual name of the legal form is free to choose and doesn't need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.",
-        "operationId" : "createLegalForm_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/LegalFormRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "New legal form successfully created",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LegalFormDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed request parameters"
-          },
-          "409" : {
-            "description" : "Legal form with specified technical key already exists"
-          }
-        }
-      }
-    },
-    "/v6/legal-entities/search" : {
-      "post" : {
-        "tags" : [ "Legal Entity Controller" ],
-        "summary" : "Returns legal entities by different search parameters",
-        "description" : "Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
-        "operationId" : "postLegalEntitySearch",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/LegalEntitySearchRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Found legal entites",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed request parameters or if number of requested bpns exceeds limit"
-          }
-        }
-      }
-    },
     "/v7/legal-entities/search" : {
       "post" : {
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns legal entities by different search parameters",
         "description" : "Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
-        "operationId" : "postLegalEntitySearch_1",
+        "operationId" : "postLegalEntitySearch",
         "parameters" : [ {
           "name" : "page",
           "in" : "query",
@@ -1908,6 +1497,470 @@
           },
           "409" : {
             "description" : "Identifier type with specified technical key already exists"
+          }
+        }
+      }
+    },
+    "/v7/addresses/search" : {
+      "post" : {
+        "tags" : [ "Address Controller" ],
+        "summary" : "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
+        "description" : "Search business partners of type address by their BPNA or their parents' BPNL or BPNS.",
+        "operationId" : "searchAddresses_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AddressSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found sites for the specified sites and legal entities",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/v6/sites/search" : {
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Returns sites by an array of BPNS and/or an array of corresponding BPNL",
+        "description" : "Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities",
+        "operationId" : "postSiteSearch_2",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SiteSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found sites that belong to specified legal entites",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          }
+        }
+      }
+    },
+    "/v6/sites/legal-main-sites" : {
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Create a new site with legal entity reference",
+        "description" : "Create a business partner site with the given legal entity reference. It will designate the address information as both legal and site main address.",
+        "operationId" : "createSiteWithLegalReference_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/SiteCreateRequestWithLegalAddressAsMain"
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New sites request was processed successfully, possible errors are returned",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SitePartnerCreateResponseWrapper"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          }
+        }
+      }
+    },
+    "/v6/members/sites/search" : {
+      "post" : {
+        "tags" : [ "Site Controller" ],
+        "operationId" : "postSiteSearch_3",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SiteSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoSiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v6/members/legal-entities/search" : {
+      "post" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "operationId" : "searchLegalEntities_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LegalEntitySearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v6/members/changelog/search" : {
+      "post" : {
+        "tags" : [ "Changelog Controller" ],
+        "operationId" : "searchChangelogEntries_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ChangelogSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoChangelogEntryVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v6/members/addresses/search" : {
+      "post" : {
+        "tags" : [ "Address Controller" ],
+        "operationId" : "searchAddresses_2",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/AddressSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v6/legal-forms" : {
+      "get" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Returns all legal forms",
+        "description" : "Lists all currently known legal forms in a paginated result",
+        "operationId" : "getLegalForms_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Page of existing legal forms, may be empty",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalFormDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Metadata Controller" ],
+        "summary" : "Creates a new legal form",
+        "description" : "Create a new legal form which can be referenced by business partner records. The actual name of the legal form is free to choose and doesn't need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.",
+        "operationId" : "createLegalForm_1",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LegalFormRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "New legal form successfully created",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalFormDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "409" : {
+            "description" : "Legal form with specified technical key already exists"
+          }
+        }
+      }
+    },
+    "/v6/legal-entities/search" : {
+      "post" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns legal entities by different search parameters",
+        "description" : "Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.",
+        "operationId" : "postLegalEntitySearch_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/LegalEntitySearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Found legal entites",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters or if number of requested bpns exceeds limit"
           }
         }
       }
@@ -2269,59 +2322,6 @@
         "tags" : [ "Address Controller" ],
         "summary" : "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
         "description" : "Search business partners of type address by their BPNA or their parents' BPNL or BPNS.",
-        "operationId" : "searchAddresses_2",
-        "parameters" : [ {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AddressSearchRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Found sites for the specified sites and legal entities",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed pagination request"
-          }
-        }
-      }
-    },
-    "/v7/addresses/search" : {
-      "post" : {
-        "tags" : [ "Address Controller" ],
-        "summary" : "Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.",
-        "description" : "Search business partners of type address by their BPNA or their parents' BPNL or BPNS.",
         "operationId" : "searchAddresses_3",
         "parameters" : [ {
           "name" : "page",
@@ -2405,42 +2405,7 @@
         }
       }
     },
-    "/v6/sites/{bpns}" : {
-      "get" : {
-        "tags" : [ "Site Controller" ],
-        "summary" : "Returns a site by its BPNS",
-        "description" : "Get business partners of type site by BPNS ignoring case.",
-        "operationId" : "getSite_1",
-        "parameters" : [ {
-          "name" : "bpns",
-          "in" : "path",
-          "description" : "BPNS value",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Found site with specified BPNS",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SiteWithMainAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed request parameters"
-          },
-          "404" : {
-            "description" : "No site found under specified BPNS"
-          }
-        }
-      }
-    },
-    "/v6/legal-entities/{idValue}" : {
+    "/v7/legal-entities/{idValue}" : {
       "get" : {
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
@@ -2483,50 +2448,7 @@
         }
       }
     },
-    "/v7/legal-entities/{idValue}" : {
-      "get" : {
-        "tags" : [ "Legal Entity Controller" ],
-        "summary" : "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
-        "description" : "This endpoint tries to find a business partner by the specified identifier. The identifier value is case insensitively compared but needs to be given exactly. By default the value given is interpreted as a BPN. By specifying the technical key of another identifier typethe value is matched against the identifiers of that given type.",
-        "operationId" : "getLegalEntity_1",
-        "parameters" : [ {
-          "name" : "idValue",
-          "in" : "path",
-          "description" : "Identifier value",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "idType",
-          "in" : "query",
-          "description" : "Type of identifier to use, defaults to BPN when omitted",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Found business partner with specified identifier",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LegalEntityWithLegalAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed request parameters"
-          },
-          "404" : {
-            "description" : "No business partner found under specified identifier or specified identifier type not found"
-          }
-        }
-      }
-    },
-    "/v6/legal-entities/{bpnl}/sites" : {
+    "/v7/legal-entities/{bpnl}/sites" : {
       "get" : {
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns all sites of a legal entity with a specific BPNL",
@@ -2580,7 +2502,174 @@
         }
       }
     },
-    "/v7/legal-entities/{bpnl}/sites" : {
+    "/v7/legal-entities/{bpnl}/addresses" : {
+      "get" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns all addresses of a legal entity with a specific BPNL",
+        "description" : "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.",
+        "operationId" : "getAddresses_2",
+        "parameters" : [ {
+          "name" : "bpnl",
+          "in" : "path",
+          "description" : "BPNL value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Number of page to get results from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "minimum" : 0
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "Size of each page",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "maximum" : 100,
+            "minimum" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The addresses for the specified BPNL",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed pagination request"
+          },
+          "404" : {
+            "description" : "No business partner found for specified BPNL"
+          }
+        }
+      }
+    },
+    "/v7/addresses/{bpna}" : {
+      "get" : {
+        "tags" : [ "Address Controller" ],
+        "summary" : "Returns an address by its BPNA",
+        "description" : "Get business partners of type address by BPNA ignoring case.",
+        "operationId" : "getAddress",
+        "parameters" : [ {
+          "name" : "bpna",
+          "in" : "path",
+          "description" : "BPNA value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Found address with specified BPNA",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LogisticAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "404" : {
+            "description" : "No address found under specified BPNA"
+          }
+        }
+      }
+    },
+    "/v6/sites/{bpns}" : {
+      "get" : {
+        "tags" : [ "Site Controller" ],
+        "summary" : "Returns a site by its BPNS",
+        "description" : "Get business partners of type site by BPNS ignoring case.",
+        "operationId" : "getSite_1",
+        "parameters" : [ {
+          "name" : "bpns",
+          "in" : "path",
+          "description" : "BPNS value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Found site with specified BPNS",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SiteWithMainAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "404" : {
+            "description" : "No site found under specified BPNS"
+          }
+        }
+      }
+    },
+    "/v6/legal-entities/{idValue}" : {
+      "get" : {
+        "tags" : [ "Legal Entity Controller" ],
+        "summary" : "Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type",
+        "description" : "This endpoint tries to find a business partner by the specified identifier. The identifier value is case insensitively compared but needs to be given exactly. By default the value given is interpreted as a BPN. By specifying the technical key of another identifier typethe value is matched against the identifiers of that given type.",
+        "operationId" : "getLegalEntity_1",
+        "parameters" : [ {
+          "name" : "idValue",
+          "in" : "path",
+          "description" : "Identifier value",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "idType",
+          "in" : "query",
+          "description" : "Type of identifier to use, defaults to BPN when omitted",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Found business partner with specified identifier",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalEntityWithLegalAddressVerboseDto"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "On malformed request parameters"
+          },
+          "404" : {
+            "description" : "No business partner found under specified identifier or specified identifier type not found"
+          }
+        }
+      }
+    },
+    "/v6/legal-entities/{bpnl}/sites" : {
       "get" : {
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns all sites of a legal entity with a specific BPNL",
@@ -2635,60 +2724,6 @@
       }
     },
     "/v6/legal-entities/{bpnl}/addresses" : {
-      "get" : {
-        "tags" : [ "Legal Entity Controller" ],
-        "summary" : "Returns all addresses of a legal entity with a specific BPNL",
-        "description" : "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.",
-        "operationId" : "getAddresses_2",
-        "parameters" : [ {
-          "name" : "bpnl",
-          "in" : "path",
-          "description" : "BPNL value",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Number of page to get results from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "minimum" : 0
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Size of each page",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "maximum" : 100,
-            "minimum" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "The addresses for the specified BPNL",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageDtoLogisticAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed pagination request"
-          },
-          "404" : {
-            "description" : "No business partner found for specified BPNL"
-          }
-        }
-      }
-    },
-    "/v7/legal-entities/{bpnl}/addresses" : {
       "get" : {
         "tags" : [ "Legal Entity Controller" ],
         "summary" : "Returns all addresses of a legal entity with a specific BPNL",
@@ -2905,41 +2940,6 @@
         "tags" : [ "Address Controller" ],
         "summary" : "Returns an address by its BPNA",
         "description" : "Get business partners of type address by BPNA ignoring case.",
-        "operationId" : "getAddress",
-        "parameters" : [ {
-          "name" : "bpna",
-          "in" : "path",
-          "description" : "BPNA value",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Found address with specified BPNA",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LogisticAddressVerboseDto"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "On malformed request parameters"
-          },
-          "404" : {
-            "description" : "No address found under specified BPNA"
-          }
-        }
-      }
-    },
-    "/v7/addresses/{bpna}" : {
-      "get" : {
-        "tags" : [ "Address Controller" ],
-        "summary" : "Returns an address by its BPNA",
-        "description" : "Get business partners of type address by BPNA ignoring case.",
         "operationId" : "getAddress_1",
         "parameters" : [ {
           "name" : "bpna",
@@ -3115,9 +3115,9 @@
             "type" : "string",
             "description" : "The BPNS of the site the address belongs to."
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the address is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the address is owned and thus provided by a Data Space Participant."
           },
           "createdAt" : {
             "type" : "string",
@@ -3142,7 +3142,7 @@
             "description" : "User defined index to conveniently match this entry to the corresponding entry in the response."
           }
         },
-        "required" : [ "bpna", "confidenceCriteria", "createdAt", "identifiers", "isCatenaXMemberData", "physicalPostalAddress", "states", "updatedAt" ]
+        "required" : [ "bpna", "confidenceCriteria", "createdAt", "identifiers", "isParticipantData", "physicalPostalAddress", "states", "updatedAt" ]
       },
       "AddressPartnerUpdateRequest" : {
         "type" : "object",
@@ -3531,6 +3531,30 @@
         },
         "required" : [ "memberships" ]
       },
+      "DataSpaceParticipantDto" : {
+        "type" : "object",
+        "properties" : {
+          "bpnL" : {
+            "type" : "string"
+          },
+          "isDataSpaceParticipant" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "bpnL", "isDataSpaceParticipant" ]
+      },
+      "DataSpaceParticipantUpdateRequest" : {
+        "type" : "object",
+        "properties" : {
+          "participants" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/DataSpaceParticipantDto"
+            }
+          }
+        },
+        "required" : [ "participants" ]
+      },
       "ErrorInfoAddressCreateError" : {
         "type" : "object",
         "description" : "Holds information about failures when creating or updating an entity",
@@ -3851,9 +3875,9 @@
           "confidenceCriteria" : {
             "$ref" : "#/components/schemas/ConfidenceCriteriaDto"
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the legal entity is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the legal entity is owned and thus provided by a Data Space Participant."
           },
           "legalAddress" : {
             "$ref" : "#/components/schemas/LogisticAddressDto",
@@ -3867,7 +3891,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "confidenceCriteria", "identifiers", "isCatenaXMemberData", "legalAddress", "legalName", "states" ]
+        "required" : [ "confidenceCriteria", "identifiers", "isParticipantData", "legalAddress", "legalName", "states" ]
       },
       "LegalEntityPartnerCreateResponseWrapper" : {
         "type" : "object",
@@ -3942,9 +3966,9 @@
           "confidenceCriteria" : {
             "$ref" : "#/components/schemas/ConfidenceCriteriaDto"
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the legal entity is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the legal entity is owned and thus provided by a Data Space Participant."
           },
           "createdAt" : {
             "type" : "string",
@@ -3965,7 +3989,7 @@
             "description" : "User defined index to conveniently match this entry to the corresponding entry in the response."
           }
         },
-        "required" : [ "bpnl", "confidenceCriteria", "createdAt", "currentness", "identifiers", "isCatenaXMemberData", "legalAddress", "legalName", "relations", "states", "updatedAt" ]
+        "required" : [ "bpnl", "confidenceCriteria", "createdAt", "currentness", "identifiers", "isParticipantData", "legalAddress", "legalName", "relations", "states", "updatedAt" ]
       },
       "LegalEntityPartnerUpdateRequest" : {
         "type" : "object",
@@ -4002,9 +4026,9 @@
           "confidenceCriteria" : {
             "$ref" : "#/components/schemas/ConfidenceCriteriaDto"
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the legal entity is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the legal entity is owned and thus provided by a Data Space Participant."
           },
           "legalAddress" : {
             "$ref" : "#/components/schemas/LogisticAddressDto",
@@ -4014,7 +4038,7 @@
             "type" : "string"
           }
         },
-        "required" : [ "bpnl", "confidenceCriteria", "identifiers", "isCatenaXMemberData", "legalAddress", "legalName", "requestKey", "states" ]
+        "required" : [ "bpnl", "confidenceCriteria", "identifiers", "isParticipantData", "legalAddress", "legalName", "requestKey", "states" ]
       },
       "LegalEntityPartnerUpdateResponseWrapper" : {
         "type" : "object",
@@ -4147,9 +4171,9 @@
           "confidenceCriteria" : {
             "$ref" : "#/components/schemas/ConfidenceCriteriaDto"
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the legal entity is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the legal entity is owned and thus provided by a Data Space Participant."
           },
           "createdAt" : {
             "type" : "string",
@@ -4166,7 +4190,7 @@
             "description" : "The official, legal correspondence address to be provided to government and tax authorities and used in all legal or court documents."
           }
         },
-        "required" : [ "bpnl", "confidenceCriteria", "createdAt", "currentness", "identifiers", "isCatenaXMemberData", "legalAddress", "legalName", "relations", "states", "updatedAt" ]
+        "required" : [ "bpnl", "confidenceCriteria", "createdAt", "currentness", "identifiers", "isParticipantData", "legalAddress", "legalName", "relations", "states", "updatedAt" ]
       },
       "LegalFormDto" : {
         "type" : "object",
@@ -4183,7 +4207,7 @@
           "transliteratedName" : {
             "type" : "string"
           },
-          "abbreviation" : {
+          "abbreviations" : {
             "type" : "string",
             "description" : "The abbreviated name of the legal form, such as AG for German Aktiengesellschaft."
           },
@@ -4223,7 +4247,7 @@
             "type" : "string",
             "description" : "Transliterated name of the legal form"
           },
-          "abbreviation" : {
+          "abbreviations" : {
             "type" : "string",
             "description" : "Comma separed list of abbreviations of the legal form name"
           },
@@ -4326,9 +4350,9 @@
             "type" : "string",
             "description" : "The BPNS of the site the address belongs to."
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the address is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the address is owned and thus provided by a Data Space Participant."
           },
           "createdAt" : {
             "type" : "string",
@@ -4349,7 +4373,7 @@
             "enum" : [ "LegalAndSiteMainAddress", "LegalAddress", "SiteMainAddress", "AdditionalAddress" ]
           }
         },
-        "required" : [ "bpna", "confidenceCriteria", "createdAt", "identifiers", "isCatenaXMemberData", "physicalPostalAddress", "states", "updatedAt" ]
+        "required" : [ "bpna", "confidenceCriteria", "createdAt", "identifiers", "isParticipantData", "physicalPostalAddress", "states", "updatedAt" ]
       },
       "PageDtoChangelogEntryVerboseDto" : {
         "type" : "object",
@@ -4448,6 +4472,40 @@
             "description" : "Collection of results in the page",
             "items" : {
               "$ref" : "#/components/schemas/CxMembershipDto"
+            }
+          }
+        },
+        "required" : [ "content", "contentSize", "page", "totalElements", "totalPages" ]
+      },
+      "PageDtoDataSpaceParticipantDto" : {
+        "type" : "object",
+        "description" : "Paginated collection of results",
+        "properties" : {
+          "totalElements" : {
+            "type" : "integer",
+            "format" : "int64",
+            "description" : "Total number of all results in all pages"
+          },
+          "totalPages" : {
+            "type" : "integer",
+            "format" : "int32",
+            "description" : "Total number pages"
+          },
+          "page" : {
+            "type" : "integer",
+            "format" : "int32",
+            "description" : "Current page number"
+          },
+          "contentSize" : {
+            "type" : "integer",
+            "format" : "int32",
+            "description" : "Number of results in the page"
+          },
+          "content" : {
+            "type" : "array",
+            "description" : "Collection of results in the page",
+            "items" : {
+              "$ref" : "#/components/schemas/DataSpaceParticipantDto"
             }
           }
         },
@@ -4933,9 +4991,9 @@
               "$ref" : "#/components/schemas/SiteStateVerboseDto"
             }
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the site is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the site is owned and thus provided by a Data Space Participant."
           },
           "bpnLegalEntity" : {
             "type" : "string",
@@ -4963,7 +5021,7 @@
             "description" : "User defined index to conveniently match this entry to the corresponding entry in the response."
           }
         },
-        "required" : [ "bpnLegalEntity", "bpns", "confidenceCriteria", "createdAt", "isCatenaXMemberData", "mainAddress", "name", "states", "updatedAt" ]
+        "required" : [ "bpnLegalEntity", "bpns", "confidenceCriteria", "createdAt", "isParticipantData", "mainAddress", "name", "states", "updatedAt" ]
       },
       "SitePartnerUpdateRequest" : {
         "type" : "object",
@@ -5104,9 +5162,9 @@
               "$ref" : "#/components/schemas/SiteStateVerboseDto"
             }
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the site is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the site is owned and thus provided by a Data Space Participant."
           },
           "bpnLegalEntity" : {
             "type" : "string",
@@ -5126,7 +5184,7 @@
             "$ref" : "#/components/schemas/ConfidenceCriteriaDto"
           }
         },
-        "required" : [ "bpnLegalEntity", "bpns", "confidenceCriteria", "createdAt", "isCatenaXMemberData", "name", "states", "updatedAt" ]
+        "required" : [ "bpnLegalEntity", "bpns", "confidenceCriteria", "createdAt", "isParticipantData", "name", "states", "updatedAt" ]
       },
       "SiteWithMainAddressVerboseDto" : {
         "type" : "object",
@@ -5146,9 +5204,9 @@
               "$ref" : "#/components/schemas/SiteStateVerboseDto"
             }
           },
-          "isCatenaXMemberData" : {
+          "isParticipantData" : {
             "type" : "boolean",
-            "description" : "Indicates whether the site is owned and thus provided by a Catena-X Member."
+            "description" : "Indicates whether the site is owned and thus provided by a Data Space Participant."
           },
           "bpnLegalEntity" : {
             "type" : "string",
@@ -5172,7 +5230,7 @@
             "description" : "The address, where typically the main entrance or the reception is located, or where the mail is delivered to."
           }
         },
-        "required" : [ "bpnLegalEntity", "bpns", "confidenceCriteria", "createdAt", "isCatenaXMemberData", "mainAddress", "name", "states", "updatedAt" ]
+        "required" : [ "bpnLegalEntity", "bpns", "confidenceCriteria", "createdAt", "isParticipantData", "mainAddress", "name", "states", "updatedAt" ]
       },
       "StreetDto" : {
         "type" : "object",

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -1,7 +1,9 @@
 openapi: 3.1.0
 info:
   title: Business Partner Data Management Pool
-  description: Service that manages and shares business partner data with other CatenaX services
+  description: >-
+    Service that manages and shares business partner data with other CatenaX
+    services
   version: 7.0.0-SNAPSHOT
 servers:
   - url: http://localhost:8080
@@ -15,7 +17,9 @@ tags:
   - name: Legal Entity Controller
     description: Read, create and update business partner of type legal entity
   - name: Metadata Controller
-    description: Read and create supporting data that is referencable in business partner data
+    description: >-
+      Read and create supporting data that is referencable in business partner
+      data
   - name: Site Controller
     description: Read, create and update business partner of type site
   - name: Bpn Controller
@@ -78,7 +82,10 @@ paths:
       tags:
         - Site Controller
       summary: Updates an existing site
-      description: Update existing business partner records of type site referenced via BPNS. The endpoint expects to receive the full updated record, including values that didn't change.
+      description: >-
+        Update existing business partner records of type site referenced via
+        BPNS. The endpoint expects to receive the full updated record, including
+        values that didn't change.
       operationId: updateSite
       requestBody:
         content:
@@ -90,7 +97,9 @@ paths:
         required: true
       responses:
         '200':
-          description: Update sites request was processed successfully, possible errors are returned
+          description: >-
+            Update sites request was processed successfully, possible errors are
+            returned
           content:
             application/json:
               schema:
@@ -101,7 +110,12 @@ paths:
       tags:
         - Site Controller
       summary: Creates a new site
-      description: Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
+      description: >-
+        Create new business partners of type site by specifying the BPNL of the
+        legal entity each site belongs to. If the legal entitiy cannot be found,
+        the record is ignored.For matching purposes, on each record you can
+        specify your own index value which will reappear in the corresponding
+        record of the response.
       operationId: createSite
       requestBody:
         content:
@@ -113,11 +127,286 @@ paths:
         required: true
       responses:
         '200':
-          description: New sites request was processed successfully, possible errors are returned
+          description: >-
+            New sites request was processed successfully, possible errors are
+            returned
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SitePartnerCreateResponseWrapper'
+        '400':
+          description: On malformed requests
+  /v7/legal-entities:
+    get:
+      tags:
+        - Legal Entity Controller
+      summary: Returns legal entities by different search parameters
+      description: >-
+        This endpoint tries to find matches among all existing business partners
+        of type legal entity, filtering out partners which entirely do not match
+        and ranking the remaining partners according to the accuracy of the
+        match.
+      operationId: getLegalEntities
+      parameters:
+        - name: bpnLs
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: legalName
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of business partners matching the search criteria, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto
+        '400':
+          description: On malformed search or pagination request
+    put:
+      tags:
+        - Legal Entity Controller
+      summary: Updates an existing legal entity
+      description: >-
+        Update existing business partner records of type legal entity referenced
+        via BPNL. The endpoint expects to receive the full updated record,
+        including values that didn't change.
+      operationId: updateBusinessPartners
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/LegalEntityPartnerUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: >-
+            Update legal entities request was processed successfully, possible
+            errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalEntityPartnerUpdateResponseWrapper'
+        '400':
+          description: On malformed requests
+    post:
+      tags:
+        - Legal Entity Controller
+      summary: Creates a new legal entity
+      description: >-
+        Create new business partners of type legal entity. The given additional
+        identifiers of a record need to be unique, otherwise they are ignored.
+        For matching purposes, on each record you can specify your own index
+        value which will reappear in the corresponding record of the response.
+      operationId: createBusinessPartners
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/LegalEntityPartnerCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: >-
+            New legal entities request was processed successfully, possible
+            errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalEntityPartnerCreateResponseWrapper'
+        '400':
+          description: On malformed requests
+  /v7/data-space-participants:
+    get:
+      tags:
+        - data-space-participants-controller
+      operationId: get
+      parameters:
+        - name: bpnLs
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoDataSpaceParticipantDto'
+    put:
+      tags:
+        - data-space-participants-controller
+      operationId: put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataSpaceParticipantUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+  /v7/addresses:
+    get:
+      tags:
+        - Address Controller
+      summary: Returns addresses by different search parameters
+      description: >-
+        This endpoint tries to find matches among all existing business partners
+        of type address, filtering out partners which entirely do not match and
+        ranking the remaining partners according to the accuracy of the match.
+        The match of a partner is better the higher its relevancy score.
+      operationId: getAddresses
+      parameters:
+        - name: addressBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: legalEntityBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: siteBpns
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of addresses matching the search criteria, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+        '400':
+          description: On malformed search or pagination request
+    put:
+      tags:
+        - Address Controller
+      summary: Updates an existing address
+      description: >-
+        Update existing business partner records of type address referenced via
+        BPNA. The endpoint expects to receive the full updated record, including
+        values that didn't change.
+      operationId: updateAddresses
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/AddressPartnerUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: The successfully updated records, possible errors are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddressPartnerUpdateResponseWrapper'
+        '400':
+          description: On malformed requests
+    post:
+      tags:
+        - Address Controller
+      summary: Creates a new address
+      description: >-
+        Create new business partners of type address by specifying the BPN of
+        the parent each address belongs to. A parent can be either a site or
+        legal entity business partner. If the parent cannot be found, the record
+        is ignored.For matching purposes, on each record you can specify your
+        own index value which will reappear in the corresponding record of the
+        response.
+      operationId: createAddresses
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/AddressPartnerCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: >-
+            New business partner record successfully created, possible errors
+            are returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddressPartnerCreateResponseWrapper'
         '400':
           description: On malformed requests
   /v6/sites:
@@ -175,7 +464,10 @@ paths:
       tags:
         - Site Controller
       summary: Updates an existing site
-      description: Update existing business partner records of type site referenced via BPNS. The endpoint expects to receive the full updated record, including values that didn't change.
+      description: >-
+        Update existing business partner records of type site referenced via
+        BPNS. The endpoint expects to receive the full updated record, including
+        values that didn't change.
       operationId: updateSite_1
       requestBody:
         content:
@@ -187,7 +479,9 @@ paths:
         required: true
       responses:
         '200':
-          description: Update sites request was processed successfully, possible errors are returned
+          description: >-
+            Update sites request was processed successfully, possible errors are
+            returned
           content:
             application/json:
               schema:
@@ -198,7 +492,12 @@ paths:
       tags:
         - Site Controller
       summary: Creates a new site
-      description: Create new business partners of type site by specifying the BPNL of the legal entity each site belongs to. If the legal entitiy cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
+      description: >-
+        Create new business partners of type site by specifying the BPNL of the
+        legal entity each site belongs to. If the legal entitiy cannot be found,
+        the record is ignored.For matching purposes, on each record you can
+        specify your own index value which will reappear in the corresponding
+        record of the response.
       operationId: createSite_1
       requestBody:
         content:
@@ -210,7 +509,9 @@ paths:
         required: true
       responses:
         '200':
-          description: New sites request was processed successfully, possible errors are returned
+          description: >-
+            New sites request was processed successfully, possible errors are
+            returned
           content:
             application/json:
               schema:
@@ -222,97 +523,11 @@ paths:
       tags:
         - Legal Entity Controller
       summary: Returns legal entities by different search parameters
-      description: 'This endpoint tries to find matches among all existing business partners of type legal entity, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. '
-      operationId: getLegalEntities
-      parameters:
-        - name: bpnLs
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-        - name: legalName
-          in: query
-          required: false
-          schema:
-            type: string
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      responses:
-        '200':
-          description: Page of business partners matching the search criteria, may be empty
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
-        '400':
-          description: On malformed search or pagination request
-    put:
-      tags:
-        - Legal Entity Controller
-      summary: Updates an existing legal entity
-      description: Update existing business partner records of type legal entity referenced via BPNL. The endpoint expects to receive the full updated record, including values that didn't change.
-      operationId: updateBusinessPartners
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/LegalEntityPartnerUpdateRequest'
-        required: true
-      responses:
-        '200':
-          description: Update legal entities request was processed successfully, possible errors are returned
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegalEntityPartnerUpdateResponseWrapper'
-        '400':
-          description: On malformed requests
-    post:
-      tags:
-        - Legal Entity Controller
-      summary: Creates a new legal entity
-      description: Create new business partners of type legal entity. The given additional identifiers of a record need to be unique, otherwise they are ignored. For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
-      operationId: createBusinessPartners
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/LegalEntityPartnerCreateRequest'
-        required: true
-      responses:
-        '200':
-          description: New legal entities request was processed successfully, possible errors are returned
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegalEntityPartnerCreateResponseWrapper'
-        '400':
-          description: On malformed requests
-  /v7/legal-entities:
-    get:
-      tags:
-        - Legal Entity Controller
-      summary: Returns legal entities by different search parameters
-      description: 'This endpoint tries to find matches among all existing business partners of type legal entity, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. '
+      description: >-
+        This endpoint tries to find matches among all existing business partners
+        of type legal entity, filtering out partners which entirely do not match
+        and ranking the remaining partners according to the accuracy of the
+        match.
       operationId: getLegalEntities_1
       parameters:
         - name: bpnLs
@@ -348,14 +563,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
+                $ref: >-
+                  #/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto
         '400':
           description: On malformed search or pagination request
     put:
       tags:
         - Legal Entity Controller
       summary: Updates an existing legal entity
-      description: Update existing business partner records of type legal entity referenced via BPNL. The endpoint expects to receive the full updated record, including values that didn't change.
+      description: >-
+        Update existing business partner records of type legal entity referenced
+        via BPNL. The endpoint expects to receive the full updated record,
+        including values that didn't change.
       operationId: updateBusinessPartners_1
       requestBody:
         content:
@@ -367,7 +586,9 @@ paths:
         required: true
       responses:
         '200':
-          description: Update legal entities request was processed successfully, possible errors are returned
+          description: >-
+            Update legal entities request was processed successfully, possible
+            errors are returned
           content:
             application/json:
               schema:
@@ -378,7 +599,11 @@ paths:
       tags:
         - Legal Entity Controller
       summary: Creates a new legal entity
-      description: Create new business partners of type legal entity. The given additional identifiers of a record need to be unique, otherwise they are ignored. For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
+      description: >-
+        Create new business partners of type legal entity. The given additional
+        identifiers of a record need to be unique, otherwise they are ignored.
+        For matching purposes, on each record you can specify your own index
+        value which will reappear in the corresponding record of the response.
       operationId: createBusinessPartners_1
       requestBody:
         content:
@@ -390,61 +615,15 @@ paths:
         required: true
       responses:
         '200':
-          description: New legal entities request was processed successfully, possible errors are returned
+          description: >-
+            New legal entities request was processed successfully, possible
+            errors are returned
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/LegalEntityPartnerCreateResponseWrapper'
         '400':
           description: On malformed requests
-  /v7/cx-memberships:
-    get:
-      tags:
-        - cx-membership-controller
-      operationId: get
-      parameters:
-        - name: bpnLs
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoCxMembershipDto'
-    put:
-      tags:
-        - cx-membership-controller
-      operationId: put
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CxMembershipUpdateRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
   /v6/cx-memberships:
     get:
       tags:
@@ -498,111 +677,11 @@ paths:
       tags:
         - Address Controller
       summary: Returns addresses by different search parameters
-      description: 'This endpoint tries to find matches among all existing business partners of type address, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. The match of a partner is better the higher its relevancy score. '
-      operationId: getAddresses
-      parameters:
-        - name: addressBpns
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-        - name: legalEntityBpns
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-        - name: siteBpns
-          in: query
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-        - name: name
-          in: query
-          required: false
-          schema:
-            type: string
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      responses:
-        '200':
-          description: Page of addresses matching the search criteria, may be empty
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
-        '400':
-          description: On malformed search or pagination request
-    put:
-      tags:
-        - Address Controller
-      summary: Updates an existing address
-      description: Update existing business partner records of type address referenced via BPNA. The endpoint expects to receive the full updated record, including values that didn't change.
-      operationId: updateAddresses
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/AddressPartnerUpdateRequest'
-        required: true
-      responses:
-        '200':
-          description: The successfully updated records, possible errors are returned
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AddressPartnerUpdateResponseWrapper'
-        '400':
-          description: On malformed requests
-    post:
-      tags:
-        - Address Controller
-      summary: Creates a new address
-      description: Create new business partners of type address by specifying the BPN of the parent each address belongs to. A parent can be either a site or legal entity business partner. If the parent cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
-      operationId: createAddresses
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/AddressPartnerCreateRequest'
-        required: true
-      responses:
-        '200':
-          description: New business partner record successfully created, possible errors are returned
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AddressPartnerCreateResponseWrapper'
-        '400':
-          description: On malformed requests
-  /v7/addresses:
-    get:
-      tags:
-        - Address Controller
-      summary: Returns addresses by different search parameters
-      description: 'This endpoint tries to find matches among all existing business partners of type address, filtering out partners which entirely do not match and ranking the remaining partners according to the accuracy of the match. The match of a partner is better the higher its relevancy score. '
+      description: >-
+        This endpoint tries to find matches among all existing business partners
+        of type address, filtering out partners which entirely do not match and
+        ranking the remaining partners according to the accuracy of the match.
+        The match of a partner is better the higher its relevancy score.
       operationId: getAddresses_1
       parameters:
         - name: addressBpns
@@ -659,7 +738,10 @@ paths:
       tags:
         - Address Controller
       summary: Updates an existing address
-      description: Update existing business partner records of type address referenced via BPNA. The endpoint expects to receive the full updated record, including values that didn't change.
+      description: >-
+        Update existing business partner records of type address referenced via
+        BPNA. The endpoint expects to receive the full updated record, including
+        values that didn't change.
       operationId: updateAddresses_1
       requestBody:
         content:
@@ -682,7 +764,13 @@ paths:
       tags:
         - Address Controller
       summary: Creates a new address
-      description: Create new business partners of type address by specifying the BPN of the parent each address belongs to. A parent can be either a site or legal entity business partner. If the parent cannot be found, the record is ignored.For matching purposes, on each record you can specify your own index value which will reappear in the corresponding record of the response.
+      description: >-
+        Create new business partners of type address by specifying the BPN of
+        the parent each address belongs to. A parent can be either a site or
+        legal entity business partner. If the parent cannot be found, the record
+        is ignored.For matching purposes, on each record you can specify your
+        own index value which will reappear in the corresponding record of the
+        response.
       operationId: createAddresses_1
       requestBody:
         content:
@@ -694,19 +782,23 @@ paths:
         required: true
       responses:
         '200':
-          description: New business partner record successfully created, possible errors are returned
+          description: >-
+            New business partner record successfully created, possible errors
+            are returned
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AddressPartnerCreateResponseWrapper'
         '400':
           description: On malformed requests
-  /v6/sites/search:
+  /v7/sites/search:
     post:
       tags:
         - Site Controller
       summary: Returns sites by an array of BPNS and/or an array of corresponding BPNL
-      description: Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities
+      description: >-
+        Search business partners of type site by their BPNSs or by the BPNLs of
+        their parent legal entities
       operationId: postSiteSearch
       parameters:
         - name: page
@@ -739,13 +831,689 @@ paths:
                 $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
         '400':
           description: On malformed request parameters
-  /v7/sites/search:
+  /v7/sites/legal-main-sites:
+    post:
+      tags:
+        - Site Controller
+      summary: Create a new site with legal entity reference
+      description: >-
+        Create a business partner site with the given legal entity reference. It
+        will designate the address information as both legal and site main
+        address.
+      operationId: createSiteWithLegalReference
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/SiteCreateRequestWithLegalAddressAsMain'
+        required: true
+      responses:
+        '200':
+          description: >-
+            New sites request was processed successfully, possible errors are
+            returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SitePartnerCreateResponseWrapper'
+        '400':
+          description: On malformed pagination request
+  /v7/participants/sites/search:
+    post:
+      tags:
+        - Site Controller
+      operationId: postSiteSearch_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SiteSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
+  /v7/participants/legal-entities/search:
+    post:
+      tags:
+        - Legal Entity Controller
+      operationId: searchLegalEntities
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalEntitySearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto
+  /v7/participants/changelog/search:
+    post:
+      tags:
+        - Changelog Controller
+      operationId: searchChangelogEntries
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangelogSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoChangelogEntryVerboseDto'
+  /v7/participants/addresses/search:
+    post:
+      tags:
+        - Address Controller
+      operationId: searchAddresses
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddressSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+  /v7/legal-forms:
+    get:
+      tags:
+        - Metadata Controller
+      summary: Returns all legal forms
+      description: Lists all currently known legal forms in a paginated result
+      operationId: getLegalForms
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: Page of existing legal forms, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLegalFormDto'
+        '400':
+          description: On malformed request parameters
+    post:
+      tags:
+        - Metadata Controller
+      summary: Creates a new legal form
+      description: >-
+        Create a new legal form which can be referenced by business partner
+        records. The actual name of the legal form is free to choose and doesn't
+        need to be unique. The technical key can be freely chosen but needs to
+        be unique for the businessPartnerType as it is used as reference by the
+        business partner records. A recommendation for technical keys: They
+        should be short, descriptive and use a restricted common character set
+        in order to ensure compatibility with older systems.
+      operationId: createLegalForm
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalFormRequest'
+        required: true
+      responses:
+        '200':
+          description: New legal form successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalFormDto'
+        '400':
+          description: On malformed request parameters
+        '409':
+          description: Legal form with specified technical key already exists
+  /v7/legal-entities/search:
+    post:
+      tags:
+        - Legal Entity Controller
+      summary: Returns legal entities by different search parameters
+      description: >-
+        Search legal entity partners by their BPNLs. The response can contain
+        less results than the number of BPNLs that were requested, if some of
+        the BPNLs did not exist. For a single request, the maximum number of
+        BPNLs to search for is limited to ${bpdm.bpn.search-request-limit}
+        entries.
+      operationId: postLegalEntitySearch
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LegalEntitySearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Found legal entites
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  #/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto
+        '400':
+          description: >-
+            On malformed request parameters or if number of requested bpns
+            exceeds limit
+  /v7/identifier-types:
+    get:
+      tags:
+        - Metadata Controller
+      summary: >-
+        Returns all identifier types filtered by business partner type and
+        country.
+      description: >-
+        Lists all matching identifier types including validity details in a
+        paginated result
+      operationId: getIdentifierTypes
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+        - name: businessPartnerType
+          in: query
+          required: true
+          schema:
+            type: string
+            description: >-
+              Specifies if an identifier type is valid for legal entities (L) or
+              addresses (A). Sites (S) are not supported.
+            enum:
+              - LEGAL_ENTITY
+              - ADDRESS
+        - name: country
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - UNDEFINED
+              - AC
+              - AD
+              - AE
+              - AF
+              - AG
+              - AI
+              - AL
+              - AM
+              - AN
+              - AO
+              - AQ
+              - AR
+              - AS
+              - AT
+              - AU
+              - AW
+              - AX
+              - AZ
+              - BA
+              - BB
+              - BD
+              - BE
+              - BF
+              - BG
+              - BH
+              - BI
+              - BJ
+              - BL
+              - BM
+              - BN
+              - BO
+              - BQ
+              - BR
+              - BS
+              - BT
+              - BU
+              - BV
+              - BW
+              - BY
+              - BZ
+              - CA
+              - CC
+              - CD
+              - CF
+              - CG
+              - CH
+              - CI
+              - CK
+              - CL
+              - CM
+              - CN
+              - CO
+              - CP
+              - CR
+              - CS
+              - CU
+              - CV
+              - CW
+              - CX
+              - CY
+              - CZ
+              - DE
+              - DG
+              - DJ
+              - DK
+              - DM
+              - DO
+              - DZ
+              - EA
+              - EC
+              - EE
+              - EG
+              - EH
+              - ER
+              - ES
+              - ET
+              - EU
+              - EZ
+              - FI
+              - FJ
+              - FK
+              - FM
+              - FO
+              - FR
+              - FX
+              - GA
+              - GB
+              - GD
+              - GE
+              - GF
+              - GG
+              - GH
+              - GI
+              - GL
+              - GM
+              - GN
+              - GP
+              - GQ
+              - GR
+              - GS
+              - GT
+              - GU
+              - GW
+              - GY
+              - HK
+              - HM
+              - HN
+              - HR
+              - HT
+              - HU
+              - IC
+              - ID
+              - IE
+              - IL
+              - IM
+              - IN
+              - IO
+              - IQ
+              - IR
+              - IS
+              - IT
+              - JE
+              - JM
+              - JO
+              - JP
+              - KE
+              - KG
+              - KH
+              - KI
+              - KM
+              - KN
+              - KP
+              - KR
+              - KW
+              - KY
+              - KZ
+              - LA
+              - LB
+              - LC
+              - LI
+              - LK
+              - LR
+              - LS
+              - LT
+              - LU
+              - LV
+              - LY
+              - MA
+              - MC
+              - MD
+              - ME
+              - MF
+              - MG
+              - MH
+              - MK
+              - ML
+              - MM
+              - MN
+              - MO
+              - MP
+              - MQ
+              - MR
+              - MS
+              - MT
+              - MU
+              - MV
+              - MW
+              - MX
+              - MY
+              - MZ
+              - NA
+              - NC
+              - NE
+              - NF
+              - NG
+              - NI
+              - NL
+              - 'NO'
+              - NP
+              - NR
+              - NT
+              - NU
+              - NZ
+              - OM
+              - PA
+              - PE
+              - PF
+              - PG
+              - PH
+              - PK
+              - PL
+              - PM
+              - PN
+              - PR
+              - PS
+              - PT
+              - PW
+              - PY
+              - QA
+              - RE
+              - RO
+              - RS
+              - RU
+              - RW
+              - SA
+              - SB
+              - SC
+              - SD
+              - SE
+              - SF
+              - SG
+              - SH
+              - SI
+              - SJ
+              - SK
+              - SL
+              - SM
+              - SN
+              - SO
+              - SR
+              - SS
+              - ST
+              - SU
+              - SV
+              - SX
+              - SY
+              - SZ
+              - TA
+              - TC
+              - TD
+              - TF
+              - TG
+              - TH
+              - TJ
+              - TK
+              - TL
+              - TM
+              - TN
+              - TO
+              - TP
+              - TR
+              - TT
+              - TV
+              - TW
+              - TZ
+              - UA
+              - UG
+              - UK
+              - UM
+              - US
+              - UY
+              - UZ
+              - VA
+              - VC
+              - VE
+              - VG
+              - VI
+              - VN
+              - VU
+              - WF
+              - WS
+              - XI
+              - XU
+              - XK
+              - YE
+              - YT
+              - YU
+              - ZA
+              - ZM
+              - ZR
+              - ZW
+      responses:
+        '200':
+          description: Page of existing identifier types, may be empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoIdentifierTypeDto'
+        '400':
+          description: On malformed request parameters
+    post:
+      tags:
+        - Metadata Controller
+      summary: Creates a new identifier type
+      description: >-
+        Create a new identifier type (including validity details) which can be
+        referenced by business partner records. Identifier types such as BPN or
+        VAT determine with which kind of values a business partner can be
+        identified with. The actual name of the identifier type is free to
+        choose and doesn't need to be unique. The technical key can be freely
+        chosen but needs to be unique for the businessPartnerType as it is used
+        as reference by the business partner records. A recommendation for
+        technical keys: They should be short, descriptive and use a restricted
+        common character set in order to ensure compatibility with older
+        systems.
+      operationId: createIdentifierType
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentifierTypeDto'
+        required: true
+      responses:
+        '200':
+          description: New identifier type successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentifierTypeDto'
+        '400':
+          description: On malformed request parameters
+        '409':
+          description: Identifier type with specified technical key already exists
+  /v7/addresses/search:
+    post:
+      tags:
+        - Address Controller
+      summary: >-
+        Returns addresses by an array of BPNA and/or an array of corresponding
+        BPNS and/or an array of corresponding BPNL.
+      description: >-
+        Search business partners of type address by their BPNA or their parents'
+        BPNL or BPNS.
+      operationId: searchAddresses_1
+      parameters:
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddressSearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Found sites for the specified sites and legal entities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+        '400':
+          description: On malformed pagination request
+  /v6/sites/search:
     post:
       tags:
         - Site Controller
       summary: Returns sites by an array of BPNS and/or an array of corresponding BPNL
-      description: Search business partners of type site by their BPNSs or by the BPNLs of their parent legal entities
-      operationId: postSiteSearch_1
+      description: >-
+        Search business partners of type site by their BPNSs or by the BPNLs of
+        their parent legal entities
+      operationId: postSiteSearch_2
       parameters:
         - name: page
           in: query
@@ -782,31 +1550,10 @@ paths:
       tags:
         - Site Controller
       summary: Create a new site with legal entity reference
-      description: Create a business partner site with the given legal entity reference. It will designate the address information as both legal and site main address.
-      operationId: createSiteWithLegalReference
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/SiteCreateRequestWithLegalAddressAsMain'
-        required: true
-      responses:
-        '200':
-          description: New sites request was processed successfully, possible errors are returned
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SitePartnerCreateResponseWrapper'
-        '400':
-          description: On malformed pagination request
-  /v7/sites/legal-main-sites:
-    post:
-      tags:
-        - Site Controller
-      summary: Create a new site with legal entity reference
-      description: Create a business partner site with the given legal entity reference. It will designate the address information as both legal and site main address.
+      description: >-
+        Create a business partner site with the given legal entity reference. It
+        will designate the address information as both legal and site main
+        address.
       operationId: createSiteWithLegalReference_1
       requestBody:
         content:
@@ -818,47 +1565,15 @@ paths:
         required: true
       responses:
         '200':
-          description: New sites request was processed successfully, possible errors are returned
+          description: >-
+            New sites request was processed successfully, possible errors are
+            returned
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SitePartnerCreateResponseWrapper'
         '400':
           description: On malformed pagination request
-  /v7/members/sites/search:
-    post:
-      tags:
-        - Site Controller
-      operationId: postSiteSearch_2
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SiteSearchRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
   /v6/members/sites/search:
     post:
       tags:
@@ -893,40 +1608,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PageDtoSiteWithMainAddressVerboseDto'
-  /v7/members/legal-entities/search:
-    post:
-      tags:
-        - Legal Entity Controller
-      operationId: searchLegalEntities
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LegalEntitySearchRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
   /v6/members/legal-entities/search:
     post:
       tags:
@@ -960,41 +1641,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
-  /v7/members/changelog/search:
-    post:
-      tags:
-        - Changelog Controller
-      operationId: searchChangelogEntries
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ChangelogSearchRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoChangelogEntryVerboseDto'
+                $ref: >-
+                  #/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto
   /v6/members/changelog/search:
     post:
       tags:
@@ -1033,41 +1681,7 @@ paths:
     post:
       tags:
         - Address Controller
-      operationId: searchAddresses
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AddressSearchRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
-  /v7/members/addresses/search:
-    post:
-      tags:
-        - Address Controller
-      operationId: searchAddresses_1
+      operationId: searchAddresses_2
       parameters:
         - name: page
           in: query
@@ -1103,61 +1717,6 @@ paths:
         - Metadata Controller
       summary: Returns all legal forms
       description: Lists all currently known legal forms in a paginated result
-      operationId: getLegalForms
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      responses:
-        '200':
-          description: Page of existing legal forms, may be empty
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLegalFormDto'
-        '400':
-          description: On malformed request parameters
-    post:
-      tags:
-        - Metadata Controller
-      summary: Creates a new legal form
-      description: 'Create a new legal form which can be referenced by business partner records. The actual name of the legal form is free to choose and doesn''t need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.'
-      operationId: createLegalForm
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LegalFormRequest'
-        required: true
-      responses:
-        '200':
-          description: New legal form successfully created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegalFormDto'
-        '400':
-          description: On malformed request parameters
-        '409':
-          description: Legal form with specified technical key already exists
-  /v7/legal-forms:
-    get:
-      tags:
-        - Metadata Controller
-      summary: Returns all legal forms
-      description: Lists all currently known legal forms in a paginated result
       operationId: getLegalForms_1
       parameters:
         - name: page
@@ -1188,7 +1747,14 @@ paths:
       tags:
         - Metadata Controller
       summary: Creates a new legal form
-      description: 'Create a new legal form which can be referenced by business partner records. The actual name of the legal form is free to choose and doesn''t need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.'
+      description: >-
+        Create a new legal form which can be referenced by business partner
+        records. The actual name of the legal form is free to choose and doesn't
+        need to be unique. The technical key can be freely chosen but needs to
+        be unique for the businessPartnerType as it is used as reference by the
+        business partner records. A recommendation for technical keys: They
+        should be short, descriptive and use a restricted common character set
+        in order to ensure compatibility with older systems.
       operationId: createLegalForm_1
       requestBody:
         content:
@@ -1212,45 +1778,12 @@ paths:
       tags:
         - Legal Entity Controller
       summary: Returns legal entities by different search parameters
-      description: Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.
-      operationId: postLegalEntitySearch
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LegalEntitySearchRequest'
-        required: true
-      responses:
-        '200':
-          description: Found legal entites
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
-        '400':
-          description: On malformed request parameters or if number of requested bpns exceeds limit
-  /v7/legal-entities/search:
-    post:
-      tags:
-        - Legal Entity Controller
-      summary: Returns legal entities by different search parameters
-      description: Search legal entity partners by their BPNLs. The response can contain less results than the number of BPNLs that were requested, if some of the BPNLs did not exist. For a single request, the maximum number of BPNLs to search for is limited to ${bpdm.bpn.search-request-limit} entries.
+      description: >-
+        Search legal entity partners by their BPNLs. The response can contain
+        less results than the number of BPNLs that were requested, if some of
+        the BPNLs did not exist. For a single request, the maximum number of
+        BPNLs to search for is limited to ${bpdm.bpn.search-request-limit}
+        entries.
       operationId: postLegalEntitySearch_1
       parameters:
         - name: page
@@ -1280,357 +1813,22 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto'
+                $ref: >-
+                  #/components/schemas/PageDtoLegalEntityWithLegalAddressVerboseDto
         '400':
-          description: On malformed request parameters or if number of requested bpns exceeds limit
-  /v7/identifier-types:
-    get:
-      tags:
-        - Metadata Controller
-      summary: Returns all identifier types filtered by business partner type and country.
-      description: Lists all matching identifier types including validity details in a paginated result
-      operationId: getIdentifierTypes
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-        - name: businessPartnerType
-          in: query
-          required: true
-          schema:
-            type: string
-            description: Specifies if an identifier type is valid for legal entities (L) or addresses (A). Sites (S) are not supported.
-            enum:
-              - LEGAL_ENTITY
-              - ADDRESS
-        - name: country
-          in: query
-          required: false
-          schema:
-            type: string
-            enum:
-              - UNDEFINED
-              - AC
-              - AD
-              - AE
-              - AF
-              - AG
-              - AI
-              - AL
-              - AM
-              - AN
-              - AO
-              - AQ
-              - AR
-              - AS
-              - AT
-              - AU
-              - AW
-              - AX
-              - AZ
-              - BA
-              - BB
-              - BD
-              - BE
-              - BF
-              - BG
-              - BH
-              - BI
-              - BJ
-              - BL
-              - BM
-              - BN
-              - BO
-              - BQ
-              - BR
-              - BS
-              - BT
-              - BU
-              - BV
-              - BW
-              - BY
-              - BZ
-              - CA
-              - CC
-              - CD
-              - CF
-              - CG
-              - CH
-              - CI
-              - CK
-              - CL
-              - CM
-              - CN
-              - CO
-              - CP
-              - CR
-              - CS
-              - CU
-              - CV
-              - CW
-              - CX
-              - CY
-              - CZ
-              - DE
-              - DG
-              - DJ
-              - DK
-              - DM
-              - DO
-              - DZ
-              - EA
-              - EC
-              - EE
-              - EG
-              - EH
-              - ER
-              - ES
-              - ET
-              - EU
-              - EZ
-              - FI
-              - FJ
-              - FK
-              - FM
-              - FO
-              - FR
-              - FX
-              - GA
-              - GB
-              - GD
-              - GE
-              - GF
-              - GG
-              - GH
-              - GI
-              - GL
-              - GM
-              - GN
-              - GP
-              - GQ
-              - GR
-              - GS
-              - GT
-              - GU
-              - GW
-              - GY
-              - HK
-              - HM
-              - HN
-              - HR
-              - HT
-              - HU
-              - IC
-              - ID
-              - IE
-              - IL
-              - IM
-              - IN
-              - IO
-              - IQ
-              - IR
-              - IS
-              - IT
-              - JE
-              - JM
-              - JO
-              - JP
-              - KE
-              - KG
-              - KH
-              - KI
-              - KM
-              - KN
-              - KP
-              - KR
-              - KW
-              - KY
-              - KZ
-              - LA
-              - LB
-              - LC
-              - LI
-              - LK
-              - LR
-              - LS
-              - LT
-              - LU
-              - LV
-              - LY
-              - MA
-              - MC
-              - MD
-              - ME
-              - MF
-              - MG
-              - MH
-              - MK
-              - ML
-              - MM
-              - MN
-              - MO
-              - MP
-              - MQ
-              - MR
-              - MS
-              - MT
-              - MU
-              - MV
-              - MW
-              - MX
-              - MY
-              - MZ
-              - NA
-              - NC
-              - NE
-              - NF
-              - NG
-              - NI
-              - NL
-              - 'NO'
-              - NP
-              - NR
-              - NT
-              - NU
-              - NZ
-              - OM
-              - PA
-              - PE
-              - PF
-              - PG
-              - PH
-              - PK
-              - PL
-              - PM
-              - PN
-              - PR
-              - PS
-              - PT
-              - PW
-              - PY
-              - QA
-              - RE
-              - RO
-              - RS
-              - RU
-              - RW
-              - SA
-              - SB
-              - SC
-              - SD
-              - SE
-              - SF
-              - SG
-              - SH
-              - SI
-              - SJ
-              - SK
-              - SL
-              - SM
-              - SN
-              - SO
-              - SR
-              - SS
-              - ST
-              - SU
-              - SV
-              - SX
-              - SY
-              - SZ
-              - TA
-              - TC
-              - TD
-              - TF
-              - TG
-              - TH
-              - TJ
-              - TK
-              - TL
-              - TM
-              - TN
-              - TO
-              - TP
-              - TR
-              - TT
-              - TV
-              - TW
-              - TZ
-              - UA
-              - UG
-              - UK
-              - UM
-              - US
-              - UY
-              - UZ
-              - VA
-              - VC
-              - VE
-              - VG
-              - VI
-              - VN
-              - VU
-              - WF
-              - WS
-              - XI
-              - XU
-              - XK
-              - YE
-              - YT
-              - YU
-              - ZA
-              - ZM
-              - ZR
-              - ZW
-      responses:
-        '200':
-          description: Page of existing identifier types, may be empty
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoIdentifierTypeDto'
-        '400':
-          description: On malformed request parameters
-    post:
-      tags:
-        - Metadata Controller
-      summary: Creates a new identifier type
-      description: 'Create a new identifier type (including validity details) which can be referenced by business partner records. Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. The actual name of the identifier type is free to choose and doesn''t need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.'
-      operationId: createIdentifierType
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/IdentifierTypeDto'
-        required: true
-      responses:
-        '200':
-          description: New identifier type successfully created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdentifierTypeDto'
-        '400':
-          description: On malformed request parameters
-        '409':
-          description: Identifier type with specified technical key already exists
+          description: >-
+            On malformed request parameters or if number of requested bpns
+            exceeds limit
   /v6/identifier-types:
     get:
       tags:
         - Metadata Controller
-      summary: Returns all identifier types filtered by business partner type and country.
-      description: Lists all matching identifier types including validity details in a paginated result
+      summary: >-
+        Returns all identifier types filtered by business partner type and
+        country.
+      description: >-
+        Lists all matching identifier types including validity details in a
+        paginated result
       operationId: getIdentifierTypes_1
       parameters:
         - name: page
@@ -1653,7 +1851,9 @@ paths:
           required: true
           schema:
             type: string
-            description: Specifies if an identifier type is valid for legal entities (L) or addresses (A). Sites (S) are not supported.
+            description: >-
+              Specifies if an identifier type is valid for legal entities (L) or
+              addresses (A). Sites (S) are not supported.
             enum:
               - LEGAL_ENTITY
               - ADDRESS
@@ -1948,7 +2148,17 @@ paths:
       tags:
         - Metadata Controller
       summary: Creates a new identifier type
-      description: 'Create a new identifier type (including validity details) which can be referenced by business partner records. Identifier types such as BPN or VAT determine with which kind of values a business partner can be identified with. The actual name of the identifier type is free to choose and doesn''t need to be unique. The technical key can be freely chosen but needs to be unique for the businessPartnerType as it is used as reference by the business partner records. A recommendation for technical keys: They should be short, descriptive and use a restricted common character set in order to ensure compatibility with older systems.'
+      description: >-
+        Create a new identifier type (including validity details) which can be
+        referenced by business partner records. Identifier types such as BPN or
+        VAT determine with which kind of values a business partner can be
+        identified with. The actual name of the identifier type is free to
+        choose and doesn't need to be unique. The technical key can be freely
+        chosen but needs to be unique for the businessPartnerType as it is used
+        as reference by the business partner records. A recommendation for
+        technical keys: They should be short, descriptive and use a restricted
+        common character set in order to ensure compatibility with older
+        systems.
       operationId: createIdentifierType_1
       requestBody:
         content:
@@ -1971,7 +2181,9 @@ paths:
     post:
       tags:
         - Changelog Controller
-      summary: Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types
+      summary: >-
+        Returns changelog entries as of a specified timestamp, optionally
+        filtered by a list of BPNL/S/A, or business partner types
       operationId: getChangelogEntries
       parameters:
         - name: page
@@ -2010,7 +2222,9 @@ paths:
     post:
       tags:
         - Changelog Controller
-      summary: Returns changelog entries as of a specified timestamp, optionally filtered by a list of BPNL/S/A, or business partner types
+      summary: >-
+        Returns changelog entries as of a specified timestamp, optionally
+        filtered by a list of BPNL/S/A, or business partner types
       operationId: getChangelogEntries_1
       parameters:
         - name: page
@@ -2049,8 +2263,16 @@ paths:
     post:
       tags:
         - Bpn Controller
-      summary: Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values
-      description: Find business partner numbers by identifiers. The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. For a single request, the maximum number of identifier values to search for is limited to ${bpdm.bpn.search-request-limit} entries.
+      summary: >-
+        Returns a list of identifier mappings of an identifier to a BPNL/A/S,
+        specified by a business partner type, identifier type and identifier
+        values
+      description: >-
+        Find business partner numbers by identifiers. The response can contain
+        less results than the number of identifier values that were requested,
+        if some of the identifiers did not exist. For a single request, the
+        maximum number of identifier values to search for is limited to
+        ${bpdm.bpn.search-request-limit} entries.
       operationId: findBpnsByIdentifiers
       requestBody:
         content:
@@ -2069,15 +2291,25 @@ paths:
                   $ref: '#/components/schemas/BpnIdentifierMappingDto'
                 uniqueItems: true
         '400':
-          description: On malformed request parameters or if number of requested bpns exceeds limit
+          description: >-
+            On malformed request parameters or if number of requested bpns
+            exceeds limit
         '404':
           description: Specified identifier type not found
   /v6/bpn/search:
     post:
       tags:
         - Bpn Controller
-      summary: Returns a list of identifier mappings of an identifier to a BPNL/A/S, specified by a business partner type, identifier type and identifier values
-      description: Find business partner numbers by identifiers. The response can contain less results than the number of identifier values that were requested, if some of the identifiers did not exist. For a single request, the maximum number of identifier values to search for is limited to ${bpdm.bpn.search-request-limit} entries.
+      summary: >-
+        Returns a list of identifier mappings of an identifier to a BPNL/A/S,
+        specified by a business partner type, identifier type and identifier
+        values
+      description: >-
+        Find business partner numbers by identifiers. The response can contain
+        less results than the number of identifier values that were requested,
+        if some of the identifiers did not exist. For a single request, the
+        maximum number of identifier values to search for is limited to
+        ${bpdm.bpn.search-request-limit} entries.
       operationId: findBpnsByIdentifiers_1
       requestBody:
         content:
@@ -2096,7 +2328,9 @@ paths:
                   $ref: '#/components/schemas/BpnIdentifierMappingDto'
                 uniqueItems: true
         '400':
-          description: On malformed request parameters or if number of requested bpns exceeds limit
+          description: >-
+            On malformed request parameters or if number of requested bpns
+            exceeds limit
         '404':
           description: Specified identifier type not found
   /v6/bpn/request-ids/search:
@@ -2149,46 +2383,12 @@ paths:
     post:
       tags:
         - Address Controller
-      summary: Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.
-      description: Search business partners of type address by their BPNA or their parents' BPNL or BPNS.
-      operationId: searchAddresses_2
-      parameters:
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AddressSearchRequest'
-        required: true
-      responses:
-        '200':
-          description: Found sites for the specified sites and legal entities
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
-        '400':
-          description: On malformed pagination request
-  /v7/addresses/search:
-    post:
-      tags:
-        - Address Controller
-      summary: Returns addresses by an array of BPNA and/or an array of corresponding BPNS and/or an array of corresponding BPNL.
-      description: Search business partners of type address by their BPNA or their parents' BPNL or BPNS.
+      summary: >-
+        Returns addresses by an array of BPNA and/or an array of corresponding
+        BPNS and/or an array of corresponding BPNL.
+      description: >-
+        Search business partners of type address by their BPNA or their parents'
+        BPNL or BPNS.
       operationId: searchAddresses_3
       parameters:
         - name: page
@@ -2246,37 +2446,19 @@ paths:
           description: On malformed request parameters
         '404':
           description: No site found under specified BPNS
-  /v6/sites/{bpns}:
-    get:
-      tags:
-        - Site Controller
-      summary: Returns a site by its BPNS
-      description: Get business partners of type site by BPNS ignoring case.
-      operationId: getSite_1
-      parameters:
-        - name: bpns
-          in: path
-          description: BPNS value
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Found site with specified BPNS
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SiteWithMainAddressVerboseDto'
-        '400':
-          description: On malformed request parameters
-        '404':
-          description: No site found under specified BPNS
-  /v6/legal-entities/{idValue}:
+  /v7/legal-entities/{idValue}:
     get:
       tags:
         - Legal Entity Controller
-      summary: Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type
-      description: This endpoint tries to find a business partner by the specified identifier. The identifier value is case insensitively compared but needs to be given exactly. By default the value given is interpreted as a BPN. By specifying the technical key of another identifier typethe value is matched against the identifiers of that given type.
+      summary: >-
+        Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID,
+        specified by the identifier type
+      description: >-
+        This endpoint tries to find a business partner by the specified
+        identifier. The identifier value is case insensitively compared but
+        needs to be given exactly. By default the value given is interpreted as
+        a BPN. By specifying the technical key of another identifier typethe
+        value is matched against the identifiers of that given type.
       operationId: getLegalEntity
       parameters:
         - name: idValue
@@ -2301,44 +2483,18 @@ paths:
         '400':
           description: On malformed request parameters
         '404':
-          description: No business partner found under specified identifier or specified identifier type not found
-  /v7/legal-entities/{idValue}:
-    get:
-      tags:
-        - Legal Entity Controller
-      summary: Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID, specified by the identifier type
-      description: This endpoint tries to find a business partner by the specified identifier. The identifier value is case insensitively compared but needs to be given exactly. By default the value given is interpreted as a BPN. By specifying the technical key of another identifier typethe value is matched against the identifiers of that given type.
-      operationId: getLegalEntity_1
-      parameters:
-        - name: idValue
-          in: path
-          description: Identifier value
-          required: true
-          schema:
-            type: string
-        - name: idType
-          in: query
-          description: Type of identifier to use, defaults to BPN when omitted
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Found business partner with specified identifier
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LegalEntityWithLegalAddressVerboseDto'
-        '400':
-          description: On malformed request parameters
-        '404':
-          description: No business partner found under specified identifier or specified identifier type not found
-  /v6/legal-entities/{bpnl}/sites:
+          description: >-
+            No business partner found under specified identifier or specified
+            identifier type not found
+  /v7/legal-entities/{bpnl}/sites:
     get:
       tags:
         - Legal Entity Controller
       summary: Returns all sites of a legal entity with a specific BPNL
-      description: Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case.
+      description: >-
+        Get business partners of type site belonging to a business partner of
+        type legal entity, identified by the business partner's bpnl ignoring
+        case.
       operationId: getSites_2
       parameters:
         - name: bpnl
@@ -2373,12 +2529,148 @@ paths:
           description: On malformed pagination request
         '404':
           description: No business partner found for specified bpnl
-  /v7/legal-entities/{bpnl}/sites:
+  /v7/legal-entities/{bpnl}/addresses:
+    get:
+      tags:
+        - Legal Entity Controller
+      summary: Returns all addresses of a legal entity with a specific BPNL
+      description: >-
+        Get business partners of type address belonging to a business partner of
+        type legal entity, identified by the business partner's BPNL ignoring
+        case.
+      operationId: getAddresses_2
+      parameters:
+        - name: bpnl
+          in: path
+          description: BPNL value
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: Number of page to get results from
+          required: false
+          schema:
+            type: string
+            minimum: 0
+        - name: size
+          in: query
+          description: Size of each page
+          required: false
+          schema:
+            type: string
+            maximum: 100
+            minimum: 0
+      responses:
+        '200':
+          description: The addresses for the specified BPNL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
+        '400':
+          description: On malformed pagination request
+        '404':
+          description: No business partner found for specified BPNL
+  /v7/addresses/{bpna}:
+    get:
+      tags:
+        - Address Controller
+      summary: Returns an address by its BPNA
+      description: Get business partners of type address by BPNA ignoring case.
+      operationId: getAddress
+      parameters:
+        - name: bpna
+          in: path
+          description: BPNA value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Found address with specified BPNA
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogisticAddressVerboseDto'
+        '400':
+          description: On malformed request parameters
+        '404':
+          description: No address found under specified BPNA
+  /v6/sites/{bpns}:
+    get:
+      tags:
+        - Site Controller
+      summary: Returns a site by its BPNS
+      description: Get business partners of type site by BPNS ignoring case.
+      operationId: getSite_1
+      parameters:
+        - name: bpns
+          in: path
+          description: BPNS value
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Found site with specified BPNS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiteWithMainAddressVerboseDto'
+        '400':
+          description: On malformed request parameters
+        '404':
+          description: No site found under specified BPNS
+  /v6/legal-entities/{idValue}:
+    get:
+      tags:
+        - Legal Entity Controller
+      summary: >-
+        Returns a legal entity by identifier, like BPN, DUNS or EU VAT ID,
+        specified by the identifier type
+      description: >-
+        This endpoint tries to find a business partner by the specified
+        identifier. The identifier value is case insensitively compared but
+        needs to be given exactly. By default the value given is interpreted as
+        a BPN. By specifying the technical key of another identifier typethe
+        value is matched against the identifiers of that given type.
+      operationId: getLegalEntity_1
+      parameters:
+        - name: idValue
+          in: path
+          description: Identifier value
+          required: true
+          schema:
+            type: string
+        - name: idType
+          in: query
+          description: Type of identifier to use, defaults to BPN when omitted
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Found business partner with specified identifier
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegalEntityWithLegalAddressVerboseDto'
+        '400':
+          description: On malformed request parameters
+        '404':
+          description: >-
+            No business partner found under specified identifier or specified
+            identifier type not found
+  /v6/legal-entities/{bpnl}/sites:
     get:
       tags:
         - Legal Entity Controller
       summary: Returns all sites of a legal entity with a specific BPNL
-      description: Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpnl ignoring case.
+      description: >-
+        Get business partners of type site belonging to a business partner of
+        type legal entity, identified by the business partner's bpnl ignoring
+        case.
       operationId: getSites_3
       parameters:
         - name: bpnl
@@ -2418,47 +2710,10 @@ paths:
       tags:
         - Legal Entity Controller
       summary: Returns all addresses of a legal entity with a specific BPNL
-      description: Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.
-      operationId: getAddresses_2
-      parameters:
-        - name: bpnl
-          in: path
-          description: BPNL value
-          required: true
-          schema:
-            type: string
-        - name: page
-          in: query
-          description: Number of page to get results from
-          required: false
-          schema:
-            type: string
-            minimum: 0
-        - name: size
-          in: query
-          description: Size of each page
-          required: false
-          schema:
-            type: string
-            maximum: 100
-            minimum: 0
-      responses:
-        '200':
-          description: The addresses for the specified BPNL
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PageDtoLogisticAddressVerboseDto'
-        '400':
-          description: On malformed pagination request
-        '404':
-          description: No business partner found for specified BPNL
-  /v7/legal-entities/{bpnl}/addresses:
-    get:
-      tags:
-        - Legal Entity Controller
-      summary: Returns all addresses of a legal entity with a specific BPNL
-      description: Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's BPNL ignoring case.
+      description: >-
+        Get business partners of type address belonging to a business partner of
+        type legal entity, identified by the business partner's BPNL ignoring
+        case.
       operationId: getAddresses_3
       parameters:
         - name: bpnl
@@ -2497,8 +2752,12 @@ paths:
     get:
       tags:
         - Metadata Controller
-      summary: Get all field quality rules filtered by country (specified by its ISO 3166-1 alpha-2 country code)
-      description: List the country specific data rules for entity fields.All fields that are not in this list are considered to be forbidden.
+      summary: >-
+        Get all field quality rules filtered by country (specified by its ISO
+        3166-1 alpha-2 country code)
+      description: >-
+        List the country specific data rules for entity fields.All fields that
+        are not in this list are considered to be forbidden.
       operationId: getFieldQualityRules
       parameters:
         - name: country
@@ -2795,8 +3054,12 @@ paths:
     get:
       tags:
         - Metadata Controller
-      summary: Get all field quality rules filtered by country (specified by its ISO 3166-1 alpha-2 country code)
-      description: List the country specific data rules for entity fields.All fields that are not in this list are considered to be forbidden.
+      summary: >-
+        Get all field quality rules filtered by country (specified by its ISO
+        3166-1 alpha-2 country code)
+      description: >-
+        List the country specific data rules for entity fields.All fields that
+        are not in this list are considered to be forbidden.
       operationId: getFieldQualityRules_1
       parameters:
         - name: country
@@ -3093,8 +3356,12 @@ paths:
     get:
       tags:
         - Metadata Controller
-      summary: Get page of country subdivisions suitable for the administrativeAreaLevel1 address property
-      description: Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result
+      summary: >-
+        Get page of country subdivisions suitable for the
+        administrativeAreaLevel1 address property
+      description: >-
+        Lists all currently known country subdivisions according to ISO 3166-2
+        in a paginated result
       operationId: getAdminAreasLevel1
       parameters:
         - name: page
@@ -3125,8 +3392,12 @@ paths:
     get:
       tags:
         - Metadata Controller
-      summary: Get page of country subdivisions suitable for the administrativeAreaLevel1 address property
-      description: Lists all currently known country subdivisions according to ISO 3166-2 in a paginated result
+      summary: >-
+        Get page of country subdivisions suitable for the
+        administrativeAreaLevel1 address property
+      description: >-
+        Lists all currently known country subdivisions according to ISO 3166-2
+        in a paginated result
       operationId: getAdminAreasLevel1_1
       parameters:
         - name: page
@@ -3159,31 +3430,6 @@ paths:
         - Address Controller
       summary: Returns an address by its BPNA
       description: Get business partners of type address by BPNA ignoring case.
-      operationId: getAddress
-      parameters:
-        - name: bpna
-          in: path
-          description: BPNA value
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Found address with specified BPNA
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogisticAddressVerboseDto'
-        '400':
-          description: On malformed request parameters
-        '404':
-          description: No address found under specified BPNA
-  /v7/addresses/{bpna}:
-    get:
-      tags:
-        - Address Controller
-      summary: Returns an address by its BPNA
-      description: Get business partners of type address by BPNA ignoring case.
       operationId: getAddress_1
       parameters:
         - name: bpna
@@ -3207,7 +3453,9 @@ components:
   schemas:
     AddressIdentifierDto:
       type: object
-      description: An address identifier (uniquely) identifies the address, such as the Global Location Number (GLN).
+      description: >-
+        An address identifier (uniquely) identifies the address, such as the
+        Global Location Number (GLN).
       properties:
         value:
           type: string
@@ -3220,7 +3468,9 @@ components:
         - value
     AddressIdentifierVerboseDto:
       type: object
-      description: An address identifier (uniquely) identifies the address, such as the Global Location Number (GLN).
+      description: >-
+        An address identifier (uniquely) identifies the address, such as the
+        Global Location Number (GLN).
       properties:
         value:
           type: string
@@ -3233,11 +3483,25 @@ components:
         - value
     AddressPartnerCreateRequest:
       type: object
-      description: Request for creating new business partner record of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA.
+      description: >-
+        Request for creating new business partner record of type address. In
+        general, an address is a collection of information to describe a
+        physical location, using a street name with a house number and/or a post
+        office box as reference. In addition, an address consists of several
+        postal attributes, such as country, region (state), county, township,
+        city, district, or postal code, which help deliver mail.In Catena-X, an
+        address is a type of business partner representing the legal address of
+        a legal entity, and/or the main address of a site, or any additional
+        address of a legal entity or site (such as different gates).An address
+        is owned by a legal entity. Thus, exactly one legal entity is assigned
+        to an address. An address can belong to a site. Thus, one or no site is
+        assigned to an address. An address is uniquely identified by the BPNA.
       properties:
         name:
           type: string
-          description: The name of the address. This is not according to official registers but according to the name the sharing member chooses.
+          description: >-
+            The name of the address. This is not according to official registers
+            but according to the name the sharing member chooses.
         states:
           type: array
           items:
@@ -3248,18 +3512,26 @@ components:
             $ref: '#/components/schemas/AddressIdentifierDto'
         physicalPostalAddress:
           $ref: '#/components/schemas/PhysicalPostalAddressDto'
-          description: The physical postal address of the address, such as an office, warehouse, gate, etc.
+          description: >-
+            The physical postal address of the address, such as an office,
+            warehouse, gate, etc.
         alternativePostalAddress:
           $ref: '#/components/schemas/AlternativePostalAddressDto'
-          description: The alternative postal address of the address, for example if the goods are to be picked up somewhere else.
+          description: >-
+            The alternative postal address of the address, for example if the
+            goods are to be picked up somewhere else.
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
         bpnParent:
           type: string
-          description: BPNL of the legal entity or BPNS of the site this address belongs to.
+          description: >-
+            BPNL of the legal entity or BPNS of the site this address belongs
+            to.
         index:
           type: string
-          description: User defined index to conveniently match this entry to the corresponding entry in the response.
+          description: >-
+            User defined index to conveniently match this entry to the
+            corresponding entry in the response.
         requestKey:
           type: string
       required:
@@ -3270,7 +3542,9 @@ components:
         - states
     AddressPartnerCreateResponseWrapper:
       type: object
-      description: Holds information about successfully and failed entities after the creating/updating of several objects
+      description: >-
+        Holds information about successfully and failed entities after the
+        creating/updating of several objects
       properties:
         entities:
           type: array
@@ -3293,14 +3567,35 @@ components:
         - errors
     AddressPartnerCreateVerboseDto:
       type: object
-      description: Created business partner of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA.
+      description: >-
+        Created business partner of type address. In general, an address is a
+        collection of information to describe a physical location, using a
+        street name with a house number and/or a post office box as reference.
+        In addition, an address consists of several postal attributes, such as
+        country, region (state), county, township, city, district, or postal
+        code, which help deliver mail.In Catena-X, an address is a type of
+        business partner representing the legal address of a legal entity,
+        and/or the main address of a site, or any additional address of a legal
+        entity or site (such as different gates).An address is owned by a legal
+        entity. Thus, exactly one legal entity is assigned to an address. An
+        address can belong to a site. Thus, one or no site is assigned to an
+        address. An address is uniquely identified by the BPNA.
       properties:
         bpna:
           type: string
-          description: A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity.
+          description: >-
+            A BPNA represents and uniquely identifies an address, which can be
+            the legal address of a legal entity, and/or the main address of a
+            site, or any additional address of a legal entity or site (such as
+            different gates). It is important to note that only the BPNL must be
+            used to uniquely identify a legal entity. Even in the case that the
+            BPNA represents the legal address of the legal entity, it shall not
+            be used to uniquely identify the legal entity.
         name:
           type: string
-          description: The name of the address. This is not according to official registers but according to the name the sharing member chooses.
+          description: >-
+            The name of the address. This is not according to official registers
+            but according to the name the sharing member chooses.
         states:
           type: array
           items:
@@ -3311,19 +3606,25 @@ components:
             $ref: '#/components/schemas/AddressIdentifierVerboseDto'
         physicalPostalAddress:
           $ref: '#/components/schemas/PhysicalPostalAddressVerboseDto'
-          description: The physical postal address of the address, such as an office, warehouse, gate, etc.
+          description: >-
+            The physical postal address of the address, such as an office,
+            warehouse, gate, etc.
         alternativePostalAddress:
           $ref: '#/components/schemas/AlternativePostalAddressVerboseDto'
-          description: The alternative postal address of the address, for example if the goods are to be picked up somewhere else.
+          description: >-
+            The alternative postal address of the address, for example if the
+            goods are to be picked up somewhere else.
         bpnLegalEntity:
           type: string
           description: The BPNL of the legal entity owning the address.
         bpnSite:
           type: string
           description: The BPNS of the site the address belongs to.
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the address is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the address is owned and thus provided by a Data
+            Space Participant.
         createdAt:
           type: string
           format: date-time
@@ -3336,7 +3637,12 @@ components:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
         addressType:
           type: string
-          description: Indicates the address type, the legal address to a legal entity or the main address to a site, an additional address, or both legal and site address.The site main address is where typically the main entrance or the reception is located, or where the mail is delivered to.
+          description: >-
+            Indicates the address type, the legal address to a legal entity or
+            the main address to a site, an additional address, or both legal and
+            site address.The site main address is where typically the main
+            entrance or the reception is located, or where the mail is delivered
+            to.
           enum:
             - LegalAndSiteMainAddress
             - LegalAddress
@@ -3344,26 +3650,49 @@ components:
             - AdditionalAddress
         index:
           type: string
-          description: User defined index to conveniently match this entry to the corresponding entry in the response.
+          description: >-
+            User defined index to conveniently match this entry to the
+            corresponding entry in the response.
       required:
         - bpna
         - confidenceCriteria
         - createdAt
         - identifiers
-        - isCatenaXMemberData
+        - isParticipantData
         - physicalPostalAddress
         - states
         - updatedAt
     AddressPartnerUpdateRequest:
       type: object
-      description: Request for updating a business partner record of type address. In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA.
+      description: >-
+        Request for updating a business partner record of type address. In
+        general, an address is a collection of information to describe a
+        physical location, using a street name with a house number and/or a post
+        office box as reference. In addition, an address consists of several
+        postal attributes, such as country, region (state), county, township,
+        city, district, or postal code, which help deliver mail.In Catena-X, an
+        address is a type of business partner representing the legal address of
+        a legal entity, and/or the main address of a site, or any additional
+        address of a legal entity or site (such as different gates).An address
+        is owned by a legal entity. Thus, exactly one legal entity is assigned
+        to an address. An address can belong to a site. Thus, one or no site is
+        assigned to an address. An address is uniquely identified by the BPNA.
       properties:
         bpna:
           type: string
-          description: A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity.
+          description: >-
+            A BPNA represents and uniquely identifies an address, which can be
+            the legal address of a legal entity, and/or the main address of a
+            site, or any additional address of a legal entity or site (such as
+            different gates). It is important to note that only the BPNL must be
+            used to uniquely identify a legal entity. Even in the case that the
+            BPNA represents the legal address of the legal entity, it shall not
+            be used to uniquely identify the legal entity.
         name:
           type: string
-          description: The name of the address. This is not according to official registers but according to the name the sharing member chooses.
+          description: >-
+            The name of the address. This is not according to official registers
+            but according to the name the sharing member chooses.
         states:
           type: array
           items:
@@ -3374,10 +3703,14 @@ components:
             $ref: '#/components/schemas/AddressIdentifierDto'
         physicalPostalAddress:
           $ref: '#/components/schemas/PhysicalPostalAddressDto'
-          description: The physical postal address of the address, such as an office, warehouse, gate, etc.
+          description: >-
+            The physical postal address of the address, such as an office,
+            warehouse, gate, etc.
         alternativePostalAddress:
           $ref: '#/components/schemas/AlternativePostalAddressDto'
-          description: The alternative postal address of the address, for example if the goods are to be picked up somewhere else.
+          description: >-
+            The alternative postal address of the address, for example if the
+            goods are to be picked up somewhere else.
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
         requestKey:
@@ -3391,7 +3724,9 @@ components:
         - states
     AddressPartnerUpdateResponseWrapper:
       type: object
-      description: Holds information about successfully and failed entities after the creating/updating of several objects
+      description: >-
+        Holds information about successfully and failed entities after the
+        creating/updating of several objects
       properties:
         entities:
           type: array
@@ -3435,7 +3770,11 @@ components:
         - siteBpns
     AddressStateDto:
       type: object
-      description: An address state indicates if the address is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the business partner is still operating at that address.
+      description: >-
+        An address state indicates if the address is active or inactive. This
+        does not describe the relation between a sharing member and a business
+        partner and whether they have active business, but it describes whether
+        the business partner is still operating at that address.
       properties:
         validFrom:
           type: string
@@ -3455,7 +3794,11 @@ components:
         - type
     AddressStateVerboseDto:
       type: object
-      description: An address state indicates if the address is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the business partner is still operating at that address.
+      description: >-
+        An address state indicates if the address is active or inactive. This
+        does not describe the relation between a sharing member and a business
+        partner and whether they have active business, but it describes whether
+        the business partner is still operating at that address.
       properties:
         validFrom:
           type: string
@@ -3472,13 +3815,17 @@ components:
         - type
     AlternativePostalAddressDto:
       type: object
-      description: An alternative postal address describes an alternative way of delivery for example if the goods are to be picked up somewhere else.
+      description: >-
+        An alternative postal address describes an alternative way of delivery
+        for example if the goods are to be picked up somewhere else.
       properties:
         geographicCoordinates:
           $ref: '#/components/schemas/GeoCoordinateDto'
         country:
           type: string
-          description: The 2-digit country code of the physical postal address according to ISO 3166-1.
+          description: >-
+            The 2-digit country code of the physical postal address according to
+            ISO 3166-1.
           enum:
             - UNDEFINED
             - AC
@@ -3754,26 +4101,44 @@ components:
             - ZW
         administrativeAreaLevel1:
           type: string
-          description: The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country.
+          description: >-
+            The 2-digit country subdivision code according to ISO 3166-2, such
+            as a region within a country.
         postalCode:
           type: string
-          description: The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code.
+          description: >-
+            The alphanumeric identifier (sometimes including spaces or
+            punctuation) of the physical postal address for the purpose of
+            sorting mail, synonyms:postcode, post code, PIN or ZIP code.
         city:
           type: string
-          description: 'The name of the city of the physical postal address, synonyms: town, village, municipality.'
+          description: >-
+            The name of the city of the physical postal address, synonyms: town,
+            village, municipality.
         deliveryServiceType:
           type: string
-          description: 'One of the alternative postal address types: P.O. box, private bag, boite postale.'
+          description: >-
+            One of the alternative postal address types: P.O. box, private bag,
+            boite postale.
           enum:
             - PO_BOX
             - PRIVATE_BAG
             - BOITE_POSTALE
         deliveryServiceQualifier:
           type: string
-          description: The qualifier uniquely identifying the delivery service endpoint of the alternative postal address in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number is assigned multiple times in some cities.
+          description: >-
+            The qualifier uniquely identifying the delivery service endpoint of
+            the alternative postal address in conjunction with the delivery
+            service number. In some countries for example, entering a P.O. box
+            number, postal code and city is not sufficient to uniquely identify
+            a P.O. box, because the same P.O. box number is assigned multiple
+            times in some cities.
         deliveryServiceNumber:
           type: string
-          description: The number indicating the delivery service endpoint of the alternative postal address to which the delivery is to be delivered, such as a P.O. box number or a private bag number.
+          description: >-
+            The number indicating the delivery service endpoint of the
+            alternative postal address to which the delivery is to be delivered,
+            such as a P.O. box number or a private bag number.
       required:
         - city
         - country
@@ -3781,35 +4146,57 @@ components:
         - deliveryServiceType
     AlternativePostalAddressVerboseDto:
       type: object
-      description: An alternative postal address describes an alternative way of delivery for example if the goods are to be picked up somewhere else.
+      description: >-
+        An alternative postal address describes an alternative way of delivery
+        for example if the goods are to be picked up somewhere else.
       properties:
         geographicCoordinates:
           $ref: '#/components/schemas/GeoCoordinateDto'
         country:
           $ref: '#/components/schemas/TypeKeyNameVerboseDtoCountryCode'
-          description: The 2-digit country code of the physical postal address according to ISO 3166-1.
+          description: >-
+            The 2-digit country code of the physical postal address according to
+            ISO 3166-1.
         administrativeAreaLevel1:
           $ref: '#/components/schemas/RegionDto'
-          description: The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country.
+          description: >-
+            The 2-digit country subdivision code according to ISO 3166-2, such
+            as a region within a country.
         postalCode:
           type: string
-          description: The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code.
+          description: >-
+            The alphanumeric identifier (sometimes including spaces or
+            punctuation) of the physical postal address for the purpose of
+            sorting mail, synonyms:postcode, post code, PIN or ZIP code.
         city:
           type: string
-          description: 'The name of the city of the physical postal address, synonyms: town, village, municipality.'
+          description: >-
+            The name of the city of the physical postal address, synonyms: town,
+            village, municipality.
         deliveryServiceType:
           type: string
-          description: 'One of the alternative postal address types: P.O. box, private bag, boite postale.'
+          description: >-
+            One of the alternative postal address types: P.O. box, private bag,
+            boite postale.
           enum:
             - PO_BOX
             - PRIVATE_BAG
             - BOITE_POSTALE
         deliveryServiceQualifier:
           type: string
-          description: The qualifier uniquely identifying the delivery service endpoint of the alternative postal address in conjunction with the delivery service number. In some countries for example, entering a P.O. box number, postal code and city is not sufficient to uniquely identify a P.O. box, because the same P.O. box number is assigned multiple times in some cities.
+          description: >-
+            The qualifier uniquely identifying the delivery service endpoint of
+            the alternative postal address in conjunction with the delivery
+            service number. In some countries for example, entering a P.O. box
+            number, postal code and city is not sufficient to uniquely identify
+            a P.O. box, because the same P.O. box number is assigned multiple
+            times in some cities.
         deliveryServiceNumber:
           type: string
-          description: The number indicating the delivery service endpoint of the alternative postal address to which the delivery is to be delivered, such as a P.O. box number or a private bag number.
+          description: >-
+            The number indicating the delivery service endpoint of the
+            alternative postal address to which the delivery is to be delivered,
+            such as a P.O. box number or a private bag number.
       required:
         - city
         - country
@@ -3855,14 +4242,21 @@ components:
         - requestedIdentifiers
     ChangelogEntryVerboseDto:
       type: object
-      description: An entry of the changelog, which is created each time a business partner is modified and contains data about the change. The actual new state of the business partner is not included.
+      description: >-
+        An entry of the changelog, which is created each time a business partner
+        is modified and contains data about the change. The actual new state of
+        the business partner is not included.
       properties:
         bpn:
           type: string
-          description: The business partner number for which the changelog entry was created. Can be either a BPNL, BPNS or BPNA.
+          description: >-
+            The business partner number for which the changelog entry was
+            created. Can be either a BPNL, BPNS or BPNA.
         businessPartnerType:
           type: string
-          description: 'One of the types of business partners for which the changelog entry was created: legal entity, site, address.'
+          description: >-
+            One of the types of business partners for which the changelog entry
+            was created: legal entity, site, address.
           enum:
             - LEGAL_ENTITY
             - SITE
@@ -3874,7 +4268,9 @@ components:
           description: The date and time when the changelog entry was created.
         changelogType:
           type: string
-          description: 'One of the actions for which the changelog entry was created: create, update.'
+          description: >-
+            One of the actions for which the changelog entry was created:
+            create, update.
           enum:
             - CREATE
             - UPDATE
@@ -4242,6 +4638,25 @@ components:
             $ref: '#/components/schemas/CxMembershipDto'
       required:
         - memberships
+    DataSpaceParticipantDto:
+      type: object
+      properties:
+        bpnL:
+          type: string
+        isDataSpaceParticipant:
+          type: boolean
+      required:
+        - bpnL
+        - isDataSpaceParticipant
+    DataSpaceParticipantUpdateRequest:
+      type: object
+      properties:
+        participants:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSpaceParticipantDto'
+      required:
+        - participants
     ErrorInfoAddressCreateError:
       type: object
       description: Holds information about failures when creating or updating an entity
@@ -4682,7 +5097,9 @@ components:
         - qualityLevel
     GeoCoordinateDto:
       type: object
-      description: The exact location of the physical postal address in latitude, longitude, and altitude.
+      description: >-
+        The exact location of the physical postal address in latitude,
+        longitude, and altitude.
       properties:
         longitude:
           type: number
@@ -4701,11 +5118,15 @@ components:
         - longitude
     IdentifierTypeDetailDto:
       type: object
-      description: Information for which countries an identifier type is valid and mandatory.
+      description: >-
+        Information for which countries an identifier type is valid and
+        mandatory.
       properties:
         country:
           type: string
-          description: 2-digit country code for which this identifier is valid; null for universal identifiers.
+          description: >-
+            2-digit country code for which this identifier is valid; null for
+            universal identifiers.
           enum:
             - UNDEFINED
             - AC
@@ -4986,14 +5407,21 @@ components:
         - mandatory
     IdentifierTypeDto:
       type: object
-      description: An identifier type defines the name or category of an identifier, such as the German Handelsregisternummer, VAT number, Global Location Number (GLN), etc. The identifier type is valid for a business partner type.
+      description: >-
+        An identifier type defines the name or category of an identifier, such
+        as the German Handelsregisternummer, VAT number, Global Location Number
+        (GLN), etc. The identifier type is valid for a business partner type.
       properties:
         technicalKey:
           type: string
-          description: The technical identifier (unique in combination with businessPartnerType).
+          description: >-
+            The technical identifier (unique in combination with
+            businessPartnerType).
         businessPartnerType:
           type: string
-          description: One of the types of business partners for which the identifier type is valid.
+          description: >-
+            One of the types of business partners for which the identifier type
+            is valid.
           enum:
             - LEGAL_ENTITY
             - ADDRESS
@@ -5002,7 +5430,9 @@ components:
           description: The name of the identifier type.
         abbreviation:
           type: string
-          description: The local short form of the identifier type used in particular country.
+          description: >-
+            The local short form of the identifier type used in particular
+            country.
         transliteratedName:
           type: string
           description: The transliterated (Latinized) form of the name.
@@ -5043,7 +5473,9 @@ components:
         - idValues
     LegalEntityIdentifierDto:
       type: object
-      description: A legal entity identifier (uniquely) identifies the legal entity, such as the German Handelsregisternummer, a VAT number, etc.
+      description: >-
+        A legal entity identifier (uniquely) identifies the legal entity, such
+        as the German Handelsregisternummer, a VAT number, etc.
       properties:
         value:
           type: string
@@ -5053,13 +5485,18 @@ components:
           description: The type of the identifier.
         issuingBody:
           type: string
-          description: The name of the official register, where the identifier is registered. For example, a Handelsregisternummer in Germany is only valid with its corresponding Handelsregister.
+          description: >-
+            The name of the official register, where the identifier is
+            registered. For example, a Handelsregisternummer in Germany is only
+            valid with its corresponding Handelsregister.
       required:
         - type
         - value
     LegalEntityIdentifierVerboseDto:
       type: object
-      description: A legal entity identifier (uniquely) identifies the legal entity, such as the German Handelsregisternummer, a VAT number, etc.
+      description: >-
+        A legal entity identifier (uniquely) identifies the legal entity, such
+        as the German Handelsregisternummer, a VAT number, etc.
       properties:
         value:
           type: string
@@ -5069,13 +5506,30 @@ components:
           description: The type of the identifier.
         issuingBody:
           type: string
-          description: The name of the official register, where the identifier is registered. For example, a Handelsregisternummer in Germany is only valid with its corresponding Handelsregister.
+          description: >-
+            The name of the official register, where the identifier is
+            registered. For example, a Handelsregisternummer in Germany is only
+            valid with its corresponding Handelsregister.
       required:
         - type
         - value
     LegalEntityPartnerCreateRequest:
       type: object
-      description: Request for creating new business partner record of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL.
+      description: >-
+        Request for creating new business partner record of type legal entity.
+        In general, a legal entity is a juridical person that has legal rights
+        and duties related to contracts, agreements, and obligations. The term
+        especially applies to any kind of organization (such as an enterprise or
+        company, university, association, etc.) established under the law
+        applicable to a country.In Catena-X, a legal entity is a type of
+        business partner representing a legally registered organization with its
+        official registration information, such as legal name (including legal
+        form, if registered), legal address and tax number.A legal entity has
+        exactly one legal address, but it is possible to specify additional
+        addresses that a legal entity owns. Thus, at least one address is
+        assigned to a legal entity. A legal entity can own sites. Thus, many or
+        no sites are assigned to a legal entity. A legal entity is uniquely
+        identified by the BPNL.
       properties:
         legalName:
           type: string
@@ -5096,27 +5550,36 @@ components:
             $ref: '#/components/schemas/LegalEntityStateDto'
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the legal entity is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the legal entity is owned and thus provided by a
+            Data Space Participant.
         legalAddress:
           $ref: '#/components/schemas/LogisticAddressDto'
-          description: The official, legal correspondence address to be provided to government and tax authorities and used in all legal or court documents.
+          description: >-
+            The official, legal correspondence address to be provided to
+            government and tax authorities and used in all legal or court
+            documents.
         index:
           type: string
-          description: User defined index to conveniently match this entry to the corresponding entry in the response.
+          description: >-
+            User defined index to conveniently match this entry to the
+            corresponding entry in the response.
         requestKey:
           type: string
       required:
         - confidenceCriteria
         - identifiers
-        - isCatenaXMemberData
+        - isParticipantData
         - legalAddress
         - legalName
         - states
     LegalEntityPartnerCreateResponseWrapper:
       type: object
-      description: Holds information about successfully and failed entities after the creating/updating of several objects
+      description: >-
+        Holds information about successfully and failed entities after the
+        creating/updating of several objects
       properties:
         entities:
           type: array
@@ -5139,11 +5602,28 @@ components:
         - errors
     LegalEntityPartnerCreateVerboseDto:
       type: object
-      description: Created/updated business partner of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL.
+      description: >-
+        Created/updated business partner of type legal entity. In general, a
+        legal entity is a juridical person that has legal rights and duties
+        related to contracts, agreements, and obligations. The term especially
+        applies to any kind of organization (such as an enterprise or company,
+        university, association, etc.) established under the law applicable to a
+        country.In Catena-X, a legal entity is a type of business partner
+        representing a legally registered organization with its official
+        registration information, such as legal name (including legal form, if
+        registered), legal address and tax number.A legal entity has exactly one
+        legal address, but it is possible to specify additional addresses that a
+        legal entity owns. Thus, at least one address is assigned to a legal
+        entity. A legal entity can own sites. Thus, many or no sites are
+        assigned to a legal entity. A legal entity is uniquely identified by the
+        BPNL.
       properties:
         bpnl:
           type: string
-          description: A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number.
+          description: >-
+            A BPNL represents and uniquely identifies a legal entity, which is
+            defined by its legal name (including legal form, if registered),
+            legal address and tax number.
         legalName:
           type: string
           description: The name of the legal entity according to official registers.
@@ -5168,12 +5648,16 @@ components:
         currentness:
           type: string
           format: date-time
-          description: The date the business partner data was last indicated to be still current.
+          description: >-
+            The date the business partner data was last indicated to be still
+            current.
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the legal entity is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the legal entity is owned and thus provided by a
+            Data Space Participant.
         createdAt:
           type: string
           format: date-time
@@ -5184,17 +5668,22 @@ components:
           description: The date when the data record has been last updated.
         legalAddress:
           $ref: '#/components/schemas/LogisticAddressVerboseDto'
-          description: The official, legal correspondence address to be provided to government and tax authorities and used in all legal or court documents.
+          description: >-
+            The official, legal correspondence address to be provided to
+            government and tax authorities and used in all legal or court
+            documents.
         index:
           type: string
-          description: User defined index to conveniently match this entry to the corresponding entry in the response.
+          description: >-
+            User defined index to conveniently match this entry to the
+            corresponding entry in the response.
       required:
         - bpnl
         - confidenceCriteria
         - createdAt
         - currentness
         - identifiers
-        - isCatenaXMemberData
+        - isParticipantData
         - legalAddress
         - legalName
         - relations
@@ -5202,11 +5691,28 @@ components:
         - updatedAt
     LegalEntityPartnerUpdateRequest:
       type: object
-      description: Request for updating a business partner record of type legal entity. In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL.
+      description: >-
+        Request for updating a business partner record of type legal entity. In
+        general, a legal entity is a juridical person that has legal rights and
+        duties related to contracts, agreements, and obligations. The term
+        especially applies to any kind of organization (such as an enterprise or
+        company, university, association, etc.) established under the law
+        applicable to a country.In Catena-X, a legal entity is a type of
+        business partner representing a legally registered organization with its
+        official registration information, such as legal name (including legal
+        form, if registered), legal address and tax number.A legal entity has
+        exactly one legal address, but it is possible to specify additional
+        addresses that a legal entity owns. Thus, at least one address is
+        assigned to a legal entity. A legal entity can own sites. Thus, many or
+        no sites are assigned to a legal entity. A legal entity is uniquely
+        identified by the BPNL.
       properties:
         bpnl:
           type: string
-          description: A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number.
+          description: >-
+            A BPNL represents and uniquely identifies a legal entity, which is
+            defined by its legal name (including legal form, if registered),
+            legal address and tax number.
         legalName:
           type: string
           description: The name of the legal entity according to official registers.
@@ -5226,26 +5732,33 @@ components:
             $ref: '#/components/schemas/LegalEntityStateDto'
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the legal entity is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the legal entity is owned and thus provided by a
+            Data Space Participant.
         legalAddress:
           $ref: '#/components/schemas/LogisticAddressDto'
-          description: The official, legal correspondence address to be provided to government and tax authorities and used in all legal or court documents.
+          description: >-
+            The official, legal correspondence address to be provided to
+            government and tax authorities and used in all legal or court
+            documents.
         requestKey:
           type: string
       required:
         - bpnl
         - confidenceCriteria
         - identifiers
-        - isCatenaXMemberData
+        - isParticipantData
         - legalAddress
         - legalName
         - requestKey
         - states
     LegalEntityPartnerUpdateResponseWrapper:
       type: object
-      description: Holds information about successfully and failed entities after the creating/updating of several objects
+      description: >-
+        Holds information about successfully and failed entities after the
+        creating/updating of several objects
       properties:
         entities:
           type: array
@@ -5279,7 +5792,11 @@ components:
         - bpnLs
     LegalEntityStateDto:
       type: object
-      description: A legal entity state indicates if the legal entity is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the legal entity is still operating.
+      description: >-
+        A legal entity state indicates if the legal entity is active or
+        inactive. This does not describe the relation between a sharing member
+        and a business partner and whether they have active business, but it
+        describes whether the legal entity is still operating.
       properties:
         validFrom:
           type: string
@@ -5299,7 +5816,11 @@ components:
         - type
     LegalEntityStateVerboseDto:
       type: object
-      description: A legal entity state indicates if the legal entity is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the legal entity is still operating.
+      description: >-
+        A legal entity state indicates if the legal entity is active or
+        inactive. This does not describe the relation between a sharing member
+        and a business partner and whether they have active business, but it
+        describes whether the legal entity is still operating.
       properties:
         validFrom:
           type: string
@@ -5316,11 +5837,27 @@ components:
         - type
     LegalEntityWithLegalAddressVerboseDto:
       type: object
-      description: In general, a legal entity is a juridical person that has legal rights and duties related to contracts, agreements, and obligations. The term especially applies to any kind of organization (such as an enterprise or company, university, association, etc.) established under the law applicable to a country.In Catena-X, a legal entity is a type of business partner representing a legally registered organization with its official registration information, such as legal name (including legal form, if registered), legal address and tax number.A legal entity has exactly one legal address, but it is possible to specify additional addresses that a legal entity owns. Thus, at least one address is assigned to a legal entity. A legal entity can own sites. Thus, many or no sites are assigned to a legal entity. A legal entity is uniquely identified by the BPNL.
+      description: >-
+        In general, a legal entity is a juridical person that has legal rights
+        and duties related to contracts, agreements, and obligations. The term
+        especially applies to any kind of organization (such as an enterprise or
+        company, university, association, etc.) established under the law
+        applicable to a country.In Catena-X, a legal entity is a type of
+        business partner representing a legally registered organization with its
+        official registration information, such as legal name (including legal
+        form, if registered), legal address and tax number.A legal entity has
+        exactly one legal address, but it is possible to specify additional
+        addresses that a legal entity owns. Thus, at least one address is
+        assigned to a legal entity. A legal entity can own sites. Thus, many or
+        no sites are assigned to a legal entity. A legal entity is uniquely
+        identified by the BPNL.
       properties:
         bpnl:
           type: string
-          description: A BPNL represents and uniquely identifies a legal entity, which is defined by its legal name (including legal form, if registered), legal address and tax number.
+          description: >-
+            A BPNL represents and uniquely identifies a legal entity, which is
+            defined by its legal name (including legal form, if registered),
+            legal address and tax number.
         legalName:
           type: string
           description: The name of the legal entity according to official registers.
@@ -5345,12 +5882,16 @@ components:
         currentness:
           type: string
           format: date-time
-          description: The date the business partner data was last indicated to be still current.
+          description: >-
+            The date the business partner data was last indicated to be still
+            current.
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the legal entity is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the legal entity is owned and thus provided by a
+            Data Space Participant.
         createdAt:
           type: string
           format: date-time
@@ -5361,14 +5902,17 @@ components:
           description: The date when the data record has been last updated.
         legalAddress:
           $ref: '#/components/schemas/LogisticAddressVerboseDto'
-          description: The official, legal correspondence address to be provided to government and tax authorities and used in all legal or court documents.
+          description: >-
+            The official, legal correspondence address to be provided to
+            government and tax authorities and used in all legal or court
+            documents.
       required:
         - bpnl
         - confidenceCriteria
         - createdAt
         - currentness
         - identifiers
-        - isCatenaXMemberData
+        - isParticipantData
         - legalAddress
         - legalName
         - relations
@@ -5376,7 +5920,9 @@ components:
         - updatedAt
     LegalFormDto:
       type: object
-      description: A legal form is a mandatory corporate legal framework by which companies can conduct business, charitable or other permissible activities.
+      description: >-
+        A legal form is a mandatory corporate legal framework by which companies
+        can conduct business, charitable or other permissible activities.
       properties:
         technicalKey:
           type: string
@@ -5386,9 +5932,11 @@ components:
           description: The name of legal form according to ISO 20275.
         transliteratedName:
           type: string
-        abbreviation:
+        abbreviations:
           type: string
-          description: The abbreviated name of the legal form, such as AG for German Aktiengesellschaft.
+          description: >-
+            The abbreviated name of the legal form, such as AG for German
+            Aktiengesellschaft.
         country:
           type: string
           enum:
@@ -5875,7 +6423,7 @@ components:
         transliteratedName:
           type: string
           description: Transliterated name of the legal form
-        abbreviation:
+        abbreviations:
           type: string
           description: Comma separed list of abbreviations of the legal form name
         transliteratedAbbreviations:
@@ -6358,11 +6906,24 @@ components:
         - technicalKey
     LogisticAddressDto:
       type: object
-      description: In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA.
+      description: >-
+        In general, an address is a collection of information to describe a
+        physical location, using a street name with a house number and/or a post
+        office box as reference. In addition, an address consists of several
+        postal attributes, such as country, region (state), county, township,
+        city, district, or postal code, which help deliver mail.In Catena-X, an
+        address is a type of business partner representing the legal address of
+        a legal entity, and/or the main address of a site, or any additional
+        address of a legal entity or site (such as different gates).An address
+        is owned by a legal entity. Thus, exactly one legal entity is assigned
+        to an address. An address can belong to a site. Thus, one or no site is
+        assigned to an address. An address is uniquely identified by the BPNA.
       properties:
         name:
           type: string
-          description: The name of the address. This is not according to official registers but according to the name the sharing member chooses.
+          description: >-
+            The name of the address. This is not according to official registers
+            but according to the name the sharing member chooses.
         states:
           type: array
           items:
@@ -6373,10 +6934,14 @@ components:
             $ref: '#/components/schemas/AddressIdentifierDto'
         physicalPostalAddress:
           $ref: '#/components/schemas/PhysicalPostalAddressDto'
-          description: The physical postal address of the address, such as an office, warehouse, gate, etc.
+          description: >-
+            The physical postal address of the address, such as an office,
+            warehouse, gate, etc.
         alternativePostalAddress:
           $ref: '#/components/schemas/AlternativePostalAddressDto'
-          description: The alternative postal address of the address, for example if the goods are to be picked up somewhere else.
+          description: >-
+            The alternative postal address of the address, for example if the
+            goods are to be picked up somewhere else.
         confidenceCriteria:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
       required:
@@ -6386,14 +6951,34 @@ components:
         - states
     LogisticAddressVerboseDto:
       type: object
-      description: In general, an address is a collection of information to describe a physical location, using a street name with a house number and/or a post office box as reference. In addition, an address consists of several postal attributes, such as country, region (state), county, township, city, district, or postal code, which help deliver mail.In Catena-X, an address is a type of business partner representing the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates).An address is owned by a legal entity. Thus, exactly one legal entity is assigned to an address. An address can belong to a site. Thus, one or no site is assigned to an address. An address is uniquely identified by the BPNA.
+      description: >-
+        In general, an address is a collection of information to describe a
+        physical location, using a street name with a house number and/or a post
+        office box as reference. In addition, an address consists of several
+        postal attributes, such as country, region (state), county, township,
+        city, district, or postal code, which help deliver mail.In Catena-X, an
+        address is a type of business partner representing the legal address of
+        a legal entity, and/or the main address of a site, or any additional
+        address of a legal entity or site (such as different gates).An address
+        is owned by a legal entity. Thus, exactly one legal entity is assigned
+        to an address. An address can belong to a site. Thus, one or no site is
+        assigned to an address. An address is uniquely identified by the BPNA.
       properties:
         bpna:
           type: string
-          description: A BPNA represents and uniquely identifies an address, which can be the legal address of a legal entity, and/or the main address of a site, or any additional address of a legal entity or site (such as different gates). It is important to note that only the BPNL must be used to uniquely identify a legal entity. Even in the case that the BPNA represents the legal address of the legal entity, it shall not be used to uniquely identify the legal entity.
+          description: >-
+            A BPNA represents and uniquely identifies an address, which can be
+            the legal address of a legal entity, and/or the main address of a
+            site, or any additional address of a legal entity or site (such as
+            different gates). It is important to note that only the BPNL must be
+            used to uniquely identify a legal entity. Even in the case that the
+            BPNA represents the legal address of the legal entity, it shall not
+            be used to uniquely identify the legal entity.
         name:
           type: string
-          description: The name of the address. This is not according to official registers but according to the name the sharing member chooses.
+          description: >-
+            The name of the address. This is not according to official registers
+            but according to the name the sharing member chooses.
         states:
           type: array
           items:
@@ -6404,19 +6989,25 @@ components:
             $ref: '#/components/schemas/AddressIdentifierVerboseDto'
         physicalPostalAddress:
           $ref: '#/components/schemas/PhysicalPostalAddressVerboseDto'
-          description: The physical postal address of the address, such as an office, warehouse, gate, etc.
+          description: >-
+            The physical postal address of the address, such as an office,
+            warehouse, gate, etc.
         alternativePostalAddress:
           $ref: '#/components/schemas/AlternativePostalAddressVerboseDto'
-          description: The alternative postal address of the address, for example if the goods are to be picked up somewhere else.
+          description: >-
+            The alternative postal address of the address, for example if the
+            goods are to be picked up somewhere else.
         bpnLegalEntity:
           type: string
           description: The BPNL of the legal entity owning the address.
         bpnSite:
           type: string
           description: The BPNS of the site the address belongs to.
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the address is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the address is owned and thus provided by a Data
+            Space Participant.
         createdAt:
           type: string
           format: date-time
@@ -6429,7 +7020,12 @@ components:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
         addressType:
           type: string
-          description: Indicates the address type, the legal address to a legal entity or the main address to a site, an additional address, or both legal and site address.The site main address is where typically the main entrance or the reception is located, or where the mail is delivered to.
+          description: >-
+            Indicates the address type, the legal address to a legal entity or
+            the main address to a site, an additional address, or both legal and
+            site address.The site main address is where typically the main
+            entrance or the reception is located, or where the mail is delivered
+            to.
           enum:
             - LegalAndSiteMainAddress
             - LegalAddress
@@ -6440,7 +7036,7 @@ components:
         - confidenceCriteria
         - createdAt
         - identifiers
-        - isCatenaXMemberData
+        - isParticipantData
         - physicalPostalAddress
         - states
         - updatedAt
@@ -6531,6 +7127,37 @@ components:
           description: Collection of results in the page
           items:
             $ref: '#/components/schemas/CxMembershipDto'
+      required:
+        - content
+        - contentSize
+        - page
+        - totalElements
+        - totalPages
+    PageDtoDataSpaceParticipantDto:
+      type: object
+      description: Paginated collection of results
+      properties:
+        totalElements:
+          type: integer
+          format: int64
+          description: Total number of all results in all pages
+        totalPages:
+          type: integer
+          format: int32
+          description: Total number pages
+        page:
+          type: integer
+          format: int32
+          description: Current page number
+        contentSize:
+          type: integer
+          format: int32
+          description: Number of results in the page
+        content:
+          type: array
+          description: Collection of results in the page
+          items:
+            $ref: '#/components/schemas/DataSpaceParticipantDto'
       required:
         - content
         - contentSize
@@ -6725,13 +7352,17 @@ components:
         - totalPages
     PhysicalPostalAddressDto:
       type: object
-      description: A physical postal address describes the physical location of an office, warehouse, gate, etc.
+      description: >-
+        A physical postal address describes the physical location of an office,
+        warehouse, gate, etc.
       properties:
         geographicCoordinates:
           $ref: '#/components/schemas/GeoCoordinateDto'
         country:
           type: string
-          description: The 2-digit country code of the physical postal address according to ISO 3166-1.
+          description: >-
+            The 2-digit country code of the physical postal address according to
+            ISO 3166-1.
           enum:
             - UNDEFINED
             - AC
@@ -7007,92 +7638,148 @@ components:
             - ZW
         administrativeAreaLevel1:
           type: string
-          description: The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country.
+          description: >-
+            The 2-digit country subdivision code according to ISO 3166-2, such
+            as a region within a country.
         administrativeAreaLevel2:
           type: string
-          description: The name of the locally regulated secondary country subdivision of the physical postal address, such as county within a country.
+          description: >-
+            The name of the locally regulated secondary country subdivision of
+            the physical postal address, such as county within a country.
         administrativeAreaLevel3:
           type: string
-          description: The name of the locally regulated tertiary country subdivision of the physical address, such as townships within a country.
+          description: >-
+            The name of the locally regulated tertiary country subdivision of
+            the physical address, such as townships within a country.
         postalCode:
           type: string
-          description: The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code.
+          description: >-
+            The alphanumeric identifier (sometimes including spaces or
+            punctuation) of the physical postal address for the purpose of
+            sorting mail, synonyms:postcode, post code, PIN or ZIP code.
         city:
           type: string
-          description: 'The name of the city of the physical postal address, synonyms: town, village, municipality.'
+          description: >-
+            The name of the city of the physical postal address, synonyms: town,
+            village, municipality.
         district:
           type: string
-          description: The name of the district of the physical postal address which divides the city in several smaller areas.
+          description: >-
+            The name of the district of the physical postal address which
+            divides the city in several smaller areas.
         street:
           $ref: '#/components/schemas/StreetDto'
         companyPostalCode:
           type: string
-          description: The company postal code of the physical postal address, which is sometimes required for large companies.
+          description: >-
+            The company postal code of the physical postal address, which is
+            sometimes required for large companies.
         industrialZone:
           type: string
-          description: 'The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area.'
+          description: >-
+            The industrial zone of the physical postal address, designating an
+            area for industrial development, synonym: industrial area.
         building:
           type: string
-          description: The alphanumeric identifier of the building addressed by the physical postal address.
+          description: >-
+            The alphanumeric identifier of the building addressed by the
+            physical postal address.
         floor:
           type: string
-          description: 'The number of a floor in the building addressed by the physical postal address, synonym: level.'
+          description: >-
+            The number of a floor in the building addressed by the physical
+            postal address, synonym: level.
         door:
           type: string
-          description: 'The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite.'
+          description: >-
+            The number of a door in the building on the respective floor
+            addressed by the physical postal address, synonyms: room, suite.
         taxJurisdictionCode:
           type: string
-          description: Tax jurisdiction codes are used to identify the specific jurisdiction(s) that a company belong to, particularly in bureaucratic processes such as tax returns and IRS forms.
+          description: >-
+            Tax jurisdiction codes are used to identify the specific
+            jurisdiction(s) that a company belong to, particularly in
+            bureaucratic processes such as tax returns and IRS forms.
       required:
         - city
         - country
     PhysicalPostalAddressVerboseDto:
       type: object
-      description: A physical postal address describes the physical location of an office, warehouse, gate, etc.
+      description: >-
+        A physical postal address describes the physical location of an office,
+        warehouse, gate, etc.
       properties:
         geographicCoordinates:
           $ref: '#/components/schemas/GeoCoordinateDto'
         country:
           $ref: '#/components/schemas/TypeKeyNameVerboseDtoCountryCode'
-          description: The 2-digit country code of the physical postal address according to ISO 3166-1.
+          description: >-
+            The 2-digit country code of the physical postal address according to
+            ISO 3166-1.
         administrativeAreaLevel1:
           $ref: '#/components/schemas/RegionDto'
-          description: The 2-digit country subdivision code according to ISO 3166-2, such as a region within a country.
+          description: >-
+            The 2-digit country subdivision code according to ISO 3166-2, such
+            as a region within a country.
         administrativeAreaLevel2:
           type: string
-          description: The name of the locally regulated secondary country subdivision of the physical postal address, such as county within a country.
+          description: >-
+            The name of the locally regulated secondary country subdivision of
+            the physical postal address, such as county within a country.
         administrativeAreaLevel3:
           type: string
-          description: The name of the locally regulated tertiary country subdivision of the physical address, such as townships within a country.
+          description: >-
+            The name of the locally regulated tertiary country subdivision of
+            the physical address, such as townships within a country.
         postalCode:
           type: string
-          description: The alphanumeric identifier (sometimes including spaces or punctuation) of the physical postal address for the purpose of sorting mail, synonyms:postcode, post code, PIN or ZIP code.
+          description: >-
+            The alphanumeric identifier (sometimes including spaces or
+            punctuation) of the physical postal address for the purpose of
+            sorting mail, synonyms:postcode, post code, PIN or ZIP code.
         city:
           type: string
-          description: 'The name of the city of the physical postal address, synonyms: town, village, municipality.'
+          description: >-
+            The name of the city of the physical postal address, synonyms: town,
+            village, municipality.
         district:
           type: string
-          description: The name of the district of the physical postal address which divides the city in several smaller areas.
+          description: >-
+            The name of the district of the physical postal address which
+            divides the city in several smaller areas.
         street:
           $ref: '#/components/schemas/StreetDto'
         companyPostalCode:
           type: string
-          description: The company postal code of the physical postal address, which is sometimes required for large companies.
+          description: >-
+            The company postal code of the physical postal address, which is
+            sometimes required for large companies.
         industrialZone:
           type: string
-          description: 'The industrial zone of the physical postal address, designating an area for industrial development, synonym: industrial area.'
+          description: >-
+            The industrial zone of the physical postal address, designating an
+            area for industrial development, synonym: industrial area.
         building:
           type: string
-          description: The alphanumeric identifier of the building addressed by the physical postal address.
+          description: >-
+            The alphanumeric identifier of the building addressed by the
+            physical postal address.
         floor:
           type: string
-          description: 'The number of a floor in the building addressed by the physical postal address, synonym: level.'
+          description: >-
+            The number of a floor in the building addressed by the physical
+            postal address, synonym: level.
         door:
           type: string
-          description: 'The number of a door in the building on the respective floor addressed by the physical postal address, synonyms: room, suite.'
+          description: >-
+            The number of a door in the building on the respective floor
+            addressed by the physical postal address, synonyms: room, suite.
         taxJurisdictionCode:
           type: string
-          description: Tax jurisdiction codes are used to identify the specific jurisdiction(s) that a company belong to, particularly in bureaucratic processes such as tax returns and IRS forms.
+          description: >-
+            Tax jurisdiction codes are used to identify the specific
+            jurisdiction(s) that a company belong to, particularly in
+            bureaucratic processes such as tax returns and IRS forms.
       required:
         - city
         - country
@@ -7381,7 +8068,9 @@ components:
           description: Abbreviation or shorthand of the area
         regionName:
           type: string
-          description: Describes the full name of the region within a country according to ISO 3166-214
+          description: >-
+            Describes the full name of the region within a country according to
+            ISO 3166-214
       required:
         - countryCode
         - regionCode
@@ -7414,7 +8103,9 @@ components:
       properties:
         name:
           type: string
-          description: The name of the site. This is not according to official registers but according to the name the owner chooses.
+          description: >-
+            The name of the site. This is not according to official registers
+            but according to the name the owner chooses.
         states:
           type: array
           items:
@@ -7430,11 +8121,26 @@ components:
         - states
     SitePartnerCreateRequest:
       type: object
-      description: Request for creating new business partner record of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS.
+      description: >-
+        Request for creating new business partner record of type site. In
+        general, a site is a delimited geographical area in which an
+        organization (such as an enterprise or company, university, association,
+        etc.) conducts business. In Catena-X, a site is a type of business
+        partner representing a physical location or area owned by a legal
+        entity, where a production plant, a warehouse, or an office building is
+        located. A site is owned by a legal entity. Thus, exactly one legal
+        entity is assigned to a site. A site has exactly one main address, but
+        it is possible to specify additional addresses (such as different
+        gates), that belong to a site. Thus, at least one address is assigned to
+        a site. A site can only be uploaded and modified by the owner (the legal
+        entity), because only the owner knows which addresses belong to which
+        site. A site is uniquely identified by the BPNS.
       properties:
         name:
           type: string
-          description: The name of the site. This is not according to official registers but according to the name the owner chooses.
+          description: >-
+            The name of the site. This is not according to official registers
+            but according to the name the owner chooses.
         states:
           type: array
           items:
@@ -7448,7 +8154,9 @@ components:
           description: The BPNL of the legal entity owning the site.
         index:
           type: string
-          description: User defined index to conveniently match this entry to the corresponding entry in the response.
+          description: >-
+            User defined index to conveniently match this entry to the
+            corresponding entry in the response.
         requestKey:
           type: string
       required:
@@ -7459,7 +8167,9 @@ components:
         - states
     SitePartnerCreateResponseWrapper:
       type: object
-      description: Holds information about successfully and failed entities after the creating/updating of several objects
+      description: >-
+        Holds information about successfully and failed entities after the
+        creating/updating of several objects
       properties:
         entities:
           type: array
@@ -7482,21 +8192,41 @@ components:
         - errors
     SitePartnerCreateVerboseDto:
       type: object
-      description: Created/updated business partner of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS.
+      description: >-
+        Created/updated business partner of type site. In general, a site is a
+        delimited geographical area in which an organization (such as an
+        enterprise or company, university, association, etc.) conducts business.
+        In Catena-X, a site is a type of business partner representing a
+        physical location or area owned by a legal entity, where a production
+        plant, a warehouse, or an office building is located. A site is owned by
+        a legal entity. Thus, exactly one legal entity is assigned to a site. A
+        site has exactly one main address, but it is possible to specify
+        additional addresses (such as different gates), that belong to a site.
+        Thus, at least one address is assigned to a site. A site can only be
+        uploaded and modified by the owner (the legal entity), because only the
+        owner knows which addresses belong to which site. A site is uniquely
+        identified by the BPNS.
       properties:
         bpns:
           type: string
-          description: A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located.
+          description: >-
+            A BPNS represents and uniquely identifies a site, which is where for
+            example a production plant, a warehouse, or an office building is
+            located.
         name:
           type: string
-          description: The name of the site. This is not according to official registers but according to the name the owner chooses.
+          description: >-
+            The name of the site. This is not according to official registers
+            but according to the name the owner chooses.
         states:
           type: array
           items:
             $ref: '#/components/schemas/SiteStateVerboseDto'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the site is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the site is owned and thus provided by a Data
+            Space Participant.
         bpnLegalEntity:
           type: string
           description: The BPNL of the legal entity owning the site.
@@ -7512,30 +8242,52 @@ components:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
         mainAddress:
           $ref: '#/components/schemas/LogisticAddressVerboseDto'
-          description: The address, where typically the main entrance or the reception is located, or where the mail is delivered to.
+          description: >-
+            The address, where typically the main entrance or the reception is
+            located, or where the mail is delivered to.
         index:
           type: string
-          description: User defined index to conveniently match this entry to the corresponding entry in the response.
+          description: >-
+            User defined index to conveniently match this entry to the
+            corresponding entry in the response.
       required:
         - bpnLegalEntity
         - bpns
         - confidenceCriteria
         - createdAt
-        - isCatenaXMemberData
+        - isParticipantData
         - mainAddress
         - name
         - states
         - updatedAt
     SitePartnerUpdateRequest:
       type: object
-      description: Request for updating a business partner record of type site. In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS.
+      description: >-
+        Request for updating a business partner record of type site. In general,
+        a site is a delimited geographical area in which an organization (such
+        as an enterprise or company, university, association, etc.) conducts
+        business. In Catena-X, a site is a type of business partner representing
+        a physical location or area owned by a legal entity, where a production
+        plant, a warehouse, or an office building is located. A site is owned by
+        a legal entity. Thus, exactly one legal entity is assigned to a site. A
+        site has exactly one main address, but it is possible to specify
+        additional addresses (such as different gates), that belong to a site.
+        Thus, at least one address is assigned to a site. A site can only be
+        uploaded and modified by the owner (the legal entity), because only the
+        owner knows which addresses belong to which site. A site is uniquely
+        identified by the BPNS.
       properties:
         bpns:
           type: string
-          description: A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located.
+          description: >-
+            A BPNS represents and uniquely identifies a site, which is where for
+            example a production plant, a warehouse, or an office building is
+            located.
         name:
           type: string
-          description: The name of the site. This is not according to official registers but according to the name the owner chooses.
+          description: >-
+            The name of the site. This is not according to official registers
+            but according to the name the owner chooses.
         states:
           type: array
           items:
@@ -7555,7 +8307,9 @@ components:
         - states
     SitePartnerUpdateResponseWrapper:
       type: object
-      description: Holds information about successfully and failed entities after the creating/updating of several objects
+      description: >-
+        Holds information about successfully and failed entities after the
+        creating/updating of several objects
       properties:
         entities:
           type: array
@@ -7594,7 +8348,11 @@ components:
         - siteBpns
     SiteStateDto:
       type: object
-      description: A site state indicates if the site is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the site is still operating.
+      description: >-
+        A site state indicates if the site is active or inactive. This does not
+        describe the relation between a sharing member and a business partner
+        and whether they have active business, but it describes whether the site
+        is still operating.
       properties:
         validFrom:
           type: string
@@ -7614,7 +8372,11 @@ components:
         - type
     SiteStateVerboseDto:
       type: object
-      description: A site state indicates if the site is active or inactive. This does not describe the relation between a sharing member and a business partner and whether they have active business, but it describes whether the site is still operating.
+      description: >-
+        A site state indicates if the site is active or inactive. This does not
+        describe the relation between a sharing member and a business partner
+        and whether they have active business, but it describes whether the site
+        is still operating.
       properties:
         validFrom:
           type: string
@@ -7631,21 +8393,40 @@ components:
         - type
     SiteVerboseDto:
       type: object
-      description: In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS.
+      description: >-
+        In general, a site is a delimited geographical area in which an
+        organization (such as an enterprise or company, university, association,
+        etc.) conducts business. In Catena-X, a site is a type of business
+        partner representing a physical location or area owned by a legal
+        entity, where a production plant, a warehouse, or an office building is
+        located. A site is owned by a legal entity. Thus, exactly one legal
+        entity is assigned to a site. A site has exactly one main address, but
+        it is possible to specify additional addresses (such as different
+        gates), that belong to a site. Thus, at least one address is assigned to
+        a site. A site can only be uploaded and modified by the owner (the legal
+        entity), because only the owner knows which addresses belong to which
+        site. A site is uniquely identified by the BPNS.
       properties:
         bpns:
           type: string
-          description: A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located.
+          description: >-
+            A BPNS represents and uniquely identifies a site, which is where for
+            example a production plant, a warehouse, or an office building is
+            located.
         name:
           type: string
-          description: The name of the site. This is not according to official registers but according to the name the owner chooses.
+          description: >-
+            The name of the site. This is not according to official registers
+            but according to the name the owner chooses.
         states:
           type: array
           items:
             $ref: '#/components/schemas/SiteStateVerboseDto'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the site is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the site is owned and thus provided by a Data
+            Space Participant.
         bpnLegalEntity:
           type: string
           description: The BPNL of the legal entity owning the site.
@@ -7664,27 +8445,46 @@ components:
         - bpns
         - confidenceCriteria
         - createdAt
-        - isCatenaXMemberData
+        - isParticipantData
         - name
         - states
         - updatedAt
     SiteWithMainAddressVerboseDto:
       type: object
-      description: In general, a site is a delimited geographical area in which an organization (such as an enterprise or company, university, association, etc.) conducts business. In Catena-X, a site is a type of business partner representing a physical location or area owned by a legal entity, where a production plant, a warehouse, or an office building is located. A site is owned by a legal entity. Thus, exactly one legal entity is assigned to a site. A site has exactly one main address, but it is possible to specify additional addresses (such as different gates), that belong to a site. Thus, at least one address is assigned to a site. A site can only be uploaded and modified by the owner (the legal entity), because only the owner knows which addresses belong to which site. A site is uniquely identified by the BPNS.
+      description: >-
+        In general, a site is a delimited geographical area in which an
+        organization (such as an enterprise or company, university, association,
+        etc.) conducts business. In Catena-X, a site is a type of business
+        partner representing a physical location or area owned by a legal
+        entity, where a production plant, a warehouse, or an office building is
+        located. A site is owned by a legal entity. Thus, exactly one legal
+        entity is assigned to a site. A site has exactly one main address, but
+        it is possible to specify additional addresses (such as different
+        gates), that belong to a site. Thus, at least one address is assigned to
+        a site. A site can only be uploaded and modified by the owner (the legal
+        entity), because only the owner knows which addresses belong to which
+        site. A site is uniquely identified by the BPNS.
       properties:
         bpns:
           type: string
-          description: A BPNS represents and uniquely identifies a site, which is where for example a production plant, a warehouse, or an office building is located.
+          description: >-
+            A BPNS represents and uniquely identifies a site, which is where for
+            example a production plant, a warehouse, or an office building is
+            located.
         name:
           type: string
-          description: The name of the site. This is not according to official registers but according to the name the owner chooses.
+          description: >-
+            The name of the site. This is not according to official registers
+            but according to the name the owner chooses.
         states:
           type: array
           items:
             $ref: '#/components/schemas/SiteStateVerboseDto'
-        isCatenaXMemberData:
+        isParticipantData:
           type: boolean
-          description: Indicates whether the site is owned and thus provided by a Catena-X Member.
+          description: >-
+            Indicates whether the site is owned and thus provided by a Data
+            Space Participant.
         bpnLegalEntity:
           type: string
           description: The BPNL of the legal entity owning the site.
@@ -7700,47 +8500,66 @@ components:
           $ref: '#/components/schemas/ConfidenceCriteriaDto'
         mainAddress:
           $ref: '#/components/schemas/LogisticAddressVerboseDto'
-          description: The address, where typically the main entrance or the reception is located, or where the mail is delivered to.
+          description: >-
+            The address, where typically the main entrance or the reception is
+            located, or where the mail is delivered to.
       required:
         - bpnLegalEntity
         - bpns
         - confidenceCriteria
         - createdAt
-        - isCatenaXMemberData
+        - isParticipantData
         - mainAddress
         - name
         - states
         - updatedAt
     StreetDto:
       type: object
-      description: 'The street of the physical postal address, synonyms: road, avenue, lane, boulevard, highway'
+      description: >-
+        The street of the physical postal address, synonyms: road, avenue, lane,
+        boulevard, highway
       properties:
         name:
           type: string
           description: The name of the street.
         houseNumber:
           type: string
-          description: The number representing the exact location of a building within the street.
+          description: >-
+            The number representing the exact location of a building within the
+            street.
         houseNumberSupplement:
           type: string
         milestone:
           type: string
-          description: The number representing the exact location of an addressed object within a street without house numbers, such as within long roads.
+          description: >-
+            The number representing the exact location of an addressed object
+            within a street without house numbers, such as within long roads.
         direction:
           type: string
-          description: The cardinal direction describing where the exit to the location of the addressed object on large highways / motorways is located, such as Highway 101 South.
+          description: >-
+            The cardinal direction describing where the exit to the location of
+            the addressed object on large highways / motorways is located, such
+            as Highway 101 South.
         namePrefix:
           type: string
-          description: The street related information, which is usually printed before the official street name on an address label.
+          description: >-
+            The street related information, which is usually printed before the
+            official street name on an address label.
         additionalNamePrefix:
           type: string
-          description: The additional street related information, which is usually printed before the official street name on an address label.
+          description: >-
+            The additional street related information, which is usually printed
+            before the official street name on an address label.
         nameSuffix:
           type: string
-          description: The street related information, which is usually printed after the official street name on an address label.
+          description: >-
+            The street related information, which is usually printed after the
+            official street name on an address label.
         additionalNameSuffix:
           type: string
-          description: The additional street related information, which is usually printed after the official street name on an address label.
+          description: >-
+            The additional street related information, which is usually printed
+            after the official street name on an address label.
     TypeKeyNameVerboseDtoBusinessStateType:
       type: object
       description: Named type uniquely identified by its technical key
@@ -8061,12 +8880,15 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
+          tokenUrl: >-
+            http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
           scopes: {}
         authorizationCode:
           authorizationUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/auth
-          tokenUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
-          refreshUrl: http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
+          tokenUrl: >-
+            http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
+          refreshUrl: >-
+            http://localhost:8180/realms/CX-Central/protocol/openid-connect/token
           scopes: {}
     bearer_scheme:
       type: http


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request adds the changes for renaming on existing api attributes/fields as per the 25.06 standards for both Gate and Pool services. Also, adapted changes on Orchestrator service.

The changes included in BPDM application version 7 are listed below, 
- [X] attribute "IsCatenaXMemberData" at legal entity, site and address is renamed to "IsParticipantData" 
- [X] attribute "Abbreviation" at legal forms is renamed to "Abbreviations"
- [X] "members" endpoints are renamed to "participants"

Also, separated logic on service layer for pervious BPDM app version i.e. v6.

This pull request contributes to #1304 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
