### PR TITLE
feat(Pool): Refine 'IsManagedBy' validation error messages for role-specific clarity

### DIFF
--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
@@ -207,7 +207,7 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
 
         val resultSingleManagerViolation = upsertRelationsGoldenRecordIntoPool("TASK_VIOLATE_MANAGER", violatingSingleManager)
         assertThat(resultSingleManagerViolation[0].errors).hasSize(1)
-        assertThat(resultSingleManagerViolation[0].errors[0].description).contains("already managed by")
+        assertThat(resultSingleManagerViolation[0].errors[0].description).contains("already managed by another Managing Legal Entity")
 
         // Step 3b: Try to make B managed by C -> should fail validateNoChain
         val violatingChain = BusinessPartnerRelations(
@@ -218,7 +218,7 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
 
         val resultChainViolation = upsertRelationsGoldenRecordIntoPool("TASK_VIOLATE_CHAIN", violatingChain)
         assertThat(resultChainViolation[0].errors).hasSize(1)
-        assertThat(resultChainViolation[0].errors[0].description).contains("Invalid relation")
+        assertThat(resultChainViolation[0].errors[0].description).contains("already a Managing Legal Entity.")
     }
 
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request supports the broader feature for handling `IsManagedBy` relations in the Pool. 
It ensures validation failures are actionable and traceable by providing clean and precise error messages.

### Example Error Scenarios

- A Managing Legal Entity cannot also be a Managed Legal Entity
- A Managed Legal Entity cannot have multiple managers

No changes to business logic, only exception message content and structure refined.

Contributes to #1364 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
