### PR TITLE
CICD: Create Docker Tags for Feature Branches

### DIFF
--- a/.github/workflows/deploy-docker-all.yaml
+++ b/.github/workflows/deploy-docker-all.yaml
@@ -27,7 +27,6 @@ on:
     branches:
       - main
       - 'feat/headquarter-relocation'
-  pull_request:
 
 jobs:
   build-docker-pool:

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -99,9 +99,6 @@ jobs:
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
 
       - name: Create Docker Tags
         id: dockerTags
@@ -116,3 +113,26 @@ jobs:
             echo "tags=${FEATURE_TAGS}" >> $GITHUB_OUTPUT
             echo "tags=${FEATURE_TAGS}"
           fi
+
+      - name: DockerHub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64
+          push: true
+          file: ${{ inputs.dockerfilePath }}/Dockerfile
+          tags: ${{ steps.dockerTags.outputs.tags }}
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ${{ inputs.dockerfilePath }}/DOCKER_NOTICE.md


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Currently our docker container deployment workflow is only able to deploy images for the main branch, creating release,snapshot and pre-release tagged images. In order to also deploy images for feature branches we want the workflow to deploy images tagged with the feature branch name instead.

In the end this enables us to deploy helm charts referencing docker images for feature branches.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
