### PR TITLE
feat(bpdm-cleaning): add configuration and scheduling support for relation cleaning tasks with test coverage

### DIFF
--- a/.github/workflows/app-test-charts.yaml
+++ b/.github/workflows/app-test-charts.yaml
@@ -183,6 +183,8 @@ jobs:
               repository: bpdm-cleaning-service-dummy
               tag: test
             startupDelaySeconds: 120
+            springProfiles:
+              system-tester
           tests:
             image:
               registry: kind-registry:5000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 - BPDM: Support for 'IsManagedBy' business partner relations across Gate, Orchestrator, and Pool, including golden record processing and validation for relation chains and unique manager constraints [#1364](https://github.com/eclipse-tractusx/bpdm/issues/1364).
 - CICD: Code Coverage Analysis and Reporting for BPDM [#1338](https://github.com/eclipse-tractusx/bpdm/issues/1338)
+- BPDM Cleaning Dummy: Configuration and scheduling support for relation cleaning dummy service with unit test coverage [#1383](https://github.com/eclipse-tractusx/bpdm/issues/1383).
 
 ### Changed
 

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/CleaningServiceConfigProperties.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/CleaningServiceConfigProperties.kt
@@ -26,7 +26,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = PREFIX)
 class CleaningServiceConfigProperties (
     val step: TaskStep,
-    val dependencyCheck: DependencyCheckConfig
+    val dependencyCheck: DependencyCheckConfig,
+    val relationCleaning: RelationTaskProcessProperties = RelationTaskProcessProperties()
 ){
     companion object{
         const val PREFIX = "bpdm.golden-record-process"
@@ -35,4 +36,9 @@ class CleaningServiceConfigProperties (
     data class DependencyCheckConfig(
         val cron: String = "-"
     )
+
+    data class RelationTaskProcessProperties(
+        val cron: String = "-"
+    )
+
 }

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/RelationCleaningTaskConfiguration.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/config/RelationCleaningTaskConfiguration.kt
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.cleaning.config
+
+import jakarta.annotation.PostConstruct
+import org.eclipse.tractusx.bpdm.cleaning.service.RelationCleaningServiceDummy
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.support.CronTrigger
+
+@Configuration
+class RelationCleaningTaskConfiguration(
+    private val cleaningServiceConfigProperties: CleaningServiceConfigProperties,
+    private val taskScheduler: TaskScheduler,
+    private val relationCleaningServiceDummy: RelationCleaningServiceDummy
+) {
+
+    @PostConstruct
+    fun scheduleRelationCleaningTask() {
+        taskScheduler.scheduleIfEnabled(
+            { relationCleaningServiceDummy.relationPollForCleanAndSyncTasks() },
+            cleaningServiceConfigProperties.relationCleaning.cron
+        )
+    }
+
+    private fun TaskScheduler.scheduleIfEnabled(task: Runnable, cronExpression: String) {
+        if (cronExpression != "-") {
+            schedule(task, CronTrigger(cronExpression))
+        }
+    }
+}

--- a/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/RelationCleaningServiceDummy.kt
+++ b/bpdm-cleaning-service-dummy/src/main/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/RelationCleaningServiceDummy.kt
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.cleaning.service
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.springframework.stereotype.Service
+
+@Service
+class RelationCleaningServiceDummy(
+    private val orchestrationApiClient: OrchestrationApiClient,
+    private val cleaningServiceConfigProperties: CleaningServiceConfigProperties
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    fun relationPollForCleanAndSyncTasks() {
+        processRelationPollingTasks(cleaningServiceConfigProperties.step)
+    }
+
+    private fun processRelationPollingTasks(step: TaskStep) {
+        try {
+            logger.info { "Starting polling for relation cleaning tasks from Orchestrator... TaskStep ${step.name}" }
+
+            do {
+                val cleaningRelationRequest =
+                    orchestrationApiClient.relationsGoldenRecordTasks.reserveTasksForStep(TaskStepReservationRequest(amount = 10, step))
+
+                val cleaningRelationTasks = cleaningRelationRequest.reservedTasks
+
+                logger.info { "${cleaningRelationTasks.size} relation tasks found for cleaning. Proceeding with cleaning..." }
+
+                if (cleaningRelationTasks.isNotEmpty()) {
+                    val cleaningRelationResults = cleaningRelationTasks.map { reservedTask ->
+                        processRelationCleaningTask(reservedTask)
+                    }
+
+                    orchestrationApiClient.relationsGoldenRecordTasks.resolveStepResults(TaskRelationsStepResultRequest(step, cleaningRelationResults))
+                    logger.info { "Relation cleaning tasks processing completed for this iteration." }
+                }
+            } while (cleaningRelationRequest.reservedTasks.isNotEmpty())
+        } catch (e: Exception) {
+            logger.error(e) { "Error while processing relation cleaning task" }
+        }
+    }
+
+    fun processRelationCleaningTask(reservedTask: TaskRelationsStepReservationEntryDto): TaskRelationsStepResultEntryDto {
+        val cleanedBusinessPartnerRelation = reservedTask.businessPartnerRelations
+        return TaskRelationsStepResultEntryDto(reservedTask.taskId, cleanedBusinessPartnerRelation)
+    }
+
+}

--- a/bpdm-cleaning-service-dummy/src/main/resources/application-system-tester.yml
+++ b/bpdm-cleaning-service-dummy/src/main/resources/application-system-tester.yml
@@ -1,0 +1,25 @@
+################################################################################
+# Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+#BPDM system tester specific configuration
+bpdm:
+  golden-record-process:
+    relationCleaning:
+      # No scheduler for cleaning service to poll for relation tasks in the orchestrator
+      cron: "-"

--- a/bpdm-cleaning-service-dummy/src/main/resources/application.yml
+++ b/bpdm-cleaning-service-dummy/src/main/resources/application.yml
@@ -52,7 +52,9 @@ bpdm:
     dependencyCheck:
        # How often the golden record connection dependencies should be checked for being healthy
       cron: '*/30 * * * * *'
-
+    relationCleaning:
+      # When and how often the cleaning service should poll for relation tasks in the orchestrator
+      cron: "5/30 * * * * *"
   cleaningService:
     # When and how often the cleaning service should poll for golden record tasks in the orchestrator
     pollingCron: "5/30 * * * * *"

--- a/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/RelationCleaningServiceApiCallsTest.kt
+++ b/bpdm-cleaning-service-dummy/src/test/kotlin/org/eclipse/tractusx/bpdm/cleaning/service/RelationCleaningServiceApiCallsTest.kt
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.cleaning.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.admin.model.ServeEventQuery
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.eclipse.tractusx.bpdm.cleaning.config.CleaningServiceConfigProperties
+import org.eclipse.tractusx.bpdm.cleaning.config.OrchestratorConfigProperties
+import org.eclipse.tractusx.orchestrator.api.ApiCommons
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.tractusx.orchestrator.api.model.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
+import java.util.UUID
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["${OrchestratorConfigProperties.PREFIX}.security-enabled=false"]
+)
+@ActiveProfiles("test")
+class RelationCleaningServiceApiCallsTest @Autowired constructor(
+    private val relationCleaningServiceDummy: RelationCleaningServiceDummy,
+    private val jacksonObjectMapper: ObjectMapper,
+    private val cleaningServiceConfigProperties: CleaningServiceConfigProperties
+) {
+
+    companion object {
+        const val ORCHESTRATOR_RESERVE_TASKS_URL = "${ApiCommons.BASE_PATH_V7_RELATIONS}/step-reservations"
+        const val ORCHESTRATOR_RESOLVE_TASKS_URL = "${ApiCommons.BASE_PATH_V7_RELATIONS}/step-results"
+
+        const val RESERVATION_SCENARIO = "Reservation"
+        const val RESERVED_STATE = "Reserved"
+
+        @JvmField
+        @RegisterExtension
+        val orchestratorMockApi: WireMockExtension = WireMockExtension.newInstance()
+            .options(WireMockConfiguration.wireMockConfig().dynamicPort())
+            .build()
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("bpdm.client.orchestrator.base-url") { orchestratorMockApi.baseUrl() }
+        }
+    }
+
+    val fixedTaskId = "1"
+
+    @BeforeEach
+    fun beforeEach() {
+        orchestratorMockApi.resetAll()
+
+        orchestratorMockApi.stubFor(
+            post(urlPathEqualTo(ORCHESTRATOR_RESERVE_TASKS_URL))
+                .inScenario(RESERVATION_SCENARIO)
+                .whenScenarioStateIs(RESERVED_STATE)
+                .willReturn(okJson(jacksonObjectMapper.writeValueAsString(TaskRelationsStepReservationResponse(emptyList(), Instant.now()))))
+        )
+    }
+
+    @ParameterizedTest
+    @EnumSource(RelationType::class)
+    fun `Relation Cleaning Test for all RelationTypes`(relationType: RelationType) {
+        val mockedRelation = createRelation("rel1", relationType)
+
+        val resolveMapping = mockOrchestratorResolveApi()
+        mockOrchestratorReserveApi(mockedRelation)
+
+        val expectedResponse = TaskRelationsStepResultRequest(
+            cleaningServiceConfigProperties.step,
+            listOf(TaskRelationsStepResultEntryDto(fixedTaskId, mockedRelation))
+        )
+
+        relationCleaningServiceDummy.relationPollForCleanAndSyncTasks()
+        val actualResponse = getResolveResult(resolveMapping)
+
+        assertThat(actualResponse).isEqualTo(expectedResponse)
+    }
+
+    fun mockOrchestratorReserveApi(relation: BusinessPartnerRelations): StubMapping {
+        return orchestratorMockApi.stubFor(
+            post(urlPathEqualTo(ORCHESTRATOR_RESERVE_TASKS_URL))
+                .inScenario(RESERVATION_SCENARIO)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo(RESERVED_STATE)
+                .willReturn(
+                    okJson(
+                        jacksonObjectMapper.writeValueAsString(
+                            TaskRelationsStepReservationResponse(
+                                listOf(TaskRelationsStepReservationEntryDto(fixedTaskId, UUID.randomUUID().toString(), relation)),
+                                Instant.now()
+                            )
+                        )
+                    )
+                )
+        )
+    }
+
+    fun mockOrchestratorResolveApi(): StubMapping {
+        return orchestratorMockApi.stubFor(
+            post(urlPathEqualTo(ORCHESTRATOR_RESOLVE_TASKS_URL))
+                .willReturn(aResponse().withStatus(200))
+        )
+    }
+
+    private fun getResolveResult(stubMapping: StubMapping): TaskRelationsStepResultRequest {
+        val serveEvents = orchestratorMockApi.getServeEvents(ServeEventQuery.forStubMapping(stubMapping)).requests
+        assertEquals(1, serveEvents.size)
+        val actualRequest = serveEvents.first().request
+        return jacksonObjectMapper.readValue(actualRequest.body, TaskRelationsStepResultRequest::class.java)
+    }
+
+    private fun createRelation(idSuffix: String, relationType: RelationType): BusinessPartnerRelations {
+        return BusinessPartnerRelations(
+            relationType = relationType,
+            businessPartnerSourceBpnl = "BPNL_SOURCE_$idSuffix",
+            businessPartnerTargetBpnl = "BPNL_TARGET_$idSuffix"
+        )
+    }
+}
+
+

--- a/bpdm-system-tester/README.md
+++ b/bpdm-system-tester/README.md
@@ -10,7 +10,7 @@ For a local execution you can follow the following steps:
 ```bash
 mvn -B -U clean package -pl bpdm-system-tester -am -DskipTests
 ```
-2. Install and run the BPDM applications locally with authentication
+2. Install and run the BPDM applications, make sure to use the `system-tester` configuration wherever available.
 3. Run the JAR file so the tests will be executed:
 ```bash
 java -jar bpdm-system-tester/target/bpdm-system-tester.jar


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This PR introduces support for relation cleaning task configuration and execution within the cleaning service dummy. 
The changes include:

- [x] Configuration Enhancement:  Extended `CleaningServiceConfigProperties` with a new `relationCleaning` property that enables scheduled execution for relation cleaning tasks using cron expressions.
- [x] New Task Scheduler:  Added `RelationCleaningTaskConfiguration` which conditionally schedules `relationPollForCleanAndSyncTasks()` based on the provided cron config.
- [x] Test Improvements:  Created a parameterized integration test (`RelationCleaningServiceApiCallsTest`) to verify behavior for all enum values of `RelationType`.

Contributes to #1383


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
