### PR TITLE
cicd(workflows): fix kind node setup in chart tests

### DIFF
--- a/.github/workflows/app-test-charts.yaml
+++ b/.github/workflows/app-test-charts.yaml
@@ -23,7 +23,7 @@ on:
     inputs:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
-        default: 'kindest/node:v1.34.0'
+        default: 'kindest/node:v1.35.0'
         required: false
         type: string
       upgrade_from:
@@ -39,7 +39,7 @@ on:
     inputs:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
-        default: 'kindest/node:v1.32.1'
+        default: 'kindest/node:v1.35.0'
         required: false
         type: string
       upgrade_from:
@@ -74,10 +74,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Kubernetes KinD Cluster
-        uses: container-tools/kind-action@v2
+        uses: helm/kind-action@v1
         with:
-          version: v0.20.0
-          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.32.1' }}
+          version: v0.31.0
+          registry: true
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.35.0' }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Update the node image version for the chart testing workflow. Also use the more popular helm/kind-action github action instead of the one provided by containertools.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
