### PR TITLE
docs: updated maven cucumber version 7.28.1

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,6 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.5.18, EPL-1.0 AND LGPL-2.1-only, approved, #18704
 maven/mavencentral/ch.qos.logback/logback-core/1.5.18, EPL-1.0 AND LGPL-2.1-only, approved, #15210
+maven/mavencentral/com.ethlo.time/itu/1.10.3, Apache-2.0, approved, #13168
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.19.2, Apache-2.0, approved, #21911
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.19.2, Apache-2.0 AND MIT, approved, #21916
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.19.2, Apache-2.0, approved, #21909
@@ -26,6 +27,7 @@ maven/mavencentral/com.github.tomakehurst/wiremock-jre8-standalone/2.35.2, MIT A
 maven/mavencentral/com.ibm.async/asyncutil/0.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.jayway.jsonpath/json-path/2.9.0, Apache-2.0, approved, #20009
 maven/mavencentral/com.neovisionaries/nv-i18n/1.29, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.networknt/json-schema-validator/1.5.8, Apache-2.0 AND Unicode-TOU, approved, #15630
 maven/mavencentral/com.nimbusds/content-type/2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.4, Apache-2.0, approved, #11701
@@ -45,26 +47,25 @@ maven/mavencentral/commons-io/commons-io/2.20.0, Apache-2.0, approved, #22562
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/commons-logging/commons-logging/1.3.5, Apache-2.0, approved, #11783
 maven/mavencentral/io.cucumber/ci-environment/10.0.1, MIT, approved, #15218
-maven/mavencentral/io.cucumber/cucumber-core/7.29.0, MIT AND (Apache-2.0 AND MIT), approved, #23408
+maven/mavencentral/io.cucumber/cucumber-core/7.28.1, MIT AND (Apache-2.0 AND MIT), approved, #23171
 maven/mavencentral/io.cucumber/cucumber-expressions/18.0.1, MIT, approved, #19277
-maven/mavencentral/io.cucumber/cucumber-gherkin-messages/7.29.0, MIT, approved, #23409
-maven/mavencentral/io.cucumber/cucumber-gherkin/7.29.0, MIT, approved, #23410
-maven/mavencentral/io.cucumber/cucumber-java/7.29.0, MIT, approved, #23411
-maven/mavencentral/io.cucumber/cucumber-json-formatter/0.2.1, MIT, approved, #23412
-maven/mavencentral/io.cucumber/cucumber-junit/7.29.0, MIT, approved, #23413
-maven/mavencentral/io.cucumber/cucumber-plugin/7.29.0, MIT, approved, #23414
-maven/mavencentral/io.cucumber/cucumber-spring/7.29.0, MIT, approved, #23415
-maven/mavencentral/io.cucumber/datatable/7.29.0, MIT, approved, #23416
-maven/mavencentral/io.cucumber/docstring/7.29.0, MIT, approved, #23419
-maven/mavencentral/io.cucumber/gherkin/35.1.0, MIT, approved, #23421
-maven/mavencentral/io.cucumber/html-formatter/21.15.1, Apache-2.0 AND MIT, approved, #23422
-maven/mavencentral/io.cucumber/junit-xml-formatter/0.9.0, MIT, approved, #23423
-maven/mavencentral/io.cucumber/messages/29.0.1, MIT, approved, #23424
-maven/mavencentral/io.cucumber/pretty-formatter/2.3.0, MIT, approved, #23425
-maven/mavencentral/io.cucumber/query/14.3.0, MIT, approved, #23426
+maven/mavencentral/io.cucumber/cucumber-gherkin-messages/7.28.1, MIT, approved, #23172
+maven/mavencentral/io.cucumber/cucumber-gherkin/7.28.1, MIT, approved, #23173
+maven/mavencentral/io.cucumber/cucumber-java/7.28.1, MIT, approved, #23174
+maven/mavencentral/io.cucumber/cucumber-json-formatter/0.1.2, MIT, approved, #23175
+maven/mavencentral/io.cucumber/cucumber-junit/7.28.1, MIT, approved, #23176
+maven/mavencentral/io.cucumber/cucumber-plugin/7.28.1, MIT, approved, #23177
+maven/mavencentral/io.cucumber/cucumber-spring/7.28.1, MIT, approved, #23178
+maven/mavencentral/io.cucumber/datatable/7.28.1, MIT, approved, #23179
+maven/mavencentral/io.cucumber/docstring/7.28.1, MIT, approved, #23180
+maven/mavencentral/io.cucumber/gherkin/34.0.0, MIT, approved, clearlydefined
+maven/mavencentral/io.cucumber/html-formatter/21.13.0, Apache-2.0 AND MIT, approved, #22565
+maven/mavencentral/io.cucumber/junit-xml-formatter/0.8.1, MIT, approved, clearlydefined
+maven/mavencentral/io.cucumber/messages/28.1.0, MIT, approved, clearlydefined
+maven/mavencentral/io.cucumber/pretty-formatter/2.1.0, MIT, approved, clearlydefined
+maven/mavencentral/io.cucumber/query/13.6.0, MIT, approved, #22826
 maven/mavencentral/io.cucumber/tag-expressions/6.1.2, MIT AND (BSD-3-Clause AND MIT) AND BSD-3-Clause, approved, #14277
-maven/mavencentral/io.cucumber/teamcity-formatter/0.1.1, MIT, approved, #23427
-maven/mavencentral/io.cucumber/testng-xml-formatter/0.6.0, MIT, approved, #23428
+maven/mavencentral/io.cucumber/testng-xml-formatter/0.5.0, MIT, approved, clearlydefined
 maven/mavencentral/io.github.microutils/kotlin-logging-jvm/3.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.micrometer/micrometer-commons/1.15.4, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #23144
 maven/mavencentral/io.micrometer/micrometer-core/1.15.4, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #23142

--- a/bpdm-system-tester/pom.xml
+++ b/bpdm-system-tester/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <cucumber.version>7.29.0</cucumber.version>
+        <cucumber.version>7.28.1</cucumber.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request downgrades the cucumber version to 7.28.1 to have restricted free dependencies in BPDM project.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
