### PR TITLE
feat(Pool): validate no changes to IsManagedBy relation validities in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 ### Changed
 
 - BPDM Orchestrator: fixed finished task events with correct content size in api response [#1580](https://github.com/eclipse-tractusx/bpdm/issues/1580)
+- BPDM Pool: Add validation for IsManagedBy relations to not overwrite validity periods that lie in the past [#1555](https://github.com/eclipse-tractusx/bpdm/issues/1555)
+
 
 ## [7.2.0] - 2025-12-01
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AlternativeHeadquarterRelationUpsertService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AlternativeHeadquarterRelationUpsertService.kt
@@ -41,7 +41,13 @@ class AlternativeHeadquarterRelationUpsertService(
         validateOnlyOneAlternative(standardisedRequest)
 
         val result = relationUpsertService.upsertRelation(
-            RelationUpsertService.UpsertRequest(standardisedRequest.source, standardisedRequest.target, RelationType.IsAlternativeHeadquarterFor, standardisedRequest.validityPeriods)
+            RelationUpsertService.UpsertRequest(
+                standardisedRequest.source,
+                standardisedRequest.target,
+                RelationType.IsAlternativeHeadquarterFor,
+                standardisedRequest.validityPeriods,
+                standardisedRequest.existingRelation
+            )
         )
 
         return result
@@ -52,13 +58,9 @@ class AlternativeHeadquarterRelationUpsertService(
         val proposedTarget = upsertRequest.target
 
         val sourceIsOlder = proposedSource.createdAt < proposedTarget.createdAt
-        val upsertRequest = if(sourceIsOlder){
-            IRelationUpsertStrategyService.UpsertRequest(source = proposedTarget, target = proposedSource, validityPeriods = upsertRequest.validityPeriods)
-        }else{
-            IRelationUpsertStrategyService.UpsertRequest(source = proposedSource, target = proposedTarget,  validityPeriods = upsertRequest.validityPeriods)
-        }
+        val standardisedUpsertRequest = if(sourceIsOlder) upsertRequest.copy(source = proposedTarget, target = proposedSource) else upsertRequest
 
-        return upsertRequest
+        return standardisedUpsertRequest
     }
 
     private fun validateOnlyOneAlternative(upsertRequest: IRelationUpsertStrategyService.UpsertRequest){

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IRelationUpsertStrategyService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IRelationUpsertStrategyService.kt
@@ -31,6 +31,7 @@ interface IRelationUpsertStrategyService {
     data class UpsertRequest(
         val source: LegalEntityDb,
         val target: LegalEntityDb,
-        val validityPeriods: Collection<RelationValidityPeriodDb>
+        val validityPeriods: Collection<RelationValidityPeriodDb>,
+        val existingRelation: RelationDb?
     )
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/OwnedByRelationUpsertService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/OwnedByRelationUpsertService.kt
@@ -43,7 +43,13 @@ class OwnedByRelationUpsertService(
 
 
         val result = relationUpsertService.upsertRelation(
-            RelationUpsertService.UpsertRequest(proposedSource, proposedTarget, RelationType.IsOwnedBy, upsertRequest.validityPeriods)
+            RelationUpsertService.UpsertRequest(
+                proposedSource,
+                proposedTarget,
+                RelationType.IsOwnedBy,
+                upsertRequest.validityPeriods,
+                upsertRequest.existingRelation
+            )
         )
 
         return result

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/RelationUpsertService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/RelationUpsertService.kt
@@ -43,20 +43,12 @@ class RelationUpsertService(
     fun upsertRelation(upsertRequest: UpsertRequest): UpsertResult<RelationDb>{
         val source = upsertRequest.source
         val target = upsertRequest.target
-        val relationType = upsertRequest.relationType
+        val existingRelation = upsertRequest.existingRelation
 
         // Prevent self-referencing relations
         if (source == target) {
             throw BpdmValidationException("A legal entity cannot have a relation to itself (BPNL: ${source.bpn}).")
         }
-
-        val existingRelation = relationRepository.findAll(
-            RelationRepository.byRelation(
-                startNode = source,
-                endNode = target,
-                type = relationType
-            )
-        ).singleOrNull()
 
         val upsertResult = if (existingRelation != null) {
             // Update validity periods if changed
@@ -133,7 +125,8 @@ class RelationUpsertService(
         val source: LegalEntityDb,
         val target: LegalEntityDb,
         val relationType: RelationType,
-        val validityPeriods: Collection<RelationValidityPeriodDb>
+        val validityPeriods: Collection<RelationValidityPeriodDb>,
+        val existingRelation: RelationDb?
     )
 
     data class TimePeriod(

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
@@ -196,6 +196,8 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
         val savedB = response.entities.toList()[1]
         val savedC = response.entities.toList()[2]
 
+        val nowDate = LocalDate.now()
+
         /**
          * Scenario 1: A→B exists
          */
@@ -204,8 +206,8 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
             businessPartnerSourceBpnl = savedA.legalEntity.bpnl,
             businessPartnerTargetBpnl = savedB.legalEntity.bpnl,
             validityPeriods = listOf(RelationValidityPeriod(
-                validFrom = LocalDate.parse("2020-01-01"),
-                validTo = LocalDate.parse("2020-12-31")
+                validFrom = nowDate.plusYears(1),
+                validTo = nowDate.plusYears(2)
             ))
         )
         val resultAB = upsertRelationsGoldenRecordIntoPool("TASK_AB", relationAB)
@@ -219,8 +221,8 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
             businessPartnerSourceBpnl = savedA.legalEntity.bpnl,
             businessPartnerTargetBpnl = savedC.legalEntity.bpnl,
             validityPeriods = listOf(RelationValidityPeriod(
-                validFrom = LocalDate.parse("2020-06-01"),
-                validTo = LocalDate.parse("2020-09-30")
+                validFrom = nowDate.plusYears(1).plusMonths(6),
+                validTo = nowDate.plusYears(1).plusMonths(9)
             ))
         )
         val resultAC_conflict = upsertRelationsGoldenRecordIntoPool("TASK_AC_CONFLICT", relationAC_conflict)
@@ -234,8 +236,8 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
             businessPartnerSourceBpnl = savedA.legalEntity.bpnl,
             businessPartnerTargetBpnl = savedC.legalEntity.bpnl,
             validityPeriods = listOf(RelationValidityPeriod(
-                validFrom = LocalDate.parse("2021-01-01"),
-                validTo = LocalDate.parse("2021-12-31")
+                validFrom = nowDate.plusYears(2),
+                validTo = nowDate.plusYears(3)
             ))
         )
         val resultAC_nonOverlap = upsertRelationsGoldenRecordIntoPool("TASK_AC_NON_OVERLAP", relationAC_nonOverlap)
@@ -246,8 +248,8 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
             businessPartnerSourceBpnl = savedA.legalEntity.bpnl,
             businessPartnerTargetBpnl = savedC.legalEntity.bpnl,
             validityPeriods = listOf(RelationValidityPeriod(
-                validFrom = LocalDate.parse("2021-06-01"),
-                validTo = LocalDate.parse("2022-06-30")
+                validFrom = nowDate.plusYears(2),
+                validTo = nowDate.plusYears(3).plusMonths(6)
             ))
         )
         val resultAC_new = upsertRelationsGoldenRecordIntoPool("TASK_AC_NEW", relationAC_new)
@@ -258,8 +260,8 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
             .legalEntity.relations.first { it.businessPartnerTargetBpnl == savedC.legalEntity.bpnl }
         assertThat(updatedRelationAC.validityPeriods).hasSize(1)
         val stateAC = updatedRelationAC.validityPeriods.first()
-        assertThat(stateAC.validFrom).isEqualTo(LocalDate.parse("2021-06-01"))
-        assertThat(stateAC.validTo).isEqualTo(LocalDate.parse("2022-06-30"))
+        assertThat(stateAC.validFrom).isEqualTo(nowDate.plusYears(2))
+        assertThat(stateAC.validTo).isEqualTo(nowDate.plusYears(3).plusMonths(6))
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <argLine>
+                            --add-opens java.base/java.time=ALL-UNNAMED
+                            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        </argLine>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>integration-test</id>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds validations to the IsManagedBy relation upsert logic, making sure that validity periods that lie in the past can not be overwritten.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Implments #1555 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
