### PR TITLE
fix(bpdm-pool): response when creating legal form for unknown administrative area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Pool: maintained nanoseconds timestamps accuracy while creating/updating entity [#1449](https://github.com/eclipse-tractusx/bpdm/issues/1449)
 - BPDM Pool: fixed error response while creating duplicate legal address site [#1471](https://github.com/eclipse-tractusx/bpdm/issues/1471)
 - BPDM: The default logging level is now INFO [#1523](https://github.com/eclipse-tractusx/bpdm/issues/1523)
+- BPDM Pool: fixed response while creating legal form with unknown administrative area and stopped legal form being created [#1446](https://github.com/eclipse-tractusx/bpdm/issues/1446)
 
 ## [7.1.0] - 2025-09-30
 

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/MetadataControllerIT.kt
@@ -156,6 +156,17 @@ class MetadataControllerIT @Autowired constructor(
     }
 
     /**
+     * WHEN creating legal form for unknown administrative area
+     * THEN legalForm is not created and error returned
+     */
+    @Test
+    fun createLegalform_UnknownAdministrativeArea(){
+        val legalFormToCreate = BusinessPartnerNonVerboseValues.legalForm2.copy(technicalKey = "UNKNOWN_ADMINISTRATIVE_AREA_TEST", administrativeAreaLevel1 = "UNKNOWN")
+        //Expect Error when posting legal form with same technical key
+        assertThrows<Throwable>{ poolClient.metadata.createLegalForm(legalFormToCreate) }
+    }
+
+    /**
      * Given identifier types
      * When asking for identifier type entries
      * Then that identifier types returned

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/metadata/LegalFormIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/v6/operator/metadata/LegalFormIT.kt
@@ -26,7 +26,6 @@ import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.LegalFormDto
 import org.eclipse.tractusx.bpdm.pool.api.v6.model.request.LegalFormRequest
 import org.eclipse.tractusx.bpdm.pool.v6.operator.OperatorTest
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
@@ -107,13 +106,8 @@ class LegalFormIT: OperatorTest(){
     /**
      * WHEN operator tries to create legal form for unknown administrative area
      * THEN 400 BAD REQUEST returned
-     *
-     * ToDo:
-     * Currently not fulfilled!
-     * Bug Ticket for tracking: https://github.com/eclipse-tractusx/bpdm/issues/1446
      */
     @Test
-    @Disabled
     fun `try create new legal form with unknown admin area`(){
         val request = createLegalFormRequest(testName)
             .copy(administrativeAreaLevel1 = "UNKNOWN")


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request fixes HTTP response while creating legal form with unknown administrative area and stops creating legal form.

Fixes #1446 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
