### PR TITLE
feat(Pool): Change legal address on replaced by relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM: Introduced support for business partner address-to-address relations with the new `IsReplacedBy` relation type. [#1561](https://github.com/eclipse-tractusx/bpdm/issues/1561)
 - BPDM Pool: Add endpoints to manage reason code metadata [1562](https://github.com/eclipse-tractusx/bpdm/issues/1562)
 - BPDM: Add reason codes to business partner relations [1562](https://github.com/eclipse-tractusx/bpdm/issues/1562)
+- BPDM Pool: Relocate legal entity headquarter when a replaced by relation between a legal address and an additional address activates [#1586](https://github.com/eclipse-tractusx/bpdm/issues/1586)
 
 ### Changed
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
@@ -327,6 +327,7 @@ class GoldenRecordUpdateChunkService(
         updateIdentifiers(businessPartner.identifiers, address.identifiers.map(::toEntity), BusinessPartnerType.ADDRESS)
         updateStates(businessPartner.states, address.states, BusinessPartnerType.ADDRESS)
         businessPartner.addressName = address.name
+        businessPartner.postalAddress.addressType = address.addressType
         businessPartner.postalAddress.physicalPostalAddress = address.physicalPostalAddress.toEntity()
         businessPartner.postalAddress.alternativePostalAddress = address.alternativePostalAddress?.toEntity()
         businessPartner.addressConfidence?.let { update(it,  address.confidenceCriteria) }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/GoldenRecordEventTriggerConfigProperties.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/config/GoldenRecordEventTriggerConfigProperties.kt
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.config
+
+import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordEventTriggerConfigProperties.Companion.PREFIX
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = PREFIX)
+data class GoldenRecordEventTriggerConfigProperties(
+    val cron: String
+){
+    companion object{
+        const val PREFIX = "bpdm.event-triggers"
+        private const val QUALIFIED_NAME = "org.eclipse.tractusx.bpdm.pool.config.GoldenRecordEventTriggerConfigProperties"
+        private const val BEAN_QUALIFIER = "'${PREFIX}-$QUALIFIED_NAME'"
+
+        const val GET_CRON = "@$BEAN_QUALIFIER.getCron()"
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/AddressRelationEventTriggerDb.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/AddressRelationEventTriggerDb.kt
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.entity
+
+import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationEventTriggerDb.Companion.EVENT_TYPE_COLUMN
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationEventTriggerDb.Companion.IS_PROCESSED_COLUMN
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationEventTriggerDb.Companion.RELATION_ID_COLUMN
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationEventTriggerDb.Companion.TRIGGER_DATE_COLUMN
+import java.time.LocalDate
+
+@Entity
+@Table(
+    name = "address_relation_event_triggers",
+    indexes = [
+        Index(name = "idx_address_relation_event_triggers_relation_event_type", columnList = "$RELATION_ID_COLUMN,$EVENT_TYPE_COLUMN"),
+        Index(name = "idx_address_relation_event_triggers_is_processed_trigger_date", columnList = "$IS_PROCESSED_COLUMN,$TRIGGER_DATE_COLUMN"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(name = "uc_address_relation_event_type_trigger_date", columnNames = [RELATION_ID_COLUMN, EVENT_TYPE_COLUMN, TRIGGER_DATE_COLUMN])
+    ]
+)
+class AddressRelationEventTriggerDb(
+    @Column(name = TRIGGER_DATE_COLUMN, nullable = false)
+    var triggerDate: LocalDate,
+    @Column(name = IS_PROCESSED_COLUMN, nullable = false)
+    var isProcessed: Boolean,
+    @Column(name = EVENT_TYPE_COLUMN, nullable = false)
+    @Enumerated(EnumType.STRING)
+    var eventType: TriggerEventType,
+    @ManyToOne
+    @JoinColumn(name = "relation_id", nullable = false)
+    var relation: AddressRelationDb
+): BaseEntity(){
+    companion object{
+        const val TRIGGER_DATE_COLUMN = "trigger_date"
+        const val EVENT_TYPE_COLUMN = "event_type"
+        const val RELATION_ID_COLUMN = "relation_id"
+        const val IS_PROCESSED_COLUMN = "is_processed"
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/TriggerEventType.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/TriggerEventType.kt
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.entity
+
+enum class TriggerEventType {
+    ReplacedAddress
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/AddressRelationEventTriggerRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/AddressRelationEventTriggerRepository.kt
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.repository
+
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationDb
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationEventTriggerDb
+import org.eclipse.tractusx.bpdm.pool.entity.TriggerEventType
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.CrudRepository
+import java.time.LocalDate
+
+interface AddressRelationEventTriggerRepository:  CrudRepository<AddressRelationEventTriggerDb, Long> {
+
+    fun findByRelationAndEventType(relation: AddressRelationDb, eventType: TriggerEventType): Set<AddressRelationEventTriggerDb>
+
+    @Query("SELECT trigger FROM AddressRelationEventTriggerDb trigger WHERE trigger.isProcessed = FALSE AND trigger.triggerDate <= :before ORDER BY trigger.triggerDate ASC LIMIT 1")
+    fun findNextUnprocessed(before: LocalDate): AddressRelationEventTriggerDb?
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationTriggerExecutionService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationTriggerExecutionService.kt
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationEventTriggerDb
+import org.eclipse.tractusx.bpdm.pool.entity.TriggerEventType
+import org.eclipse.tractusx.bpdm.pool.repository.AddressRelationEventTriggerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class AddressRelationTriggerExecutionService(
+    private val headquarterSyncService: HeadquarterSyncService,
+    private val addressRelationEventTriggerRepository: AddressRelationEventTriggerRepository
+): IsBatchProcessService {
+    private val logger = KotlinLogging.logger { }
+
+    @Transactional
+    override fun executeNextBatch(): Boolean {
+        val nextUnprocessedTrigger = addressRelationEventTriggerRepository.findNextUnprocessed(LocalDate.now())
+            ?: return false
+
+        when (nextUnprocessedTrigger.eventType) {
+            TriggerEventType.ReplacedAddress -> executeHeadquarterRelocationSync(nextUnprocessedTrigger)
+        }
+
+        nextUnprocessedTrigger.isProcessed = true
+        addressRelationEventTriggerRepository.save(nextUnprocessedTrigger)
+
+        return true
+    }
+
+    private fun executeHeadquarterRelocationSync(trigger: AddressRelationEventTriggerDb) {
+        val legalEntity = trigger.relation.startAddress.legalEntity
+
+        if(legalEntity != null){
+            headquarterSyncService.synchronizeHeadquarter(legalEntity)
+        }else{
+            logger.error { "Encountered an address without reference to a legal entity when processing replaced by triggers: ${trigger.relation.startAddress}. Trigger will be deactivated." }
+        }
+
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationUpsertService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationUpsertService.kt
@@ -30,15 +30,20 @@ import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationDb
 import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddressDb
 import org.eclipse.tractusx.bpdm.pool.entity.ReasonCodeDb
 import org.eclipse.tractusx.bpdm.pool.entity.RelationValidityPeriodDb
+import org.eclipse.tractusx.bpdm.pool.entity.*
 import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
+import org.eclipse.tractusx.bpdm.pool.repository.AddressRelationEventTriggerRepository
 import org.eclipse.tractusx.bpdm.pool.repository.AddressRelationRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 class AddressRelationUpsertService(
     private val addressRelationRepository: AddressRelationRepository,
-    private val changelogService: PartnerChangelogService
+    private val changelogService: PartnerChangelogService,
+    private val headquarterSyncService: HeadquarterSyncService,
+    private val addressRelationEventTriggerRepository: AddressRelationEventTriggerRepository
 ): IAddressRelationUpsertStratergyService {
 
     @Transactional
@@ -68,13 +73,15 @@ class AddressRelationUpsertService(
             if (validityPeriodsDiffer(existingRelation.validityPeriods, upsertRequest.validityPeriods)) {
                 existingRelation.validityPeriods.clear()
                 existingRelation.validityPeriods.addAll(upsertRequest.validityPeriods)
-                addressRelationRepository.save(existingRelation)
+                addressRelationRepository.saveAndFlush(existingRelation)
+
+                handleHeadquarterSynchronization(existingRelation)
                 UpsertResult(existingRelation, UpsertType.Updated)
             } else {
                 UpsertResult(existingRelation, UpsertType.NoChange)
             }
         } else {
-            UpsertResult(createNewAddressRelation(
+            val newRelation = createNewAddressRelation(
                 UpsertRequest(
                     source = sourceAddress,
                     target = targetAddress,
@@ -82,7 +89,11 @@ class AddressRelationUpsertService(
                     validityPeriods = validityPeriods,
                     reasonCode = upsertRequest.reasonCode
                 )
-            ), UpsertType.Created)
+            )
+
+            handleHeadquarterSynchronization(newRelation)
+
+            UpsertResult(newRelation, UpsertType.Created)
         }
 
         return upsertResult
@@ -122,12 +133,32 @@ class AddressRelationUpsertService(
             reasonCode = upsertRequest.reasonCode
         )
 
-        addressRelationRepository.save(newRelation)
+        addressRelationRepository.saveAndFlush(newRelation)
 
         changelogService.createChangelogEntry(ChangelogEntryCreateRequest(source.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS))
         changelogService.createChangelogEntry(ChangelogEntryCreateRequest(target.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS))
 
         return newRelation
+    }
+
+    private fun handleHeadquarterSynchronization(relation: AddressRelationDb){
+        val today = LocalDate.now()
+
+        if(relation.validityPeriods.any { it.validFrom <= today}){
+            headquarterSyncService.synchronizeHeadquarter(relation.startAddress.legalEntity!!)
+        }
+
+         val existingUnprocessedTriggers = addressRelationEventTriggerRepository.findByRelationAndEventType(relation, TriggerEventType.ReplacedAddress)
+            .filterNot { it.isProcessed }
+
+        addressRelationEventTriggerRepository.deleteAll(existingUnprocessedTriggers)
+
+
+        val futureEventTriggers = relation.validityPeriods
+            .filter { it.validFrom > today }
+            .map { AddressRelationEventTriggerDb(it.validFrom, false, TriggerEventType.ReplacedAddress, relation) }
+
+        addressRelationEventTriggerRepository.saveAll(futureEventTriggers)
     }
 
     data class UpsertRequest(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BatchProcessExecutionService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BatchProcessExecutionService.kt
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Service
+
+@Service
+class BatchProcessExecutionService(
+    private val entityManager: EntityManager
+) {
+    fun executeUntilFinished(batchProcessService: IsBatchProcessService){
+        var hasNext: Boolean
+        do{
+            hasNext = batchProcessService.executeNextBatch()
+            entityManager.clear()
+        }while (hasNext)
+
+    }
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/HeadquarterSyncService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/HeadquarterSyncService.kt
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
+import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
+import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
+import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
+import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationDb
+import org.eclipse.tractusx.bpdm.pool.entity.LegalEntityDb
+import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddressDb
+import org.eclipse.tractusx.bpdm.pool.entity.RelationValidityPeriodDb
+import org.eclipse.tractusx.bpdm.pool.repository.AddressRelationRepository
+import org.eclipse.tractusx.bpdm.pool.repository.LegalEntityRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class HeadquarterSyncService(
+    private val relationRepository: AddressRelationRepository,
+    private val legalEntityRepository: LegalEntityRepository,
+    private val changelogService: PartnerChangelogService
+) {
+    private val logger = KotlinLogging.logger { }
+
+    @Transactional
+    fun synchronizeHeadquarter(legalEntityDb: LegalEntityDb){
+        val addressesToProcess = ArrayDeque<LogisticAddressDb>()
+        val relocatedAddresses = mutableListOf<LogisticAddressDb>()
+        val visitedValidityPeriods = mutableListOf<RelationValidityPeriod>()
+
+        val today = LocalDate.now()
+
+        addressesToProcess.add(legalEntityDb.legalAddress)
+
+        do{
+            val nextAddress = addressesToProcess.removeFirst()
+            val replacingRelations =  relationRepository.findByTypeAndStartAddress(AddressRelationType.IsReplacedBy, nextAddress)
+
+            val replacingRelationValidities =  replacingRelations
+                .flatMap { relation -> relation.validityPeriods.map { RelationValidityPeriod(relation, it) } }
+
+            val notVisitiedValidities = replacingRelationValidities
+                .filterNot{ visitedValidityPeriods.contains(it) }
+
+            val activeValidities = notVisitiedValidities
+                .filter {  it.validityPeriod.validFrom <= today && (it.validityPeriod.validTo?: LocalDate.MAX) > today }
+
+            activeValidities.forEach { visitedValidityPeriods.add(it) }
+
+            val activeReplacingRelation = activeValidities.map { it.relation }.firstOrNull()
+
+            if(activeReplacingRelation != null){
+                relocatedAddresses.add(activeReplacingRelation.startAddress)
+                relocatedAddresses.add(activeReplacingRelation.endAddress)
+                addressesToProcess.add(activeReplacingRelation.endAddress)
+            }
+        }while (addressesToProcess.isNotEmpty())
+
+        val newLegalAddress = relocatedAddresses.lastOrNull()
+
+        if(newLegalAddress != null){
+            val currentLegalAddress = legalEntityDb.legalAddress
+            legalEntityDb.legalAddress = newLegalAddress
+
+            legalEntityRepository.save(legalEntityDb)
+            logger.info { "Updated legal address of legal entity '${legalEntityDb.bpn}': From '${currentLegalAddress.bpn}' to '${newLegalAddress.bpn}'" }
+
+            changelogService.createChangelogEntry(ChangelogEntryCreateRequest(legalEntityDb.bpn, ChangelogType.UPDATE, BusinessPartnerType.LEGAL_ENTITY))
+            changelogService.createChangelogEntry(ChangelogEntryCreateRequest(currentLegalAddress.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS))
+            changelogService.createChangelogEntry(ChangelogEntryCreateRequest(newLegalAddress.bpn, ChangelogType.UPDATE, BusinessPartnerType.ADDRESS))
+        }
+    }
+
+    private data class RelationValidityPeriod(
+        val relation: AddressRelationDb,
+        val validityPeriod: RelationValidityPeriodDb
+    )
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IsBatchProcessService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IsBatchProcessService.kt
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+interface IsBatchProcessService {
+
+    /**
+     * Starts the execution of the next batch
+     *
+     * @return True if there is another batch, otherwise False
+     */
+    fun executeNextBatch(): Boolean
+
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TriggerBatchProcessExecutionService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TriggerBatchProcessExecutionService.kt
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import mu.KotlinLogging
+import org.eclipse.tractusx.bpdm.pool.config.GoldenRecordEventTriggerConfigProperties
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class TriggerBatchProcessExecutionService(
+    private val batchProcessExecutionService: BatchProcessExecutionService,
+    private val addressRelationTriggerExecutionService: AddressRelationTriggerExecutionService
+) {
+    private val logger = KotlinLogging.logger { }
+
+    @Scheduled(cron = "#{${GoldenRecordEventTriggerConfigProperties.GET_CRON}}", zone = "UTC")
+    fun executeUnprocessedTriggers(){
+        logger.info("Execute unprocessed triggers")
+        batchProcessExecutionService.executeUntilFinished(addressRelationTriggerExecutionService)
+    }
+
+
+}

--- a/bpdm-pool/src/main/resources/application.yml
+++ b/bpdm-pool/src/main/resources/application.yml
@@ -89,6 +89,9 @@ bpdm:
     cron: '15/30 * * * * *'
     # Up to how many tasks can be requested at the same time
     batchSize: 20
+  eventTriggers:
+    # How often the Pool should check for golden record event triggers to be processed (e.g. IsReplacedByRelation takes into effect)
+    cron: '0/30 * * * * *'
   security:
     # Allowed origins for CORS
     cors-origins: '*'

--- a/bpdm-pool/src/main/resources/db/migration/V7_3_0_6__create_address_relation_triggers.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V7_3_0_6__create_address_relation_triggers.sql
@@ -1,0 +1,18 @@
+CREATE TABLE address_relation_event_triggers
+(
+    id                          BIGINT                      NOT NULL,
+    uuid                        UUID                        NOT NULL,
+    created_at                  TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    updated_at                  TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    trigger_date                DATE                        NOT NULL,
+    is_processed                BOOLEAN                     NOT NULL,
+    event_type                  VARCHAR(255)                NOT NULL,
+    relation_id                 BIGINT                      NOT NULL,
+    CONSTRAINT pk_address_relation_event_triggers PRIMARY KEY (id),
+    CONSTRAINT uc_address_relation_event_type_trigger_date UNIQUE (trigger_date, event_type, relation_id)
+);
+
+CREATE INDEX idx_address_relation_event_triggers_relation_event_type ON address_relation_event_triggers (relation_id, event_type);
+CREATE INDEX idx_address_relation_event_triggers_is_processed_trigger_date ON address_relation_event_triggers (is_processed, trigger_date);
+
+

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionHeadquarterRelocationIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionHeadquarterRelocationIT.kt
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.Application
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
+import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerRequestFactory
+import org.eclipse.tractusx.bpdm.test.testdata.pool.ExpectedBusinessPartnerResultFactory
+import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
+import org.eclipse.tractusx.bpdm.test.testdata.pool.TestDataEnvironment
+import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
+import org.eclipse.tractusx.bpdm.test.util.PoolAssertHelper
+import org.eclipse.tractusx.bpdm.test.util.Timeframe
+import org.eclipse.tractusx.orchestrator.api.model.BusinessPartnerRelations
+import org.eclipse.tractusx.orchestrator.api.model.RelationType
+import org.eclipse.tractusx.orchestrator.api.model.RelationValidityPeriod
+import org.eclipse.tractusx.orchestrator.api.model.TaskRelationsStepReservationEntryDto
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import java.time.Instant
+import java.time.LocalDate
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
+)
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
+@ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
+class TaskRelationsResolutionHeadquarterRelocationIT @Autowired constructor(
+    private val taskRelationsResolutionService: TaskRelationsResolutionService,
+    private val poolApiClient: PoolApiClient,
+    private val dataHelper: PoolDataHelper,
+    private val dbTestHelpers: DbTestHelpers,
+    private val poolAssertHelper: PoolAssertHelper
+) {
+
+    private lateinit var testDataEnvironment: TestDataEnvironment
+    private lateinit var testName: String
+    private lateinit var requestFactory: BusinessPartnerRequestFactory
+    private lateinit var resultFactory: ExpectedBusinessPartnerResultFactory
+
+    @BeforeEach
+    fun beforeEach(testInfo: TestInfo) {
+        dbTestHelpers.truncateDbTables()
+        testDataEnvironment = dataHelper.createTestDataEnvironment()
+        requestFactory = testDataEnvironment.requestFactory
+        resultFactory = testDataEnvironment.expectFactory
+        testName = testInfo.displayName
+    }
+
+
+    /**
+     * GIVEN a legal entity and an additional address
+     * WHEN additional address replaces legal address effective immediately
+     * THEN user sees legal entity has the former additional address as new legal address
+     */
+    @Test
+    fun `replaced legal address changes headquarter`(){
+        //GIVEN
+        val legalEntityRequest = requestFactory.createLegalEntityRequest(testName, true)
+        val createdLegalEntity = poolApiClient.legalEntities.createBusinessPartners(listOf(legalEntityRequest)).entities.single()
+
+        val addAddressRequest = requestFactory.buildAdditionalAddressCreateRequest("$testName 2", createdLegalEntity.legalEntity.bpnl)
+        val createdAddAddress = poolApiClient.addresses.createAddresses(listOf(addAddressRequest)).entities.single()
+
+        //WHEN
+        val activeNow = listOf(RelationValidityPeriod(LocalDate.now(), null))
+        val replacedByRelation = BusinessPartnerRelations(RelationType.IsReplacedBy, createdLegalEntity.legalAddress.bpna, createdAddAddress.address.bpna, activeNow, anyReasonCode())
+        val taskToResolve = TaskRelationsStepReservationEntryDto("Any", "Any", replacedByRelation)
+        taskRelationsResolutionService.upsertRelationsGoldenRecordIntoPool(listOf(taskToResolve))
+
+        //THEN
+        val actualLegalEntity = poolApiClient.legalEntities.getLegalEntity(createdLegalEntity.legalEntity.bpnl)
+        val expectedLegalEntity = buildExpectedRelocatedHeadquarterLegalEntity(createdLegalEntity, createdAddAddress, replacedByRelation)
+
+        poolAssertHelper.assertLegalEntityResponse(listOf(actualLegalEntity), listOf(expectedLegalEntity), Timeframe(Instant.now().minusSeconds(1), Instant.now()))
+    }
+
+    /**
+     * GIVEN a legal entity and an additional address
+     * WHEN additional address replaces legal address effective some point in the future
+     * THEN user sees legal address of legal entity did not change
+     */
+    @Test
+    fun `replacing legal address in the future does not change headquarter`(){
+        //GIVEN
+        val legalEntityRequest = requestFactory.createLegalEntityRequest(testName, true)
+        val createdLegalEntity = poolApiClient.legalEntities.createBusinessPartners(listOf(legalEntityRequest)).entities.single()
+
+        val addAddressRequest = requestFactory.buildAdditionalAddressCreateRequest("$testName 2", createdLegalEntity.legalEntity.bpnl)
+        val createdAddAddress = poolApiClient.addresses.createAddresses(listOf(addAddressRequest)).entities.single()
+
+        //WHEN
+        val activeLater = listOf(RelationValidityPeriod(LocalDate.now().plusDays(1), null))
+        val replacedByRelation = BusinessPartnerRelations(RelationType.IsReplacedBy, createdLegalEntity.legalAddress.bpna, createdAddAddress.address.bpna, activeLater, anyReasonCode())
+        val taskToResolve = TaskRelationsStepReservationEntryDto("Any", "Any", replacedByRelation)
+        taskRelationsResolutionService.upsertRelationsGoldenRecordIntoPool(listOf(taskToResolve))
+
+        //THEN
+        val actualLegalEntity = poolApiClient.legalEntities.getLegalEntity(createdLegalEntity.legalEntity.bpnl)
+        val expectedLegalEntity = LegalEntityWithLegalAddressVerboseDto(
+            createdLegalEntity.legalEntity,
+            createdLegalEntity.legalAddress.copy(relations = createdLegalEntity.legalAddress.relations.plus(buildAddressReplacedByRelation(replacedByRelation)))
+        )
+
+        poolAssertHelper.assertLegalEntityResponse(listOf(actualLegalEntity), listOf(expectedLegalEntity), Timeframe(Instant.now().minusSeconds(1), Instant.now()))
+    }
+
+    private fun anyReasonCode(): String{
+        return poolApiClient.metadata.getReasonCodes(PaginationRequest()).content.first().technicalKey
+    }
+
+    private fun buildExpectedRelocatedHeadquarterLegalEntity(
+        legalEntity: LegalEntityPartnerCreateVerboseDto,
+        newLegalAddress: AddressPartnerCreateVerboseDto,
+        replacedByRelation: BusinessPartnerRelations
+        ): LegalEntityWithLegalAddressVerboseDto{
+        val newReplacedRelation = buildAddressReplacedByRelation(replacedByRelation)
+
+        return LegalEntityWithLegalAddressVerboseDto(
+            legalEntity = legalEntity.legalEntity,
+            legalAddress = newLegalAddress.address.copy(addressType = AddressType.LegalAddress, relations = newLegalAddress.address.relations.plus(newReplacedRelation))
+        )
+    }
+
+    private fun buildAddressReplacedByRelation(replacedByRelation: BusinessPartnerRelations): AddressRelationVerboseDto{
+        return AddressRelationVerboseDto(
+            type = AddressRelationType.IsReplacedBy,
+            businessPartnerSourceBpna = replacedByRelation.businessPartnerSourceBpn,
+            businessPartnerTargetBpna = replacedByRelation.businessPartnerTargetBpn,
+            validityPeriods = replacedByRelation.validityPeriods.map { org.eclipse.tractusx.bpdm.pool.api.model.RelationValidityPeriod(it.validFrom, it.validTo) },
+            reasonCode = replacedByRelation.reasonCode
+        )
+    }
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TriggerBatchProcessExecutionServiceIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TriggerBatchProcessExecutionServiceIT.kt
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.Application
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
+import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerRequestFactory
+import org.eclipse.tractusx.bpdm.test.testdata.pool.ExpectedBusinessPartnerResultFactory
+import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
+import org.eclipse.tractusx.bpdm.test.testdata.pool.TestDataEnvironment
+import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
+import org.eclipse.tractusx.bpdm.test.util.PoolAssertHelper
+import org.eclipse.tractusx.bpdm.test.util.Timeframe
+import org.eclipse.tractusx.orchestrator.api.model.BusinessPartnerRelations
+import org.eclipse.tractusx.orchestrator.api.model.RelationType
+import org.eclipse.tractusx.orchestrator.api.model.RelationValidityPeriod
+import org.eclipse.tractusx.orchestrator.api.model.TaskRelationsStepReservationEntryDto
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import java.time.*
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
+)
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
+@ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
+class TriggerBatchProcessExecutionServiceIT @Autowired constructor(
+    private val taskRelationsResolutionService: TaskRelationsResolutionService,
+    private val triggerBatchProcessExecutionService: TriggerBatchProcessExecutionService,
+    private val poolApiClient: PoolApiClient,
+    private val dataHelper: PoolDataHelper,
+    private val dbTestHelpers: DbTestHelpers,
+    private val poolAssertHelper: PoolAssertHelper
+){
+
+    private lateinit var testDataEnvironment: TestDataEnvironment
+    private lateinit var testName: String
+    private lateinit var requestFactory: BusinessPartnerRequestFactory
+    private lateinit var resultFactory: ExpectedBusinessPartnerResultFactory
+
+    @BeforeEach
+    fun beforeEach(testInfo: TestInfo) {
+        dbTestHelpers.truncateDbTables()
+        testDataEnvironment = dataHelper.createTestDataEnvironment()
+        requestFactory = testDataEnvironment.requestFactory
+        resultFactory = testDataEnvironment.expectFactory
+        testName = testInfo.displayName
+    }
+
+    /**
+     * GIVEN legal address to be replaced by additional address at date X
+     * WHEN date X has arrived
+     * THEN user sees legal entity has former additional address as legal address
+     */
+    @Test
+    fun `event trigger invokes headquarter relocation`(){
+        //GIVEN
+        val legalEntityRequest = requestFactory.createLegalEntityRequest(testName, true)
+        val createdLegalEntity = poolApiClient.legalEntities.createBusinessPartners(listOf(legalEntityRequest)).entities.single()
+
+        val addAddressRequest = requestFactory.buildAdditionalAddressCreateRequest("$testName 2", createdLegalEntity.legalEntity.bpnl)
+        val createdAddAddress = poolApiClient.addresses.createAddresses(listOf(addAddressRequest)).entities.single()
+
+        val activeLater = listOf(RelationValidityPeriod(LocalDate.now().plusDays(1), null))
+        val replacedByRelation = BusinessPartnerRelations(RelationType.IsReplacedBy, createdLegalEntity.legalAddress.bpna, createdAddAddress.address.bpna, activeLater, anyReasonCode())
+        val taskToResolve = TaskRelationsStepReservationEntryDto("Any", "Any", replacedByRelation)
+        taskRelationsResolutionService.upsertRelationsGoldenRecordIntoPool(listOf(taskToResolve))
+
+        //WHEN
+        executeAtDate(LocalDate.now().plusDays(1)){ triggerBatchProcessExecutionService.executeUnprocessedTriggers() }
+
+        //THEN
+        val actualLegalEntity = poolApiClient.legalEntities.getLegalEntity(createdLegalEntity.legalEntity.bpnl)
+        val expectedLegalEntity = buildExpectedRelocatedHeadquarterLegalEntity(createdLegalEntity, createdAddAddress, replacedByRelation)
+
+        poolAssertHelper.assertLegalEntityResponse(listOf(actualLegalEntity), listOf(expectedLegalEntity), Timeframe(Instant.now().minusSeconds(2), Instant.now()))
+    }
+
+
+    /**
+     * GIVEN legal address to be replaced by additional address at date X
+     * WHEN date X not yet arrived
+     * THEN user sees legal entity legal address has not changed
+     */
+    @Test
+    fun `not yet ready event trigger is ignored`(){
+        //GIVEN
+        val legalEntityRequest = requestFactory.createLegalEntityRequest(testName, true)
+        val createdLegalEntity = poolApiClient.legalEntities.createBusinessPartners(listOf(legalEntityRequest)).entities.single()
+
+        val addAddressRequest = requestFactory.buildAdditionalAddressCreateRequest("$testName 2", createdLegalEntity.legalEntity.bpnl)
+        val createdAddAddress = poolApiClient.addresses.createAddresses(listOf(addAddressRequest)).entities.single()
+
+        val activeLater = listOf(RelationValidityPeriod(LocalDate.now().plusDays(1), null))
+        val replacedByRelation = BusinessPartnerRelations(RelationType.IsReplacedBy, createdLegalEntity.legalAddress.bpna, createdAddAddress.address.bpna, activeLater, anyReasonCode())
+        val taskToResolve = TaskRelationsStepReservationEntryDto("Any", "Any", replacedByRelation)
+        taskRelationsResolutionService.upsertRelationsGoldenRecordIntoPool(listOf(taskToResolve))
+
+        val originalLegalEntity = poolApiClient.legalEntities.getLegalEntity(createdLegalEntity.legalEntity.bpnl)
+
+        //WHEN
+        triggerBatchProcessExecutionService.executeUnprocessedTriggers()
+
+        //THEN
+        val actualLegalEntity = poolApiClient.legalEntities.getLegalEntity(createdLegalEntity.legalEntity.bpnl)
+        val expectedLegalEntity = originalLegalEntity
+
+        poolAssertHelper.assertLegalEntityResponse(listOf(actualLegalEntity), listOf(expectedLegalEntity), Timeframe(Instant.now().minusSeconds(2), Instant.now()))
+    }
+
+    private fun executeAtDate(executionDate: LocalDate, methodToExecute: () -> Unit){
+        val offset = Duration.between(Instant.now(), executionDate.atStartOfDay(ZoneOffset.UTC).toInstant())
+        val offsetClock = Clock.offset(Clock.systemUTC(), offset)
+
+        mockkStatic(Instant::class)
+        mockkStatic(Clock::class)
+        every { Instant.now() } returns offsetClock.instant()
+        every { Clock.systemUTC() } returns offsetClock
+        every { Clock.systemDefaultZone() } returns offsetClock
+
+        methodToExecute()
+        unmockkStatic(Instant::class)
+        unmockkStatic(Clock::class)
+    }
+
+    private fun buildExpectedRelocatedHeadquarterLegalEntity(
+        legalEntity: LegalEntityPartnerCreateVerboseDto,
+        newLegalAddress: AddressPartnerCreateVerboseDto,
+        replacedByRelation: BusinessPartnerRelations
+    ): LegalEntityWithLegalAddressVerboseDto{
+        val newReplacedRelation = buildAddressReplacedByRelation(replacedByRelation)
+
+        return LegalEntityWithLegalAddressVerboseDto(
+            legalEntity = legalEntity.legalEntity,
+            legalAddress = newLegalAddress.address.copy(addressType = AddressType.LegalAddress, relations = newLegalAddress.address.relations.plus(newReplacedRelation))
+        )
+    }
+
+    private fun buildAddressReplacedByRelation(replacedByRelation: BusinessPartnerRelations): AddressRelationVerboseDto{
+        return AddressRelationVerboseDto(
+            type = AddressRelationType.IsReplacedBy,
+            businessPartnerSourceBpna = replacedByRelation.businessPartnerSourceBpn,
+            businessPartnerTargetBpna = replacedByRelation.businessPartnerTargetBpn,
+            validityPeriods = replacedByRelation.validityPeriods.map { org.eclipse.tractusx.bpdm.pool.api.model.RelationValidityPeriod(it.validFrom, it.validTo) },
+            reasonCode = replacedByRelation.reasonCode
+        )
+    }
+
+    private fun anyReasonCode(): String{
+        return poolApiClient.metadata.getReasonCodes(PaginationRequest()).content.first().technicalKey
+    }
+
+}

--- a/bpdm-pool/src/test/resources/application-test-scheduling-disabled.yml
+++ b/bpdm-pool/src/test/resources/application-test-scheduling-disabled.yml
@@ -22,6 +22,8 @@ bpdm:
     cron: '-'
   sharingMemberRecords:
     cron: '-'
+  eventTriggers:
+    cron: '-'
 spring:
   datasource:
     hikari:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,6 +23,7 @@
       * [Sharing Business Partner Data](#sharing-business-partner-data)
       * [Sharing Other Company's Data](#sharing-other-companys-data)
       * [Sharing Own Company Data](#sharing-own-company-data)
+      * [Headquarter Relocation With No Leftover](#headquarter-relocation-with-no-leftover)
     * [VAS Providers](#vas-providers)
     * [Golden Record Processing Service Providers](#golden-record-processing-service-providers)
       * [Outdated Tasks](#outdated-tasks)
@@ -249,6 +250,22 @@ Additionally, you are required to mark the business partner as `isOwnCompanyData
 This is the way to recognize that you want to share your own data.
 
 In contrast to sharing other company's data you are allowed to specify site information including whether an address is a site main address.
+
+#### Headquarter Relocation With No Leftover
+
+The sharing member wants to report to the network that the headquarters address of a legal entity changed (or will change in the future).
+The old headquarters address will not be active anymore (hence 'No Leftover').
+
+Steps for the sharing member to take in order to realize that use case:
+
+1. The sharing member MUST create a business partner record `A` for the existing headquarters address
+2. The sharing member MUST create a business partner record `B` for the new headquarters address
+3. The sharing member MUST create a IsReplacedBy relation from `A` to `B`
+4. The sharing member MUST update the old headquarters address `A` to have an inactive business state
+
+In order to make sure that the golden record process processed the shared records correctly it is recommended that the sharing member SHOULD wait for the output results between steps 1 - 3.
+To clearly indicate that an old headquarters address is set to inactive and not the current legal entity, the sharing member MUST wait for step 3 correct output results before executing the final step 4.
+
 
 ### VAS Providers
 


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds logic to the Pool for changing the legal address of legal entities when a replaced by relation between a legal address and an additional address becomes active. The logic also covers cases in which legal addresses have been replaced already in the past. As well as cases in which the replaced by relation will become active in the future.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Solves #1586

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
