### PR TITLE
test(System-Tester): introduce fixed order for relation tests

### DIFF
--- a/bpdm-system-tester/src/main/resources/cucumber/share_business_partner_relation.feature
+++ b/bpdm-system-tester/src/main/resources/cucumber/share_business_partner_relation.feature
@@ -12,7 +12,7 @@ Feature: Share Business Partner Relations (SHR)
     Scenario: SHR-CAHO
         Share new IsAlternativeHeadquarterFor relation with wrong order
 
-        Given shared legal entity with external-ID 'LE-1' and BPNL 'BPNL-1'
+        Given shared legal entity with external-ID 'LE-1' and BPNL 'BPNL-1' finished sharing
         And shared legal entity with external-ID 'LE-2' and BPNL 'BPNL-2'
         When sharing relation with external-ID 'RE-1' of type 'IsAlternativeHeadquarterFor', source 'LE-1' and target 'LE-2'
         Then Pool has relation of type 'IsAlternativeHeadquarterFor', source 'BPNL-2' and target 'BPNL-1'


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request introduces a fixed order for the system-tester's IsAlternativeHeadquarter relation tests. This way we remove a race condition since the Pool orders the relation's source and target based on the legal entitie's creation time.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
