### PR TITLE
test: fix waiting for confidences to stabilize

### DIFF
--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/stepdefinations/ShareGenericNoBpnStepDefs.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/stepdefinations/ShareGenericNoBpnStepDefs.kt
@@ -71,7 +71,7 @@ class ShareGenericNoBpnStepDefs(
             .copy(isOwnCompanyData = true)
 
         stepUtils.waitForBusinessPartnerResult(expectedOutput.externalId)
-        stepUtils.waitForBusinessPartnerResultConfidenceSync(expectedOutput.externalId)
+        stepUtils.waitForBusinessPartnerResultConfidenceSync(expectedOutput.externalId, expectedLegalEntityNumberOfSharingMembers)
 
         val actualOutput = gateClient.businessParters.getBusinessPartnersOutput(listOf(expectedOutput.externalId), PaginationRequest()).content.single()
 

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/utils/StepUtils.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/utils/StepUtils.kt
@@ -51,12 +51,13 @@ class StepUtils(
         } as SharingStateType
     }
 
-    fun waitForBusinessPartnerResultConfidenceSync(externalId: String): BusinessPartnerOutputDto = runBlocking {
+    fun waitForBusinessPartnerResultConfidenceSync(externalId: String, expectedLegalEntityNumberOfSharingMembers: Int): BusinessPartnerOutputDto = runBlocking {
         println("Waiting for business partner result confidences to stabilize for $externalId ...")
         withTimeout(Duration.ofMinutes(2)) {
             while (true) {
                 val currentOutput = gateClient.businessParters.getBusinessPartnersOutput(listOf(externalId), PaginationRequest()).content.single()
-                if(currentOutput.address.confidenceCriteria.numberOfSharingMembers == 1){
+                if(currentOutput.address.confidenceCriteria.numberOfSharingMembers == 1
+                    && currentOutput.legalEntity.confidenceCriteria.numberOfSharingMembers == expectedLegalEntityNumberOfSharingMembers){
                     return@withTimeout currentOutput
                 }
                 delay(Duration.ofSeconds(10))


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes the system tester tests sharing business partners by introducing another condition to wait for the number of sharing members in the confidence criteria to stabilize.

This fixes some possible race condition in  the test where the business partner output is compared to the expected final result prematurely. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
