### PR TITLE
feat(security): deny all requests on default

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/MethodMatchPointcut.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/MethodMatchPointcut.kt
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.util
+
+import org.springframework.aop.ClassFilter
+import org.springframework.aop.MethodMatcher
+import org.springframework.aop.Pointcut
+
+/**
+ * General Pointcut implementation that just matches by a given method matcher strategy
+ */
+class MethodMatchPointcut(
+    private val _methodMatcher: MethodMatcher
+): Pointcut {
+    override fun getClassFilter(): ClassFilter = ClassFilter.TRUE
+
+    override fun getMethodMatcher(): MethodMatcher = _methodMatcher
+}

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/UnsecuredRestControllerMethodsMatcher.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/UnsecuredRestControllerMethodsMatcher.kt
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.util
+
+import org.springframework.aop.MethodMatcher
+import org.springframework.core.annotation.MergedAnnotations
+import org.springframework.security.access.prepost.PostAuthorize
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+import java.lang.reflect.Method
+
+/**
+ * Matches all methods which are in a RestController but are not secured by MethodSecurity-Annotations
+ */
+class UnsecuredRestControllerMethodsMatcher: MethodMatcher {
+    override fun matches(method: Method, targetClass: Class<*>): Boolean {
+        val methodAnnotations = MergedAnnotations.from(method)
+        val classAnnotations = MergedAnnotations.from(targetClass)
+
+        val classIsRestController = classAnnotations.get(RestController::class.java).isPresent
+        if(!classIsRestController) return false
+
+        val methodHasMethodSecurity = methodAnnotations.get(PreAuthorize::class.java).isPresent
+                || methodAnnotations.get(PostAuthorize::class.java).isPresent
+
+        return !methodHasMethodSecurity
+    }
+
+    override fun isRuntime(): Boolean = false
+
+    override fun matches(method: Method, targetClass: Class<*>, vararg args: Any?): Boolean = matches(method, targetClass)
+}

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -142,6 +142,22 @@ You can obtain the generated Open-API documents from the running apps at these s
 
 Please use the formatting as-is when updating the corresponding documents in the api documentation folder.
 
+## Deny Requests on Unsecured Endpoints By Default
+
+In BPDM we make use of two Spring supported security strategies: Request-based and method-based security.
+In the request-based security we define which URL paths and HTTP methods of our APIs should be authenticated or not.
+The actual authorization happens then on individual method-level via Spring's method security implementations.
+Each method that is resolved through request mapping will then evaluate the necessary permissions to access it. 
+A drawback of method-security-based authorization is that there is no default denial on missing method security configuration.
+This means, if a developer forgets to put on a RestController method a permission requirement, any authenticated user can access the endpoint.
+
+For this reason BPDM implements a default behaviour in which we require each RestController method to have a method security annotation.
+If such an annotation is not present, the corresponding request will be denied with a 403 forbidden response.
+
+For the developer this means, they should make sure to give any method in a RestController class an appropriate security annotation.
+Also, all methods in such a controller should be for the sole purpose of request mapping.
+Alternative authorization mechanisms that do not involve method security annotations are thus not supported at the moment.
+
 ## NOTICE
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request introduces a security feature in which all authenticated API requests are denied on default if the requested endpoint has not been configured with authorization permissions. This improves security in case an endpoint has been forgotten to be configured with permission requirements.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Implements #1417

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
