### PR TITLE
Feat(Pool): Only One Alternative Headquarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 ## [7.2.0] - tbd
 
+### Changed
+
+- BPDM Pool: each legal entity can now have only one alternative headquarter
+
 ## [7.1.0] - 2025-09-30
 
 ### Added

--- a/bpdm-system-tester/src/main/resources/cucumber/share_business_partner_relation.feature
+++ b/bpdm-system-tester/src/main/resources/cucumber/share_business_partner_relation.feature
@@ -18,25 +18,3 @@ Feature: Share Business Partner Relations (SHR)
         Then Pool has relation of type 'IsAlternativeHeadquarterFor', source 'BPNL-2' and target 'BPNL-1'
         And Gate has relation output with external-ID 'RE-1' of type of type 'IsAlternativeHeadquarterFor', source 'BPNL-2' and target 'BPNL-1'
 
-    Scenario: SHR-CAHT
-        IsAlternativeHeadquarterFor relation is transitive
-
-        Given shared legal entity with external-ID 'LE-1' and BPNL 'BPNL-1'
-        And shared legal entity with external-ID 'LE-2' and BPNL 'BPNL-2'
-        And shared legal entity with external-ID 'LE-3' and BPNL 'BPNL-3'
-        And shared relation with external-ID 'RE-1' of type 'IsAlternativeHeadquarterFor', source 'LE-2' and target 'LE-1'
-        When sharing relation with external-ID 'RE-2' of type 'IsAlternativeHeadquarterFor', source 'LE-3' and target 'LE-1'
-        Then Pool has relation of type 'IsAlternativeHeadquarterFor', source 'BPNL-3' and target 'BPNL-2'
-
-    Scenario: SHR-UAHT
-        Update existing IsAlternativeHeadquarterFor relation
-
-        Given shared legal entity with external-ID 'LE-1' and BPNL 'BPNL-1'
-        And shared legal entity with external-ID 'LE-2' and BPNL 'BPNL-2'
-        And shared legal entity with external-ID 'LE-3' and BPNL 'BPNL-3'
-        And shared relation with external-ID 'RE-1' of type 'IsAlternativeHeadquarterFor', source 'LE-2' and target 'LE-1'
-        When sharing relation with external-ID 'RE-1' of type 'IsAlternativeHeadquarterFor', source 'LE-3' and target 'LE-1'
-        Then Pool has relation of type 'IsAlternativeHeadquarterFor', source 'BPNL-3' and target 'BPNL-1'
-        And Gate has relation output with external-ID 'RE-1' of type of type 'IsAlternativeHeadquarterFor', source 'BPNL-3' and target 'BPNL-1'
-        And Gate has relation changelog entry with external-ID 'RE-1' with type 'UPDATE'
-

--- a/docs/admin/MIGRATION_GUIDE.md
+++ b/docs/admin/MIGRATION_GUIDE.md
@@ -2,11 +2,21 @@
 
 <!-- TOC -->
 * [Migration Guide](#migration-guide)
+  * [7.1.x to 7.2.x](#71x-to-72x)
+    * [Alternative Headquarters Restriction](#alternative-headquarters-restriction)
   * [7.0.x to 7.1.x](#70x-to-71x)
     * [EDC Version 0.11](#edc-version-011)
     * [Golden Record Process for IsManagedBy Relations](#golden-record-process-for-ismanagedby-relations)
     * [Business Partner Identifier Amount Limit](#business-partner-identifier-amount-limit)
 <!-- TOC -->
+
+## 7.1.x to 7.2.x
+
+### Alternative Headquarters Restriction
+
+Now each legal entity can have only up to one alternative headquarters.
+Please make sure in your Pool and Gate output database each legal entity is part of up to only one such relation and remove relations that violate this constraint.
+Otherwise, the golden record process may show unexpected behaviour. 
 
 ## 7.0.x to 7.1.x
 


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request introduces a restriction creating alternative headquarters for legal entities. Now only up-to one alternative headquarter can be specified. The Pool now rejects  IsAlternativeHeadquarterFor relations if one of the legal entities is already in another IsAlternativeHeadquarterFor relation.

Adapted the tests accordingly.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Implements #1512

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
