### PR TITLE
fix(Pool): all identifier types now have at least the default category 'OTH

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -92,8 +92,16 @@ fun IdentifierTypeDb.toTypeKeyNameDto(): TypeKeyNameVerboseDto<String> {
 }
 
 fun IdentifierTypeDb.toDto(): IdentifierTypeDto {
-    return IdentifierTypeDto(technicalKey, businessPartnerType, name, abbreviation, transliteratedName, transliteratedAbbreviation,
-        format, categories.toSortedSet(), details.map { IdentifierTypeDetailDto(it.countryCode, it.mandatory) })
+    return IdentifierTypeDto(
+        technicalKey = technicalKey,
+        businessPartnerType = businessPartnerType,
+        name = name,
+        abbreviation = abbreviation,
+        transliteratedName = transliteratedName,
+        transliteratedAbbreviation = transliteratedAbbreviation,
+        format = format,
+        categories = categories.ifEmpty { mutableSetOf(IdentifierTypeCategory.OTH) }.toSortedSet(),
+        details = details.map { IdentifierTypeDetailDto(it.countryCode, it.mandatory) })
 }
 
 fun LegalFormDb.toDto(): LegalFormDto {


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This pull request fixes the identifier types, making it that every identifier type has at least the category 'OTH' according to https://github.com/eclipse-tractusx/bpdm/issues/1297#issuecomment-2820315829 .

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Contributes to #1297

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
