### PR TITLE
fix(Auth): scope to deny access to unsecured endpoints

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/SecurityConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/SecurityConfig.kt
@@ -130,7 +130,7 @@ class OAuthSecurityConfig(
     @Bean
     fun denyUnsecuredRestControllerMethodAdvisor(): Advisor{
         return AuthorizationManagerBeforeMethodInterceptor(
-            MethodMatchPointcut(UnsecuredRestControllerMethodsMatcher()),
+            MethodMatchPointcut(UnsecuredRestControllerMethodsMatcher("org.eclipse.tractusx.bpdm")),
             SingleResultAuthorizationManager.denyAll()
         )
     }

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/UnsecuredRestControllerMethodsMatcher.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/util/UnsecuredRestControllerMethodsMatcher.kt
@@ -23,19 +23,36 @@ import org.springframework.aop.MethodMatcher
 import org.springframework.core.annotation.MergedAnnotations
 import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.lang.reflect.Method
 
 /**
  * Matches all methods which are in a RestController but are not secured by MethodSecurity-Annotations
  */
-class UnsecuredRestControllerMethodsMatcher: MethodMatcher {
+class UnsecuredRestControllerMethodsMatcher(
+    private val packagePrefix: String
+): MethodMatcher {
     override fun matches(method: Method, targetClass: Class<*>): Boolean {
-        val methodAnnotations = MergedAnnotations.from(method)
-        val classAnnotations = MergedAnnotations.from(targetClass)
+        val methodAnnotations = MergedAnnotations.from(method, MergedAnnotations.SearchStrategy.TYPE_HIERARCHY)
+        val classAnnotations = MergedAnnotations.from(targetClass, MergedAnnotations.SearchStrategy.TYPE_HIERARCHY)
+
+        if(!targetClass.packageName.startsWith(packagePrefix)) return false
 
         val classIsRestController = classAnnotations.get(RestController::class.java).isPresent
         if(!classIsRestController) return false
+
+        val methodHasRequestMapping = methodAnnotations.get(RequestMapping::class.java).isPresent
+                || methodAnnotations.get(GetMapping::class.java).isPresent
+                || methodAnnotations.get(PostMapping::class.java).isPresent
+                || methodAnnotations.get(PutMapping::class.java).isPresent
+                || methodAnnotations.get(DeleteMapping::class.java).isPresent
+
+        if(!methodHasRequestMapping) return false
 
         val methodHasMethodSecurity = methodAnnotations.get(PreAuthorize::class.java).isPresent
                 || methodAnnotations.get(PostAuthorize::class.java).isPresent


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the scope on which we apply the default behaviour of denying access to all unsecured endpoints. Now only BPDM defined endpoints have this default behaviour and only on methods which are actually mapped to endpoint requests.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
