### PR TITLE
test: Fix database connection pool size

### DIFF
--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/containers/PostgreSQLContextInitializer.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/containers/PostgreSQLContextInitializer.kt
@@ -37,6 +37,7 @@ class PostgreSQLContextInitializer : ApplicationContextInitializer<ConfigurableA
                 .parse("docker.io/postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a")
                 .asCompatibleSubstituteFor("postgres")
             )
+            .withCommand("max_connections=200")
             .withAccessToHost(true)
             .withNetwork(Network.SHARED)
     }

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/containers/PostgreSQLContextInitializer.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/containers/PostgreSQLContextInitializer.kt
@@ -37,7 +37,7 @@ class PostgreSQLContextInitializer : ApplicationContextInitializer<ConfigurableA
                 .parse("docker.io/postgres:18.3@sha256:a9abf4275f9e99bff8e6aed712b3b7dfec9cac1341bba01c1ffdfce9ff9fc34a")
                 .asCompatibleSubstituteFor("postgres")
             )
-            .withCommand("max_connections=200")
+            .withCommand("-c max_connections=200")
             .withAccessToHost(true)
             .withNetwork(Network.SHARED)
     }

--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/DbTestHelpers.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/util/DbTestHelpers.kt
@@ -20,19 +20,14 @@
 package org.eclipse.tractusx.bpdm.test.util
 
 import jakarta.persistence.EntityManager
-import jakarta.persistence.EntityManagerFactory
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Component
 
 
 @Component
-class DbTestHelpers(private val entityManagerFactory: EntityManagerFactory?) {
+class DbTestHelpers(private val entityManager: EntityManager?) {
 
-    val em: EntityManager? by lazy {
-        entityManagerFactory?.createEntityManager()
-    }
-
-
-
+    @Transactional
     fun truncateDbTables() {
         truncateDbTablesFromSchema("bpdm")
         truncateDbTablesFromSchema("bpdmgate")
@@ -41,9 +36,7 @@ class DbTestHelpers(private val entityManagerFactory: EntityManagerFactory?) {
     }
 
     private fun truncateDbTablesFromSchema(dbSchemaName: String) {
-        em?.transaction?.begin()
-
-        em?.createNativeQuery(
+        entityManager?.createNativeQuery(
             """
                     DO $$ DECLARE table_names RECORD;
                     BEGIN
@@ -57,8 +50,6 @@ class DbTestHelpers(private val entityManagerFactory: EntityManagerFactory?) {
                     END $$;
                 """.trimIndent()
         )?.executeUpdate()
-
-        em?.transaction?.commit()
     }
 
 


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request increases the amount of connections that are being available to the databse during testing.

This fixes a recurring error when a the test database (which is shared between all tests) runs out of connections as the test contexts hold the connections through the whole test procedure. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
