### PR TITLE
Feat(Pool): automatically calculate confidence levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 
 - BPDM Orchestrator: fixed finished task events with correct content size in api response [#1580](https://github.com/eclipse-tractusx/bpdm/issues/1580)
 - BPDM Pool: Add validation for IsManagedBy relations to not overwrite validity periods that lie in the past [#1555](https://github.com/eclipse-tractusx/bpdm/issues/1555)
-
+- BPDM Pool: Automatically calculate a business partner's confidence level based on the other confidence criteria [#1554](https://github.com/eclipse-tractusx/bpdm/issues/1554)
 
 ## [7.2.0] - 2025-12-01
 

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/BusinessPartnerVerboseValues.kt
@@ -140,7 +140,7 @@ object BusinessPartnerVerboseValues {
         numberOfSharingMembers = 0,
         lastConfidenceCheckAt = LocalDateTime.of(2023, 10, 10, 10, 10, 10),
         nextConfidenceCheckAt = LocalDateTime.of(2024, 10, 10, 10, 10, 10),
-        confidenceLevel = 10
+        confidenceLevel = 8
     )
 
     private val confidenceCriteria2 = ConfidenceCriteriaDto(
@@ -149,7 +149,7 @@ object BusinessPartnerVerboseValues {
         numberOfSharingMembers = 0,
         lastConfidenceCheckAt = LocalDateTime.of(2022, 10, 10, 10, 10, 10),
         nextConfidenceCheckAt = LocalDateTime.of(2025, 10, 10, 10, 10, 10),
-        confidenceLevel = 6
+        confidenceLevel = 0
     )
 
     private val confidenceCriteria3 = ConfidenceCriteriaDto(
@@ -158,7 +158,7 @@ object BusinessPartnerVerboseValues {
         numberOfSharingMembers = 0,
         lastConfidenceCheckAt = LocalDateTime.of(2021, 10, 10, 10, 10, 10),
         nextConfidenceCheckAt = LocalDateTime.of(2026, 10, 10, 10, 10, 10),
-        confidenceLevel = 3
+        confidenceLevel = 5
     )
 
     val address1 = PhysicalPostalAddressVerboseDto(

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/common/BusinessPartnerCommonRequestFactory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/pool/common/BusinessPartnerCommonRequestFactory.kt
@@ -79,7 +79,7 @@ abstract class BusinessPartnerCommonRequestFactory(
                 numberOfSharingMembers = 2,
                 lastConfidenceCheckAt = timeStamp.plusDays(10),
                 nextConfidenceCheckAt = timeStamp.plusDays(20),
-                confidenceLevel = 4
+                confidenceLevel = 5
             )
         )
     }
@@ -104,7 +104,7 @@ abstract class BusinessPartnerCommonRequestFactory(
                 numberOfSharingMembers = 2,
                 lastConfidenceCheckAt = timeStamp.plusDays(10),
                 nextConfidenceCheckAt = timeStamp.plusDays(20),
-                confidenceLevel = 4
+                confidenceLevel = 5
             )
         )
     }
@@ -188,7 +188,7 @@ abstract class BusinessPartnerCommonRequestFactory(
                 numberOfSharingMembers = 2,
                 lastConfidenceCheckAt = timeStamp.plusDays(10),
                 nextConfidenceCheckAt = timeStamp.plusDays(20),
-                confidenceLevel = 4
+                confidenceLevel = 5
             )
         )
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/ConfidenceCriteriaDb.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/ConfidenceCriteriaDb.kt
@@ -30,12 +30,28 @@ data class ConfidenceCriteriaDb(
     val sharedByOwner: Boolean,
     @Column(name = "checked_by_external_data_source", nullable = false)
     val checkedByExternalDataSource: Boolean,
-    @Column(name = "number_of_business_partners", nullable = false)
-    val numberOfBusinessPartners: Int,
+    @Column(name = "number_of_sharing_members", nullable = false)
+    val numberOfSharingMembers: Int,
     @Column(name = "last_confidence_check_at", nullable = false)
     val lastConfidenceCheckAt: LocalDateTime,
     @Column(name = "next_confidence_check_at", nullable = false)
-    val nextConfidenceCheckAt: LocalDateTime,
-    @Column(name = "confidence_level", nullable = false)
-    val confidenceLevel: Int,
-)
+    val nextConfidenceCheckAt: LocalDateTime
+){
+    companion object{
+        const val SHARED_BY_OWNER_WEIGHT = 5
+        const val CHECKED_BY_EXTERNAL_DATASOURCE_WEIGHT = 3
+        const val SHARING_MEMBERS_THRESHOLD = 3
+        const val SHARING_MEMBERS_WEIGHT = 1
+    }
+
+    @get:Column(name = "confidence_level", nullable = false)
+    val confidenceLevel: Int
+        get() {
+            val sharedByOwnerLevel = if(sharedByOwner) SHARED_BY_OWNER_WEIGHT else 0
+            val checkedByExternalDataSourceLevel = if(checkedByExternalDataSource) CHECKED_BY_EXTERNAL_DATASOURCE_WEIGHT else 0
+            val numberOfSharingMembersLevel = if(numberOfSharingMembers >= SHARING_MEMBERS_THRESHOLD) SHARING_MEMBERS_WEIGHT else 0
+
+            return sharedByOwnerLevel + checkedByExternalDataSourceLevel + numberOfSharingMembersLevel
+        }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -717,14 +717,13 @@ class BusinessPartnerBuildService(
             ConfidenceCriteriaDb(
                 sharedByOwner = confidenceCriteria.sharedByOwner!!,
                 checkedByExternalDataSource = confidenceCriteria.checkedByExternalDataSource!!,
-                numberOfBusinessPartners = numberOfSharingMembers,
+                numberOfSharingMembers = numberOfSharingMembers,
                 lastConfidenceCheckAt = confidenceCriteria.lastConfidenceCheckAt!!,
-                nextConfidenceCheckAt = confidenceCriteria.nextConfidenceCheckAt!!,
-                confidenceLevel = confidenceCriteria.confidenceLevel!!
+                nextConfidenceCheckAt = confidenceCriteria.nextConfidenceCheckAt!!
             )
 
         fun updateConfidenceCriteria(oldConfidence: ConfidenceCriteriaDb, newConfidence: IConfidenceCriteriaDto) =
-            createConfidenceCriteria(newConfidence).copy(numberOfBusinessPartners = oldConfidence.numberOfBusinessPartners)
+            createConfidenceCriteria(newConfidence).copy(numberOfSharingMembers = oldConfidence.numberOfSharingMembers)
     }
 
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerEquivalenceMapper.kt
@@ -118,7 +118,7 @@ class BusinessPartnerEquivalenceMapper {
             ConfidenceCriteriaEquivalenceDto(
                 sharedByOwner,
                 checkedByExternalDataSource,
-                numberOfBusinessPartners,
+                numberOfSharingMembers,
                 lastConfidenceCheckAt,
                 nextConfidenceCheckAt,
                 confidenceLevel

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerSearchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerSearchService.kt
@@ -338,7 +338,7 @@ class BusinessPartnerSearchService(
                 BusinessPartnerConfidenceCriteriaDto(
                     sharedByOwner = sharedByOwner,
                     checkedByExternalDataSource = checkedByExternalDataSource,
-                    numberOfSharingMembers = numberOfBusinessPartners,
+                    numberOfSharingMembers = numberOfSharingMembers,
                     lastConfidenceCheckAt = lastConfidenceCheckAt,
                     nextConfidenceCheckAt = nextConfidenceCheckAt,
                     confidenceLevel = confidenceLevel
@@ -361,7 +361,7 @@ class BusinessPartnerSearchService(
                     BusinessPartnerConfidenceCriteriaDto(
                         sharedByOwner = sharedByOwner,
                         checkedByExternalDataSource = checkedByExternalDataSource,
-                        numberOfSharingMembers = numberOfBusinessPartners,
+                        numberOfSharingMembers = numberOfSharingMembers,
                         lastConfidenceCheckAt = lastConfidenceCheckAt,
                         nextConfidenceCheckAt = nextConfidenceCheckAt,
                         confidenceLevel = confidenceLevel
@@ -447,7 +447,7 @@ class BusinessPartnerSearchService(
                 BusinessPartnerConfidenceCriteriaDto(
                     sharedByOwner = sharedByOwner,
                     checkedByExternalDataSource = checkedByExternalDataSource,
-                    numberOfSharingMembers = numberOfBusinessPartners,
+                    numberOfSharingMembers = numberOfSharingMembers,
                     lastConfidenceCheckAt = lastConfidenceCheckAt,
                     nextConfidenceCheckAt = nextConfidenceCheckAt,
                     confidenceLevel = confidenceLevel

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -284,7 +284,7 @@ fun ConfidenceCriteriaDb.toDto(): ConfidenceCriteriaDto =
     ConfidenceCriteriaDto(
         sharedByOwner,
         checkedByExternalDataSource,
-        numberOfBusinessPartners,
+        numberOfSharingMembers,
         lastConfidenceCheckAt,
         nextConfidenceCheckAt,
         confidenceLevel

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SharingMemberConfidenceService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SharingMemberConfidenceService.kt
@@ -80,19 +80,19 @@ class SharingMemberConfidenceService(
 
     private fun updateNumberOfSharingMembers(address: LogisticAddressDb): Result{
         val newNumberOfSharingMembers = countSharingMembers(address)
-        val addressHasChanges = address.confidenceCriteria.numberOfBusinessPartners != newNumberOfSharingMembers
+        val addressHasChanges = address.confidenceCriteria.numberOfSharingMembers != newNumberOfSharingMembers
 
         if(addressHasChanges){
-            address.confidenceCriteria = address.confidenceCriteria.copy(numberOfBusinessPartners = newNumberOfSharingMembers)
+            address.confidenceCriteria = address.confidenceCriteria.copy(numberOfSharingMembers = newNumberOfSharingMembers)
             logisticAddressRepository.save(address)
             changelogService.createChangelogEntry(ChangelogEntryCreateRequest(address.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS))
         }
 
         val legalEntity = address.legalEntity!!
         if(legalEntity.legalAddress == address){
-            val legalEntityHasChanges = legalEntity.confidenceCriteria.numberOfBusinessPartners != newNumberOfSharingMembers
+            val legalEntityHasChanges = legalEntity.confidenceCriteria.numberOfSharingMembers != newNumberOfSharingMembers
             if(legalEntityHasChanges){
-                legalEntity.confidenceCriteria = legalEntity.confidenceCriteria.copy(numberOfBusinessPartners = newNumberOfSharingMembers)
+                legalEntity.confidenceCriteria = legalEntity.confidenceCriteria.copy(numberOfSharingMembers = newNumberOfSharingMembers)
                 legalEntityRepository.save(legalEntity)
                 changelogService.createChangelogEntry(ChangelogEntryCreateRequest(legalEntity.bpn, ChangelogType.UPDATE, BusinessPartnerType.LEGAL_ENTITY))
             }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -624,13 +624,13 @@ class TaskStepBuildService(
 
     private fun PostalAddress.withUpdatedNumberOfSharingMembers(fromCandidates: Collection<LogisticAddressDb>): PostalAddress{
         return copy(
-            confidenceCriteria = confidenceCriteria.copy(numberOfSharingMembers = fromCandidates.find { it.bpn == this.bpnReference.referenceValue }?.confidenceCriteria?.numberOfBusinessPartners ?: confidenceCriteria.numberOfSharingMembers )
+            confidenceCriteria = confidenceCriteria.copy(numberOfSharingMembers = fromCandidates.find { it.bpn == this.bpnReference.referenceValue }?.confidenceCriteria?.numberOfSharingMembers ?: confidenceCriteria.numberOfSharingMembers )
         )
     }
 
     private fun LegalEntity.withUpdatedNumberOfSharingMembers(legalEntityCandidates: Collection<LegalEntityDb>, legalAddressCandidates: Collection<LogisticAddressDb>): LegalEntity{
         return copy(
-            confidenceCriteria = confidenceCriteria.copy(numberOfSharingMembers = legalEntityCandidates.find { it.bpn == this.bpnReference.referenceValue }?.confidenceCriteria?.numberOfBusinessPartners ?: confidenceCriteria.numberOfSharingMembers),
+            confidenceCriteria = confidenceCriteria.copy(numberOfSharingMembers = legalEntityCandidates.find { it.bpn == this.bpnReference.referenceValue }?.confidenceCriteria?.numberOfSharingMembers ?: confidenceCriteria.numberOfSharingMembers),
             legalAddress = legalAddress.withUpdatedNumberOfSharingMembers(legalAddressCandidates)
         )
     }

--- a/bpdm-pool/src/main/resources/db/migration/V7_3_0_1__set_confidence_level.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V7_3_0_1__set_confidence_level.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION calc_conf_level(
+    shared_by_owner BOOLEAN,
+    checked_by_external_datasource BOOLEAN,
+    sharing_members INT
+)
+RETURNS INT AS $$
+DECLARE
+    shared_by_owner_level INT := 0;
+    checked_by_external_datasource_level INT := 0;
+    sharing_members_level INT := 0;
+BEGIN
+    -- Assign points if shared by owner
+    IF shared_by_owner THEN
+        shared_by_owner_level := 5;
+    END IF;
+
+    -- Assign points if checked by external datasource
+    IF checked_by_external_datasource THEN
+        checked_by_external_datasource_level := 3;
+    END IF;
+
+    -- Assign points if more than 2 members are sharing
+    IF sharing_members > 2 THEN
+        sharing_members_level := 1;
+    END IF;
+
+    -- Return total confidence level
+    RETURN shared_by_owner_level
+         + checked_by_external_datasource_level
+         + sharing_members_level;
+END;
+$$ LANGUAGE plpgsql;
+
+UPDATE legal_entities
+SET confidence_level = calc_conf_level(shared_by_owner, checked_by_external_data_source, number_of_business_partners),
+    updated_at = LOCALTIMESTAMP;
+
+INSERT INTO partner_changelog_entries(id, uuid, created_at, updated_at, changelog_type, bpn, business_partner_type)
+SELECT nextval('bpdm_sequence'), gen_random_uuid(), LOCALTIMESTAMP, LOCALTIMESTAMP, 'UPDATE', le.bpn, 'LEGAL_ENTITY'
+FROM legal_entities le;
+
+UPDATE sites
+SET confidence_level = calc_conf_level(shared_by_owner, checked_by_external_data_source, number_of_business_partners),
+    updated_at = LOCALTIMESTAMP;
+
+INSERT INTO partner_changelog_entries(id, uuid, created_at, updated_at, changelog_type, bpn, business_partner_type)
+SELECT nextval('bpdm_sequence'), gen_random_uuid(), LOCALTIMESTAMP, LOCALTIMESTAMP, 'UPDATE', sites.bpn, 'SITE'
+FROM sites;
+
+UPDATE logistic_addresses
+SET confidence_level = calc_conf_level(shared_by_owner, checked_by_external_data_source, number_of_business_partners),
+    updated_at = LOCALTIMESTAMP;
+
+INSERT INTO partner_changelog_entries(id, uuid, created_at, updated_at, changelog_type, bpn, business_partner_type)
+SELECT nextval('bpdm_sequence'), gen_random_uuid(), LOCALTIMESTAMP, LOCALTIMESTAMP, 'UPDATE', la.bpn, 'ADDRESS'
+FROM logistic_addresses la;

--- a/bpdm-pool/src/main/resources/db/migration/V7_3_0_2__alter_sharing_member_no_column_name.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V7_3_0_2__alter_sharing_member_no_column_name.sql
@@ -1,0 +1,3 @@
+ALTER TABLE legal_entities RENAME COLUMN number_of_business_partners TO number_of_sharing_members;
+ALTER TABLE sites RENAME COLUMN number_of_business_partners TO number_of_sharing_members;
+ALTER TABLE logistic_addresses RENAME COLUMN number_of_business_partners TO number_of_sharing_members;

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/utils/GateOutputFactory.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/utils/GateOutputFactory.kt
@@ -41,7 +41,7 @@ class GateOutputFactory(
         checkedByExternalDataSource = false,
         lastConfidenceCheckAt = LocalDateTime.now(),
         nextConfidenceCheckAt = LocalDateTime.now().plus (5, ChronoUnit.DAYS),
-        confidenceLevel = 0
+        confidenceLevel = 5
     )
 
     fun createOutput(fromSeed: String, externalId: String = fromSeed): BusinessPartnerOutputDto{

--- a/docs/admin/MIGRATION_GUIDE.md
+++ b/docs/admin/MIGRATION_GUIDE.md
@@ -2,6 +2,8 @@
 
 <!-- TOC -->
 * [Migration Guide](#migration-guide)
+  * [7.2.x to 7.3.x](#72x-to-73x)
+    * [Automatic Confidence Level](#automatic-confidence-level)
   * [7.1.x to 7.2.x](#71x-to-72x)
     * [Alternative Headquarters Restriction](#alternative-headquarters-restriction)
     * [Default Logging Level](#default-logging-level)
@@ -10,6 +12,19 @@
     * [Golden Record Process for IsManagedBy Relations](#golden-record-process-for-ismanagedby-relations)
     * [Business Partner Identifier Amount Limit](#business-partner-identifier-amount-limit)
 <!-- TOC -->
+
+## 7.2.x to 7.3.x
+
+### Automatic Confidence Level
+
+A golden record's confidence level is now automatically managed by the Pool according to the [golden record standards](https://catenax-ev.github.io/docs/next/standards/CX-0076-GoldenRecordEndtoEndRequirementsStandard#2112-confidence-level).
+
+Please be aware that this version will automatically update the confidence levels of all existing golden records in the Pool.
+This update will also result in changelog entries.
+This way, the new confidence levels will be propagated to all sharing members and interested parties.
+
+Please note that this migration will create changelog entries for every existing golden record in the Pool.
+
 
 ## 7.1.x to 7.2.x
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request introduces logic to let the Pool automatically calculate the confidence level of golden records based on the other confidence criteria.

It also includes a migration to the set the confidence level of already existing golden records to that calculated value.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Implements #1554

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
