### PR TITLE
fix: reason codes not nullable

### DIFF
--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/RelationDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/RelationDto.kt
@@ -37,7 +37,7 @@ data class RelationDto(
     @Schema(description = RelationValidityPeriodDescription.header)
     val validityPeriods: Collection<RelationValidityPeriodDto>,
     @get:Schema(description = RelationDescription.reasonCode)
-    val reasonCode: String,
+    val reasonCode: String?,
     @get:Schema(description = RelationDescription.updatedAt)
     val updatedAt: Instant,
     @get:Schema(description = RelationDescription.createdAt)

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/RelationOutputDto.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/RelationOutputDto.kt
@@ -37,7 +37,7 @@ data class RelationOutputDto(
     @get:Schema(description = RelationValidityPeriodDescription.header)
     val validityPeriods: Collection<RelationValidityPeriodDto>,
     @get:Schema(description = RelationDescription.reasonCode)
-    val reasonCode: String,
+    val reasonCode: String?,
     @get:Schema(description = RelationDescription.updatedAt)
     val updatedAt: Instant
 )

--- a/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/RelationPutEntry.kt
+++ b/bpdm-gate-api/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/api/model/request/RelationPutEntry.kt
@@ -37,7 +37,7 @@ data class RelationPutEntry(
     @Schema(description = "The external identifier of the business partner to which the relation should point (the target)")
     override val businessPartnerTargetExternalId: String,
     @get:Schema(description = RelationDescription.reasonCode)
-    val reasonCode: String,
+    val reasonCode: String?,
     @Schema(description = RelationValidityPeriodDescription.header)
     val validityPeriods: List<RelationValidityPeriodDto> = listOf(),
 ): IRelationDto

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationOutputDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationOutputDb.kt
@@ -43,6 +43,6 @@ class RelationOutputDb(
         indexes = [Index(name = "idx_output_validity_periods_relation_id", columnList = "output_id")]
     )
     var validityPeriods: MutableList<RelationValidityPeriodDb>,
-    @Column(name = "reason_code", nullable = false)
-    var reasonCode: String
+    @Column(name = "reason_code")
+    var reasonCode: String?
 ) : BaseEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationStageDb.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/entity/RelationStageDb.kt
@@ -55,8 +55,8 @@ class RelationStageDb (
         indexes = [Index(name = "idx_stage_validity_periods_relation_id", columnList = "relation_stage_id")]
     )
     var validityPeriods: MutableList<RelationValidityPeriodDb>,
-    @Column(name = "reason_code", nullable = false)
-    var reasonCode: String
+    @Column(name = "reason_code")
+    var reasonCode: String?
 ): BaseEntity(){
     companion object{
         const val COLUMN_RELATION = "relation_id"

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/IRelationService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/IRelationService.kt
@@ -61,6 +61,6 @@ interface IRelationService {
         val businessPartnerSourceExternalId: String,
         val businessPartnerTargetExternalId: String,
         val validityPeriods: Collection<RelationValidityPeriodDto>,
-        val reasonCode: String
+        val reasonCode: String?
     )
 }

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationService.kt
@@ -180,7 +180,7 @@ class RelationService(
         sourceBusinessPartnerExternalId: String,
         targetBusinessPartnerExternalId: String,
         validityPeriods: List<RelationValidityPeriodDto>,
-        reasonCode: String
+        reasonCode: String?
     ): RelationDto {
         val existingRelationship = relationRepository.findByTenantBpnLAndExternalId(tenantBpnL.value, externalId)
         val upsertedRelationStage = if(existingRelationship == null)
@@ -197,7 +197,7 @@ class RelationService(
         sourceBpnL: String,
         targetBpnL: String,
         validityPeriods: Collection<RelationValidityPeriodDto>,
-        reasonCode: String
+        reasonCode: String?
     ): RelationDb{
         if(sourceBpnL == targetBpnL)
             throw BpdmInvalidRelationException("Source and target should not be the same")
@@ -227,7 +227,7 @@ class RelationService(
         sourceBusinessPartnerExternalId: String,
         targetBusinessPartnerExternalId: String,
         validityPeriods: List<RelationValidityPeriodDto>,
-        reasonCode: String
+        reasonCode: String?
     ): RelationStageDb{
         if(sourceBusinessPartnerExternalId == targetBusinessPartnerExternalId)
             throw BpdmInvalidRelationException("Source and target '$sourceBusinessPartnerExternalId' should not be equal.")
@@ -270,7 +270,7 @@ class RelationService(
         sourceBusinessPartnerExternalId: String,
         targetBusinessPartnerExternalId: String,
         validityPeriods: List<RelationValidityPeriodDto>,
-        reasonCode: String
+        reasonCode: String?
     ): RelationStageDb{
         val existingRelationship = relationRepository.findByTenantBpnLAndExternalId(tenantBpnL.value, externalId) ?: throw BpdmMissingRelationException(externalId)
         return updateInputStage(
@@ -289,7 +289,7 @@ class RelationService(
         sourceBusinessPartnerExternalId: String,
         targetBusinessPartnerExternalId: String,
         validityPeriods: List<RelationValidityPeriodDto>,
-        reasonCode: String
+        reasonCode: String?
     ): RelationStageDb{
         if(sourceBusinessPartnerExternalId == targetBusinessPartnerExternalId)
             throw BpdmInvalidRelationException("Source and target '$sourceBusinessPartnerExternalId' should not be equal.")
@@ -368,7 +368,7 @@ class RelationService(
         val source: SharingStateDb,
         val target: SharingStateDb,
         val validityPeriods: MutableList<RelationValidityPeriodDb>,
-        val reasonCode: String
+        val reasonCode: String?
     )
 
     private fun validateValidityPeriods(validityPeriods: Collection<RelationValidityPeriodDto>) {

--- a/bpdm-gate/src/main/resources/db/migration/V7_4_0_3__add_relation_reason_code.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V7_4_0_3__add_relation_reason_code.sql
@@ -1,5 +1,5 @@
 ALTER TABLE business_partner_relation_stages
-ADD COLUMN reason_code VARCHAR(255) NOT NULL;
+ADD COLUMN reason_code VARCHAR(255);
 
 ALTER TABLE business_partner_relations
 ADD COLUMN output_reason_code VARCHAR(255);

--- a/bpdm-gate/src/main/resources/db/migration/V7_4_0_4__extract_relation_output_to_entity.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V7_4_0_4__extract_relation_output_to_entity.sql
@@ -8,7 +8,7 @@ CREATE TABLE relation_outputs
     source_bpn        VARCHAR(255)                NOT NULL,
     target_bpn        VARCHAR(255)                NOT NULL,
     result_updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
-    reason_code       VARCHAR(255)                NOT NULL,
+    reason_code       VARCHAR(255),
     CONSTRAINT pk_relation_outputs PRIMARY KEY (id),
     CONSTRAINT uc_relation_outputs_uuid UNIQUE (uuid)
 );

--- a/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerRelations.kt
+++ b/bpdm-orchestrator-api/src/main/kotlin/org/eclipse/tractusx/orchestrator/api/model/BusinessPartnerRelations.kt
@@ -35,7 +35,7 @@ data class BusinessPartnerRelations(
     @Schema(description = RelationValidityPeriodDescription.header)
     val validityPeriods : Collection<RelationValidityPeriod>,
     @Schema(description = RelationDescription.reasonCode)
-    val reasonCode: String,
+    val reasonCode: String?,
 ) {
     companion object {
         val empty = BusinessPartnerRelations(
@@ -43,7 +43,7 @@ data class BusinessPartnerRelations(
             businessPartnerSourceBpn = "",
             businessPartnerTargetBpn = "",
             validityPeriods = emptyList(),
-            reasonCode = ""
+            reasonCode = null
         )
     }
 }

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/RelationsGoldenRecordTaskDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/RelationsGoldenRecordTaskDb.kt
@@ -118,8 +118,8 @@ class RelationsGoldenRecordTaskDb(
             indexes = [Index(name = "idx_relation_task_validity_periods_relation_id", columnList = "relation_id")]
         )
         var validityPeriods: MutableList<RelationValidityPeriod> = mutableListOf(),
-        @Column(name = "reason_code", nullable = false)
-        var reasonCode: String
+        @Column(name = "reason_code")
+        var reasonCode: String?
     )
 
 

--- a/bpdm-orchestrator/src/main/resources/db/migration/V7_4_0_3__add_relation_reason_code.sql
+++ b/bpdm-orchestrator/src/main/resources/db/migration/V7_4_0_3__add_relation_reason_code.sql
@@ -1,2 +1,2 @@
 ALTER TABLE relations_golden_record_tasks
-ADD COLUMN reason_code VARCHAR(255) NOT NULL;
+ADD COLUMN reason_code VARCHAR(255);

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressRelationVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/AddressRelationVerboseDto.kt
@@ -41,5 +41,5 @@ data class AddressRelationVerboseDto(
     val validityPeriods: Collection<RelationValidityPeriod>,
 
     @get:Schema(description = RelationDescription.reasonCode)
-    val reasonCode: String
+    val reasonCode: String?
 )

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/RelationVerboseDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/RelationVerboseDto.kt
@@ -35,5 +35,5 @@ data class RelationVerboseDto(
 
     val validityPeriods: Collection<RelationValidityPeriod>,
 
-    val reasonCode: String
+    val reasonCode: String?
 )

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/AddressRelationDb.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/AddressRelationDb.kt
@@ -53,7 +53,7 @@ class AddressRelationDb(
     var validityPeriods: MutableList<RelationValidityPeriodDb> = mutableListOf(),
 
     @ManyToOne
-    @JoinColumn(name = "reason_code_id", nullable = false)
-    var reasonCode: ReasonCodeDb
+    @JoinColumn(name = "reason_code_id")
+    var reasonCode: ReasonCodeDb?
 
 ): BaseEntity()

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/RelationDb.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/entity/RelationDb.kt
@@ -53,7 +53,7 @@ class RelationDb(
     var validityPeriods: MutableList<RelationValidityPeriodDb> = mutableListOf(),
 
     @ManyToOne
-    @JoinColumn(name = "reason_code_id", nullable = false)
-    var reasonCode: ReasonCodeDb
+    @JoinColumn(name = "reason_code_id")
+    var reasonCode: ReasonCodeDb?
 ) : BaseEntity()
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationUpsertService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationUpsertService.kt
@@ -26,10 +26,6 @@ import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
 import org.eclipse.tractusx.bpdm.pool.dto.ChangelogEntryCreateRequest
 import org.eclipse.tractusx.bpdm.pool.dto.UpsertResult
 import org.eclipse.tractusx.bpdm.pool.dto.UpsertType
-import org.eclipse.tractusx.bpdm.pool.entity.AddressRelationDb
-import org.eclipse.tractusx.bpdm.pool.entity.LogisticAddressDb
-import org.eclipse.tractusx.bpdm.pool.entity.ReasonCodeDb
-import org.eclipse.tractusx.bpdm.pool.entity.RelationValidityPeriodDb
 import org.eclipse.tractusx.bpdm.pool.entity.*
 import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
 import org.eclipse.tractusx.bpdm.pool.repository.AddressRelationEventTriggerRepository
@@ -166,7 +162,7 @@ class AddressRelationUpsertService(
         val target: LogisticAddressDb,
         val addressRelationType: AddressRelationType,
         val validityPeriods: Collection<RelationValidityPeriodDb>,
-        val reasonCode: ReasonCodeDb
+        val reasonCode: ReasonCodeDb?
     )
 
     private fun validityPeriodsDiffer(existingValidityPeriods: Collection<RelationValidityPeriodDb>, newValidityPeriods: Collection<RelationValidityPeriodDb>): Boolean {

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IAddressRelationUpsertStratergyService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IAddressRelationUpsertStratergyService.kt
@@ -33,6 +33,6 @@ interface IAddressRelationUpsertStratergyService {
         val source: LogisticAddressDb,
         val target: LogisticAddressDb,
         val validityPeriods: Collection<RelationValidityPeriodDb>,
-        val reasonCode: ReasonCodeDb
+        val reasonCode: ReasonCodeDb?
     )
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IRelationUpsertStrategyService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/IRelationUpsertStrategyService.kt
@@ -34,6 +34,6 @@ interface IRelationUpsertStrategyService {
         val target: LegalEntityDb,
         val validityPeriods: Collection<RelationValidityPeriodDb>,
         val existingRelation: RelationDb?,
-        val reasonCode: ReasonCodeDb
+        val reasonCode: ReasonCodeDb?
     )
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/RelationUpsertService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/RelationUpsertService.kt
@@ -129,7 +129,7 @@ class RelationUpsertService(
         val legalEntityRelationType: LegalEntityRelationType,
         val validityPeriods: Collection<RelationValidityPeriodDb>,
         val existingRelation: RelationDb?,
-        val reasonCode: ReasonCodeDb
+        val reasonCode: ReasonCodeDb?
     )
 
     data class TimePeriod(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/ResponseMappings.kt
@@ -279,7 +279,7 @@ fun RelationDb.toDto(): RelationVerboseDto {
         businessPartnerSourceBpnl = startNode.bpn,
         businessPartnerTargetBpnl = endNode.bpn,
         validityPeriods = validityPeriods.sortedBy { it.validFrom }.map { it.toDto() },
-        reasonCode = reasonCode.technicalKey
+        reasonCode = reasonCode?.technicalKey
     )
 }
 
@@ -289,7 +289,7 @@ fun AddressRelationDb.toDto(): AddressRelationVerboseDto {
         businessPartnerSourceBpna = startAddress.bpn,
         businessPartnerTargetBpna = endAddress.bpn,
         validityPeriods = validityPeriods.sortedBy { it.validFrom }.map { it.toDto() },
-        reasonCode = reasonCode.technicalKey
+        reasonCode = reasonCode?.technicalKey
     )
 }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskAddressRelationsStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskAddressRelationsStepBuildService.kt
@@ -56,8 +56,9 @@ class TaskAddressRelationsStepBuildService(
         val targetAddress = logisticAddressRepository.findByBpn(addressRelationDto.businessPartnerTargetBpn)
             ?: throw BpdmValidationException("Target address BPNA ${addressRelationDto.businessPartnerTargetBpn} not found")
 
-        val reasonCode  = reasonCodeRepository.findByTechnicalKey(addressRelationDto.reasonCode)
-            ?: throw BpdmValidationException("Relation reason code '${addressRelationDto.reasonCode}' not found")
+        val reasonCode = addressRelationDto.reasonCode?.let {
+            reasonCodeRepository.findByTechnicalKey(it) ?: throw BpdmValidationException("Relation reason code '${addressRelationDto.reasonCode}' not found")
+        }
 
         validateValidityPeriods(addressRelationDto)
 
@@ -99,7 +100,7 @@ class TaskAddressRelationsStepBuildService(
                     validTo = it.validTo
                 )
             },
-            reasonCode = reasonCode.technicalKey
+            reasonCode = reasonCode?.technicalKey
         )
     }
 

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskLegalEntityRelationsStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskLegalEntityRelationsStepBuildService.kt
@@ -58,8 +58,9 @@ class TaskLegalEntityRelationsStepBuildService(
         val targetLegalEntity = legalEntityRepository.findByBpnIgnoreCase(relationDto.businessPartnerTargetBpn)
             ?: throw BpdmValidationException("Target legal entity with specified BPNL : ${relationDto.businessPartnerTargetBpn} not found")
 
-        val reasonCode  = reasonCodeRepository.findByTechnicalKey(relationDto.reasonCode)
-            ?: throw BpdmValidationException("Relation reason code '${relationDto.reasonCode}' not found")
+        val reasonCode  = relationDto.reasonCode?.let {
+            reasonCodeRepository.findByTechnicalKey(it) ?: throw BpdmValidationException("Relation reason code '${relationDto.reasonCode}' not found")
+        }
 
         validateValidityPeriods(relationDto)
 
@@ -119,7 +120,7 @@ class TaskLegalEntityRelationsStepBuildService(
                     validTo = it.validTo
                 )
             },
-            reasonCode = reasonCode.technicalKey
+            reasonCode = reasonCode?.technicalKey
         )
     }
 

--- a/bpdm-pool/src/main/resources/db/migration/V7_4_0_4__create_relation_reason_code.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V7_4_0_4__create_relation_reason_code.sql
@@ -1,7 +1,7 @@
 ALTER TABLE relations
-ADD COLUMN reason_code_id BIGINT NOT NULL,
+ADD COLUMN reason_code_id BIGINT,
 ADD CONSTRAINT fk_relations_reason_code_id FOREIGN KEY (reason_code_id) REFERENCES reason_codes(id);
 
 ALTER TABLE address_relations
-ADD COLUMN reason_code_id BIGINT NOT NULL,
+ADD COLUMN reason_code_id BIGINT,
 ADD CONSTRAINT fk_address_relations_reason_code_id FOREIGN KEY (reason_code_id) REFERENCES reason_codes(id);


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

For migration purposes reason codes for business partner relations should be nullable on principle. Also, there are no reason codes defined for relations like IsOwnedBy and IsAlternativeHeadquarterFor. So the reason code in principle can be nullable but may be enforced for some relation types.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
