### PR TITLE
cicd(workflows): pin trivy action version to specific SHA

### DIFF
--- a/.github/workflows/app-test-trivy.yaml
+++ b/.github/workflows/app-test-trivy.yaml
@@ -47,7 +47,7 @@ jobs:
           load: true
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: "bpdm-${{ matrix.app }}:test"
           exit-code: "1"

--- a/.github/workflows/app-test-trivy.yaml
+++ b/.github/workflows/app-test-trivy.yaml
@@ -17,6 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
+# Executes for Pull Requests
 name: 'Perform Trivy Scan on All Apps'
 on:
   workflow_dispatch:

--- a/.github/workflows/app-test-trivy.yaml
+++ b/.github/workflows/app-test-trivy.yaml
@@ -17,7 +17,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-# Executes for Pull Requests
 name: 'Perform Trivy Scan on All Apps'
 on:
   workflow_dispatch:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -59,7 +59,7 @@ jobs:
           load: true
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: "bpdm-${{ matrix.app }}:test"
           format: "sarif"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request pins the trivy action that we use in our cicd pipeline to a specific SHA version, making sure that actual version used is not mutable.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Contributes to #1646

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
