### PR TITLE
docs: renaming attributes and edc assets as per the standards 25.06

### DIFF
--- a/docs/postman/EDC Provider Setup.postman_collection.json
+++ b/docs/postman/EDC Provider Setup.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "b31ee538-f301-4ba6-bf33-60153d6cda1e",
+		"_postman_id": "5715c0cb-68e3-4f3b-9ca7-03869e6fa7de",
 		"name": "EDC Provider Setup",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "29584075"
+		"_exporter_id": "26818013"
 	},
 	"item": [
 		{
@@ -192,7 +192,7 @@
 					]
 				},
 				{
-					"name": "Pool Member Read Access",
+					"name": "Pool Participant Read Access",
 					"item": [
 						{
 							"name": "Create Asset",
@@ -203,7 +203,7 @@
 										"exec": [
 											"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
 											"    var uuid = require('uuid');",
-											"    pm.collectionVariables.set(\"ASSET_POOL_CX_MEMBER_READ\", uuid.v4())",
+											"    pm.collectionVariables.set(\"ASSET_POOL_PARTICIPANT_READ\", uuid.v4())",
 											"}"
 										],
 										"type": "text/javascript",
@@ -216,7 +216,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"http://purl.org/dc/terms/\",\n        \"cx-taxo\": \"https://w3id.org/catenax/taxonomy/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\"\n    },\n    \"@type\": \"Asset\", \n    \"@id\": \"{{ASSET_POOL_CX_MEMBER_READ}}\", \n    \"properties\": { \n        \"dct:type\": {\n            \"@id\":  \"cx-taxo:BPDMPool\"\n        },\n        \"dct:subject\": {\n            \"@id\": \"cx-taxo:ReadAccessPoolForCatenaXMember\"\n        },\n        \"dct:description\": \"Grants the Catena-X Member read access to the Pool API. This can be used to read legal entity, site, address, legal form, identifier type and administrative area level 1 data. To that end, it also grants read access to the respective changelog entries and identifier mappings, as well as relational data.\",\n        \"cx-common:version\": \"7\"\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"{{POOL_API}}/v7\",\n        \"oauth2:tokenUrl\": \"{{TOKEN_URL}}\",\n        \"oauth2:clientId\": \"{{CLIENT_ID_POOL_CX_MEMBER_READ}}\",\n        \"oauth2:clientSecretKey\": \"{{CLIENT_SECRET_PATH_POOL_CX_MEMBER_READ_CLIENT}}\", \n        \"proxyMethod\": \"true\",\n        \"proxyPath\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"http://purl.org/dc/terms/\",\n        \"cx-taxo\": \"https://w3id.org/catenax/taxonomy/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\"\n    },\n    \"@type\": \"Asset\", \n    \"@id\": \"{{ASSET_POOL_PARTICIPANT_READ}}\", \n    \"properties\": { \n        \"dct:type\": {\n            \"@id\":  \"cx-taxo:BPDMPool\"\n        },\n        \"dct:subject\": {\n            \"@id\": \"cx-taxo:ReadAccessPoolForDataSpaceParticipant\"\n        },\n        \"dct:description\": \"Grants the DataSpace Participant read access to the Pool API. This can be used to read legal entity, site, address, legal form, identifier type and administrative area level 1 data. To that end, it also grants read access to the respective changelog entries and identifier mappings, as well as relational data.\",\n        \"cx-common:version\": \"7\"\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"{{POOL_API}}/v7\",\n        \"oauth2:tokenUrl\": \"{{TOKEN_URL}}\",\n        \"oauth2:clientId\": \"{{CLIENT_ID_POOL_PARTICIPANT_READ}}\",\n        \"oauth2:clientSecretKey\": \"{{CLIENT_SECRET_PATH_POOL_PARTICIPANT_READ_CLIENT}}\", \n        \"proxyMethod\": \"true\",\n        \"proxyPath\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -245,7 +245,7 @@
 										"exec": [
 											"if(pm.collectionVariables.get(\"GENERATE_UUIDS\").toLocaleLowerCase() == \"true\"){",
 											"    var uuid = require('uuid');",
-											"    pm.collectionVariables.set(\"CONTRACT_POOL_CX_MEMBER_READ\", uuid.v4())",
+											"    pm.collectionVariables.set(\"CONTRACT_POOL_PARTICIPANT_READ\", uuid.v4())",
 											"}",
 											""
 										],
@@ -259,7 +259,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"http://purl.org/dc/terms/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\"\n    },\n    \"@id\": \"{{CONTRACT_POOL_CX_MEMBER_READ}}\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"{{POLICY_BUSINESS_PARTNER_NUMBER}}\",\n    \"contractPolicyId\": \"{{POLICY_ACCEPT_PURPOSE_POOL}}\",\n    \"assetsSelector\": {\n        \"@type\": \"CriterionDto\",\n        \"operandLeft\": \"https://w3id.org/edc/v0.0.1/ns/id\",\n        \"operator\": \"in\",\n        \"operandRight\": [\n            \"{{ASSET_POOL_CX_MEMBER_READ}}\"\n        ]\n    },\n    \"privateProperties\": {\n        \"BusinessPartnerNumber\": \"{{CONSUMER_BPNL}}\",\n        \"dct:type\": \"ReadAccessPoolForCatenaXMember\",\n        \"cx-common:version\": \"7\"\n    }\n}",
+									"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"dct\": \"http://purl.org/dc/terms/\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\"\n    },\n    \"@id\": \"{{CONTRACT_POOL_PARTICIPANT_READ}}\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"{{POLICY_BUSINESS_PARTNER_NUMBER}}\",\n    \"contractPolicyId\": \"{{POLICY_ACCEPT_PURPOSE_POOL}}\",\n    \"assetsSelector\": {\n        \"@type\": \"CriterionDto\",\n        \"operandLeft\": \"https://w3id.org/edc/v0.0.1/ns/id\",\n        \"operator\": \"in\",\n        \"operandRight\": [\n            \"{{ASSET_POOL_PARTICIPANT_READ}}\"\n        ]\n    },\n    \"privateProperties\": {\n        \"BusinessPartnerNumber\": \"{{CONSUMER_BPNL}}\",\n        \"dct:type\": \"ReadAccessPoolForDataSpaceParticipant\",\n        \"cx-common:version\": \"7\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -623,7 +623,7 @@
 			"type": "string"
 		},
 		{
-			"key": "CLIENT_ID_POOL_CX_MEMBER_READ",
+			"key": "CLIENT_ID_POOL_PARTICIPANT_READ",
 			"value": "CLIENT_2_ID",
 			"type": "string"
 		},
@@ -643,7 +643,7 @@
 			"type": "string"
 		},
 		{
-			"key": "CLIENT_SECRET_PATH_POOL_CX_MEMBER_READ_CLIENT",
+			"key": "CLIENT_SECRET_PATH_POOL_PARTICIPANT_READ_CLIENT",
 			"value": "vault/path/client/1/secret",
 			"type": "string"
 		},
@@ -684,11 +684,11 @@
 			"value": ""
 		},
 		{
-			"key": "ASSET_POOL_CX_MEMBER_READ",
+			"key": "ASSET_POOL_PARTICIPANT_READ",
 			"value": ""
 		},
 		{
-			"key": "CONTRACT_POOL_CX_MEMBER_READ",
+			"key": "CONTRACT_POOL_PARTICIPANT_READ",
 			"value": ""
 		},
 		{


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request adds documentation changes for postman collection of EDC consumer and provider as per the standard 25.06.

Contributes to #1304

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
