### PR TITLE
cicd(Workflows): fix code injection vulnerabilities

### DIFF
--- a/.github/workflows/app-test-charts.yaml
+++ b/.github/workflows/app-test-charts.yaml
@@ -259,10 +259,12 @@ jobs:
           cat charts/bpdm/ci/test-upgrade-values.yaml
 
       - name: Run helm upgrade
+        env:
+          UPGRADE_FROM: ${{ github.event.inputs.upgrade_from && '--version github.event.inputs.upgrade_from' || '' }}
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-          helm install -f charts/bpdm/ci/test-upgrade-values.yaml  bpdm-test tractusx-dev/bpdm ${{ github.event.inputs.upgrade_from && '--version github.event.inputs.upgrade_from' || '' }}
+          helm install -f charts/bpdm/ci/test-upgrade-values.yaml  bpdm-test tractusx-dev/bpdm $UPGRADE_FROM
           helm dependency update charts/bpdm
           helm upgrade -f charts/bpdm/ci/test-upgrade-values.yaml  bpdm-test charts/bpdm
 

--- a/.github/workflows/chart-test-lint.yaml
+++ b/.github/workflows/chart-test-lint.yaml
@@ -80,4 +80,6 @@ jobs:
           cat .chart-testing-config.yaml
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --config .chart-testing-config.yaml
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: ct lint --target-branch $DEFAULT_BRANCH --config .chart-testing-config.yaml

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -68,8 +68,11 @@ jobs:
 
       - name: Create Docker Tags
         id: dockerTags
+        env:
+          IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
-          FULL_IMAGE_NAME="${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}"
+          FULL_IMAGE_NAME="$IMAGE_NAMESPACE/$IMAGE_NAME"
           SUFFIX="${{ steps.semVer.outputs.prerelease &&  '-' || '' }}${{ steps.semVer.outputs.prerelease }}"
           MAJOR="${{ steps.semVer.outputs.major }}"
           MINOR="${MAJOR}.${{ steps.semVer.outputs.minor }}"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request removes all direct accesses of untrusted data from shell commands in the Github action workflows.

This way we remove the possibiltiy of code injections from outside contributions.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes [#4813](https://github.com/eclipse-tractusx/bpdm/security/code-scanning/4813)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
