### PR TITLE
fix(pool): add read permission requirements to legal-entity/sites endpoint

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -86,7 +86,7 @@ class LegalEntityController(
         )
     }
 
-
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
     override fun getSites(
         bpnl: String,
         paginationRequest: PaginationRequest

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/LegalEntityController.kt
@@ -79,7 +79,7 @@ class LegalEntityController(
         )
     }
 
-
+    @PreAuthorize("hasAuthority(${PermissionConfigProperties.READ_PARTNER})")
     override fun getSites(
         bpnl: String,
         paginationRequest: PaginationRequest


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes a vulnerability issue by adding missing read-permission requirements to the legal-entity/sites endpoint of both v6 and v7 API versions.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1414 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
