### PR TITLE
test(Gate): fix Pool API mock returning legal and site main address data

### DIFF
--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/v6/util/GateTestDataClientV6.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/v6/util/GateTestDataClientV6.kt
@@ -84,7 +84,7 @@ class GateTestDataClientV6 (
     }
 
     fun refineToLegalEntityOnSite(input: BusinessPartnerInputDto, seed: String = input.externalId): PoolMockDataFactory.SiteWithLegalEntityParent{
-        val poolMockResult = poolMockDataFactory.mockSiteAndMainAddressSearchResult(seed)
+        val poolMockResult = poolMockDataFactory.mockLegalAndSiteMainAddressSearchResult(seed)
 
         val owningCompany = if(input.isOwnCompanyData) tenantBpnL else null
         orchestratorMockDataFactory.mockRefineToLegalEntityOnSite(


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request fixes the Gate testing setup by changing the used Pool API mock. Added a method that correctly mocks returning a legal and site main address business partner hierarchy.

This fix only fixes the tests and has no impact on any existing service logic.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
