### PR TITLE
Fix: persist script variants for created sites with legal address as main

### DIFF
--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteDto.kt
@@ -34,4 +34,13 @@ data class SiteDto(
     override val confidenceCriteria: ConfidenceCriteriaDto,
 
     val scriptVariants: List<SiteScriptVariantDto> = emptyList()
-) : IBaseSiteDto
+) : IBaseSiteDto{
+    fun toHeader(): SiteHeaderDto{
+        return SiteHeaderDto(
+            name,
+            states,
+            confidenceCriteria,
+            scriptVariants.map { it.toHeader() }
+        )
+    }
+}

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteHeaderDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteHeaderDto.kt
@@ -17,23 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.request
+package org.eclipse.tractusx.bpdm.pool.api.model
 
 import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.pool.api.model.ConfidenceCriteriaDto
-import org.eclipse.tractusx.bpdm.pool.api.model.SiteHeaderDto
-import org.eclipse.tractusx.bpdm.pool.api.model.SiteHeaderScriptVariantDto
-import org.eclipse.tractusx.bpdm.pool.api.model.SiteStateDto
 
-data class SiteCreateRequestWithLegalAddressAsMain(
+data class SiteHeaderDto (
     override val name: String,
     override val states: Collection<SiteStateDto>,
     override val confidenceCriteria: ConfidenceCriteriaDto,
-    val bpnLParent: String,
     val scriptVariants: List<SiteHeaderScriptVariantDto> = emptyList()
-) : IBaseSiteDto{
-    fun toHeader(): SiteHeaderDto{
-        return SiteHeaderDto(name, states, confidenceCriteria, scriptVariants)
-    }
-}
-
+): IBaseSiteDto

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteHeaderScriptVariantDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteHeaderScriptVariantDto.kt
@@ -17,23 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.eclipse.tractusx.bpdm.pool.api.model.request
+package org.eclipse.tractusx.bpdm.pool.api.model
 
-import org.eclipse.tractusx.bpdm.common.dto.IBaseSiteDto
-import org.eclipse.tractusx.bpdm.pool.api.model.ConfidenceCriteriaDto
-import org.eclipse.tractusx.bpdm.pool.api.model.SiteHeaderDto
-import org.eclipse.tractusx.bpdm.pool.api.model.SiteHeaderScriptVariantDto
-import org.eclipse.tractusx.bpdm.pool.api.model.SiteStateDto
-
-data class SiteCreateRequestWithLegalAddressAsMain(
-    override val name: String,
-    override val states: Collection<SiteStateDto>,
-    override val confidenceCriteria: ConfidenceCriteriaDto,
-    val bpnLParent: String,
-    val scriptVariants: List<SiteHeaderScriptVariantDto> = emptyList()
-) : IBaseSiteDto{
-    fun toHeader(): SiteHeaderDto{
-        return SiteHeaderDto(name, states, confidenceCriteria, scriptVariants)
-    }
-}
-
+data class SiteHeaderScriptVariantDto (
+    val scriptCode: String,
+    val name: String
+)

--- a/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteScriptVariantDto.kt
+++ b/bpdm-pool-api/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/api/model/SiteScriptVariantDto.kt
@@ -23,4 +23,11 @@ data class SiteScriptVariantDto(
     val scriptCode: String,
     val name: String,
     val mainAddress: PostalAddressScriptVariantDto
-)
+){
+    fun toHeader(): SiteHeaderScriptVariantDto{
+        return SiteHeaderScriptVariantDto(
+            scriptCode,
+            name
+        )
+    }
+}

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerBuildService.kt
@@ -108,6 +108,9 @@ class BusinessPartnerBuildService(
 
         val bpnSs = bpnIssuingService.issueSiteBpns(requests.size)
 
+        val siteHeaderMetadataMapping = SiteHeaderMetadataMapping(metadataService.getSiteHeaderScriptCodes(requests.flatMap { it.scriptVariants })
+            .associateBy { it.technicalKey })
+
         val createdSites = requests.zip(bpnSs).map { (siteRequest, bpnS) ->
             if (legalEntitiesByBpn[siteRequest.bpnLParent] == null) {
                 return SitePartnerCreateResponseWrapper(emptyList(), listOf(
@@ -127,7 +130,7 @@ class BusinessPartnerBuildService(
                 ))
             }
 
-            createSite(siteRequest, bpnS, legalEntitiesByBpn[siteRequest.bpnLParent]!!)
+            createSiteHeader(siteRequest.toHeader(), bpnS, legalEntitiesByBpn[siteRequest.bpnLParent]!!, siteHeaderMetadataMapping)
                 .apply { mainAddress = legalEntitiesByBpn[siteRequest.bpnLParent]!!.legalAddress }
                 .apply { mainAddress.site = this }
         }
@@ -159,7 +162,7 @@ class BusinessPartnerBuildService(
         val legalEntitiesByBpn = legalEntities.associateBy { it.bpn }
         val bpnSs = bpnIssuingService.issueSiteBpns(validRequests.size)
         fun createSiteWithMainAddress(bpnIndex: Int, request: SitePartnerCreateRequest) =
-            createSiteHeader(request.site, bpnSs[bpnIndex], legalEntitiesByBpn[request.bpnlParent]!!, siteHeaderMetadata)
+            createSiteHeader(request.site.toHeader(), bpnSs[bpnIndex], legalEntitiesByBpn[request.bpnlParent]!!, siteHeaderMetadata)
                 .apply {
                     mainAddress = createLogisticAddress(address, request.site.toMainAddressWithScriptVariants(), address.bpn, this.legalEntity, this, mainAddressMetadata)
                 }.let { site -> Pair(site, request) }
@@ -187,7 +190,7 @@ class BusinessPartnerBuildService(
         val bpnAs = bpnIssuingService.issueAddressBpns(validRequests.size)
 
         fun createSiteWithMainAddress(bpnIndex: Int, request: SitePartnerCreateRequest) =
-            createSiteHeader(request.site, bpnSs[bpnIndex], legalEntitiesByBpn[request.bpnlParent]!!, siteHeaderMetadata)
+            createSiteHeader(request.site.toHeader(), bpnSs[bpnIndex], legalEntitiesByBpn[request.bpnlParent]!!, siteHeaderMetadata)
                 .apply { mainAddress = createLogisticAddress(request.site.toMainAddressWithScriptVariants(), bpnAs[bpnIndex], this.legalEntity, this, mainAddressMetadata) }
                 .let { site -> Pair(site, request) }
 
@@ -424,13 +427,13 @@ class BusinessPartnerBuildService(
     }
 
     private fun createSiteHeader(
-        siteDto: SiteDto,
+        siteHeaderRequest: SiteHeaderDto,
         bpnS: String,
         partner: LegalEntityDb,
         metadataMap: SiteHeaderMetadataMapping
     ): SiteDb{
-        val createdSite = createSite(siteDto, bpnS, partner)
-        createdSite.scriptVariants.replace(siteDto.scriptVariants.map { SiteScriptVariantDb(metadataMap.scriptCodes[it.scriptCode]!!, it.name) })
+        val createdSite = createSite(siteHeaderRequest, bpnS, partner)
+        createdSite.scriptVariants.replace(siteHeaderRequest.scriptVariants.map { SiteScriptVariantDb(metadataMap.scriptCodes[it.scriptCode]!!, it.name) })
 
         return createdSite
     }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/MetadataService.kt
@@ -200,6 +200,9 @@ class MetadataService(
         return SiteMetadataDto(scriptCodes, addressMetadata)
     }
 
+    fun getSiteHeaderScriptCodes(scriptVariants: Collection<SiteHeaderScriptVariantDto>): Set<ScriptCodeDb> =
+        scriptCodeRepository.findByTechnicalKeyIn(scriptVariants.map { it.scriptCode }.toSet())
+
     fun getMetadata(requests: Collection<IBaseLegalEntityDto>): LegalEntityInvariantHeaderMetadataDto {
         val idTypeKeys = requests.flatMap { it.identifiers }.map { it.type }.toSet()
         val idTypes = identifierTypeRepository.findByBusinessPartnerTypeAndTechnicalKeyIn(IdentifierBusinessPartnerType.LEGAL_ENTITY, idTypeKeys)

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskStepBuildService.kt
@@ -298,7 +298,8 @@ class TaskStepBuildService(
                 name = poolSite.name,
                 states = poolSite.states,
                 confidenceCriteria = poolSite.confidenceCriteria.copy(numberOfSharingMembers = 1),
-                bpnLParent = legalEntityBpn
+                bpnLParent = legalEntityBpn,
+                scriptVariants = poolSite.scriptVariants.map { it.toHeader() }
             )
             businessPartnerBuildService.createSitesWithLegalAddressAsMain(listOf(createRequest))
         }else{

--- a/docs/api/pool.json
+++ b/docs/api/pool.json
@@ -3276,11 +3276,11 @@
               "$ref" : "#/components/schemas/ErrorInfoAddressCreateError"
             }
           },
-          "entityCount" : {
+          "errorCount" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "errorCount" : {
+          "entityCount" : {
             "type" : "integer",
             "format" : "int32"
           }
@@ -3431,11 +3431,11 @@
               "$ref" : "#/components/schemas/ErrorInfoAddressUpdateError"
             }
           },
-          "entityCount" : {
+          "errorCount" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "errorCount" : {
+          "entityCount" : {
             "type" : "integer",
             "format" : "int32"
           }
@@ -4411,11 +4411,11 @@
               "$ref" : "#/components/schemas/ErrorInfoLegalEntityCreateError"
             }
           },
-          "entityCount" : {
+          "errorCount" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "errorCount" : {
+          "entityCount" : {
             "type" : "integer",
             "format" : "int32"
           }
@@ -4571,11 +4571,11 @@
               "$ref" : "#/components/schemas/ErrorInfoLegalEntityUpdateError"
             }
           },
-          "entityCount" : {
+          "errorCount" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "errorCount" : {
+          "entityCount" : {
             "type" : "integer",
             "format" : "int32"
           }
@@ -5779,6 +5779,23 @@
           },
           "bpnLParent" : {
             "type" : "string"
+          },
+          "scriptVariants" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SiteHeaderScriptVariantDto"
+            }
+          }
+        }
+      },
+      "SiteHeaderScriptVariantDto" : {
+        "type" : "object",
+        "properties" : {
+          "scriptCode" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
           }
         }
       },
@@ -5836,11 +5853,11 @@
               "$ref" : "#/components/schemas/ErrorInfoSiteCreateError"
             }
           },
-          "entityCount" : {
+          "errorCount" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "errorCount" : {
+          "entityCount" : {
             "type" : "integer",
             "format" : "int32"
           }
@@ -5953,11 +5970,11 @@
               "$ref" : "#/components/schemas/ErrorInfoSiteUpdateError"
             }
           },
-          "entityCount" : {
+          "errorCount" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "errorCount" : {
+          "entityCount" : {
             "type" : "integer",
             "format" : "int32"
           }

--- a/docs/api/pool.yaml
+++ b/docs/api/pool.yaml
@@ -3602,10 +3602,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ErrorInfoAddressCreateError"
-        entityCount:
+        errorCount:
           type: integer
           format: int32
-        errorCount:
+        entityCount:
           type: integer
           format: int32
     AddressPartnerCreateVerboseDto:
@@ -3756,10 +3756,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ErrorInfoAddressUpdateError"
-        entityCount:
+        errorCount:
           type: integer
           format: int32
-        errorCount:
+        entityCount:
           type: integer
           format: int32
     AddressPartnerUpdateVerboseDto:
@@ -5719,10 +5719,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ErrorInfoLegalEntityCreateError"
-        entityCount:
+        errorCount:
           type: integer
           format: int32
-        errorCount:
+        entityCount:
           type: integer
           format: int32
     LegalEntityPartnerCreateVerboseDto:
@@ -5868,10 +5868,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ErrorInfoLegalEntityUpdateError"
-        entityCount:
+        errorCount:
           type: integer
           format: int32
-        errorCount:
+        entityCount:
           type: integer
           format: int32
     LegalEntityPropertiesSearchRequest:
@@ -8614,6 +8614,17 @@ components:
           $ref: "#/components/schemas/ConfidenceCriteriaDto"
         bpnLParent:
           type: string
+        scriptVariants:
+          type: array
+          items:
+            $ref: "#/components/schemas/SiteHeaderScriptVariantDto"
+    SiteHeaderScriptVariantDto:
+      type: object
+      properties:
+        scriptCode:
+          type: string
+        name:
+          type: string
     SitePartnerCreateRequest:
       type: object
       description: "Request for creating new business partner record of type site.\
@@ -8665,10 +8676,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ErrorInfoSiteCreateError"
-        entityCount:
+        errorCount:
           type: integer
           format: int32
-        errorCount:
+        entityCount:
           type: integer
           format: int32
     SitePartnerCreateVerboseDto:
@@ -8778,10 +8789,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ErrorInfoSiteUpdateError"
-        entityCount:
+        errorCount:
           type: integer
           format: int32
-        errorCount:
+        entityCount:
           type: integer
           format: int32
     SiteScriptVariantDto:


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull reqeust fixes the bug in which the site name script variants are ignored when a new site with a legal address as main address is created. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1698 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
