### PR TITLE
build(dependencies): increase spring boot starter version to 4.0.6

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -10,9 +10,9 @@ maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-prov
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.21.1, Apache-2.0, approved, #25588
 maven/mavencentral/com.fasterxml/classmate/1.7.3, Apache-2.0, approved, #24482
 maven/mavencentral/com.github.dasniko/testcontainers-keycloak/3.2.0, Apache-2.0, approved, #14719
-maven/mavencentral/com.github.docker-java/docker-java-api/3.7.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.docker-java/docker-java-api/3.7.0, Apache-2.0, approved, #26612
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.7.0, Apache-2.0 AND MPL-2.0, approved, #25269
-maven/mavencentral/com.github.docker-java/docker-java-transport/3.7.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.7.0, Apache-2.0, approved, #26615
 maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-only, approved, #15201
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 OR LGPL-3.0-or-later, approved, #15186
 maven/mavencentral/com.github.java-json-tools/json-patch/1.13, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ23929
@@ -38,7 +38,7 @@ maven/mavencentral/commons-beanutils/commons-beanutils/1.11.0, Apache-2.0, appro
 maven/mavencentral/commons-codec/commons-codec/1.19.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #22613
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, #15185
 maven/mavencentral/commons-io/commons-io/2.20.0, Apache-2.0, approved, #22562
-maven/mavencentral/commons-logging/commons-logging/1.3.5, Apache-2.0, approved, #11783
+maven/mavencentral/commons-logging/commons-logging/1.3.6, Apache-2.0, approved, #11783
 maven/mavencentral/io.cucumber/ci-environment/12.0.0, MIT, approved, #24491
 maven/mavencentral/io.cucumber/cucumber-core/7.34.2, MIT AND (Apache-2.0 AND MIT), approved, #26038
 maven/mavencentral/io.cucumber/cucumber-expressions/18.1.0, MIT, approved, #26039
@@ -63,39 +63,39 @@ maven/mavencentral/io.cucumber/teamcity-formatter/0.2.0, MIT, approved, #24509
 maven/mavencentral/io.cucumber/testng-xml-formatter/0.7.0, MIT, approved, #24510
 maven/mavencentral/io.cucumber/usage-formatter/0.1.0, MIT, approved, #24511
 maven/mavencentral/io.github.microutils/kotlin-logging-jvm/3.0.5, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-commons/1.16.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #24726
-maven/mavencentral/io.micrometer/micrometer-core/1.16.3, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #24722
-maven/mavencentral/io.micrometer/micrometer-jakarta9/1.16.3, Apache-2.0, approved, #25608
-maven/mavencentral/io.micrometer/micrometer-observation/1.16.3, Apache-2.0, approved, #24713
+maven/mavencentral/io.micrometer/micrometer-commons/1.16.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #24726
+maven/mavencentral/io.micrometer/micrometer-core/1.16.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #24722
+maven/mavencentral/io.micrometer/micrometer-jakarta9/1.16.5, Apache-2.0, approved, #25608
+maven/mavencentral/io.micrometer/micrometer-observation/1.16.5, Apache-2.0, approved, #24713
 maven/mavencentral/io.mockk/mockk-agent-api-jvm/1.13.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-agent-jvm/1.13.3, MIT, approved, #10192
 maven/mavencentral/io.mockk/mockk-core-jvm/1.13.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-dsl-jvm/1.13.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-jvm/1.13.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.netty/netty-buffer/4.2.10.Final, Apache-2.0, approved, #16116
-maven/mavencentral/io.netty/netty-codec-base/4.2.10.Final, Apache-2.0, approved, #21322
-maven/mavencentral/io.netty/netty-codec-classes-quic/4.2.10.Final, Apache-2.0, approved, #21311
-maven/mavencentral/io.netty/netty-codec-compression/4.2.10.Final, Apache-2.0, approved, #16109
-maven/mavencentral/io.netty/netty-codec-dns/4.2.10.Final, Apache-2.0, approved, #16112
-maven/mavencentral/io.netty/netty-codec-http/4.2.10.Final, Apache-2.0 AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND BSD-3-Clause), approved, #16121
-maven/mavencentral/io.netty/netty-codec-http2/4.2.10.Final, Apache-2.0, approved, #16125
-maven/mavencentral/io.netty/netty-codec-http3/4.2.10.Final, Apache-2.0, approved, #25607
-maven/mavencentral/io.netty/netty-codec-native-quic/4.2.10.Final, Apache-2.0, approved, #21319
-maven/mavencentral/io.netty/netty-codec-socks/4.2.10.Final, Apache-2.0, approved, #16117
-maven/mavencentral/io.netty/netty-common/4.2.10.Final, Apache-2.0 AND (Apache-2.0 AND CC0-1.0) AND (Apache-2.0 AND MIT), approved, #16124
-maven/mavencentral/io.netty/netty-handler-proxy/4.2.10.Final, Apache-2.0, approved, #16111
-maven/mavencentral/io.netty/netty-handler/4.2.10.Final, Apache-2.0, approved, #16123
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.2.10.Final, Apache-2.0, approved, #21316
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.2.10.Final, Apache-2.0, approved, #21330
-maven/mavencentral/io.netty/netty-resolver-dns/4.2.10.Final, Apache-2.0, approved, #16110
-maven/mavencentral/io.netty/netty-resolver/4.2.10.Final, Apache-2.0, approved, #16126
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.2.10.Final, Apache-2.0, approved, #21317
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.2.10.Final, Apache-2.0, approved, #21327
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.2.10.Final, Apache-2.0, approved, #21329
-maven/mavencentral/io.netty/netty-transport/4.2.10.Final, Apache-2.0, approved, #16113
-maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.3.3, Apache-2.0, approved, #25603
-maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.3.3, Apache-2.0, approved, #25597
-maven/mavencentral/io.projectreactor/reactor-core/3.8.3, Apache-2.0, approved, #25635
+maven/mavencentral/io.netty/netty-buffer/4.2.12.Final, Apache-2.0, approved, #16116
+maven/mavencentral/io.netty/netty-codec-base/4.2.12.Final, Apache-2.0, approved, #21322
+maven/mavencentral/io.netty/netty-codec-classes-quic/4.2.12.Final, Apache-2.0, approved, #21311
+maven/mavencentral/io.netty/netty-codec-compression/4.2.12.Final, Apache-2.0, approved, #16109
+maven/mavencentral/io.netty/netty-codec-dns/4.2.12.Final, Apache-2.0, approved, #16112
+maven/mavencentral/io.netty/netty-codec-http/4.2.12.Final, Apache-2.0 AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND BSD-3-Clause), approved, #16121
+maven/mavencentral/io.netty/netty-codec-http2/4.2.12.Final, Apache-2.0, approved, #16125
+maven/mavencentral/io.netty/netty-codec-http3/4.2.12.Final, Apache-2.0, approved, #25607
+maven/mavencentral/io.netty/netty-codec-native-quic/4.2.12.Final, Apache-2.0, approved, #21319
+maven/mavencentral/io.netty/netty-codec-socks/4.2.12.Final, Apache-2.0, approved, #16117
+maven/mavencentral/io.netty/netty-common/4.2.12.Final, Apache-2.0 AND (Apache-2.0 AND CC0-1.0) AND (Apache-2.0 AND MIT), approved, #16124
+maven/mavencentral/io.netty/netty-handler-proxy/4.2.12.Final, Apache-2.0, approved, #16111
+maven/mavencentral/io.netty/netty-handler/4.2.12.Final, Apache-2.0, approved, #16123
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.2.12.Final, Apache-2.0, approved, #21316
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.2.12.Final, Apache-2.0, approved, #21330
+maven/mavencentral/io.netty/netty-resolver-dns/4.2.12.Final, Apache-2.0, approved, #16110
+maven/mavencentral/io.netty/netty-resolver/4.2.12.Final, Apache-2.0, approved, #16126
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.2.12.Final, Apache-2.0, approved, #21317
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.2.12.Final, Apache-2.0, approved, #21327
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.2.12.Final, Apache-2.0, approved, #21329
+maven/mavencentral/io.netty/netty-transport/4.2.12.Final, Apache-2.0, approved, #16113
+maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.3.5, Apache-2.0, approved, #25603
+maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.3.5, Apache-2.0, approved, #25597
+maven/mavencentral/io.projectreactor/reactor-core/3.8.5, Apache-2.0, approved, #25635
 maven/mavencentral/io.quarkus/quarkus-junit4-mock/3.2.0.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.41, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.41, Apache-2.0, approved, #5929
@@ -126,11 +126,11 @@ maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approv
 maven/mavencentral/org.apache.james/apache-mime4j-core/0.8.9, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.james/apache-mime4j-dom/0.8.9, Apache-2.0, approved, #2340
 maven/mavencentral/org.apache.james/apache-mime4j-storage/0.8.9, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.logging.log4j/log4j-api/2.25.3, Apache-2.0, approved, #21940
-maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.25.3, Apache-2.0, approved, #21937
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/11.0.18, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-or-later), approved, #19217
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/11.0.18, Apache-2.0, approved, #22421
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/11.0.18, Apache-2.0, approved, #21065
+maven/mavencentral/org.apache.logging.log4j/log4j-api/2.25.4, Apache-2.0, approved, #21940
+maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.25.4, Apache-2.0, approved, #21937
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/11.0.21, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-or-later), approved, #19217
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/11.0.21, Apache-2.0, approved, #22421
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/11.0.21, Apache-2.0, approved, #21065
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641
 maven/mavencentral/org.aspectj/aspectjweaver/1.9.25.1, EPL-1.0, approved, tools.aspectj
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
@@ -139,15 +139,15 @@ maven/mavencentral/org.checkerframework/checker-qual/3.52.0, MIT, approved, #260
 maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.angus/angus-activation/2.0.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.angus/angus-mail/2.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
-maven/mavencentral/org.eclipse.tractusx/bpdm-cleaning-service-dummy/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-common-test/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-common/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-gate/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx/bpdm-pool/7.3.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-cleaning-service-dummy/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-common-test/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-common/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-gate-api/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-gate/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator-api/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-orchestrator/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-pool-api/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/bpdm-pool/7.4.0-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/11.14.1, Apache-2.0, approved, #25604
 maven/mavencentral/org.flywaydb/flyway-database-postgresql/11.14.1, Apache-2.0, approved, #25627
 maven/mavencentral/org.glassfish.jaxb/codemodel/4.0.6, BSD-3-Clause, approved, ee4j.jaxb-impl
@@ -161,9 +161,9 @@ maven/mavencentral/org.hamcrest/hamcrest-core/3.0, BSD-3-Clause, approved, clear
 maven/mavencentral/org.hamcrest/hamcrest/3.0, BSD-3-Clause, approved, #17661
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
 maven/mavencentral/org.hibernate.models/hibernate-models/1.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.hibernate.orm/hibernate-core/7.2.4.Final, Apache-2.0 AND (EPL-2.0 OR BSD-3-Clause), approved, #25611
+maven/mavencentral/org.hibernate.orm/hibernate-core/7.2.12.Final, Apache-2.0 AND (EPL-2.0 OR BSD-3-Clause), approved, #25611
 maven/mavencentral/org.hibernate.validator/hibernate-validator/9.0.1.Final, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.jboss.logging/jboss-logging/3.6.2.Final, Apache-2.0, approved, #26108
+maven/mavencentral/org.jboss.logging/jboss-logging/3.6.3.Final, Apache-2.0, approved, #26108
 maven/mavencentral/org.jboss.resteasy/resteasy-client-api/6.2.4.Final, Apache-2.0, approved, #10223
 maven/mavencentral/org.jboss.resteasy/resteasy-client/6.2.4.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss.resteasy/resteasy-core-spi/6.2.4.Final, Apache-2.0, approved, clearlydefined
@@ -206,85 +206,85 @@ maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.17, MIT, approved, #7698
 maven/mavencentral/org.slf4j/slf4j-api/2.0.17, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/3.0.1, Apache-2.0, approved, #25648
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/3.0.1, Apache-2.0, approved, #25723
-maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/3.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/4.0.3, Apache-2.0, approved, #26090
-maven/mavencentral/org.springframework.boot/spring-boot-actuator/4.0.3, Apache-2.0, approved, #26087
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/4.0.3, Apache-2.0, approved, #24987
-maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/4.0.3, Apache-2.0, approved, #26123
-maven/mavencentral/org.springframework.boot/spring-boot-data-commons/4.0.3, Apache-2.0, approved, #25784
-maven/mavencentral/org.springframework.boot/spring-boot-data-jpa/4.0.3, Apache-2.0, approved, #25785
-maven/mavencentral/org.springframework.boot/spring-boot-flyway/4.0.3, Apache-2.0, approved, #25631
-maven/mavencentral/org.springframework.boot/spring-boot-health/4.0.3, Apache-2.0, approved, #26072
-maven/mavencentral/org.springframework.boot/spring-boot-hibernate/4.0.3, Apache-2.0, approved, #25787
-maven/mavencentral/org.springframework.boot/spring-boot-http-codec/4.0.3, Apache-2.0, approved, #26127
-maven/mavencentral/org.springframework.boot/spring-boot-http-converter/4.0.3, Apache-2.0, approved, #26122
-maven/mavencentral/org.springframework.boot/spring-boot-jackson/4.0.3, Apache-2.0, approved, #26138
-maven/mavencentral/org.springframework.boot/spring-boot-jdbc/4.0.3, Apache-2.0, approved, #25788
-maven/mavencentral/org.springframework.boot/spring-boot-jpa/4.0.3, Apache-2.0, approved, #25783
-maven/mavencentral/org.springframework.boot/spring-boot-micrometer-metrics/4.0.3, Apache-2.0, approved, #26096
-maven/mavencentral/org.springframework.boot/spring-boot-micrometer-observation/4.0.3, Apache-2.0, approved, #26082
-maven/mavencentral/org.springframework.boot/spring-boot-netty/4.0.3, Apache-2.0, approved, #26139
-maven/mavencentral/org.springframework.boot/spring-boot-persistence/4.0.3, Apache-2.0, approved, #25782
-maven/mavencentral/org.springframework.boot/spring-boot-reactor-netty/4.0.3, Apache-2.0, approved, #26121
-maven/mavencentral/org.springframework.boot/spring-boot-reactor/4.0.3, Apache-2.0, approved, #25618
-maven/mavencentral/org.springframework.boot/spring-boot-security-oauth2-client/4.0.3, Apache-2.0, approved, #26194
-maven/mavencentral/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.0.3, Apache-2.0, approved, #26190
-maven/mavencentral/org.springframework.boot/spring-boot-security/4.0.3, Apache-2.0, approved, #26195
-maven/mavencentral/org.springframework.boot/spring-boot-servlet/4.0.3, Apache-2.0, approved, #26101
-maven/mavencentral/org.springframework.boot/spring-boot-sql/4.0.3, Apache-2.0, approved, #25605
-maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/4.0.3, Apache-2.0, approved, #25622
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/4.0.3, Apache-2.0, approved, #25626
-maven/mavencentral/org.springframework.boot/spring-boot-starter-flyway/4.0.3, Apache-2.0, approved, #26186
-maven/mavencentral/org.springframework.boot/spring-boot-starter-jackson/4.0.3, Apache-2.0, approved, #26126
-maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/4.0.3, Apache-2.0, approved, #25616
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/4.0.3, Apache-2.0, approved, #25602
-maven/mavencentral/org.springframework.boot/spring-boot-starter-micrometer-metrics/4.0.3, Apache-2.0, approved, #26120
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/4.0.3, Apache-2.0, approved, #26191
-maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/4.0.3, Apache-2.0, approved, #26130
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security-oauth2-client/4.0.3, Apache-2.0, approved, #26192
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security-oauth2-resource-server/4.0.3, Apache-2.0, approved, #26193
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security/4.0.3, Apache-2.0, approved, #25630
-maven/mavencentral/org.springframework.boot/spring-boot-starter-test/4.0.3, Apache-2.0, approved, #25598
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat-runtime/4.0.3, Apache-2.0, approved, #25612
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/4.0.3, Apache-2.0, approved, #26097
-maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/4.0.3, Apache-2.0, approved, #25629
-maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/4.0.3, Apache-2.0, approved, #26129
-maven/mavencentral/org.springframework.boot/spring-boot-starter-webmvc/4.0.3, Apache-2.0, approved, #26187
-maven/mavencentral/org.springframework.boot/spring-boot-starter/4.0.3, Apache-2.0, approved, #25636
-maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/4.0.3, Apache-2.0, approved, #24996
-maven/mavencentral/org.springframework.boot/spring-boot-test/4.0.3, Apache-2.0, approved, #24997
-maven/mavencentral/org.springframework.boot/spring-boot-tomcat/4.0.3, Apache-2.0, approved, #26083
-maven/mavencentral/org.springframework.boot/spring-boot-transaction/4.0.3, Apache-2.0, approved, #25786
-maven/mavencentral/org.springframework.boot/spring-boot-validation/4.0.3, Apache-2.0, approved, #26084
-maven/mavencentral/org.springframework.boot/spring-boot-web-server/4.0.3, Apache-2.0, approved, #24984
-maven/mavencentral/org.springframework.boot/spring-boot-webflux/4.0.3, Apache-2.0, approved, #26135
-maven/mavencentral/org.springframework.boot/spring-boot-webmvc/4.0.3, Apache-2.0, approved, #26105
-maven/mavencentral/org.springframework.boot/spring-boot-webtestclient/4.0.3, Apache-2.0, approved, #26104
-maven/mavencentral/org.springframework.boot/spring-boot/4.0.3, Apache-2.0, approved, #24993
-maven/mavencentral/org.springframework.data/spring-data-commons/4.0.3, Apache-2.0, approved, #25623
-maven/mavencentral/org.springframework.data/spring-data-jpa/4.0.3, Apache-2.0, approved, #25600
-maven/mavencentral/org.springframework.security/spring-security-config/7.0.3, Apache-2.0, approved, #26189
-maven/mavencentral/org.springframework.security/spring-security-core/7.0.3, Apache-2.0, approved, #25609
-maven/mavencentral/org.springframework.security/spring-security-crypto/7.0.3, Apache-2.0 AND ISC, approved, #25599
-maven/mavencentral/org.springframework.security/spring-security-oauth2-client/7.0.3, Apache-2.0, approved, #25621
-maven/mavencentral/org.springframework.security/spring-security-oauth2-core/7.0.3, Apache-2.0, approved, #25634
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/7.0.3, Apache-2.0, approved, #25601
-maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/7.0.3, Apache-2.0, approved, #25624
-maven/mavencentral/org.springframework.security/spring-security-test/7.0.3, Apache-2.0, approved, #25614
-maven/mavencentral/org.springframework.security/spring-security-web/7.0.3, Apache-2.0, approved, #25617
-maven/mavencentral/org.springframework/spring-aop/7.0.5, Apache-2.0, approved, #24985
-maven/mavencentral/org.springframework/spring-aspects/7.0.5, Apache-2.0, approved, #25619
-maven/mavencentral/org.springframework/spring-beans/7.0.5, Apache-2.0, approved, #24991
-maven/mavencentral/org.springframework/spring-context/7.0.5, Apache-2.0, approved, #24986
-maven/mavencentral/org.springframework/spring-core/7.0.5, Apache-2.0 AND BSD-3-Clause, approved, #24992
-maven/mavencentral/org.springframework/spring-expression/7.0.5, Apache-2.0, approved, #24988
-maven/mavencentral/org.springframework/spring-jdbc/7.0.5, Apache-2.0, approved, #25610
-maven/mavencentral/org.springframework/spring-orm/7.0.5, Apache-2.0, approved, #25628
-maven/mavencentral/org.springframework/spring-test/7.0.5, Apache-2.0, approved, #24998
-maven/mavencentral/org.springframework/spring-tx/7.0.5, Apache-2.0, approved, #25615
-maven/mavencentral/org.springframework/spring-web/7.0.5, Apache-2.0, approved, #24989
-maven/mavencentral/org.springframework/spring-webflux/7.0.5, Apache-2.0, approved, #25625
-maven/mavencentral/org.springframework/spring-webmvc/7.0.5, Apache-2.0, approved, #25606
+maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/3.0.1, Apache-2.0, approved, #27667
+maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/4.0.6, Apache-2.0, approved, #26090
+maven/mavencentral/org.springframework.boot/spring-boot-actuator/4.0.6, Apache-2.0, approved, #26087
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/4.0.6, Apache-2.0, approved, #24987
+maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/4.0.6, Apache-2.0, approved, #26123
+maven/mavencentral/org.springframework.boot/spring-boot-data-commons/4.0.6, Apache-2.0, approved, #25784
+maven/mavencentral/org.springframework.boot/spring-boot-data-jpa/4.0.6, Apache-2.0, approved, #25785
+maven/mavencentral/org.springframework.boot/spring-boot-flyway/4.0.6, Apache-2.0, approved, #25631
+maven/mavencentral/org.springframework.boot/spring-boot-health/4.0.6, Apache-2.0, approved, #26072
+maven/mavencentral/org.springframework.boot/spring-boot-hibernate/4.0.6, Apache-2.0, approved, #25787
+maven/mavencentral/org.springframework.boot/spring-boot-http-codec/4.0.6, Apache-2.0, approved, #26127
+maven/mavencentral/org.springframework.boot/spring-boot-http-converter/4.0.6, Apache-2.0, approved, #26122
+maven/mavencentral/org.springframework.boot/spring-boot-jackson/4.0.6, Apache-2.0, approved, #26138
+maven/mavencentral/org.springframework.boot/spring-boot-jdbc/4.0.6, Apache-2.0, approved, #25788
+maven/mavencentral/org.springframework.boot/spring-boot-jpa/4.0.6, Apache-2.0, approved, #25783
+maven/mavencentral/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6, Apache-2.0, approved, #26096
+maven/mavencentral/org.springframework.boot/spring-boot-micrometer-observation/4.0.6, Apache-2.0, approved, #26082
+maven/mavencentral/org.springframework.boot/spring-boot-netty/4.0.6, Apache-2.0, approved, #26139
+maven/mavencentral/org.springframework.boot/spring-boot-persistence/4.0.6, Apache-2.0, approved, #25782
+maven/mavencentral/org.springframework.boot/spring-boot-reactor-netty/4.0.6, Apache-2.0, approved, #26121
+maven/mavencentral/org.springframework.boot/spring-boot-reactor/4.0.6, Apache-2.0, approved, #25618
+maven/mavencentral/org.springframework.boot/spring-boot-security-oauth2-client/4.0.6, Apache-2.0, approved, #26194
+maven/mavencentral/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.0.6, Apache-2.0, approved, #26190
+maven/mavencentral/org.springframework.boot/spring-boot-security/4.0.6, Apache-2.0, approved, #26195
+maven/mavencentral/org.springframework.boot/spring-boot-servlet/4.0.6, Apache-2.0, approved, #26101
+maven/mavencentral/org.springframework.boot/spring-boot-sql/4.0.6, Apache-2.0, approved, #25605
+maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/4.0.6, Apache-2.0, approved, #25622
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/4.0.6, Apache-2.0, approved, #25626
+maven/mavencentral/org.springframework.boot/spring-boot-starter-flyway/4.0.6, Apache-2.0, approved, #26186
+maven/mavencentral/org.springframework.boot/spring-boot-starter-jackson/4.0.6, Apache-2.0, approved, #26126
+maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/4.0.6, Apache-2.0, approved, #25616
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/4.0.6, Apache-2.0, approved, #25602
+maven/mavencentral/org.springframework.boot/spring-boot-starter-micrometer-metrics/4.0.6, Apache-2.0, approved, #26120
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/4.0.6, Apache-2.0, approved, #26191
+maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/4.0.6, Apache-2.0, approved, #26130
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security-oauth2-client/4.0.6, Apache-2.0, approved, #26192
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security-oauth2-resource-server/4.0.6, Apache-2.0, approved, #26193
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security/4.0.6, Apache-2.0, approved, #25630
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/4.0.6, Apache-2.0, approved, #25598
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat-runtime/4.0.6, Apache-2.0, approved, #25612
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/4.0.6, Apache-2.0, approved, #26097
+maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/4.0.6, Apache-2.0, approved, #25629
+maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/4.0.6, Apache-2.0, approved, #26129
+maven/mavencentral/org.springframework.boot/spring-boot-starter-webmvc/4.0.6, Apache-2.0, approved, #26187
+maven/mavencentral/org.springframework.boot/spring-boot-starter/4.0.6, Apache-2.0, approved, #25636
+maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/4.0.6, Apache-2.0, approved, #24996
+maven/mavencentral/org.springframework.boot/spring-boot-test/4.0.6, Apache-2.0, approved, #24997
+maven/mavencentral/org.springframework.boot/spring-boot-tomcat/4.0.6, Apache-2.0, approved, #26083
+maven/mavencentral/org.springframework.boot/spring-boot-transaction/4.0.6, Apache-2.0, approved, #25786
+maven/mavencentral/org.springframework.boot/spring-boot-validation/4.0.6, Apache-2.0, approved, #26084
+maven/mavencentral/org.springframework.boot/spring-boot-web-server/4.0.6, Apache-2.0, approved, #24984
+maven/mavencentral/org.springframework.boot/spring-boot-webflux/4.0.6, Apache-2.0, approved, #26135
+maven/mavencentral/org.springframework.boot/spring-boot-webmvc/4.0.6, Apache-2.0, approved, #26105
+maven/mavencentral/org.springframework.boot/spring-boot-webtestclient/4.0.6, Apache-2.0, approved, #26104
+maven/mavencentral/org.springframework.boot/spring-boot/4.0.6, Apache-2.0, approved, #24993
+maven/mavencentral/org.springframework.data/spring-data-commons/4.0.5, Apache-2.0, approved, #25623
+maven/mavencentral/org.springframework.data/spring-data-jpa/4.0.5, Apache-2.0, approved, #25600
+maven/mavencentral/org.springframework.security/spring-security-config/7.0.5, Apache-2.0, approved, #26189
+maven/mavencentral/org.springframework.security/spring-security-core/7.0.5, Apache-2.0, approved, #25609
+maven/mavencentral/org.springframework.security/spring-security-crypto/7.0.5, Apache-2.0 AND ISC, approved, #25599
+maven/mavencentral/org.springframework.security/spring-security-oauth2-client/7.0.5, Apache-2.0, approved, #25621
+maven/mavencentral/org.springframework.security/spring-security-oauth2-core/7.0.5, Apache-2.0, approved, #25634
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/7.0.5, Apache-2.0, approved, #25601
+maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/7.0.5, Apache-2.0, approved, #25624
+maven/mavencentral/org.springframework.security/spring-security-test/7.0.5, Apache-2.0, approved, #25614
+maven/mavencentral/org.springframework.security/spring-security-web/7.0.5, Apache-2.0, approved, #25617
+maven/mavencentral/org.springframework/spring-aop/7.0.7, Apache-2.0, approved, #24985
+maven/mavencentral/org.springframework/spring-aspects/7.0.7, Apache-2.0, approved, #25619
+maven/mavencentral/org.springframework/spring-beans/7.0.7, Apache-2.0, approved, #24991
+maven/mavencentral/org.springframework/spring-context/7.0.7, Apache-2.0, approved, #24986
+maven/mavencentral/org.springframework/spring-core/7.0.7, Apache-2.0 AND BSD-3-Clause, approved, #24992
+maven/mavencentral/org.springframework/spring-expression/7.0.7, Apache-2.0, approved, #24988
+maven/mavencentral/org.springframework/spring-jdbc/7.0.7, Apache-2.0, approved, #25610
+maven/mavencentral/org.springframework/spring-orm/7.0.7, Apache-2.0, approved, #25628
+maven/mavencentral/org.springframework/spring-test/7.0.7, Apache-2.0, approved, #24998
+maven/mavencentral/org.springframework/spring-tx/7.0.7, Apache-2.0, approved, #25615
+maven/mavencentral/org.springframework/spring-web/7.0.7, Apache-2.0, approved, #24989
+maven/mavencentral/org.springframework/spring-webflux/7.0.7, Apache-2.0, approved, #25625
+maven/mavencentral/org.springframework/spring-webmvc/7.0.7, Apache-2.0, approved, #25606
 maven/mavencentral/org.testcontainers/testcontainers-database-commons/2.0.3, Apache-2.0, approved, #25271
 maven/mavencentral/org.testcontainers/testcontainers-jdbc/2.0.3, Apache-2.0, approved, #25272
 maven/mavencentral/org.testcontainers/testcontainers-junit-jupiter/2.0.3, MIT, approved, #26032

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.6</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request increases the spring boot start framework to 4.0.6. Since this is a patch version increase, no migration issues expected. We will be closing vulnerabilties with this version increase.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Contributes to #1647 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
