### PR TITLE
Test: Add Authenticated User Tests

### DIFF
--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthenticatedIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/auth/AuthenticatedIT.kt
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.gate.auth
+
+import org.eclipse.tractusx.bpdm.gate.Application
+import org.eclipse.tractusx.bpdm.gate.api.client.GateClient
+import org.eclipse.tractusx.bpdm.test.containers.AuthenticatedSelfClient
+import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
+import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ContextConfiguration(initializers = [
+    PostgreSQLContextInitializer::class,
+    KeyCloakInitializer::class,
+    AuthenticatedSelfClient::class
+])
+@ActiveProfiles("test")
+class AuthenticatedIT @Autowired constructor(
+    gateClient: GateClient,
+    authAssertionHelper: AuthAssertionHelper
+): AuthTestBase(
+    gateClient,
+    authAssertionHelper,
+    authExpectations = GateAuthExpectations(
+        businessPartner = BusinessPartnerAuthExpectations(
+            getInput = AuthExpectationType.Forbidden,
+            getOutput = AuthExpectationType.Forbidden,
+            putInput = AuthExpectationType.Forbidden
+        ),
+        changelog = ChangelogAuthExpectations(
+            getInput = AuthExpectationType.Forbidden,
+            getOutput = AuthExpectationType.Forbidden
+        ),
+        sharingState = SharingStateAuthExpectations(
+            getSharingState = AuthExpectationType.Forbidden,
+            postReady = AuthExpectationType.Forbidden
+        ),
+        stats = StatsAuthExpectations(
+            getSharingState = AuthExpectationType.Forbidden,
+            getStage = AuthExpectationType.Forbidden,
+            getAddressType = AuthExpectationType.Forbidden,
+            getConfidenceCriteria = AuthExpectationType.Forbidden
+        ),
+        uploadPartner = UploadPartnerAuthExpections(
+            postInput = AuthExpectationType.Forbidden,
+            getInputTemplate = AuthExpectationType.Forbidden
+        ),
+        relation = RelationAuthExpectations(
+            postSearch = AuthExpectationType.Forbidden,
+            put = AuthExpectationType.Forbidden
+        ),
+        relationOutput = RelationOutputAuthExpectations(
+            postSearch = AuthExpectationType.Forbidden
+        ),
+        relationSharingState = RelationSharingStateExpectations(
+            get = AuthExpectationType.Forbidden
+        ),
+        relationChangelog = RelationChangelogExpectations(
+            getInput = AuthExpectationType.Forbidden,
+            getOutput = AuthExpectationType.Forbidden
+        )
+    )
+)

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthenticatedIT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/auth/AuthenticatedIT.kt
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.orchestrator.auth
+
+import org.eclipse.tractusx.bpdm.orchestrator.Application
+import org.eclipse.tractusx.bpdm.test.containers.AuthenticatedSelfClient
+import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.util.AuthAssertionHelper
+import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
+import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ContextConfiguration(initializers = [
+    PostgreSQLContextInitializer::class,
+    KeyCloakInitializer::class,
+    AuthenticatedSelfClient::class
+])
+class AuthenticatedIT @Autowired constructor(
+    orchestratorClient: OrchestrationApiClient,
+    authAssertionHelper: AuthAssertionHelper
+): AuthTestBase(
+    orchestratorClient,
+    authAssertionHelper,
+    OrchestratorAuthExpectations(
+        tasks = TaskAuthExpectations(
+            postTask = AuthExpectationType.Forbidden,
+            postStateSearch = AuthExpectationType.Forbidden,
+            postRelationsTask = AuthExpectationType.Forbidden,
+            postRelationsStateSearch = AuthExpectationType.Forbidden
+        ),
+        steps = TaskStep.entries
+            .associateWith { TaskStepAuthExpectations(postReservation = AuthExpectationType.Forbidden, postResult = AuthExpectationType.Forbidden) }
+    )
+)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthenticatedIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthenticatedIT.kt
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.auth
+
+import org.eclipse.tractusx.bpdm.pool.Application
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.test.containers.AuthenticatedSelfClient
+import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.util.AuthExpectationType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+
+/**
+ * Tests for clients that are authenticated but have no permissions or user roles
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ContextConfiguration(initializers = [
+    PostgreSQLContextInitializer::class,
+    KeyCloakInitializer::class,
+    AuthenticatedSelfClient::class
+])
+class AuthenticatedIT @Autowired constructor(poolApiClient: PoolApiClient)
+    : AuthTestBase(
+    poolApiClient,
+    AddressAuthExpectations(
+        getAddresses = AuthExpectationType.Forbidden,
+        getAddress = AuthExpectationType.Forbidden,
+        postAddressSearch = AuthExpectationType.Forbidden,
+        postAddresses = AuthExpectationType.Forbidden,
+        putAddresses = AuthExpectationType.Forbidden
+    ),
+    SiteAuthExpectations(
+        getSites = AuthExpectationType.Forbidden,
+        getSite = AuthExpectationType.Forbidden,
+        postSiteSearch = AuthExpectationType.Forbidden,
+        postSites = AuthExpectationType.Forbidden,
+        putSites = AuthExpectationType.Forbidden
+    ),
+    LegalEntityAuthExpectations(
+        getLegalEntities = AuthExpectationType.Forbidden,
+        getLegalEntity = AuthExpectationType.Forbidden,
+        postLegalEntitySearch = AuthExpectationType.Forbidden,
+        postLegalEntities = AuthExpectationType.Forbidden,
+        putLegalEntities = AuthExpectationType.Forbidden,
+        getLegalEntityAddresses = AuthExpectationType.Forbidden,
+        getLegalEntitySites = AuthExpectationType.Forbidden
+    ),
+    MetadataAuthExpectations(
+        getLegalForm = AuthExpectationType.Forbidden,
+        postLegalForm = AuthExpectationType.Forbidden,
+        getIdentifierType = AuthExpectationType.Forbidden,
+        postIdentifierType = AuthExpectationType.Forbidden,
+        getAdminArea = AuthExpectationType.Forbidden,
+        getFieldQualityRules = AuthExpectationType.Forbidden
+    ),
+    MembersAuthExpectations(
+        postAddressSearch = AuthExpectationType.Forbidden,
+        postSiteSearch = AuthExpectationType.Forbidden,
+        postLegalEntitySearch = AuthExpectationType.Forbidden,
+        postChangelogSearch = AuthExpectationType.Forbidden
+    ),
+    CxMembershipsAuthExpectations(
+        getMemberships = AuthExpectationType.Forbidden,
+        putMemberships = AuthExpectationType.Forbidden
+    ),
+    changelogAuthExpectation = AuthExpectationType.Forbidden,
+    bpnAuthExpectation = AuthExpectationType.Forbidden
+    )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds tests for accessing endpoints by an authenticated user who has no BPDM permissions. The expectation here is that all endpoints should return a 403 Forbidden response.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Implements #1415 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
