### PR TITLE
fix(Gate): output synchronization skipping updates sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Added
 
 - BPDM: Add validity on business partner relation to the golden record process for legal entity relations [#1295](https://github.com/eclipse-tractusx/bpdm/issues/1295)
+- BPDM Gate: Fix synchronization of golden records sometimes skipping updates [#1519](https://github.com/eclipse-tractusx/bpdm/issues/1519)
 
 ### Changed
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/model/BaseSyncRecord.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/model/BaseSyncRecord.kt
@@ -31,42 +31,7 @@ interface BaseSyncRecord<SYNC_TYPE> {
     var type: SYNC_TYPE
 
     /**
-     * @see SyncStatus
-     */
-    var status: SyncStatus
-
-    /**
      * Sync run considers only data after this instant
      */
     var fromTime: Instant
-
-    /**
-     * Progress from 0 ot 1
-     */
-    var progress: Float
-
-    /**
-     * Progress counter
-     */
-    var count: Int
-
-    /**
-     * Plain message for error status
-     */
-    var errorDetails: String?
-
-    /**
-     * Optional serialized state to allow resume after error status
-     */
-    var errorSave: String?
-
-    /**
-     * Instant this sync run was started
-     */
-    var startedAt: Instant?
-
-    /**
-     * Instant this sync run was finished
-     */
-    var finishedAt: Instant?
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/SyncRecordDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/SyncRecordDb.kt
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.bpdm.gate.entity
 import jakarta.persistence.*
 import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import org.eclipse.tractusx.bpdm.common.model.BaseSyncRecord
-import org.eclipse.tractusx.bpdm.common.model.SyncStatus
 import java.time.Instant
 
 @Entity
@@ -32,29 +31,7 @@ class SyncRecordDb(
     @Column(name = "type", nullable = false, unique = true)
     override var type: SyncTypeDb,
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    override var status: SyncStatus,
-
     @Column(name = "from_time", nullable = false)
-    override var fromTime: Instant,
-
-    @Column(name = "progress", nullable = false)
-    override var progress: Float = 0f,
-
-    @Column(name = "count", nullable = false)
-    override var count: Int = 0,
-
-    @Column(name = "status_details")
-    override var errorDetails: String? = null,
-
-    @Column(name = "save_state")
-    override var errorSave: String? = null,
-
-    @Column(name = "started_at")
-    override var startedAt: Instant? = null,
-
-    @Column(name = "finished_at")
-    override var finishedAt: Instant? = null,
+    override var fromTime: Instant
 
     ) : BaseEntity(), BaseSyncRecord<SyncTypeDb>

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
@@ -83,7 +83,7 @@ class GoldenRecordUpdateChunkService(
     fun updateFromNextChunk(): UpdateStats{
         logger.info { "Update next chunk of Business Partner Output based on Golden Record Updates from the Pool..." }
 
-        val syncRecord = syncRecordService.setSynchronizationStart(SyncTypeDb.POOL_TO_GATE_OUTPUT)
+        val syncRecord = syncRecordService.getOrCreateRecord(SyncTypeDb.POOL_TO_GATE_OUTPUT)
 
         val changelogSearchRequest = ChangelogSearchRequest(timestampAfter = syncRecord.fromTime)
         val pageRequest = PaginationRequest(0, taskConfigProperties.creation.fromPool.batchSize)
@@ -100,7 +100,7 @@ class GoldenRecordUpdateChunkService(
         val updatedSites = updateSites(changedBpnSs).size
         val updatedAddresses = updateAddresses(changedBpnAs).size
 
-        syncRecordService.setSynchronizationSuccess(SyncTypeDb.POOL_TO_GATE_OUTPUT)
+        syncRecordService.updateRecord(syncRecord, poolChangelogEntries.content.lastOrNull()?.timestamp)
 
         logger.debug { "Updated '$updatedLegalEntities' legal entities, '$updatedSites' sites and '$updatedAddresses' addresses." }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskResolutionService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskResolutionService.kt
@@ -30,7 +30,6 @@ import org.eclipse.tractusx.bpdm.gate.config.GoldenRecordTaskConfigProperties
 import org.eclipse.tractusx.bpdm.gate.entity.RelationDb
 import org.eclipse.tractusx.bpdm.gate.entity.SyncTypeDb
 import org.eclipse.tractusx.bpdm.gate.repository.RelationRepository
-import org.eclipse.tractusx.bpdm.gate.repository.SyncRecordRepository
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.stereotype.Service
@@ -44,7 +43,6 @@ class RelationTaskResolutionService(
     private val taskConfigProperties: GoldenRecordTaskConfigProperties,
     private val relationService: IRelationService,
     private val sharingStateService: RelationSharingStateService,
-    private val syncRecordRepository: SyncRecordRepository,
     private val entityManager: EntityManager,
     private val transactionTemplate: TransactionTemplate
 ) {
@@ -91,10 +89,7 @@ class RelationTaskResolutionService(
         resolveAsSuccesses(successfulTasks, pendingRelationsById)
         resolveAsErrors(errorTasks, pendingRelationsById)
 
-        events.content.lastOrNull()?.let { latestEvent ->
-            syncRecord.fromTime = latestEvent.timestamp
-            syncRecordRepository.save(syncRecord)
-        }
+        syncRecordService.updateRecord(syncRecord,  events.content.lastOrNull()?.timestamp)
 
         val unresolvedSize = tasks.size - successfulTasks.size - errorTasks.size
         return ResolutionStats(successfulTasks.size, errorTasks.size, unresolvedSize, events.totalPages > 1)

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SyncRecordService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/SyncRecordService.kt
@@ -20,7 +20,6 @@
 package org.eclipse.tractusx.bpdm.gate.service
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.model.SyncStatus
 import org.eclipse.tractusx.bpdm.common.service.BaseSyncRecordService
 import org.eclipse.tractusx.bpdm.gate.entity.SyncRecordDb
 import org.eclipse.tractusx.bpdm.gate.entity.SyncTypeDb
@@ -38,7 +37,6 @@ class SyncRecordService(
     override fun newSyncRecord(type: SyncTypeDb, initialFromTime: Instant) =
         SyncRecordDb(
             type = type,
-            status = SyncStatus.NOT_SYNCED,
             fromTime = initialFromTime
         )
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskResolutionServices.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/TaskResolutionServices.kt
@@ -31,13 +31,8 @@ import org.eclipse.tractusx.bpdm.gate.entity.SyncTypeDb
 import org.eclipse.tractusx.bpdm.gate.entity.generic.BusinessPartnerDb
 import org.eclipse.tractusx.bpdm.gate.model.upsert.output.OutputUpsertData
 import org.eclipse.tractusx.bpdm.gate.repository.SharingStateRepository
-import org.eclipse.tractusx.bpdm.gate.repository.SyncRecordRepository
 import org.eclipse.tractusx.bpdm.gate.repository.generic.BusinessPartnerRepository
 import org.eclipse.tractusx.orchestrator.api.client.OrchestrationApiClient
-import org.eclipse.tractusx.orchestrator.api.model.ResultState
-import org.eclipse.tractusx.orchestrator.api.model.TaskClientStateDto
-import org.eclipse.tractusx.orchestrator.api.model.TaskResultStateSearchRequest
-import org.eclipse.tractusx.orchestrator.api.model.TaskStateRequest
 import org.eclipse.tractusx.orchestrator.api.model.*
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
@@ -99,7 +94,6 @@ class TaskResolutionChunkService(
     private val businessPartnerService: BusinessPartnerService,
     private val orchestratorMappings: OrchestratorMappings,
     private val synchRecordService: SyncRecordService,
-    private val syncRecordRepository: SyncRecordRepository,
     private val goldenRecordUpdateService: GoldenRecordUpdateChunkService
 ) {
 
@@ -154,11 +148,7 @@ class TaskResolutionChunkService(
         resolveAsUpserts(successes)
         resolveAsErrors(errors)
 
-        events.content.lastOrNull()?.let { latestEvent ->
-            syncRecord.fromTime = latestEvent.timestamp
-            syncRecordRepository.save(syncRecord)
-        }
-
+        synchRecordService.updateRecord(syncRecord, events.content.lastOrNull()?.timestamp)
 
         logger.debug { "Resolved ${successes.size} tasks as successful, ${errors.size} as errors and ${unresolved.size} still unresolved" }
 

--- a/bpdm-gate/src/main/resources/db/migration/V7_2_0_2__remove_obsolete_sync_record_columns.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V7_2_0_2__remove_obsolete_sync_record_columns.sql
@@ -1,0 +1,9 @@
+ALTER TABLE sync_records
+DROP COLUMN status,
+DROP COLUMN progress,
+DROP COLUMN "count",
+DROP COLUMN status_details,
+DROP COLUMN save_state,
+DROP COLUMN started_at,
+DROP COLUMN finished_at;
+

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/SyncRecordDb.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/SyncRecordDb.kt
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.bpdm.pool.entity
 import jakarta.persistence.*
 import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import org.eclipse.tractusx.bpdm.common.model.BaseSyncRecord
-import org.eclipse.tractusx.bpdm.common.model.SyncStatus
 import org.eclipse.tractusx.bpdm.pool.api.model.SyncType
 import java.time.Instant
 
@@ -33,29 +32,7 @@ class SyncRecordDb(
     @Column(name = "type", nullable = false, unique = true)
     override var type: SyncType,
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    override var status: SyncStatus,
-
     @Column(name = "from_time", nullable = false)
-    override var fromTime: Instant,
-
-    @Column(name = "progress", nullable = false)
-    override var progress: Float = 0f,
-
-    @Column(name = "count", nullable = false)
-    override var count: Int = 0,
-
-    @Column(name = "status_details")
-    override var errorDetails: String? = null,
-
-    @Column(name = "save_state")
-    override var errorSave: String? = null,
-
-    @Column(name = "started_at")
-    override var startedAt: Instant? = null,
-
-    @Column(name = "finished_at")
-    override var finishedAt: Instant? = null
+    override var fromTime: Instant
 
 ) : BaseEntity(), BaseSyncRecord<SyncType>

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SyncRecordService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SyncRecordService.kt
@@ -20,7 +20,6 @@
 package org.eclipse.tractusx.bpdm.pool.service
 
 import mu.KotlinLogging
-import org.eclipse.tractusx.bpdm.common.model.SyncStatus
 import org.eclipse.tractusx.bpdm.common.service.BaseSyncRecordService
 import org.eclipse.tractusx.bpdm.pool.api.model.SyncType
 import org.eclipse.tractusx.bpdm.pool.entity.SyncRecordDb
@@ -38,7 +37,6 @@ class SyncRecordService(
     override fun newSyncRecord(type: SyncType, initialFromTime: Instant) =
         SyncRecordDb(
             type = type,
-            status = SyncStatus.NOT_SYNCED,
             fromTime = initialFromTime
         )
 

--- a/bpdm-pool/src/main/resources/db/migration/V7_2_0_2__remove_obsolete_sync_record_columns.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V7_2_0_2__remove_obsolete_sync_record_columns.sql
@@ -1,0 +1,9 @@
+ALTER TABLE sync_records
+DROP COLUMN status,
+DROP COLUMN progress,
+DROP COLUMN "count",
+DROP COLUMN status_details,
+DROP COLUMN save_state,
+DROP COLUMN started_at,
+DROP COLUMN finished_at;
+

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/utils/StepUtils.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/utils/StepUtils.kt
@@ -40,7 +40,7 @@ class StepUtils(
 
     fun waitForBusinessPartnerResult(externalId: String): SharingStateType = runBlocking {
         println("Waiting for business partner result for $externalId ...")
-        withTimeout(Duration.ofMinutes(3)) {
+        withTimeout(Duration.ofMinutes(4)) {
             while (true) {
                 val sharingState = gateClient.sharingState.getSharingStates(PaginationRequest(), listOf(externalId)).content.single()
                 if (sharingState.sharingStateType == SharingStateType.Success || sharingState.sharingStateType == SharingStateType.Error) {
@@ -53,7 +53,7 @@ class StepUtils(
 
     fun waitForRelationResult(externalId: String): RelationSharingStateType = runBlocking {
         println("Waiting for relation result for $externalId ...")
-        withTimeout(Duration.ofMinutes(3)) {
+        withTimeout(Duration.ofMinutes(4)) {
             while (true) {
                 val sharingState = gateClient.relationSharingState.get(externalIds = listOf(externalId)).content.single()
                 if (sharingState.sharingStateType == RelationSharingStateType.Success || sharingState.sharingStateType == RelationSharingStateType.Error) {
@@ -66,7 +66,7 @@ class StepUtils(
 
     fun waitForRelationTask(externalId: String): String = runBlocking {
         println("Waiting relation getting task assigned for $externalId ...")
-        withTimeout(Duration.ofMinutes(3)) {
+        withTimeout(Duration.ofMinutes(4)) {
             while (true) {
                 val sharingState = gateClient.relationSharingState.get(externalIds = listOf(externalId)).content.single()
                 if(sharingState.taskId != null)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the bug of the Gate sometimes skipping golden record updates from the Pool to synchronize the business partner outputs.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

#1519

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
