### PR TITLE
refactor: gate and pool share common orchestrator mock configuration

### DIFF
--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/containers/OrchestratorMockConfiguration.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/containers/OrchestratorMockConfiguration.kt
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.test.containers
+
+import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.*
+import org.eclipse.tractusx.bpdm.test.testdata.pool.TestMetadataV7
+import org.eclipse.tractusx.orchestrator.api.model.TaskMode
+import org.eclipse.tractusx.orchestrator.api.model.TaskStep
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import tools.jackson.databind.json.JsonMapper
+import java.time.Duration
+
+/**
+ * Shared orchestrator mock bean configuration for modules that mock the Orchestrator (Gate, Pool).
+ * Not auto-configured — consumers must explicitly @Import this class.
+ * Requires a TestMetadataV7 bean to be provided by the importing module.
+ */
+@Configuration
+class OrchestratorMockConfiguration {
+
+    @Bean
+    fun refinementTestDataFactory(): RefinementTestDataFactory = RefinementTestDataFactory()
+
+    @Bean
+    fun orchestratorExpectedResultFactoryV7(): OrchestratorExpectedResultFactoryV7 =
+        OrchestratorExpectedResultFactoryV7(
+            Duration.ofDays(1),
+            Duration.ofDays(1),
+            mapOf(
+                TaskMode.UpdateFromPool to listOf(TaskStep.CleanAndSync, TaskStep.PoolSync),
+                TaskMode.UpdateFromSharingMember to listOf(TaskStep.Clean)
+            )
+        )
+
+    @Bean
+    fun orchestratorRequestFactoryCommon(testMetadataV7: TestMetadataV7): OrchestratorRequestFactoryCommon {
+        val metadata = TestMetadataReferences(
+            legalForms = testMetadataV7.legalForms.map { it.technicalKey },
+            legalEntityIdentifierTypes = testMetadataV7.legalEntityIdentifierTypes.map { it.technicalKey },
+            addressIdentifierTypes = testMetadataV7.addressIdentifierTypes.map { it.technicalKey },
+            adminAreas = testMetadataV7.adminAreas.map { it.code },
+            scriptCodes = testMetadataV7.scriptCodes.map { it.technicalKey },
+            reasonCodes = testMetadataV7.reasonCodes.map { it.technicalKey }
+        )
+        return OrchestratorRequestFactoryCommon(metadata)
+    }
+
+    @Bean
+    fun businessPartnerTestDataFactory(orchestratorRequestFactoryCommon: OrchestratorRequestFactoryCommon): BusinessPartnerTestDataFactory =
+        BusinessPartnerTestDataFactory(orchestratorRequestFactoryCommon)
+
+    @Bean
+    fun orchestratorRequestFactoryV7(
+        businessPartnerTestDataFactory: BusinessPartnerTestDataFactory,
+        orchestratorRequestFactoryCommon: OrchestratorRequestFactoryCommon
+    ): OrchestratorRequestFactoryV7 =
+        OrchestratorRequestFactoryV7(businessPartnerTestDataFactory, orchestratorRequestFactoryCommon)
+
+    @Bean
+    fun orchestratorMockDataFactory(
+        refinementTestDataFactory: RefinementTestDataFactory,
+        orchestratorRequestFactoryV7: OrchestratorRequestFactoryV7,
+        orchestratorExpectedResultFactoryV7: OrchestratorExpectedResultFactoryV7,
+        jsonMapper: JsonMapper
+    ): OrchestratorMockDataFactory =
+        OrchestratorMockDataFactory(refinementTestDataFactory, orchestratorRequestFactoryV7, orchestratorExpectedResultFactoryV7, jsonMapper)
+}

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/UnscheduledTestEnvironment.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/UnscheduledTestEnvironment.kt
@@ -20,10 +20,12 @@
 package org.eclipse.tractusx.bpdm.gate
 
 import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockContextInitializer
 import org.eclipse.tractusx.bpdm.test.containers.PoolMockContextInitializer
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
@@ -34,5 +36,6 @@ import org.springframework.test.context.ContextConfiguration
     OrchestratorMockContextInitializer::class,
     PoolMockContextInitializer::class
 ])
+@Import(OrchestratorMockConfiguration::class)
 @ActiveProfiles("test-unscheduled")
 annotation class UnscheduledTestEnvironment

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessMockConfig.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/config/GoldenRecordProcessMockConfig.kt
@@ -22,59 +22,14 @@ package org.eclipse.tractusx.bpdm.gate.config
 import com.neovisionaries.i18n.CountryCode
 import org.eclipse.tractusx.bpdm.pool.api.model.*
 import org.eclipse.tractusx.bpdm.test.testdata.GoldenRecordMockFactory
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.*
+import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.OrchestratorMockDataFactory
 import org.eclipse.tractusx.bpdm.test.testdata.pool.*
-import org.eclipse.tractusx.orchestrator.api.model.TaskMode
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import tools.jackson.databind.json.JsonMapper
-import java.time.Duration
 
 @Configuration
 class GoldenRecordProcessMockConfig {
-
-    @Bean
-    fun refinementTestDataFactory(): RefinementTestDataFactory {
-        return RefinementTestDataFactory()
-    }
-
-    @Bean
-    fun orchestratorMockDataFactory(
-        refinementTestDataFactory: RefinementTestDataFactory,
-        requestFactory: OrchestratorRequestFactoryV7,
-        resultFactory: OrchestratorExpectedResultFactoryV7,
-        jsonMapper: JsonMapper
-    ): OrchestratorMockDataFactory {
-        return OrchestratorMockDataFactory(refinementTestDataFactory,requestFactory, resultFactory, jsonMapper)
-    }
-
-    @Bean
-    fun orchestratorRequestFactoryV7(testMetadataV7: TestMetadataV7): OrchestratorRequestFactoryV7{
-        val testMetadataReferences = TestMetadataReferences(
-            testMetadataV7.legalForms.map { it.technicalKey },
-            testMetadataV7.legalEntityIdentifierTypes.map { it.technicalKey },
-            testMetadataV7.addressIdentifierTypes.map { it.technicalKey },
-            testMetadataV7.adminAreas.map { it.code },
-            testMetadataV7.reasonCodes.map { it.technicalKey },
-            testMetadataV7.scriptCodes.map { it.technicalKey }
-        )
-
-        val orchestratorCommonFactory = OrchestratorRequestFactoryCommon(testMetadataReferences)
-        return OrchestratorRequestFactoryV7(BusinessPartnerTestDataFactory(orchestratorCommonFactory), orchestratorCommonFactory)
-    }
-
-    @Bean
-    fun orchestratorExpectedResultFactoryV7(): OrchestratorExpectedResultFactoryV7{
-        return OrchestratorExpectedResultFactoryV7(
-            Duration.ofDays(1),
-            Duration.ofDays(1),
-            mapOf(
-                Pair(TaskMode.UpdateFromPool, listOf(TaskStep.CleanAndSync, TaskStep.PoolSync)),
-                Pair(TaskMode.UpdateFromSharingMember, listOf(TaskStep.Clean))
-            )
-        )
-    }
 
     @Bean
     fun testMetadataV7(): TestMetadataV7{

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/UnscheduledTestEnvironment.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/UnscheduledTestEnvironment.kt
@@ -20,9 +20,11 @@
 package org.eclipse.tractusx.bpdm.pool
 
 import org.eclipse.tractusx.bpdm.test.containers.KeyCloakInitializer
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockContextInitializer
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
@@ -32,5 +34,6 @@ import org.springframework.test.context.ContextConfiguration
     KeyCloakInitializer::class,
     OrchestratorMockContextInitializer::class
 ])
+@Import(OrchestratorMockConfiguration::class)
 @ActiveProfiles("test-unscheduled")
 annotation class UnscheduledTestEnvironment

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/config/TestDataV7Configuration.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/config/TestDataV7Configuration.kt
@@ -31,23 +31,13 @@ import org.eclipse.tractusx.bpdm.pool.v7.util.AdminAreaLevel1V7Importer
 import org.eclipse.tractusx.bpdm.pool.v7.util.IdentifierTypeV7Importer
 import org.eclipse.tractusx.bpdm.pool.v7.util.LegalFormV7Importer
 import org.eclipse.tractusx.bpdm.pool.v7.util.TestDataClientV7
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.BusinessPartnerTestDataFactory
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.OrchestratorExpectedResultFactoryV7
 import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.OrchestratorMockDataFactory
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.OrchestratorRequestFactoryCommon
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.OrchestratorRequestFactoryV7
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.RefinementTestDataFactory
-import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.TestMetadataReferences
 import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
 import org.eclipse.tractusx.bpdm.test.testdata.pool.TestMetadataV7
 import org.eclipse.tractusx.bpdm.test.testdata.pool.v7.PoolRequestFactoryV7
 import org.eclipse.tractusx.bpdm.test.testdata.pool.v7.PoolResponseFactoryV7
-import org.eclipse.tractusx.orchestrator.api.model.TaskMode
-import org.eclipse.tractusx.orchestrator.api.model.TaskStep
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import tools.jackson.databind.json.JsonMapper
-import java.time.Duration
 
 @Configuration
 class TestDataV7Configuration {
@@ -107,59 +97,6 @@ class TestDataV7Configuration {
     @Bean
     fun responseFactoryV7(testMetadata: TestMetadataV7): PoolResponseFactoryV7{
         return PoolResponseFactoryV7(testMetadata)
-    }
-
-    @Bean
-    fun refinementTestDataFactory(): RefinementTestDataFactory{
-        return RefinementTestDataFactory()
-    }
-
-    @Bean
-    fun orchestratorMockDataFactory(
-        refinementTestDataFactory: RefinementTestDataFactory,
-        requestFactoryV7: OrchestratorRequestFactoryV7,
-        resultFactoryV7: OrchestratorExpectedResultFactoryV7,
-        jsonMapper: JsonMapper
-    ): OrchestratorMockDataFactory{
-        return OrchestratorMockDataFactory(refinementTestDataFactory,requestFactoryV7, resultFactoryV7, jsonMapper)
-    }
-
-    @Bean
-    fun orchestratorRequestFactoryCommon(testMetadataV7: TestMetadataV7): OrchestratorRequestFactoryCommon{
-        val orchestratorMetadata = TestMetadataReferences(
-            legalForms = testMetadataV7.legalForms.map { it.technicalKey },
-            legalEntityIdentifierTypes = testMetadataV7.legalEntityIdentifierTypes.map { it.technicalKey },
-            addressIdentifierTypes = testMetadataV7.addressIdentifierTypes.map { it.technicalKey },
-            adminAreas = testMetadataV7.adminAreas.map { it.code },
-            scriptCodes = testMetadataV7.scriptCodes.map { it.technicalKey },
-            reasonCodes = testMetadataV7.reasonCodes.map { it.technicalKey },
-        )
-        return OrchestratorRequestFactoryCommon(orchestratorMetadata)
-    }
-
-    @Bean
-    fun businessPartnerTestDataFactory(orchestratorRequestFactoryCommon: OrchestratorRequestFactoryCommon): BusinessPartnerTestDataFactory {
-        return BusinessPartnerTestDataFactory(orchestratorRequestFactoryCommon)
-    }
-
-    @Bean
-    fun orchestratorRequestFactory(
-        businessPartnerTestDataFactory: BusinessPartnerTestDataFactory,
-        orchestratorRequestFactoryCommon: OrchestratorRequestFactoryCommon
-    ): OrchestratorRequestFactoryV7 {
-        return OrchestratorRequestFactoryV7(businessPartnerTestDataFactory, orchestratorRequestFactoryCommon)
-    }
-
-    @Bean
-    fun orchestratorExpectedResultFactoryV7(): OrchestratorExpectedResultFactoryV7{
-        return OrchestratorExpectedResultFactoryV7(
-            Duration.ofDays(1),
-            Duration.ofDays(1),
-            mapOf(
-                Pair(TaskMode.UpdateFromPool, listOf(TaskStep.CleanAndSync, TaskStep.PoolSync)),
-                Pair(TaskMode.UpdateFromSharingMember, listOf(TaskStep.Clean))
-            )
-        )
     }
 
     @Bean

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/generation/GleifCodesGenerationIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/generation/GleifCodesGenerationIT.kt
@@ -34,11 +34,13 @@ import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.entity.RegionDb
 import org.eclipse.tractusx.bpdm.pool.repository.RegionRepository
 import org.eclipse.tractusx.bpdm.pool.util.TestHelpers
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.core.io.ResourceLoader
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
@@ -57,6 +59,7 @@ import java.io.PrintWriter
     classes = [Application::class, TestHelpers::class]
 )
 @ActiveProfiles("test-no-auth")
+@Import(OrchestratorMockConfiguration::class)
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class GleifCodesGenerationIT @Autowired constructor(
     private val resourceLoader: ResourceLoader,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationStateResolutionIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationStateResolutionIT.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityRelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
 import org.eclipse.tractusx.bpdm.test.testdata.pool.TestDataEnvironment
@@ -41,6 +42,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import java.time.*
@@ -49,6 +51,7 @@ import java.time.*
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
 )
 @ActiveProfiles("test-no-auth")
+@Import(OrchestratorMockConfiguration::class)
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class TaskRelationStateResolutionIT @Autowired constructor(
     val taskRelationsResolutionService: TaskRelationsResolutionService,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionHeadquarterRelocationIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionHeadquarterRelocationIT.kt
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.PostalAddressScriptVariantDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerRequestFactory
 import org.eclipse.tractusx.bpdm.test.testdata.pool.ExpectedBusinessPartnerResultFactory
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import java.time.Instant
@@ -55,6 +57,7 @@ import java.time.LocalDate
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
 )
 @ActiveProfiles("test-no-auth", "test-scheduling-disabled")
+@Import(OrchestratorMockConfiguration::class)
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class TaskRelationsResolutionHeadquarterRelocationIT @Autowired constructor(
     private val taskRelationsResolutionService: TaskRelationsResolutionService,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
@@ -20,12 +20,14 @@
 package org.eclipse.tractusx.bpdm.pool.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.springframework.context.annotation.Import
 import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
 import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityRelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerNonVerboseValues
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerVerboseValues
@@ -49,6 +51,7 @@ import java.util.*
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
 )
 @ActiveProfiles("test-no-auth")
+@Import(OrchestratorMockConfiguration::class)
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class TaskRelationsResolutionServiceTest @Autowired constructor(
     val taskRelationsResolutionService: TaskRelationsResolutionService,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsStepBuildDispatcherServiceIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsStepBuildDispatcherServiceIT.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.LegalEntityRelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
 import org.eclipse.tractusx.bpdm.test.testdata.pool.TestDataEnvironment
@@ -38,6 +39,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import java.time.LocalDate
@@ -47,6 +49,7 @@ import java.util.*
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
 )
 @ActiveProfiles("test-no-auth")
+@Import(OrchestratorMockConfiguration::class)
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class TaskRelationsStepBuildDispatcherServiceIT @Autowired constructor(
     val taskRelationsStepBuildDispatcherService: TaskRelationsStepBuildDispatcherService,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskResolutionServiceTest.kt
@@ -26,6 +26,7 @@ import org.eclipse.tractusx.bpdm.pool.Application
 import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
 import org.eclipse.tractusx.bpdm.pool.repository.BpnRequestIdentifierRepository
 import org.eclipse.tractusx.bpdm.pool.service.TaskStepBuildService.CleaningError
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.orchestrator.*
 import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import java.time.Instant
@@ -49,6 +51,7 @@ import java.util.*
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
 )
 @ActiveProfiles("test-no-auth")
+@Import(OrchestratorMockConfiguration::class)
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class TaskResolutionServiceTest @Autowired constructor(
     val cleaningStepService: TaskResolutionService,

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TriggerBatchProcessExecutionServiceIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TriggerBatchProcessExecutionServiceIT.kt
@@ -32,6 +32,7 @@ import org.eclipse.tractusx.bpdm.pool.api.model.PostalAddressScriptVariantDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.AddressPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityPartnerCreateVerboseDto
 import org.eclipse.tractusx.bpdm.pool.api.model.response.LegalEntityWithLegalAddressVerboseDto
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
 import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
 import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerRequestFactory
 import org.eclipse.tractusx.bpdm.test.testdata.pool.ExpectedBusinessPartnerResultFactory
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import java.time.*
@@ -57,6 +59,7 @@ import java.time.*
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
 )
 @ActiveProfiles("test-no-auth", "test-scheduling-disabled")
+@Import(OrchestratorMockConfiguration::class)
 @ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
 class TriggerBatchProcessExecutionServiceIT @Autowired constructor(
     private val taskRelationsResolutionService: TaskRelationsResolutionService,


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request refactors the test setup for the orchestrator mock which is used in both the gate and the pool tests.
This reduces duplicate code and makes the configuration easier overall.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
