### PR TITLE
chore: set default logging level to INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Pool: V6 POST legal entities API can only have less than or equal to 100 identifiers.
 - BPDM Pool: maintained nanoseconds timestamps accuracy while creating/updating entity [#1449](https://github.com/eclipse-tractusx/bpdm/issues/1449)
 - BPDM Pool: fixed error response while creating duplicate legal address site [#1471](https://github.com/eclipse-tractusx/bpdm/issues/1471)
+- BPDM: The default logging level is now INFO [#1523](https://github.com/eclipse-tractusx/bpdm/issues/1523)
 
 ## [7.1.0] - 2025-09-30
 

--- a/bpdm-cleaning-service-dummy/src/main/resources/application.yml
+++ b/bpdm-cleaning-service-dummy/src/main/resources/application.yml
@@ -75,11 +75,6 @@ logging:
   level:
     # On default show only logs from INFO and above
     root: INFO
-    org:
-      eclipse:
-        tractusx:
-          # Logs from the BPDM applications should be DEBUG and above
-          bpdm: DEBUG
 management:
   endpoint:
     health:

--- a/bpdm-gate/src/main/resources/application.yml
+++ b/bpdm-gate/src/main/resources/application.yml
@@ -178,9 +178,6 @@ logging:
     level:
       # On default show only logs from INFO and above
         root: INFO
-      # Logs from this application's package should be DEBUG and above
-        org.eclipse.tractusx.bpdm.gate: DEBUG
-
 management:
     endpoint:
         health:

--- a/bpdm-orchestrator/src/main/resources/application.yml
+++ b/bpdm-orchestrator/src/main/resources/application.yml
@@ -122,11 +122,6 @@ logging:
   level:
     # On default show only logs from INFO and above
     root: INFO
-    org:
-      eclipse:
-        tractusx:
-          # Logs from the BPDM applications should be DEBUG and above
-          bpdm: DEBUG
 management:
   endpoint:
     health:

--- a/docs/admin/MIGRATION_GUIDE.md
+++ b/docs/admin/MIGRATION_GUIDE.md
@@ -4,6 +4,7 @@
 * [Migration Guide](#migration-guide)
   * [7.1.x to 7.2.x](#71x-to-72x)
     * [Alternative Headquarters Restriction](#alternative-headquarters-restriction)
+    * [Default Logging Level](#default-logging-level)
   * [7.0.x to 7.1.x](#70x-to-71x)
     * [EDC Version 0.11](#edc-version-011)
     * [Golden Record Process for IsManagedBy Relations](#golden-record-process-for-ismanagedby-relations)
@@ -17,6 +18,21 @@
 Now each legal entity can have only up to one alternative headquarters.
 Please make sure in your Pool and Gate output database each legal entity is part of up to only one such relation and remove relations that violate this constraint.
 Otherwise, the golden record process may show unexpected behaviour. 
+
+### Default Logging Level
+
+In order to reduce unnecessary logging output during CICD processing the new default logging level has been set to `INFO`.
+`DEBUG` level is now only meant to be activated when actually debugging BPDM.
+If you wish to set the logging level to `DEBUG` as before you can insert the following configuration into the application properties:
+
+```yaml
+logging:
+  level:
+    org:
+      eclipse:
+        tractusx:
+          bpdm: DEBUG
+```
 
 ## 7.0.x to 7.1.x
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request sets the default logging level for BPDM applications from DEBUG to INFO.

This helps to reduce unnecessary logging output during CICD processing, everyday development and during production.

## Pre-review checks

Contributes to #1523

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
