### PR TITLE
test(pool): add tests for operator metadata management

### DIFF
--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/client/MetadataApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/client/MetadataApiClient.kt
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.client
+
+import com.neovisionaries.i18n.CountryCode
+import org.eclipse.tractusx.bpdm.common.dto.PageDto
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.ApiCommons
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.v6.PoolMetadataApi
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.IdentifierTypeDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalFormRequest
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.service.annotation.GetExchange
+import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PostExchange
+
+@HttpExchange
+interface MetadataApiClient: PoolMetadataApi {
+
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V6}/identifier-types")
+    override fun createIdentifierType(@RequestBody identifierType: IdentifierTypeDto): IdentifierTypeDto
+
+    @PostExchange(value = "${ApiCommons.BASE_PATH_V6}/legal-forms")
+    override fun createLegalForm(@RequestBody type: LegalFormRequest): LegalFormDto
+
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V6}/identifier-types")
+    override fun getIdentifierTypes(
+        @ParameterObject paginationRequest: PaginationRequest,
+        @RequestParam businessPartnerType: IdentifierBusinessPartnerType,
+        @RequestParam country: CountryCode?
+    ): PageDto<IdentifierTypeDto>
+
+    @GetExchange(value = "${ApiCommons.BASE_PATH_V6}/legal-forms")
+    override fun getLegalForms(@ParameterObject paginationRequest: PaginationRequest): PageDto<LegalFormDto>
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/client/PoolApiClient.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/client/PoolApiClient.kt
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.client
+
+interface PoolApiClient {
+
+    val metadata: MetadataApiClient
+
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/client/PoolClientImpl.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/v6/client/PoolClientImpl.kt
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.api.v6.client
+
+import org.eclipse.tractusx.bpdm.common.service.ParameterObjectArgumentResolver
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.support.WebClientAdapter
+import org.springframework.web.service.invoker.HttpServiceProxyFactory
+
+class PoolClientImpl(
+    private val webClientProvider: () -> WebClient
+): PoolApiClient {
+
+    private val httpServiceProxyFactory: HttpServiceProxyFactory by lazy {
+        HttpServiceProxyFactory.builder()
+            .exchangeAdapter(WebClientAdapter.create(webClientProvider()))
+            .customArgumentResolver(ParameterObjectArgumentResolver())
+            .build()
+    }
+
+    override val metadata by lazy { createClient<MetadataApiClient>() }
+
+    private inline fun <reified T> createClient() =
+        httpServiceProxyFactory.createClient(T::class.java)
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/config/PoolClientV6Configuration.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/config/PoolClientV6Configuration.kt
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.v6.config
+
+import org.eclipse.tractusx.bpdm.common.util.BpdmWebClientProvider
+import org.eclipse.tractusx.bpdm.pool.api.v6.client.PoolApiClient as PoolApiClientV6
+import org.eclipse.tractusx.bpdm.pool.api.v6.client.PoolClientImpl
+import org.eclipse.tractusx.bpdm.test.config.SelfClientConfigProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnProperty(name = ["test.v6"], havingValue = "true", matchIfMissing = false)
+class PoolClientV6Configuration {
+
+    @Bean
+    fun poolClientV6(
+        webServerAppCtxt: ServletWebServerApplicationContext,
+        selfClientConfigProperties: SelfClientConfigProperties,
+        webClientProvider: BpdmWebClientProvider
+    ): PoolApiClientV6 {
+        return PoolClientImpl {
+            val properties = selfClientConfigProperties.copy(baseUrl = "http://localhost:${webServerAppCtxt.webServer.port}")
+            webClientProvider.builder(properties).build()
+        }
+    }
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/IdentifierTypeIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/IdentifierTypeIT.kt
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.v6.operator
+
+import com.neovisionaries.i18n.CountryCode
+import org.assertj.core.api.Assertions
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierBusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.IdentifierTypeDetailDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.IdentifierTypeDto
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import kotlin.random.Random
+
+class IdentifierTypeIT @Autowired constructor(
+    private val poolApiClient: PoolApiClient
+): OperatorTest() {
+
+    /**
+     * WHEN operator creates valid identifier type
+     * THEN created identifier type returned
+     */
+    @ParameterizedTest(name = "{displayName} - {arguments}")
+    @EnumSource(IdentifierBusinessPartnerType::class)
+    fun `create new identifier type`(type: IdentifierBusinessPartnerType){
+        val request = createIdentifierTypeRequest(testName, type)
+        val response = poolApiClient.metadata.createIdentifierType(request)
+
+        Assertions.assertThat(response).isEqualTo(request)
+    }
+
+    /**
+     * WHEN operator creates valid identifier type
+     * THEN operator can find new identifier type in available metadata
+     */
+    @ParameterizedTest(name = "{displayName} - {arguments}")
+    @EnumSource(IdentifierBusinessPartnerType::class)
+    fun `create new identifier type and find it`(type: IdentifierBusinessPartnerType){
+        val request = createIdentifierTypeRequest(testName, type)
+        poolApiClient.metadata.createIdentifierType(request)
+
+        var currentPage = 0
+        var found = false
+        do{
+            val response = poolApiClient.metadata.getIdentifierTypes(PaginationRequest(currentPage, 100), type, null)
+
+            val foundIdType = response.content.find { it.technicalKey == request.technicalKey }
+            if(foundIdType != null){
+                Assertions.assertThat(foundIdType)
+                    .usingRecursiveComparison()
+                    .ignoringCollectionOrder()
+                    .isEqualTo(request)
+                found = true
+            }
+
+            currentPage++
+        }while (response.content.isNotEmpty())
+
+        Assertions.assertThat(found).isTrue
+    }
+
+    /**
+     * WHEN operator tries to create identifier type with existing technical key
+     * THEN 409 CONFLICT returned
+     */
+    @ParameterizedTest(name = "{displayName} - {arguments}")
+    @EnumSource(IdentifierBusinessPartnerType::class)
+    fun `try create new identifier type with duplicate technical key`(type: IdentifierBusinessPartnerType){
+        val request = createIdentifierTypeRequest(testName, type)
+        poolApiClient.metadata.createIdentifierType(request)
+
+        Assertions.assertThatThrownBy { poolApiClient.metadata.createIdentifierType(request) }
+            .isInstanceOf(WebClientResponseException.Conflict::class.java)
+    }
+
+    private fun createIdentifierTypeRequest(seed: String, type: IdentifierBusinessPartnerType): IdentifierTypeDto{
+       val random = Random(seed.hashCode())
+
+        return IdentifierTypeDto(
+            technicalKey = seed,
+            businessPartnerType = type,
+            name = "$seed ${IdentifierTypeDto::name.name}",
+            abbreviation = "$seed ${IdentifierTypeDto::abbreviation.name}",
+            transliteratedName = "$seed ${IdentifierTypeDto::transliteratedName.name}",
+            transliteratedAbbreviation = "$seed ${IdentifierTypeDto::transliteratedAbbreviation.name}",
+            details = (1 .. random.nextInt(3, 10))
+                .map { CountryCode.entries.random(random) }
+                .toSet()
+                .map { IdentifierTypeDetailDto(it, random.nextBoolean()) }
+        )
+    }
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/LegalFormIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/LegalFormIT.kt
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.v6.operator
+
+import com.neovisionaries.i18n.CountryCode
+import com.neovisionaries.i18n.LanguageCode
+import org.assertj.core.api.Assertions
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.api.v6.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalFormDto
+import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalFormRequest
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+class LegalFormIT @Autowired constructor(
+    private val poolApiClient: PoolApiClient
+): OperatorTest(){
+
+    /**
+     * WHEN operator creates valid legal form
+     * THEN operator can find new legal forms in available metadata
+     */
+    @Test
+    fun `create new legal form and find it`(){
+        val request = createLegalFormRequest(testName)
+        poolApiClient.metadata.createLegalForm(request)
+
+        val expectedResponse = createExpectedLegalForm(request)
+
+        var currentPage = 0
+        var found = false
+        do{
+            val response = poolApiClient.metadata.getLegalForms(PaginationRequest(currentPage, 100))
+
+            val foundLegalForm = response.content.find { it.technicalKey == request.technicalKey }
+            if(foundLegalForm != null){
+                Assertions.assertThat(foundLegalForm).isEqualTo(expectedResponse)
+                found = true
+            }
+
+            currentPage++
+        }while (response.content.isNotEmpty())
+
+        Assertions.assertThat(found).isTrue
+    }
+
+    /**
+     * WHEN operator creates valid legal form
+     * THEN created legal form returned
+     */
+    @Test
+    fun `create new legal form`(){
+        val request = createLegalFormRequest(testName)
+        val response = poolApiClient.metadata.createLegalForm(request)
+
+        val expectedResponse = createExpectedLegalForm(request)
+        Assertions.assertThat(response).isEqualTo(expectedResponse)
+    }
+
+    /**
+     * WHEN operator tries to create legal form with existing technical key
+     * THEN 409 CONFLICT returned
+     */
+    @Test
+    fun `try create new legal form with duplicate technical key`(){
+        val request = createLegalFormRequest(testName)
+        poolApiClient.metadata.createLegalForm(request)
+
+        Assertions.assertThatThrownBy { poolApiClient.metadata.createLegalForm(request) }
+            .isInstanceOf(WebClientResponseException.Conflict::class.java)
+    }
+
+    /**
+     * WHEN operator tries to create legal form for unknown administrative area
+     * THEN 400 BAD REQUEST returned
+     *
+     * ToDo:
+     * Currently not fulfilled!
+     * Bug Ticket for tracking: https://github.com/eclipse-tractusx/bpdm/issues/1446
+     */
+    @Test
+    @Disabled
+    fun `try create new legal form with unknown admin area`(){
+        val request = createLegalFormRequest(testName)
+            .copy(administrativeAreaLevel1 = "UNKNOWN")
+
+        Assertions.assertThatThrownBy { poolApiClient.metadata.createLegalForm(request) }
+            .isInstanceOf(WebClientResponseException.BadRequest::class.java)
+    }
+
+
+
+    private fun createLegalFormRequest(seed: String): LegalFormRequest{
+        return LegalFormRequest(
+            technicalKey = seed,
+            name = "$seed ${LegalFormRequest::name.name}",
+            transliteratedName = "$seed ${LegalFormRequest::transliteratedName.name}",
+            abbreviation = "$seed ${LegalFormRequest::abbreviation.name}",
+            transliteratedAbbreviations = "$seed ${LegalFormRequest::transliteratedAbbreviations.name}",
+            country = CountryCode.DE,
+            language = LanguageCode.de,
+            administrativeAreaLevel1 = "DE-BW",
+            isActive = true
+        )
+    }
+
+    private fun createExpectedLegalForm(request: LegalFormRequest): LegalFormDto{
+        return  LegalFormDto(
+            technicalKey = request.technicalKey,
+            name = request.name,
+            transliteratedName = request.transliteratedName,
+            abbreviation = request.abbreviation,
+            country = request.country,
+            language = request.language,
+            administrativeAreaLevel1 = request.administrativeAreaLevel1,
+            transliteratedAbbreviations = request.transliteratedAbbreviations,
+            isActive = request.isActive
+        )
+    }
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/OperatorTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/OperatorTest.kt
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.v6.operator
+
+import org.eclipse.tractusx.bpdm.pool.Application
+import org.eclipse.tractusx.bpdm.pool.auth.SelfClientAsAdminInitializer
+import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ContextConfiguration(initializers = [
+    PostgreSQLContextInitializer::class,
+    KeyCloakInitializer::class,
+    SelfClientAsAdminInitializer::class
+])
+@ActiveProfiles("test-v6")
+abstract class OperatorTest{
+
+    lateinit var testName: String
+
+    @BeforeEach
+    fun beforeEach(testInfo: TestInfo){
+        testName = testInfo.displayName
+//        testName = if(testInfo.testMethod.getOrNull()?.name == testInfo.displayName)
+//            testInfo.displayName
+//        else
+//            "${testInfo.testMethod.get().name} ${testInfo.displayName}"
+    }
+}

--- a/bpdm-pool/src/test/resources/application-test-v6.yml
+++ b/bpdm-pool/src/test/resources/application-test-v6.yml
@@ -1,0 +1,5 @@
+test:
+  v6: "true"
+bpdm:
+  tasks:
+    cron: '-'

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -22,8 +22,8 @@ apiVersion: v2
 name: bpdm
 type: application
 description: A Helm chart for Kubernetes that deploys the BPDM applications
-version: 6.1.0-rc3
-appVersion: "7.1.0-rc3"
+version: 6.1.0-SNAPSHOT
+appVersion: "7.1.0-SNAPSHOT"
 home: https://github.com/eclipse-tractusx/bpdm
 sources:
   - https://github.com/eclipse-tractusx/bpdm
@@ -33,19 +33,19 @@ maintainers:
 
 dependencies:
   - name: bpdm-gate
-    version: 7.1.0-rc3
+    version: 7.1.0-SNAPSHOT
     alias: bpdm-gate
     condition: bpdm-gate.enabled
   - name: bpdm-pool
-    version: 8.1.0-rc3
+    version: 8.1.0-SNAPSHOT
     alias: bpdm-pool
     condition: bpdm-pool.enabled
   - name: bpdm-cleaning-service-dummy
-    version: 4.1.0-rc3
+    version: 4.1.0-SNAPSHOT
     alias: bpdm-cleaning-service-dummy
     condition: bpdm-cleaning-service-dummy.enabled
   - name: bpdm-orchestrator
-    version: 4.1.0-rc3
+    version: 4.1.0-SNAPSHOT
     alias: bpdm-orchestrator
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-cleaning-service-dummy
-appVersion: "7.1.0-rc3"
-version: 4.1.0-rc3
+appVersion: "7.1.0-SNAPSHOT"
+version: 4.1.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM cleaning service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-gate
-appVersion: "7.1.0-rc3"
-version: 7.1.0-rc3
+appVersion: "7.1.0-SNAPSHOT"
+version: 7.1.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM gate service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-orchestrator
-appVersion: "7.1.0-rc3"
-version: 4.1.0-rc3
+appVersion: "7.1.0-SNAPSHOT"
+version: 4.1.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM Orchestrator service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -21,8 +21,8 @@
 apiVersion: v2
 type: application
 name: bpdm-pool
-appVersion: "7.1.0-rc3"
-version: 8.1.0-rc3
+appVersion: "7.1.0-SNAPSHOT"
+version: 8.1.0-SNAPSHOT
 description: A Helm chart for deploying the BPDM pool service
 home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adoption%20View
 sources:

--- a/docs/api/gate.json
+++ b/docs/api/gate.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "Business Partner Data Management Gate",
     "description" : "A gate for a member to share business partner data with CatenaX",
-    "version" : "7.1.0-rc3"
+    "version" : "7.1.0-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "http://localhost:8081",

--- a/docs/api/gate.yaml
+++ b/docs/api/gate.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Business Partner Data Management Gate
   description: A gate for a member to share business partner data with CatenaX
-  version: 7.1.0-rc3
+  version: 7.1.0-SNAPSHOT
 servers:
   - url: http://localhost:8081
     description: Generated server url

--- a/docs/api/orchestrator.json
+++ b/docs/api/orchestrator.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "Business Partner Data Management Orchestrator",
     "description" : "Orchestrator component acts as a passive component and offers for each processing steps individual endpoints",
-    "version" : "7.1.0-rc3"
+    "version" : "7.1.0-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "http://localhost:8085",

--- a/docs/api/orchestrator.yaml
+++ b/docs/api/orchestrator.yaml
@@ -3,7 +3,7 @@ info:
   title: Business Partner Data Management Orchestrator
   description: Orchestrator component acts as a passive component and offers for each
     processing steps individual endpoints
-  version: 7.1.0-rc3
+  version: 7.1.0-SNAPSHOT
 servers:
   - url: http://localhost:8085
     description: Generated server url

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "Business Partner Data Management Pool",
     "description" : "Service that manages and shares business partner data with other CatenaX services",
-    "version" : "7.1.0-rc3"
+    "version" : "7.1.0-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "http://localhost:8080",

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -3,7 +3,7 @@ info:
   title: Business Partner Data Management Pool
   description: Service that manages and shares business partner data with other CatenaX
     services
-  version: 7.1.0-rc3
+  version: 7.1.0-SNAPSHOT
 servers:
   - url: http://localhost:8080
     description: Generated server url

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </modules>
 
     <properties>
-        <revision>7.1.0-rc3</revision>
+        <revision>7.1.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds missing tests for the V6 API for operators to manage metadata (legalforms and identifier types).

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
