### PR TITLE
fix(charts): make config volume mounts for deployments read-only

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 ## [6.1.0] - tbd
 
+### Changed
+
+- fix vulnerability in deployments by providing read-only volume mounts 
+
 ## [6.0.0] -  2025-06-16
 
 ### Changed

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -49,7 +49,7 @@ dependencies:
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common
-    version: 1.0.4
+    version: 1.0.5
   - name: postgresql
     version: 12.12.10
     repository: https://charts.bitnami.com/bitnami

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -29,7 +29,7 @@ sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.4
+    version: 1.0.5
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 4.1.0-SNAPSHOT

--- a/charts/bpdm/charts/bpdm-common/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-common/Chart.yaml
@@ -21,7 +21,7 @@
 apiVersion: v2
 type: library
 name: bpdm-common
-version: 1.0.4
+version: 1.0.5
 description: A library Helm Chart for other BPDM Charts
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
@@ -76,6 +76,7 @@ spec:
             - mountPath: /etc/conf
               name: config
               readOnly: true
+              recursiveReadOnly: Enabled
             - mountPath: /tmp
               name: cache
       initContainers:

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.4
+    version: 1.0.5
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 4.1.0-SNAPSHOT

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -29,7 +29,7 @@ sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
   - name: bpdm-common
-    version: 1.0.4
+    version: 1.0.5
     repository: "file://../bpdm-common"
   - name: postgresql
     version: 12.12.10

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: bpdm-common
-    version: 1.0.4
+    version: 1.0.5
     repository: "file://../bpdm-common"
   - name: centralidp
     version: 4.1.0-SNAPSHOT


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes a security vulnerability on the BPDM Helm Charts by making mounting volumes in deployments as read-only.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
