### PR TITLE
fix(bpdm-pool): identifier amount limit on legal entity POST endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Changed
 
 - BPDM Pool: each legal entity can now have only one alternative headquarter
+- BPDM Pool: V6 POST legal entities API can only have less than or equal to 100 identifiers.
 
 ## [7.1.0] - 2025-09-30
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/AddressLegacyServiceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/AddressLegacyServiceMapper.kt
@@ -36,6 +36,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.LogisticAddressVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.controller.v6.LegalEntityLegacyServiceMapper.Companion.IDENTIFIER_AMOUNT_LIMIT
 import org.eclipse.tractusx.bpdm.pool.dto.AddressMetadataDto
 import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
 import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
@@ -175,8 +176,8 @@ class AddressLegacyServiceMapper(
                 regionValidator.validate(address, request) +
                         identifiersValidator.validate(address, request) +
                         identifiersDuplicateValidator.validate(address, request, bpn = null) +
-                        parentValidator.validate(request.bpnParent, request)
-
+                        parentValidator.validate(request.bpnParent, request) +
+                        validateAddressIdentifierTooMany(address, request, AddressCreateError.IdentifiersTooMany)
             validationErrors
         }.filterValues { it.isNotEmpty() }
     }
@@ -455,7 +456,8 @@ class AddressLegacyServiceMapper(
             val validationErrors = regionValidator.validate(address, request) +
                     identifiersValidator.validate(address, request) +
                     identifiersDuplicateValidator.validate(address, request, request.bpna) +
-                    existingBpnValidator.validate(request.bpna)
+                    existingBpnValidator.validate(request.bpna) +
+                    validateAddressIdentifierTooMany(address, request, AddressUpdateError.IdentifiersTooMany)
             validationErrors
         }.filterValues { it.isNotEmpty() }
     }
@@ -471,6 +473,15 @@ class AddressLegacyServiceMapper(
             else
                 emptyList()
         }
+    }
+
+    private fun <ERROR: ErrorCode> validateAddressIdentifierTooMany(address: IBaseLogisticAddressDto, entityKey: RequestWithKey, errorCode: ERROR): Collection<ErrorInfo<ERROR>>{
+        return validatedIdentifiersTooMany(address.identifiers.size, entityKey, errorCode)
+    }
+
+    private fun  <ERROR: ErrorCode> validatedIdentifiersTooMany(identifierAmount: Int, entityKey: RequestWithKey, errorCode: ERROR): Collection<ErrorInfo<ERROR>>{
+        return if(identifierAmount > IDENTIFIER_AMOUNT_LIMIT) listOf(ErrorInfo(errorCode, "Amount of identifiers ($identifierAmount) exceeds limit of $IDENTIFIER_AMOUNT_LIMIT", entityKey.getRequestKey()))
+        else emptyList()
     }
 
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/address/AdditionalAddressCreation.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/address/AdditionalAddressCreation.kt
@@ -24,6 +24,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.AddressIdentifierDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressCreateError
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.controller.v6.LegalEntityLegacyServiceMapper.Companion.IDENTIFIER_AMOUNT_LIMIT
 import org.eclipse.tractusx.bpdm.pool.v6.operator.OperatorTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -227,12 +228,8 @@ class AdditionalAddressCreation: OperatorTest() {
      * GIVEN legal entity
      * WHEN operator tries to create a new additional address with too many identifiers
      * THEN operator sees too many identifiers error
-     *
-     * ToDo:
-     *  Currently not working: https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try create additional address with too many identifiers`(){
         //GIVEN
         val legalEntityResponse = testDataClient.createLegalEntity(testName)
@@ -245,7 +242,7 @@ class AdditionalAddressCreation: OperatorTest() {
 
 
         //THEN
-        val expectedError = ErrorInfo(AddressCreateError.IdentifiersTooMany, "IGNORED", addressRequest.index)
+        val expectedError = ErrorInfo(AddressCreateError.IdentifiersTooMany, "Amount of identifiers (101) exceeds limit of $IDENTIFIER_AMOUNT_LIMIT", addressRequest.index)
         val expectedResponse = AddressPartnerCreateResponseWrapper(emptyList(), listOf(expectedError))
 
         assertRepository.assertAdditionalAddressCreate(addressResponse, expectedResponse)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/address/AddressUpdate.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/address/AddressUpdate.kt
@@ -23,6 +23,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.AddressIdentifierDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressUpdateError
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.AddressPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.controller.v6.LegalEntityLegacyServiceMapper.Companion.IDENTIFIER_AMOUNT_LIMIT
 import org.eclipse.tractusx.bpdm.pool.v6.operator.OperatorTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -256,12 +257,8 @@ class AddressUpdate: OperatorTest() {
      * GIVEN address
      * WHEN operator tries to update the address with too many identifiers
      * THEN operator sees too many identifiers error
-     *
-     * ToDo:
-     *  Does not work at the moment https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try update address with too many identifiers`(){
         //GIVEN
         val legalEntityResponse = testDataClient.createLegalEntity(testName)
@@ -274,7 +271,7 @@ class AddressUpdate: OperatorTest() {
         val addressResponse = poolClient.addresses.updateAddresses(listOf(addressRequest))
 
         //THEN
-        val expectedError = ErrorInfo(AddressUpdateError.IdentifiersTooMany, "IGNORED", addressRequest.bpna)
+        val expectedError = ErrorInfo(AddressUpdateError.IdentifiersTooMany, "Amount of identifiers (101) exceeds limit of $IDENTIFIER_AMOUNT_LIMIT", addressRequest.bpna)
         val expectedResponse = AddressPartnerUpdateResponseWrapper(emptyList(), listOf(expectedError))
 
         assertRepository.assertAddressUpdate(addressResponse, expectedResponse)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/legalentity/LegalEntityCreationIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/legalentity/LegalEntityCreationIT.kt
@@ -27,6 +27,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityCreateError
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.controller.v6.LegalEntityLegacyServiceMapper.Companion.IDENTIFIER_AMOUNT_LIMIT
 import org.eclipse.tractusx.bpdm.pool.v6.operator.OperatorTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -277,12 +278,8 @@ class LegalEntityCreationIT: OperatorTest() {
     /**
      * WHEN operator tries to create a new legal entity with too many identifiers
      * THEN operator sees error entry in response
-     *
-     * ToDo:
-     * At the moment not as expected: https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try create legal entity with too many identifiers`(){
         //WHEN
         val newLegalEntityRequest = with(testDataFactory.request.buildLegalEntityCreateRequest(testName)){
@@ -300,12 +297,8 @@ class LegalEntityCreationIT: OperatorTest() {
     /**
      * WHEN operator tries to create a new legal entity with too many legal address identifiers
      * THEN operator sees error entry in response
-     *
-     * ToDo:
-     * At the moment not as expected: https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try create legal entity with too many legal address identifiers`(){
         //WHEN
         val newLegalEntityRequest = with(testDataFactory.request.buildLegalEntityCreateRequest(testName)){
@@ -315,7 +308,7 @@ class LegalEntityCreationIT: OperatorTest() {
         val creationResponse = poolClient.legalEntities.createBusinessPartners(listOf(newLegalEntityRequest))
 
         //THEN
-        val expectedError = ErrorInfo(LegalEntityCreateError.LegalAddressIdentifiersTooMany, "IGNORED", newLegalEntityRequest.index)
+        val expectedError = ErrorInfo(LegalEntityCreateError.LegalAddressIdentifiersTooMany, "Amount of identifiers (101) exceeds limit of $IDENTIFIER_AMOUNT_LIMIT", newLegalEntityRequest.index)
         val expectedResponse = LegalEntityPartnerCreateResponseWrapper(emptyList(), listOf(expectedError))
         assertRepository.assertLegalEntityCreate(creationResponse, expectedResponse)
     }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/legalentity/LegalEntityUpdateIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/legalentity/LegalEntityUpdateIT.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.LegalEntitySearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityUpdateError
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.LegalEntityPartnerUpdateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.controller.v6.LegalEntityLegacyServiceMapper.Companion.IDENTIFIER_AMOUNT_LIMIT
 import org.eclipse.tractusx.bpdm.pool.v6.operator.OperatorTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -264,12 +265,8 @@ class LegalEntityUpdateIT: OperatorTest() {
      * GIVEN legal entity
      * WHEN operator tries to update the legal entity with too many identifiers
      * THEN operator sees too many identifiers error in response
-     *
-     * ToDo:
-     * At the moment not as expected: https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try update legal entity with too many identifiers`(){
         //GIVEN
         val legalEntityResponse = testDataClient.createLegalEntity(testName)
@@ -291,12 +288,8 @@ class LegalEntityUpdateIT: OperatorTest() {
      * GIVEN legal entity
      * WHEN operator tries to update the legal entity with too many legal address identifiers
      * THEN operator sees too many legal address identifiers error in response
-     *
-     * ToDo:
-     * At the moment not as expected: https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try update legal entity with too many legal address identifiers`(){
         //GIVEN
         val legalEntityResponse = testDataClient.createLegalEntity(testName)
@@ -308,7 +301,7 @@ class LegalEntityUpdateIT: OperatorTest() {
         val response = poolClient.legalEntities.updateBusinessPartners(listOf(updateRequest))
 
         //THEN
-        val expectedError = ErrorInfo(LegalEntityUpdateError.LegalEntityIdentifiersTooMany, "IGNORED", updateRequest.bpnl)
+        val expectedError = ErrorInfo(LegalEntityUpdateError.LegalAddressIdentifiersTooMany, "Amount of identifiers (101) exceeds limit of $IDENTIFIER_AMOUNT_LIMIT", updateRequest.bpnl)
         val expectedResponse = LegalEntityPartnerUpdateResponseWrapper(emptyList(), listOf(expectedError))
 
         assertRepository.assertLegalEntityUpdate(response, expectedResponse)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/site/SiteCreationIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/site/SiteCreationIT.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.request.SiteSearchRequest
 import org.eclipse.tractusx.bpdm.pool.api.model.response.ErrorInfo
 import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteCreateError
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerCreateResponseWrapper
+import org.eclipse.tractusx.bpdm.pool.controller.v6.LegalEntityLegacyServiceMapper.Companion.IDENTIFIER_AMOUNT_LIMIT
 import org.eclipse.tractusx.bpdm.pool.v6.operator.OperatorTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -265,12 +266,8 @@ class SiteCreationIT: OperatorTest() {
      * GIVEN legal entity
      * WHEN operator tries to create a new site for legal entity with too many identifiers
      * THEN operator sees region not found error
-     *
-     * ToDo:
-     *  At the moment not as expected: https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try create site with too many identifiers`(){
         //GIVEN
         val legalEntityResponse = testDataClient.createLegalEntity(testName)
@@ -282,7 +279,7 @@ class SiteCreationIT: OperatorTest() {
         val siteResponse = poolClient.sites.createSite(listOf(siteRequest))
 
         //THEN
-        val expectedError = ErrorInfo(SiteCreateError.MainAddressRegionNotFound, "IGNORED", siteRequest.index)
+        val expectedError = ErrorInfo(SiteCreateError.MainAddressIdentifiersTooMany, "Amount of identifiers (101) exceeds limit of $IDENTIFIER_AMOUNT_LIMIT", siteRequest.index)
         val expectedResponse = SitePartnerCreateResponseWrapper(emptyList(), listOf(expectedError))
 
         assertRepository.assertSiteCreate(siteResponse, expectedResponse)

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/site/SiteUpdateIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/site/SiteUpdateIT.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.response.SiteUpdateError
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerCreateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SitePartnerUpdateResponseWrapper
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.response.SiteWithMainAddressVerboseDto
+import org.eclipse.tractusx.bpdm.pool.controller.v6.LegalEntityLegacyServiceMapper.Companion.IDENTIFIER_AMOUNT_LIMIT
 import org.eclipse.tractusx.bpdm.pool.v6.operator.OperatorTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -230,12 +231,8 @@ class SiteUpdateIT: OperatorTest() {
      * GIVEN site
      * WHEN operator tries to update the site with too many identifiers
      * THEN operator sees 400 bad request error
-     *
-     * ToDo:
-     *  At the moment not as expected: https://github.com/eclipse-tractusx/bpdm/issues/1464
      */
     @Test
-    @Disabled
     fun `try update site with too many identifiers`(){
         //GIVEN
         val legalEntityResponse = testDataClient.createLegalEntity(testName)
@@ -248,7 +245,7 @@ class SiteUpdateIT: OperatorTest() {
         val siteResponse = poolClient.sites.updateSite(listOf(siteRequest))
 
         //THEN
-        val expectedError = ErrorInfo(SiteUpdateError.MainAddressIdentifiersTooMany, "IGNORED", siteRequest.bpns)
+        val expectedError = ErrorInfo(SiteUpdateError.MainAddressIdentifiersTooMany, "Amount of identifiers (101) exceeds limit of $IDENTIFIER_AMOUNT_LIMIT", siteRequest.bpns)
         val expectedResponse = SitePartnerUpdateResponseWrapper(emptyList(), listOf(expectedError))
 
         assertRepository.assertSiteUpdate(siteResponse, expectedResponse)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request adds maximum amount limit of 100 identifiers while creating legal enitity via V6 POST API.

Fixes #1464 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
