### PR TITLE
fix(bpdm-pool): error response while creating duplicate legal address sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Pool: each legal entity can now have only one alternative headquarter
 - BPDM Pool: V6 POST legal entities API can only have less than or equal to 100 identifiers.
 - BPDM Pool: maintained nanoseconds timestamps accuracy while creating/updating entity [#1449](https://github.com/eclipse-tractusx/bpdm/issues/1449)
+- BPDM Pool: fixed error response while creating duplicate legal address site [#1471](https://github.com/eclipse-tractusx/bpdm/issues/1471)
 
 ## [7.1.0] - 2025-09-30
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/SiteLegacyServiceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/v6/SiteLegacyServiceMapper.kt
@@ -540,14 +540,26 @@ class SiteLegacyServiceMapper(
         val bpnSs = bpnIssuingService.issueSiteBpns(requests.size)
 
         val createdSites = requests.zip(bpnSs).map { (siteRequest, bpnS) ->
-            val legalEntityParent =
-                legalEntitiesByBpn[siteRequest.bpnLParent] ?: throw BpdmValidationException("Parent ${siteRequest.bpnLParent} not found for site to create")
+            if (legalEntitiesByBpn[siteRequest.bpnLParent] == null) {
+                return SitePartnerCreateResponseWrapper(emptyList(), listOf(
+                    ErrorInfo(
+                        SiteCreateError.LegalEntityNotFound,
+                        "Parent ${siteRequest.bpnLParent} not found for site to create",
+                        siteRequest.bpnLParent
+                    )
+                ))
+            } else if (legalEntitiesByBpn[siteRequest.bpnLParent]!!.legalAddress.site != null) {
+                return SitePartnerCreateResponseWrapper(emptyList(), listOf(
+                    ErrorInfo(
+                        SiteCreateError.MainAddressDuplicateIdentifier,
+                        "Can't create site for legal entity ${siteRequest.bpnLParent} with legal address as site main address: Legal address already belongs to site ${legalEntitiesByBpn[siteRequest.bpnLParent]!!.legalAddress.site!!.bpn}",
+                        siteRequest.name
+                    )
+                ))
+            }
 
-            if(legalEntityParent.legalAddress.site != null)
-                throw BpdmValidationException("Can't create site for legal entity ${siteRequest.bpnLParent} with legal address as site main address: Legal address already belongs to site ${legalEntityParent.legalAddress.site!!.bpn}")
-
-            createSite(siteRequest, bpnS, legalEntityParent)
-                .apply { mainAddress = legalEntityParent.legalAddress }
+            createSite(siteRequest, bpnS, legalEntitiesByBpn[siteRequest.bpnLParent]!!)
+                .apply { mainAddress = legalEntitiesByBpn[siteRequest.bpnLParent]!!.legalAddress }
                 .apply { mainAddress.site = this }
         }
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/site/SiteCreationIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/site/SiteCreationIT.kt
@@ -100,12 +100,8 @@ class SiteCreationIT: OperatorTest() {
      * GIVEN legal entity with legal address site
      * WHEN operator tries to create a new legal address site
      * THEN operator sees error
-     *
-     * ToDo:
-     *  Wrong error response: https://github.com/eclipse-tractusx/bpdm/issues/1471
      */
     @Test
-    @Disabled
     fun `try create duplicate legal address site`(){
         //GIVEN
         val legalEntityResponse = testDataClient.createLegalEntity(testName)
@@ -116,7 +112,7 @@ class SiteCreationIT: OperatorTest() {
         val response = poolClient.sites.createSiteWithLegalReference(listOf(siteRequest))
 
         //THEN
-        val expectedError = ErrorInfo(SiteCreateError.LegalEntityNotFound, "IGNORED", "0")
+        val expectedError = ErrorInfo(SiteCreateError.MainAddressDuplicateIdentifier, "Can't create site for legal entity ${siteRequest.bpnLParent} with legal address as site main address: Legal address already belongs to site ${legalEntityResponse.legalAddress.bpnSite}", siteRequest.name)
         val expectedResponse = SitePartnerCreateResponseWrapper(emptyList(), listOf(expectedError))
 
         assertRepository.assertLegalAddressSiteCreate(response, expectedResponse)


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request fixes the error response while creating duplicate legal address site.

Fixes #1471 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
