### PR TITLE
chore: create Migration Helper tool

### DIFF
--- a/bpdm-migration-helper/README.md
+++ b/bpdm-migration-helper/README.md
@@ -1,0 +1,10 @@
+# BPDM Migration Helper
+
+This is a utility tool which created database migration files from non-sql source files.
+The intended user of this tool are developers and operators of BPDM.
+
+## Usage
+
+The tool can be executed as a normal JAVA application without any configuration needed.
+Upon execution the tool will read source files and produce sql migration scripts.
+For the successful execution the tool needs read and write access to the folder from which it is executed.

--- a/bpdm-migration-helper/pom.xml
+++ b/bpdm-migration-helper/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>bpdm-migration-helper</artifactId>
+    <name>BPDM Migration Helper</name>
+    <description>Utility tool for BPDM applications to create SQL migration files from non-SQL source files</description>
+    <version>1.0.0</version>
+
+    <parent>
+        <groupId>org.eclipse.tractusx</groupId>
+        <artifactId>bpdm-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <finalName>bpdm-migration-helper</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <configuration>
+                    <args>
+                        <arg>-Xjsr305=strict</arg>
+                    </args>
+                    <compilerPlugins>
+                        <plugin>no-arg</plugin>
+                    </compilerPlugins>
+                    <jvmTarget>21</jvmTarget>
+                    <pluginOptions>
+                        <option>no-arg:annotation=org.eclipse.tractusx.bpdm.migration.helper.util.NoArg</option>
+                    </pluginOptions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/Application.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/Application.kt
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper
+
+import org.eclipse.tractusx.bpdm.migration.helper.identifier.type.MigrationFileCreator
+
+fun main(args: Array<String>) {
+    MigrationFileCreator().create()
+}

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/BusinessPartnerType.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/BusinessPartnerType.kt
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.identifier.type
+
+enum class BusinessPartnerType {
+    LEGAL_ENTITY,
+    ADDRESS
+}

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/IdentifierTypeCategory.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/IdentifierTypeCategory.kt
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.identifier.type
+
+enum class IdentifierTypeCategory {
+    VAT,
+    TIN,
+    NBR,
+    IBR,
+    OTH
+}

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/ImportEntryValidator.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/ImportEntryValidator.kt
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.identifier.type
+
+class ImportEntryValidator {
+    fun validate(unvalidatedImportEntry: UnvalidatedImportEntry): ValidatedImportEntry{
+        return ValidatedImportEntry(
+            businessPartnerType = toBusinessPartnerType(unvalidatedImportEntry.businessPartnerType!!),
+            categories = unvalidatedImportEntry.categories!!.split("/").map { IdentifierTypeCategory.valueOf(it) }.toSortedSet(),
+            technicalKey = unvalidatedImportEntry.technicalKey?.takeIf { it.isNotBlank() }!!,
+            name = unvalidatedImportEntry.name?.takeIf { it.isNotBlank() }!!,
+            transliteratedName = unvalidatedImportEntry.transliteratedName?.takeIf { it.isNotBlank() },
+            abbreviations = unvalidatedImportEntry.abbreviations?.takeIf { it.isNotBlank() },
+            transliteratedAbbreviations = unvalidatedImportEntry.transliteratedAbbreviations?.takeIf { it.isNotBlank() },
+            format = unvalidatedImportEntry.format?.takeIf { it.isNotBlank() }
+        )
+    }
+
+    private fun toBusinessPartnerType(typeDescription: String): BusinessPartnerType{
+        return when(typeDescription){
+            "L" -> BusinessPartnerType.LEGAL_ENTITY
+            "A" -> BusinessPartnerType.ADDRESS
+            else -> throw RuntimeException("Invalid business partner type '$typeDescription'")
+        }
+    }
+
+
+
+
+}

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/MigrationFileCreator.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/MigrationFileCreator.kt
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.identifier.type
+
+import com.opencsv.bean.CsvToBeanBuilder
+import java.io.File
+import java.io.InputStreamReader
+import java.io.PrintWriter
+
+class MigrationFileCreator {
+
+    fun create(){
+        val importEntryValidator = ImportEntryValidator()
+        val sqlMapper = SqlMapper()
+
+        val identifierTypesCsv = Thread.currentThread().contextClassLoader.getResourceAsStream("identifier_types/identifier-types.csv")!!
+
+        val reader = InputStreamReader(identifierTypesCsv)
+        val csvParser = CsvToBeanBuilder<UnvalidatedImportEntry>(reader)
+            .withType(UnvalidatedImportEntry::class.java)
+            .withIgnoreLeadingWhiteSpace(true)
+            .withSeparator(';')
+            .build()
+
+        val importEntries = csvParser.parse()
+
+        val validatedEntries = importEntries.map { importEntryValidator.validate(it) }
+        val sql = sqlMapper.createSql(validatedEntries)
+
+        val sqlOutput = File("create_identifier_types.sql")
+        val sqlPrinter = PrintWriter(sqlOutput)
+        sqlPrinter.print(sql)
+        sqlPrinter.flush()
+    }
+
+}

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/SqlMapper.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/SqlMapper.kt
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.identifier.type
+
+class SqlMapper {
+
+    companion object{
+        const val identifierTypeInsertHeader = "INSERT INTO identifier_types (id, uuid, created_at, updated_at, technical_key, business_partner_type, name, transliterated_name, abbreviation, transliterated_abbreviation, format)"
+        const val identifierCategoryInsertHeader = "INSERT INTO identifier_type_categories (identifier_type_id, category)"
+    }
+
+    fun createSql(entries: List<ValidatedImportEntry>): String{
+        val builder = StringBuilder()
+        entries.forEach {  builder.appendLine(createIdentifierTypeSql(it)) }
+        entries.forEach {  builder.appendLine(createIdentifierCategorySql(it)) }
+        return builder.toString()
+    }
+
+    private fun createIdentifierTypeSql(entry: ValidatedImportEntry): String{
+        val builder = StringBuilder()
+        builder.appendLine(identifierTypeInsertHeader)
+        builder.append("VALUES ")
+        builder.append("(nextval('bpdm_sequence'), gen_random_uuid(), LOCALTIMESTAMP, LOCALTIMESTAMP")
+        builder.append(toInsertValue(entry.technicalKey))
+        builder.append(toInsertValue(entry.businessPartnerType.name))
+        builder.append(toInsertValue(entry.name))
+        builder.append(toInsertValue(entry.transliteratedName))
+        builder.append(toInsertValue(entry.abbreviations))
+        builder.append(toInsertValue(entry.transliteratedAbbreviations))
+        builder.append(toInsertValue(entry.format))
+        builder.appendLine(")")
+        builder.appendLine(" ON CONFLICT (technical_key, business_partner_type)")
+        builder.append("DO UPDATE SET")
+        builder.append(" name = ${toUpdateValue(entry.name)}")
+        builder.append(", transliterated_name = ${toUpdateValue(entry.transliteratedName)}")
+        builder.append(", abbreviation = ${toUpdateValue(entry.abbreviations)}")
+        builder.append(", transliterated_abbreviation = ${toUpdateValue(entry.transliteratedAbbreviations)}")
+        builder.append(", format = ${toUpdateValue(entry.format)}")
+        builder.appendLine(";")
+        return builder.toString()
+    }
+
+    private fun createIdentifierCategorySql(entry: ValidatedImportEntry): String{
+        val builder = StringBuilder()
+        entry.categories.map { createIdentifierCategorySql(entry.technicalKey, entry.businessPartnerType, it) }.forEach { builder.appendLine(it) }
+        return builder.toString()
+    }
+
+    private fun createIdentifierCategorySql(technicalKey: String, businessPartnerType: BusinessPartnerType, category: IdentifierTypeCategory): String{
+        val builder = StringBuilder()
+        builder.appendLine(identifierCategoryInsertHeader)
+        builder.append("SELECT ")
+        builder.append("identifier_types.id")
+        builder.append(toInsertValue(category.name))
+        builder.append(" FROM identifier_types WHERE technical_key = '$technicalKey' AND business_partner_type = '${businessPartnerType.name}'")
+        builder.append(";")
+
+        return builder.toString()
+    }
+
+    private fun toInsertValue(value: String?): String {
+        return if (value == null) ", NULL" else ", '${value.replace("'", "''")}'"
+    }
+
+    private  fun toUpdateValue(value: String?): String{
+        return if (value == null) "NULL" else "'${value.replace("'", "''")}'"
+    }
+}

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/UnvalidatedImportEntry.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/UnvalidatedImportEntry.kt
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.identifier.type
+
+import com.opencsv.bean.CsvBindByName
+import org.eclipse.tractusx.bpdm.migration.helper.util.NoArg
+
+@NoArg
+data class UnvalidatedImportEntry(
+    @CsvBindByName(column = "BPT")
+    val businessPartnerType: String?,
+    @CsvBindByName(column = "Category")
+    val categories: String?,
+    @CsvBindByName(column = "ITC")
+    val technicalKey: String?,
+    @CsvBindByName(column = "Name")
+    val name: String?,
+    @CsvBindByName(column = "Transliterated Name")
+    val transliteratedName: String?,
+    @CsvBindByName(column = "Abbr")
+    val abbreviations: String?,
+    @CsvBindByName(column = "TAbbr")
+    val transliteratedAbbreviations: String?,
+    @CsvBindByName(column = "Format")
+    val format: String?,
+)

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/ValidatedImportEntry.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/identifier/type/ValidatedImportEntry.kt
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.identifier.type
+
+import java.util.*
+
+data class ValidatedImportEntry(
+    val businessPartnerType: BusinessPartnerType,
+    val categories: SortedSet<IdentifierTypeCategory>,
+    val technicalKey: String,
+    val name: String,
+    val transliteratedName: String?,
+    val abbreviations: String?,
+    val transliteratedAbbreviations: String?,
+    val format: String?,
+)

--- a/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/util/NoArg.kt
+++ b/bpdm-migration-helper/src/main/kotlin/org/eclipse/tractusx/bpdm/migration/helper/util/NoArg.kt
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.migration.helper.util
+
+annotation class NoArg

--- a/bpdm-migration-helper/src/main/resources/identifier_types/identifier-types.csv
+++ b/bpdm-migration-helper/src/main/resources/identifier_types/identifier-types.csv
@@ -1,0 +1,87 @@
+﻿C;BPT;Category;ITC;Name;Transliterated-Name;Abbr;TAbbr;Format
+AT;L;NBR;AT_FBN;Firmenbuchnummer;;FBN;;^\d{1,6}[a-z]$
+AT;L;VAT;AT_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^ATU\d{7}\d{1}$
+BE;L;NBR;BE_OND;Ondernemingsnummer / Numéro d'entreprise;Ondernemingsnummer / Numero d'entreprise;OND-(nummer) / (numéro) ENT;OND-(nummer) / (numero) ENT;^[0,1]{1}\d{3}\d{3}\d{1}\d{2}$
+BE;L;VAT;BE_BTW;Belasting over de toegevoegde waarde nummer / Numéro de taxe sur la valeur ajoutée;Belasting over de toegevoegde waarde nummer / Numero de taxe sur la valeur ajoutee;BTW(-nummer) / (numéro) TVA;BTW(-nummer) / (numero) TVA;^[0,1]\d{3}\d{3}\d{1}\d{2}$
+BE;L;VAT;BE_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^BE[0,1]\d{3}\d{3}\d{1}\d{2}$
+BG;L;NBR;BG_EIK;Единен идентификационен код;Edinen identifikatsionen kod;ЕИК;EIK;^\d{8,9}(\d{1})?$
+BG;L;VAT;BG_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^BG\d{8,9}(\d{1})?$
+CH;L;NBR/TIN;CH_UID;Unternehmens-Identifikationsnummer;;UID;;^CHE-\d{3}\.\d{3}\.\d{3}$
+CH;L;NBR;CH_EHRA_ID;Eidgenössisches Handelsregisteramt-Identifikationsnummer;Eidgenossisches Handelsregisteramt-Identifikationsnummer;EHRA-ID;;^\d{6}$
+CH;L;VAT;CH_UID_MWST;Unternehmens-Identifikationsnummer (Mehrwertsteuer);;UID MWSt.;;^CHE-\d{3}\.\d{3}\.\d{3}\s(MWST|TVA|IPA)$
+CY;L;NBR;CY_AEE;Αριθμός Εγγραφής στο Τμήμα Εφόρου Εταιρειών;Arithmos Engrafis sto Tmima Eforou Etairion;AEE;;^[A-Z]{1,2}\d{1,8}$
+CY;L;TIN;CY_AFT;Αριθμός φορολογικής ταυτότητας;Arithmos forologikis tautotitas;ΑΦΤ;AFT;^[013945]{1}\d{7}[A-Z]{1}$
+CY;L;VAT;CY_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^CY[013945]{1}\d{7}[A-Z]{1}$
+CZ;L;NBR;CZ_ICO;Identifikační číslo osoby;Identifikacni cislo osoby;IČO;ICO;^[1-9]{1}\d{6,8}\d{1}$
+CZ;L;TIN;CZ_DIC;Daňové identifikační číslo;Danove identifikacni cislo;DIČ;DIC;^[1-9]{1}\d{6,8}\d{1}$
+CZ;L;VAT;CZ_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^CZ[1-9]{1}\d{6,8}\d{1}$
+DE;L;NBR;DE_HR;Handelsregisternummer;;HR(-nummer);;^([BDFGHKMNPRTUVWXY]{1}\d{1,4}[VR]?\.)?((HRA)|(G(n|N)R)|(HRB)|(PR)|(VR)|(G(s|S)R))[1-9]{1}[A-Z0-9]{1,5}$
+DE;L;VAT;DE_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^DE\d{8}\d{1}(-\d{5})?$
+DK;L;NBR;DK_CVR;Centrale Virksomhedsregister Nummer;;CVR(-nummer);;^\d{7}\d{1}$
+DK;L;VAT;DK_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^DK\d{7}\d{1}$
+EE;L;NBR;EE_RG;Äriregistri kood;Ariregistri kood;RG(-kood);;^\d{8}$
+EE;L;VAT;EE_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^EE\d{8}\d{1}$
+ES;L;NBR;ES_RM;Número de inscripción en el registro mercantil;Numero de inscripcion en el registro mercantil.;(número) RM;(numero) RM;^\d{8}$
+ES;L;TIN;ES_NIF;Número de identificación fiscal (fka Código de identificación fiscal);Numero de identificacion fiscal (fka Codigo de identificacion fiscal);NIF;;^[A-HJ-NP-SUVW]{1}\d{2}\d{5}[A-Z0-9]{1}$
+ES;L;VAT;ES_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^ES[A-HJ-NP-SUVW]{1}\d{2}\d{5}[A-Z0-9]{1}$ 
+FI;L;NBR;FI_Y;Yritys- ja yhteisötunnus;Yritys- ja yhteisotunnus;Y(-tunnus);;^\d{7}-\d{1}$
+FI;L;VAT;FI_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^FI\d{7}\d{1}$
+FR;L;NBR;FR_SIREN;Numéro des système d'identification du répertoire des entreprises;Numero du systeme d'identification du repertoire des entreprises;(numéro) SIREN;(numero) SIREN;^\d{8}\d{1}$
+FR;A;NBR;FR_SIRET;Numéro du système d'identification du répertoire des établissements;Numero du systeme d'identification du repertoire des etablissements;(numéro) SIRET;(numero) SIRET;^\d{8}\d{1}\d{5}$
+FR;L;VAT;FR_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^FR[A-Z0-9]{2}\d{8}\d{1}$
+GB;L;NBR;GB_CRN;Company Registration Number;;CRN;;^((AC|CE|CS|FC|FE|GE|GS|IC|LP|NC|NF|NI|NL|NO|NP|OC|OE|PC|R0|RC|SA|SC|SE|SF|SG|SI|SL|SO|SR|SZ|ZC|\d{2})\d{6})|((IP|SP|RS)[A-Z\d]{6})|(SL\d{5}[\dA])$
+GB;L;TIN;GB_UTR;Unique Taxpayer Reference;;UTR;;^\d{10}$
+GB;L;VAT;GB_VAT_REG;Value-added Tax Registration Number;;VAT Reg. (number);;^GB\d{9}(\d{3})?$
+GR;L;NBR;GR_GEMI;Αριθμός του γενικού εμπορικού μητρώου;Arithmos tou genikou emporikou mitroou;(Αρ.) Γ.Ε.ΜΗ.;(Ar.) G.E.MI.;^[0-9]{1,12}$
+GR;L;TIN;GR_AFM;Αριθμός φορολογικού μητρώου;Arithmos forologikou mitroou;ΑΦΜ;AFM;^\d{8}\d{1}$
+GR;L;VAT;GR_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^EL\d{8}\d{1}$
+HR;L;NBR;HR_MBS;Matični broj subjekta trgovačkog suda;Maticni broj subjekta trgovackog suda;MBS;;^[0-1]\d{8}$
+HR;L;NBR/TIN;HR_OIB;Osobni identifikacijski broj;;OIB;;^\d{9}\d{2}$
+HR;L;VAT;HR_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^HR\d{9}\d{2}$
+HU;L;NBR;HU_CJS;Cégjegyzékszám;Cegjegyzekszam;CJS;;^\d{2}-\d{2}-\d{6}$
+HU;L;TIN;HU_AS;Adószám;Adoszam;AS;;^\d{8}-\d{1}-\d{2}$
+HU;L;VAT;HU_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^HU\d{8}$
+HU;L;VAT;HU_CSPO_AFA_AZ;Csoportos általános forgalmi adó azonosító szám;Csoportos altalanos forgalmi ado azonosito szam;Csop. ÁFA az. (sz.);Csop. AFA az. (sz.);^HU\d{8}\d{3}$
+IE;L;NBR;IE_CRO;Company Registration Office Number;;CRO (number);;^[1-9]\d{1,6}$
+IE;L;VAT;IE_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^IE\d{7}[A-Z]{2}$
+IT;L;NBR;IT_REA;Numero del registro economico amministrativo;;(numero) REA;;^[A-Z]{2}-\d{7}$
+IT;L;TIN;IT_CF;Codice fiscale;;CF;;^\d{7}\d{3}\d{1}$
+IT;L;VAT;IT_IVA;Codice imposta sul valore aggiunto;;(codice) IVA;;^\d{7}\d{3}\d{1}$
+IT;L;VAT;IT_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^IT\d{7}\d{3}\d{1}$
+LT;L;NBR;LT_JAR;Juridinių asmenų registro kodas;Juridiniu asmenu registro kodas;JAR (kodas);;^\d{1}\d{7}\d{1}$
+LT;L;VAT;LT_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^LT\d{1}\d{7}\d{1}(\d{3})?$
+LU;L;NBR;LU_RCS;Numéro registre de commerce et des sociétés;Numero registre de commerce et des societes;(numéro) RCS;(numero) RCS;^[B-Z]\d+$
+LU;L;VAT;LU_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^LU\d{6}\d{2}$
+LV;L;NBR;LV_URN;Uzņēmuma reģistrācijas numur;Uznemuma registracijas numurs;URN;;^[1-9]{1}\d{7}$
+LV;L;VAT;LV_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^LV4\d{1}[1-9]{1}\d{7}\d{1}$
+MT;L;NBR;MT_CRN;Company Registration Number;;CRN;;^(C|P|SV|SE|LP|SO|NF|RPF|FD|G)\d{1,5}$
+MT;L;VAT;MT_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^MT\d{6}\d{2}$
+NL;L;NBR;NL_KVK;Kamer van Koophandel nummer;;KVK (nummer);;^\d{8}$
+NL;L;TIN;NL_RSIN;Rechtspersonen en Samenwerkingsverbanden Informatie Nummer;;RSIN (nummer);;^[1-9]{1}\d{8}$
+NL;L;VAT;NL_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^NL[1-9]{1}\d{8}$
+NO;L;NBR/TIN;NO_ORG;Organisasjonsnummer;;ORG(-nummer);;^\d{9}$
+NO;L;VAT;NO_ORG_MVA;Organisasjonsnummer (Merverdiavgift);;ORG(-nummer) Mva.;;^\d{9}\sMVA$
+PL;L;NBR;PL_KRS;Numer w krajowym rejestrze sądowym;Numer w krajowym rejestrze sadowym;KRS (numer);;^KRS\d{10}$
+PL;L;NBR;PL_REGON;Numer identyfikacyjny rejestru gospodarki narodowe;;(numer) REGON;;^(\d{9}|\d{14})$
+PL;L;TIN;PL_NIP;Numer identyfikacji podatkowej;;NIP;;^\d{3}\d{6}\d{1}$
+PL;L;VAT;PL_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^PL\d{3}\d{6}\d{1}$
+PT;L;NBR/TIN;PT_NIPC;Número de Identificação de Pessoa Coletiva (aka Número de Identificação Fiscal);Numero de Identificacao de Pessoa Coletiva (aka Numero de Identificacao Fiscal);NIPC;;^PT5\d{7}\d{1}$
+PT;L;VAT;PT_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^PT5\d{7}\d{1}$
+RO;L;NBR;RO_NRC;Numărul de ordine în registrul comerţului;Numarul de ordine in registrul comertului;NRC;;^J[0-5]{1}[0-9]{1}/\d{4}/\d{1,6}$
+RO;L;TIN;RO_CUI;Codul Unic de Înregistrare;Codul Unic de Inregistrare;CUI;;^[1-9]\d{0,8}\d{1}$
+RO;L;VAT;RO_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^RO[1-9]\d{0,8}\d{1}$
+SE;L;NBR;SE_ORG;Organisationsnummer;;ORG(-nummer);;^\d{2}[2-9]{1}\d{3}-?\d{4}$
+SE;L;VAT;SE_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^SE\d{2}[2-9]{1}\d{3}\d{4}(\d{2})?$
+SI;L;NBR;SI_MAT;Matična številka;Maticana stevilka;MAT (št.);MAT (st.);^\d{10}$
+SI;L;TIN;SI_DAV;Davčna številka;Davcna stevilka;DAV (št.);DAV (st.);^\d{7}\d{1}$
+SI;L;VAT;SI_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^SI\d{7}\d{1}$
+SK;L;NBR;SK_ICO;Identifikačné číslo organizácie;Identifikacne cislo organizacie;IČO;ICO;^[1-9]{1}\d{7}$
+SK;L;TIN;SK_DIC;Daňové identifikačné číslo;Danove identifikacne cislo;DIČ;DIC;^[1-9]{1}\d{8}\d{1}$
+SK;L;VAT;SK_EU_VAT_ID;European Union Value-added Tax Identification Number;;EU VAT ID (number);;^SK[1-9]{1}\d{8}\d{1}$
+XI;L;NBR;XI_CRN;Company Registration Number;;CRN;;^((AC|CE|CS|FC|FE|GE|GS|IC|LP|NC|NF|NI|NL|NO|NP|OC|OE|PC|R0|RC|SA|SC|SE|SF|SG|SI|SL|SO|SR|SZ|ZC|\d{2})\d{6})|((IP|SP|RS)[A-Z\d]{6})|(SL\d{5}[\dA])$
+XI;L;TIN;XI_UTR;Unique Taxpayer Reference;;UTR;;^\d{10}$
+XI;L;VAT;XI_VAT_REG;Value-added Tax Registration Number;;VAT Reg. (number);;^(XI|GB)\d{9}(\d{3})?$
+-;L;IBR;GLEIF_LEI;Legal Entity Identifier;;LEI;;^[A-Z0-9]{18}[0-9]{2}$
+-;L;IBR;EU_EORI;Economic Operators' Registration and Identification Number;;EORI (number);;^[A-Z]{2}[0-9A-Z]+$
+-;L;OTH;GS1_GLN;Global Location Number;;GLN;;^\d{13}$
+-;L;OTH;DNB_DUNS;Data Universal Numbering System Number;;DUNS (number);;^\d{9}$

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>bpdm-orchestrator</module>
         <module>bpdm-orchestrator-api</module>
         <module>bpdm-system-tester</module>
+        <module>bpdm-migration-helper</module>
     </modules>
 
     <properties>


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request creates the new 'Migration Helper' module. This is a tool which helps creating migration scripts from non-SQL source files like CSVs. The intended users for this tool are operators and developers. Instead of being a full fledged productive solution this tool just offers utility functionality for any person who would like to create such migration files for BPDM.

Currently, the tool only supports the process of creating identifier types migration script from a given CSV resource file.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
