### PR TITLE
build(dependencies): increase jackson version to 3.1.1

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,13 +1,13 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.5.32, EPL-1.0 AND LGPL-2.1-only, approved, #18704
 maven/mavencentral/ch.qos.logback/logback-core/1.5.32, EPL-1.0 AND LGPL-2.1-only, approved, #15210
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.21, Apache-2.0, approved, #25587
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.21.1, Apache-2.0 AND MIT, approved, #25590
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.21.1, Apache-2.0, approved, #25591
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.21.1, Apache-2.0, approved, #25589
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.21.1, Apache-2.0, approved, #26441
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.21.1, Apache-2.0, approved, #26442
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.21.1, Apache-2.0, approved, #26443
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.21.1, Apache-2.0, approved, #25588
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.21.3, Apache-2.0 AND MIT, approved, #25590
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.21.3, Apache-2.0, approved, #25591
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.21.3, Apache-2.0, approved, #25589
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.21.3, Apache-2.0, approved, #26441
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.21.3, Apache-2.0, approved, #26442
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.21.3, Apache-2.0, approved, #26443
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.21.3, Apache-2.0, approved, #25588
 maven/mavencentral/com.fasterxml/classmate/1.7.3, Apache-2.0, approved, #24482
 maven/mavencentral/com.github.dasniko/testcontainers-keycloak/3.2.0, Apache-2.0, approved, #14719
 maven/mavencentral/com.github.docker-java/docker-java-api/3.7.0, Apache-2.0, approved, #26612
@@ -294,6 +294,6 @@ maven/mavencentral/org.webjars/swagger-ui/5.31.0, Apache-2.0 AND (Apache-2.0 AND
 maven/mavencentral/org.webjars/webjars-locator-lite/1.1.3, MIT, approved, #24484
 maven/mavencentral/org.xmlunit/xmlunit-core/2.10.4, Apache-2.0, approved, #14590
 maven/mavencentral/org.yaml/snakeyaml/2.5, Apache-2.0, approved, #23100
-maven/mavencentral/tools.jackson.core/jackson-core/3.1.0, Apache-2.0 AND MIT, approved, #26415
-maven/mavencentral/tools.jackson.core/jackson-databind/3.1.0, Apache-2.0, approved, #26439
-maven/mavencentral/tools.jackson.module/jackson-module-kotlin/3.1.0, Apache-2.0, approved, #26440
+maven/mavencentral/tools.jackson.core/jackson-core/3.1.1, Apache-2.0 AND MIT, approved, #26415
+maven/mavencentral/tools.jackson.core/jackson-databind/3.1.1, Apache-2.0, approved, #26439
+maven/mavencentral/tools.jackson.module/jackson-module-kotlin/3.1.1, Apache-2.0, approved, #26440

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
             jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <jacoco.version>0.8.14</jacoco.version>
-        <jackson-bom.version>3.1.0</jackson-bom.version>
-        <jackson-2-bom.version>2.21.1</jackson-2-bom.version>
+        <jackson-bom.version>3.1.1</jackson-bom.version>
+        <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
     </properties>
 
     <pluginRepositories>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request increases the jackson dependency version to 3.1.1 in the project. Also the outdated jackson dependency is updated as high as possible. This should mitigate vulnerabilty issues.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Contributes to #1647

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
