### PR TITLE
fix: adding enforce ascending by created_at to changelog search result

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ChangelogService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/ChangelogService.kt
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.bpdm.gate.api.exception.ChangeLogOutputError
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ChangelogGateDto
 import org.eclipse.tractusx.bpdm.gate.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.gate.api.model.response.PageChangeLogDto
+import org.eclipse.tractusx.bpdm.gate.entity.ChangelogEntryDb
 import org.eclipse.tractusx.bpdm.gate.entity.GoldenRecordType
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byCreatedAtGreaterThan
@@ -33,6 +34,7 @@ import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byGol
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byStage
 import org.eclipse.tractusx.bpdm.gate.repository.ChangelogRepository.Specs.byTenantBpnl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import java.time.Instant
@@ -64,7 +66,7 @@ class ChangelogService(private val changelogRepository: ChangelogRepository) {
             byGoldenRecordType(goldenRecordType)
         )
 
-        val pageable = PageRequest.of(page, pageSize)
+        val pageable = PageRequest.of(page, pageSize, Sort.by(ChangelogEntryDb::createdAt.name).ascending())
         val pageResponse = changelogRepository.findAll(spec, pageable)
         val setDistinctList = changelogRepository.findDistinctByExternalIdInAndTenantBpnl(nonNullExternalIds, tenantBpnl).map { it.externalId }
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Fixing a bug based on this issue ticket.
The changelog result does not sort by create_at in ascending order. https://github.com/eclipse-tractusx/bpdm/issues/1385
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
