### PR TITLE
fix(bpdm-pool): maintained nanoseconds timestamps accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 - BPDM Pool: each legal entity can now have only one alternative headquarter
 - BPDM Pool: V6 POST legal entities API can only have less than or equal to 100 identifiers.
+- BPDM Pool: maintained nanoseconds timestamps accuracy while creating/updating entity [#1449](https://github.com/eclipse-tractusx/bpdm/issues/1449)
 
 ## [7.1.0] - 2025-09-30
 

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/model/BaseEntity.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/model/BaseEntity.kt
@@ -58,9 +58,9 @@ abstract class BaseEntity(
 
     @Column(updatable = false, nullable = false, name = "CREATED_AT")
     @CreationTimestamp
-    val createdAt: Instant = Instant.now().truncatedTo(ChronoUnit.MICROS),
+    val createdAt: Instant = Instant.now().truncatedTo(ChronoUnit.NANOS),
 
     @Column(nullable = false, name = "UPDATED_AT")
     @UpdateTimestamp
-    var updatedAt: Instant = Instant.now().truncatedTo(ChronoUnit.MICROS)
+    var updatedAt: Instant = Instant.now().truncatedTo(ChronoUnit.NANOS)
 )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request updates bpdm pool base entity with Nanoseconds timestamp accuracy.

Fixes #1449 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
