### PR TITLE
feat(charts): make security properties for deployment's config volume mount adjustable

### DIFF
--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/values.yaml
@@ -49,6 +49,10 @@ securityContext:
     drop:
       - ALL
 
+configMountSecurity:
+  readOnly: true
+  recursiveReadOnly: Enabled
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
+++ b/charts/bpdm/charts/bpdm-common/templates/_deployment.tpl
@@ -75,8 +75,8 @@ spec:
           volumeMounts:
             - mountPath: /etc/conf
               name: config
-              readOnly: true
-              recursiveReadOnly: Enabled
+              readOnly: {{ .Values.configMountSecurity.readOnly }}
+              recursiveReadOnly: {{ .Values.configMountSecurity.recursiveReadOnly }}
             - mountPath: /tmp
               name: cache
       initContainers:

--- a/charts/bpdm/charts/bpdm-gate/values.yaml
+++ b/charts/bpdm/charts/bpdm-gate/values.yaml
@@ -49,6 +49,10 @@ securityContext:
     drop:
       - ALL
 
+configMountSecurity:
+  readOnly: true
+  recursiveReadOnly: Enabled
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/bpdm/charts/bpdm-orchestrator/values.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/values.yaml
@@ -49,6 +49,10 @@ securityContext:
     drop:
       - ALL
 
+configMountSecurity:
+  readOnly: true
+  recursiveReadOnly: Enabled
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/bpdm/charts/bpdm-pool/values.yaml
+++ b/charts/bpdm/charts/bpdm-pool/values.yaml
@@ -49,6 +49,10 @@ securityContext:
     drop:
       - ALL
 
+configMountSecurity:
+  readOnly: true
+  recursiveReadOnly: Enabled
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds Helm chart values for our BPDM application deployments to adjust the security properties of the application config volume mounts.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
