### PR TITLE
test(Auth): fix authentication test assertions

### DIFF
--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/AuthAssertionHelper.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/AuthAssertionHelper.kt
@@ -24,19 +24,18 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 class AuthAssertionHelper {
     fun assert(authType: AuthExpectationType, invocation: () -> Unit) {
-        return Assertions.assertThatNoException().isThrownBy {
-            try {
-                invocation()
-            } catch (e: WebClientResponseException.Unauthorized) {
-                if (authType != AuthExpectationType.Unauthorized) {
-                    throw e
-                }
-            } catch (e: WebClientResponseException.Forbidden) {
-                if (authType != AuthExpectationType.Forbidden) {
-                    throw e
-                }
-            } catch (_: WebClientResponseException) { }
+        val actualAuthorizationResult = try {
+            invocation()
+            AuthExpectationType.Authorized
+        } catch (_: WebClientResponseException.Unauthorized) {
+            AuthExpectationType.Unauthorized
+        } catch (_: WebClientResponseException.Forbidden) {
+            AuthExpectationType.Forbidden
+        } catch (_: WebClientResponseException) {
+            AuthExpectationType.Authorized
         }
+
+        Assertions.assertThat(actualAuthorizationResult).isEqualTo(authType)
     }
 }
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthSharingMemberIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/auth/AuthSharingMemberIT.kt
@@ -40,27 +40,27 @@ class AuthSharingMemberIT @Autowired constructor(
 ): AuthTestBase(
     poolApiClient,
     AddressAuthExpectations(
-        getAddresses = AuthExpectationType.Forbidden,
-        getAddress = AuthExpectationType.Forbidden,
-        postAddressSearch = AuthExpectationType.Forbidden,
+        getAddresses = AuthExpectationType.Authorized,
+        getAddress = AuthExpectationType.Authorized,
+        postAddressSearch = AuthExpectationType.Authorized,
         postAddresses = AuthExpectationType.Forbidden,
         putAddresses = AuthExpectationType.Forbidden
     ),
     SiteAuthExpectations(
-        getSites = AuthExpectationType.Forbidden,
-        getSite = AuthExpectationType.Forbidden,
-        postSiteSearch = AuthExpectationType.Forbidden,
+        getSites = AuthExpectationType.Authorized,
+        getSite = AuthExpectationType.Authorized,
+        postSiteSearch = AuthExpectationType.Authorized,
         postSites = AuthExpectationType.Forbidden,
         putSites = AuthExpectationType.Forbidden
     ),
     LegalEntityAuthExpectations(
-        getLegalEntities = AuthExpectationType.Forbidden,
-        getLegalEntity = AuthExpectationType.Forbidden,
-        postLegalEntitySearch = AuthExpectationType.Forbidden,
+        getLegalEntities = AuthExpectationType.Authorized,
+        getLegalEntity = AuthExpectationType.Authorized,
+        postLegalEntitySearch = AuthExpectationType.Authorized,
         postLegalEntities = AuthExpectationType.Forbidden,
         putLegalEntities = AuthExpectationType.Forbidden,
-        getLegalEntityAddresses = AuthExpectationType.Forbidden,
-        getLegalEntitySites = AuthExpectationType.Forbidden
+        getLegalEntityAddresses = AuthExpectationType.Authorized,
+        getLegalEntitySites = AuthExpectationType.Authorized
     ),
     MetadataAuthExpectations(
         getLegalForm = AuthExpectationType.Authorized,
@@ -80,8 +80,8 @@ class AuthSharingMemberIT @Autowired constructor(
         getMemberships = AuthExpectationType.Forbidden,
         putMemberships = AuthExpectationType.Forbidden
     ),
-    changelogAuthExpectation = AuthExpectationType.Forbidden,
-    bpnAuthExpectation = AuthExpectationType.Forbidden
+    changelogAuthExpectation = AuthExpectationType.Authorized,
+    bpnAuthExpectation = AuthExpectationType.Authorized
 )
 
 class SelfClientAsSharingMemberInitializer : SelfClientInitializer() {


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes how the assertion of expected responses in BPDM authentication tests work. Before, there was a problem with an assertion not being executed when an API call responds with 200.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
