### PR TITLE
fix(gate): V7 relation output changelogs always showing UPDATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - Script variants and script codes for business partner data [#1593](https://github.com/eclipse-tractusx/bpdm/issues/1593)
 - BPDM Gate: Golden record relations to business partner output [#1630](https://github.com/eclipse-tractusx/bpdm/issues/1630)
 
+### Changed
+
+- BPDM Gate: Fix V7 relation output changelog always showing "UPDATE" type even if the relation output has been created [#1665](https://github.com/eclipse-tractusx/bpdm/issues/1665)
+
 ## [7.3.0] - 2026-03-6
 
 ### BREAKING

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationDb.kt
@@ -38,7 +38,8 @@ class RelationDb(
     var tenantBpnL: String,
     @Embedded
     var sharingState: RelationSharingStateDb?,
-    @Embedded
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, optional = true)
+    @JoinColumn(name = "output_id", foreignKey = ForeignKey(name = "fk_relation_output"))
     var output: RelationOutputDb?
 ) : BaseEntity(){
     companion object{

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationOutputDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationOutputDb.kt
@@ -20,33 +20,29 @@
 package org.eclipse.tractusx.bpdm.gate.entity
 
 import jakarta.persistence.*
+import org.eclipse.tractusx.bpdm.common.model.BaseEntity
 import org.eclipse.tractusx.bpdm.gate.api.model.SharableRelationType
 import java.time.Instant
 
-@Embeddable
-data class RelationOutputDb (
+@Entity
+@Table(name = "relation_outputs")
+class RelationOutputDb(
     @Enumerated(EnumType.STRING)
-    @Column(name = "output_relation_type")
+    @Column(name = "relation_type", nullable = false)
     var relationType: SharableRelationType,
-    @Column(name = "output_source_bpn")
+    @Column(name = "source_bpn", nullable = false)
     var sourceBpn: String,
-    @Column(name = "output_target_bpn")
+    @Column(name = "target_bpn", nullable = false)
     var targetBpn: String,
-    @Column(name = "output_updated_at")
-    var updatedAt: Instant,
+    @Column(name = "result_updated_at", nullable = false)
+    var resultUpdatedAt: Instant,
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
         name = "relation_output_validity_periods",
-        joinColumns = [JoinColumn(name = "relation_id", foreignKey = ForeignKey(name = "fk_output_validity_periods_relation"))],
-        indexes = [Index(name = "idx_output_validity_periods_relation_id", columnList = "relation_id")]
+        joinColumns = [JoinColumn(name = "output_id", foreignKey = ForeignKey(name = "fk_output_validity_periods_relation"))],
+        indexes = [Index(name = "idx_output_validity_periods_relation_id", columnList = "output_id")]
     )
     var validityPeriods: MutableList<RelationValidityPeriodDb>,
-    @Column(name = "output_reason_code")
+    @Column(name = "reason_code", nullable = false)
     var reasonCode: String
-): Comparable<RelationOutputDb>{
-    override fun compareTo(other: RelationOutputDb) = compareBy(
-        RelationOutputDb::sourceBpn,
-        RelationOutputDb::targetBpn,
-        RelationOutputDb::relationType
-    ).compare(this, other)
-}
+) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/RelationRepository.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/repository/RelationRepository.kt
@@ -117,7 +117,7 @@ interface RelationRepository: JpaRepository<RelationDb, Long>, JpaSpecificationE
                 Specification<RelationDb> { root, _, builder ->
                     val updatedAtPath = root
                         .get<RelationOutputDb>(RelationDb::output.name)
-                        .get<Instant>(RelationOutputDb::updatedAt.name)
+                        .get<Instant>(RelationOutputDb::resultUpdatedAt.name)
 
                     builder.greaterThan(updatedAtPath, updatedAfter)
                 }
@@ -127,7 +127,7 @@ interface RelationRepository: JpaRepository<RelationDb, Long>, JpaSpecificationE
             Specification<RelationDb> { root, _, builder ->
                root
                     .get<RelationOutputDb>(RelationDb::output.name)
-                    .get<Instant>(RelationOutputDb::updatedAt.name)
+                    .get<Instant>(RelationOutputDb::resultUpdatedAt.name)
                     .isNotNull
             }
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationService.kt
@@ -210,7 +210,7 @@ class RelationService(
             relationType = relationType,
             sourceBpn = sourceBpnL,
             targetBpn = targetBpnL,
-            updatedAt = Instant.now(),
+            resultUpdatedAt = Instant.now(),
             validityPeriods = validityPeriods.map { RelationValidityPeriodDb(validFrom = it.validFrom, validTo = it.validTo) }.toMutableList(),
             reasonCode =  reasonCode
         )
@@ -358,7 +358,7 @@ class RelationService(
             sourceBpn = entity.output!!.sourceBpn,
             targetBpn = entity.output!!.targetBpn,
             validityPeriods = entity.output!!.validityPeriods.map { it.toDto() },
-            updatedAt = entity.output!!.updatedAt,
+            updatedAt = entity.output!!.resultUpdatedAt,
             reasonCode = entity.output!!.reasonCode
         )
     }

--- a/bpdm-gate/src/main/resources/db/migration/V7_4_0_4__extract_relation_output_to_entity.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V7_4_0_4__extract_relation_output_to_entity.sql
@@ -1,0 +1,73 @@
+CREATE TABLE relation_outputs
+(
+    id                BIGINT                      NOT NULL,
+    uuid              UUID                        NOT NULL,
+    created_at        TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    updated_at        TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    relation_type     VARCHAR(255)                NOT NULL,
+    source_bpn        VARCHAR(255)                NOT NULL,
+    target_bpn        VARCHAR(255)                NOT NULL,
+    result_updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    reason_code       VARCHAR(255)                NOT NULL,
+    CONSTRAINT pk_relation_outputs PRIMARY KEY (id),
+    CONSTRAINT uc_relation_outputs_uuid UNIQUE (uuid)
+);
+
+ALTER TABLE business_partner_relations
+    ADD COLUMN output_id BIGINT;
+
+ALTER TABLE relation_output_validity_periods
+    ADD COLUMN output_id BIGINT;
+
+DO
+$$
+    DECLARE
+        r             RECORD;
+        new_output_id BIGINT;
+    BEGIN
+        FOR r IN SELECT id,
+                        output_relation_type,
+                        output_source_bpn,
+                        output_target_bpn,
+                        output_updated_at,
+                        output_reason_code
+                 FROM business_partner_relations
+                 WHERE output_relation_type IS NOT NULL
+            LOOP
+                new_output_id := nextval('bpdm_sequence');
+                INSERT INTO relation_outputs (id, uuid, created_at, updated_at, relation_type, source_bpn, target_bpn,
+                                             result_updated_at, reason_code)
+                VALUES (new_output_id, gen_random_uuid(), NOW(), NOW(), r.output_relation_type, r.output_source_bpn,
+                        r.output_target_bpn, r.output_updated_at, r.output_reason_code);
+
+                UPDATE business_partner_relations SET output_id = new_output_id WHERE id = r.id;
+                UPDATE relation_output_validity_periods SET output_id = new_output_id WHERE relation_id = r.id;
+            END LOOP;
+    END
+$$;
+
+ALTER TABLE relation_output_validity_periods
+    DROP CONSTRAINT fk_output_validity_periods_relation;
+
+DROP INDEX idx_output_validity_periods_relation_id;
+
+ALTER TABLE relation_output_validity_periods
+    DROP COLUMN relation_id;
+
+ALTER TABLE relation_output_validity_periods
+    ALTER COLUMN output_id SET NOT NULL;
+
+ALTER TABLE relation_output_validity_periods
+    ADD CONSTRAINT fk_output_validity_periods_relation FOREIGN KEY (output_id) REFERENCES relation_outputs (id);
+
+CREATE INDEX idx_output_validity_periods_relation_id ON relation_output_validity_periods (output_id);
+
+ALTER TABLE business_partner_relations
+    ADD CONSTRAINT fk_relation_output FOREIGN KEY (output_id) REFERENCES relation_outputs (id);
+
+ALTER TABLE business_partner_relations
+    DROP COLUMN output_relation_type,
+    DROP COLUMN output_source_bpn,
+    DROP COLUMN output_target_bpn,
+    DROP COLUMN output_updated_at,
+    DROP COLUMN output_reason_code;

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/RelationOutputControllerIT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/controller/RelationOutputControllerIT.kt
@@ -309,7 +309,7 @@ class RelationOutputControllerIT @Autowired constructor(
             relationType = relationType,
             sourceBpn = source,
             targetBpn = target,
-            updatedAt = updatedAt,
+            resultUpdatedAt = updatedAt,
             validityPeriods = GateTestValues.alwaysActiveRelationValidity.map {
                     RelationValidityPeriodDb(
                         validFrom = it.validFrom,

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
     </modules>
 
     <properties>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <revision>7.4.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,6 @@
     </modules>
 
     <properties>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <revision>7.4.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
@@ -312,6 +310,18 @@
                                     <source>src/main/kotlin</source>
                                     <source>target/generated-sources/kapt/compile</source>
                                     <source>target/generated-sources/kaptKotlin</source>
+                                </sourceDirs>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>test-compile</id>
+                            <phase>test-compile</phase>
+                            <goals>
+                                <goal>test-compile</goal>
+                            </goals>
+                            <configuration>
+                                <sourceDirs>
+                                    <sourceDir>src/test/kotlin</sourceDir>
                                 </sourceDirs>
                             </configuration>
                         </execution>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Fixes a bug where all V7 relation output changelogs show "UPDATE" even though the relation has been created.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1665


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
