### PR TITLE
feat(bpdm-pool): enforce dataspace participant validation for managing entity in IsManagedBy relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - Gate: Removed constraint checks when upserting business partner relations ([1288](https://github.com/eclipse-tractusx/bpdm/issues/1288))
 - App: Renamed api attributes/fields with corresponding 25.06 standards for BPDM Pool, Gate and Orchestrator Services([#1304](https://github.com/eclipse-tractusx/bpdm/issues/1304))
 - Gate: Changed endpoint paths to better differentiate between business partner or relation endpoints ([#1327](https://github.com/eclipse-tractusx/bpdm/issues/1327))
+- Pool: Enforce dataspace participant validation for managing entity in IsManagedBy relation([#1390](https://github.com/eclipse-tractusx/bpdm/issues/1390))
 
 ### Known Knowns
 


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
This pull request enhances the validation for IsManagedBy relation by condition that managing entity must be dataspace participant. Also, when relation validates successfully then made managed legal entity as dataspace participant as well.

Contributes to #1390  

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
