### PR TITLE
fix(orchestrator): finished task events with correct content size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/),
 
 For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/CHANGELOG.md) of the charts directly.
 
+## [7.3.0] - tbd
+
+### Added
+
+### Changed
+
+- BPDM Orchestrator: fixed finished task events with correct content size in api response [#1580](https://github.com/eclipse-tractusx/bpdm/issues/1580)
+
 ## [7.2.0] - 2025-12-01
 
 ### Added

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskEventService.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/GoldenRecordTaskEventService.kt
@@ -45,7 +45,7 @@ class GoldenRecordTaskEventService(
             totalElements = finishedTasksPage.totalElements,
             totalPages = finishedTasksPage.totalPages,
             page = finishedTasksPage.number,
-            contentSize = finishedTasksPage.size,
+            contentSize = finishedTasksPage.content.size,
             content = finishedTasksPage.content.map { FinishedTaskEventsResponse.Event(it.updatedAt.instant,responseMapper.toResultState(it.processingState.resultState), it.uuid.toString()) }
         )
     }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/RelationsGoldenRecordTaskEventService.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/RelationsGoldenRecordTaskEventService.kt
@@ -44,7 +44,7 @@ class RelationsGoldenRecordTaskEventService(
             totalElements = finishedTasksPage.totalElements,
             totalPages = finishedTasksPage.totalPages,
             page = finishedTasksPage.number,
-            contentSize = finishedTasksPage.size,
+            contentSize = finishedTasksPage.content.size,
             content = finishedTasksPage.content.map { FinishedTaskEventsResponse.Event(it.updatedAt.instant, relationsResponseMapper.toResultState(it.processingState.resultState), it.uuid.toString()) }
         )
     }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request, corrects the content size on bpdm-orchestrator api response for both golden record and relation golden records tasks that have finished processing.

fixes - #1580 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
