### PR TITLE
infra(bpdm): Update postgres to version 18 in charts

### DIFF
--- a/.github/workflows/app-test-charts.yaml
+++ b/.github/workflows/app-test-charts.yaml
@@ -193,9 +193,7 @@ jobs:
       - name: Create Chart-Testing Config
         run: |
           cat <<EOF > .chart-testing-config.yaml
-          chart-repos:
-            - bitnami=https://charts.bitnami.com/bitnami
-          helm-extra-args: --timeout 600s
+          helm-extra-args: --timeout 900s
           EOF
           echo "cat .chart-testing-config.yaml"
           cat .chart-testing-config.yaml
@@ -259,9 +257,10 @@ jobs:
         env:
           UPGRADE_FROM: ${{ github.event.inputs.upgrade_from && '--version github.event.inputs.upgrade_from' || '' }}
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
           helm install -f charts/bpdm/ci/test-upgrade-values.yaml  bpdm-test tractusx-dev/bpdm $UPGRADE_FROM
           helm dependency update charts/bpdm
+          kubectl delete statefulset bpdm-postgres --ignore-not-found=true
+          kubectl delete pvc -l app.kubernetes.io/name=postgres --ignore-not-found=true
           helm upgrade -f charts/bpdm/ci/test-upgrade-values.yaml  bpdm-test charts/bpdm
 

--- a/charts/bpdm/Chart.yaml
+++ b/charts/bpdm/Chart.yaml
@@ -50,10 +50,9 @@ dependencies:
     condition: bpdm-orchestrator.enabled
   - name: bpdm-common
     version: 1.0.5
-  - name: postgresql
-    version: 12.12.10
-    repository: https://charts.bitnami.com/bitnami
-    alias: postgres
+  - name: postgres
+    version: 0.11.0
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: postgres.enabled
   - name: centralidp
     version: 4.2.1

--- a/charts/bpdm/README.md
+++ b/charts/bpdm/README.md
@@ -1,6 +1,6 @@
 # bpdm
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.2.0](https://img.shields.io/badge/AppVersion-7.2.0-informational?style=flat-square)
+![Version: 6.3.0-SNAPSHOT](https://img.shields.io/badge/Version-6.3.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.3.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for Kubernetes that deploys the BPDM applications
 
@@ -21,13 +21,13 @@ A Helm chart for Kubernetes that deploys the BPDM applications
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | bpdm-cleaning-service-dummy(bpdm-cleaning-service-dummy) | 4.2.0 |
+|  | bpdm-cleaning-service-dummy(bpdm-cleaning-service-dummy) | 4.3.0-SNAPSHOT |
 |  | bpdm-common | 1.0.5 |
-|  | bpdm-gate(bpdm-gate) | 7.2.0 |
-|  | bpdm-orchestrator(bpdm-orchestrator) | 4.2.0 |
-|  | bpdm-pool(bpdm-pool) | 8.2.0 |
-| https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
+|  | bpdm-gate(bpdm-gate) | 7.3.0-SNAPSHOT |
+|  | bpdm-orchestrator(bpdm-orchestrator) | 4.3.0-SNAPSHOT |
+|  | bpdm-pool(bpdm-pool) | 8.3.0-SNAPSHOT |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.2.1 |
+| oci://registry-1.docker.io/cloudpirates | postgres | 0.11.0 |
 
 ## Values
 
@@ -69,9 +69,8 @@ A Helm chart for Kubernetes that deploys the BPDM applications
 | postgres.auth.password | string | `"bpdm"` |  |
 | postgres.auth.username | string | `"bpdm"` |  |
 | postgres.enabled | bool | `true` |  |
-| postgres.fullnameOverride | string | `"bpdm-postgres"` |  |
-| postgres.image.repository | string | `"bitnamilegacy/postgresql"` |  |
-| postgres.image.tag | string | `"15-debian-11"` |  |
+| postgres.image.registry | string | `"docker.io"` | PostgreSQL image registry |
+| postgres.image.repository | string | `"postgres"` | PostgreSQL image repository |
 | tests.applicationConfig.bpdm.client.gate.provider.issuer-uri | string | `"http://bpdm-centralidp/auth/realms/CX-Central"` |  |
 | tests.applicationConfig.bpdm.client.orchestrator.provider.issuer-uri | string | `"http://bpdm-centralidp/auth/realms/CX-Central"` |  |
 | tests.applicationConfig.bpdm.client.pool.provider.issuer-uri | string | `"http://bpdm-centralidp/auth/realms/CX-Central"` |  |

--- a/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
+++ b/charts/bpdm/charts/bpdm-cleaning-service-dummy/README.md
@@ -1,6 +1,6 @@
 # bpdm-cleaning-service-dummy
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.2.0](https://img.shields.io/badge/AppVersion-7.2.0-informational?style=flat-square)
+![Version: 4.3.0-SNAPSHOT](https://img.shields.io/badge/Version-4.3.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.3.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM cleaning service
 

--- a/charts/bpdm/charts/bpdm-gate/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-gate/Chart.yaml
@@ -28,10 +28,9 @@ home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adop
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
-  - name: postgresql
-    version: 12.12.10
-    repository: https://charts.bitnami.com/bitnami
-    alias: postgres
+  - name: postgres
+    version: 0.11.0
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: postgres.enabled
   - name: bpdm-common
     version: 1.0.5

--- a/charts/bpdm/charts/bpdm-gate/README.md
+++ b/charts/bpdm/charts/bpdm-gate/README.md
@@ -1,6 +1,6 @@
 # bpdm-gate
 
-![Version: 7.2.0](https://img.shields.io/badge/Version-7.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.2.0](https://img.shields.io/badge/AppVersion-7.2.0-informational?style=flat-square)
+![Version: 7.3.0-SNAPSHOT](https://img.shields.io/badge/Version-7.3.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.3.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM gate service
 
@@ -22,8 +22,8 @@ A Helm chart for deploying the BPDM gate service
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../bpdm-common | bpdm-common | 1.0.5 |
-| https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.2.1 |
+| oci://registry-1.docker.io/cloudpirates | postgres | 0.11.0 |
 
 ## Values
 

--- a/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-orchestrator/Chart.yaml
@@ -31,10 +31,9 @@ dependencies:
   - name: bpdm-common
     version: 1.0.5
     repository: "file://../bpdm-common"
-  - name: postgresql
-    version: 12.12.10
-    repository: https://charts.bitnami.com/bitnami
-    alias: postgres
+  - name: postgres
+    version: 0.11.0
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: postgres.enabled
   - name: centralidp
     version: 4.2.1

--- a/charts/bpdm/charts/bpdm-orchestrator/README.md
+++ b/charts/bpdm/charts/bpdm-orchestrator/README.md
@@ -1,6 +1,6 @@
 # bpdm-orchestrator
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.2.0](https://img.shields.io/badge/AppVersion-7.2.0-informational?style=flat-square)
+![Version: 4.3.0-SNAPSHOT](https://img.shields.io/badge/Version-4.3.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.3.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM Orchestrator service
 
@@ -22,8 +22,8 @@ A Helm chart for deploying the BPDM Orchestrator service
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../bpdm-common | bpdm-common | 1.0.5 |
-| https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.2.1 |
+| oci://registry-1.docker.io/cloudpirates | postgres | 0.11.0 |
 
 ## Values
 

--- a/charts/bpdm/charts/bpdm-pool/Chart.yaml
+++ b/charts/bpdm/charts/bpdm-pool/Chart.yaml
@@ -28,10 +28,9 @@ home: https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Adop
 sources:
   - https://github.com/eclipse-tractusx/bpdm
 dependencies:
-  - name: postgresql
-    version: 12.12.10
-    repository: https://charts.bitnami.com/bitnami
-    alias: postgres
+  - name: postgres
+    version: 0.11.0
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: postgres.enabled
   - name: bpdm-common
     version: 1.0.5

--- a/charts/bpdm/charts/bpdm-pool/README.md
+++ b/charts/bpdm/charts/bpdm-pool/README.md
@@ -1,6 +1,6 @@
 # bpdm-pool
 
-![Version: 8.2.0](https://img.shields.io/badge/Version-8.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.2.0](https://img.shields.io/badge/AppVersion-7.2.0-informational?style=flat-square)
+![Version: 8.3.0-SNAPSHOT](https://img.shields.io/badge/Version-8.3.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-7.3.0--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for deploying the BPDM pool service
 
@@ -22,8 +22,8 @@ A Helm chart for deploying the BPDM pool service
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../bpdm-common | bpdm-common | 1.0.5 |
-| https://charts.bitnami.com/bitnami | postgres(postgresql) | 12.12.10 |
 | https://eclipse-tractusx.github.io/charts/dev | centralidp(centralidp) | 4.2.1 |
+| oci://registry-1.docker.io/cloudpirates | postgres | 0.11.0 |
 
 ## Values
 
@@ -74,9 +74,9 @@ A Helm chart for deploying the BPDM pool service
 | readinessProbe.timeoutSeconds | int | `1` |  |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | int | `1` |  |
-| resources.limits.memory | string | `"1Gi"` |  |
+| resources.limits.memory | string | `"1200Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
-| resources.requests.memory | string | `"1Gi"` |  |
+| resources.requests.memory | string | `"1200Mi"` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/charts/bpdm/values.yaml
+++ b/charts/bpdm/values.yaml
@@ -70,9 +70,6 @@ bpdm-orchestrator:
 
 postgres:
   enabled: true
-  image:
-    repository: bitnamilegacy/postgresql
-    tag: 15-debian-11
   fullnameOverride: bpdm-postgres
   auth:
     database: bpdm

--- a/docs/admin/MIGRATION_GUIDE.md
+++ b/docs/admin/MIGRATION_GUIDE.md
@@ -2,6 +2,8 @@
 
 <!-- TOC -->
 * [Migration Guide](#migration-guide)
+  * [7.2.x to 7.3.x](#72x-to-73x)
+    * [Postgres Version Update](#postgres-version-update)
   * [7.1.x to 7.2.x](#71x-to-72x)
     * [Alternative Headquarters Restriction](#alternative-headquarters-restriction)
     * [Default Logging Level](#default-logging-level)
@@ -10,6 +12,20 @@
     * [Golden Record Process for IsManagedBy Relations](#golden-record-process-for-ismanagedby-relations)
     * [Business Partner Identifier Amount Limit](#business-partner-identifier-amount-limit)
 <!-- TOC -->
+
+## 7.2.x to 7.3.x
+
+### Postgres Version Update
+
+The new version has been updated with Postgres version 18.0 instead of the formerly used version 15.x. With this change there was also the switch from the no longer maintained Bitnami image and helm chart to helm charts provided by Cloud Pirate which make use of the standard Postgres image published on Docker Hub.
+
+As a consequence, for a Kubernetes setup done with the provided helm charts, there is no possibility to do an automatic upgrade with the provided helm charts, as the two images are not supporting that. Instead, during update, a operator has to do the following manual steps;
+
+- Backup PostgreSQL data from the old installation 
+- Uninstall the old Helm release 
+- Delete the old PVC 
+- Perform a fresh installation with the new chart 
+- Restore data
 
 ## 7.1.x to 7.2.x
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request upgrades BPDM to use PostgreSQL with version 18.x.
Contributes to #1435 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
