### PR TITLE
fix(charts/bpdm): replace bitnami repository by bitnamilegacy

### DIFF
--- a/charts/bpdm/CHANGELOG.md
+++ b/charts/bpdm/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- fix vulnerability in deployments by providing read-only volume mounts 
+- fix vulnerability in deployments by providing read-only volume mounts
+- migrated Bitnami chart dependencies to the BitnamiLegacy repository.
 
 ## [6.0.0] -  2025-06-16
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -56,7 +56,7 @@ dependencies:
     alias: postgres
     condition: postgres.enabled
   - name: centralidp
-    version: 4.2.0
+    version: 4.2.1-rc.1
     repository: https://eclipse-tractusx.github.io/charts/dev
     alias: centralidp
     condition: centralidp.enabled

--- a/charts/bpdm/README.md
+++ b/charts/bpdm/README.md
@@ -1,6 +1,6 @@
 # bpdm
 
-![Version: 6.1.0-rc3](https://img.shields.io/badge/Version-6.1.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-rc3](https://img.shields.io/badge/AppVersion-7.1.0--rc3-informational?style=flat-square)
+![Version: 6.1.0-SNAPSHOT](https://img.shields.io/badge/Version-6.1.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.1.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for Kubernetes that deploys the BPDM applications
 
@@ -21,11 +21,11 @@ A Helm chart for Kubernetes that deploys the BPDM applications
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | bpdm-cleaning-service-dummy(bpdm-cleaning-service-dummy) | 4.1.0-rc3 |
+|  | bpdm-cleaning-service-dummy(bpdm-cleaning-service-dummy) | 4.1.0-SNAPSHOT |
 |  | bpdm-common | 1.0.5 |
-|  | bpdm-gate(bpdm-gate) | 7.1.0-rc3 |
-|  | bpdm-orchestrator(bpdm-orchestrator) | 4.1.0-rc3 |
-|  | bpdm-pool(bpdm-pool) | 8.1.0-rc3 |
+|  | bpdm-gate(bpdm-gate) | 7.1.0-SNAPSHOT |
+|  | bpdm-orchestrator(bpdm-orchestrator) | 4.1.0-SNAPSHOT |
+|  | bpdm-pool(bpdm-pool) | 8.1.0-SNAPSHOT |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.2.0 |
 
@@ -70,6 +70,8 @@ A Helm chart for Kubernetes that deploys the BPDM applications
 | postgres.auth.username | string | `"bpdm"` |  |
 | postgres.enabled | bool | `true` |  |
 | postgres.fullnameOverride | string | `"bpdm-postgres"` |  |
+| postgres.image.repository | string | `"bitnamilegacy/postgresql"` |  |
+| postgres.image.tag | string | `"15-debian-11"` |  |
 | tests.applicationConfig.bpdm.client.gate.provider.issuer-uri | string | `"http://bpdm-centralidp/auth/realms/CX-Central"` |  |
 | tests.applicationConfig.bpdm.client.orchestrator.provider.issuer-uri | string | `"http://bpdm-centralidp/auth/realms/CX-Central"` |  |
 | tests.applicationConfig.bpdm.client.pool.provider.issuer-uri | string | `"http://bpdm-centralidp/auth/realms/CX-Central"` |  |

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
@@ -1,6 +1,6 @@
 # bpdm-cleaning-service-dummy
 
-![Version: 4.1.0-rc3](https://img.shields.io/badge/Version-4.1.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-rc3](https://img.shields.io/badge/AppVersion-7.1.0--rc3-informational?style=flat-square)
+![Version: 4.1.0-SNAPSHOT](https://img.shields.io/badge/Version-4.1.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.1.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM cleaning service
 

--- a/charts/bpdm/charts/bpdm-gate/README.md
+++ b/charts/bpdm/charts/bpdm-gate/README.md
@@ -1,6 +1,6 @@
 # bpdm-gate
 
-![Version: 7.1.0-rc3](https://img.shields.io/badge/Version-7.1.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-rc3](https://img.shields.io/badge/AppVersion-7.1.0--rc3-informational?style=flat-square)
+![Version: 7.1.0-SNAPSHOT](https://img.shields.io/badge/Version-7.1.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.1.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM gate service
 

--- a/charts/bpdm/charts/bpdm-orchestrator/README.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/README.md
@@ -1,6 +1,6 @@
 # bpdm-orchestrator
 
-![Version: 4.1.0-rc3](https://img.shields.io/badge/Version-4.1.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-rc3](https://img.shields.io/badge/AppVersion-7.1.0--rc3-informational?style=flat-square)
+![Version: 4.1.0-SNAPSHOT](https://img.shields.io/badge/Version-4.1.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.1.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM Orchestrator service
 

--- a/charts/bpdm/charts/bpdm-pool/README.md
+++ b/charts/bpdm/charts/bpdm-pool/README.md
@@ -1,6 +1,6 @@
 # bpdm-pool
 
-![Version: 8.1.0-rc3](https://img.shields.io/badge/Version-8.1.0--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-rc3](https://img.shields.io/badge/AppVersion-7.1.0--rc3-informational?style=flat-square)
+![Version: 8.1.0-SNAPSHOT](https://img.shields.io/badge/Version-8.1.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.1.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM pool service
 

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -70,6 +70,9 @@ bpdm-orchestrator:
 
 postgres:
   enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 15-debian-11
   fullnameOverride: bpdm-postgres
   auth:
     database: bpdm


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Workaround to keep the latest chart running for R25.09.

Bitnami changed their container image availability to provide versioned and security hardened images only for subscribed companies.

We follow this immediate recommendation and:

- switch image to bitnamilegacy images

Contributes to #1455

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
