### PR TITLE
fix(Gate): some script variants not persisting for output

### DIFF
--- a/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/v7/BusinessPartnerOutputDtoV7Factory.kt
+++ b/bpdm-common-test/src/main/kotlin/org/eclipse/tractusx/bpdm/test/testdata/gate/v7/BusinessPartnerOutputDtoV7Factory.kt
@@ -48,7 +48,7 @@ class BusinessPartnerOutputDtoV7Factory {
             site = null,
             address = buildAddressRepresentation(legalEntity.legalAddress, AddressType.LegalAddress),
             externalSequenceTimestamp = null,
-            scriptVariants = legalEntity.scriptVariants.map { buildLegalEntityScriptVariant(it) },
+            scriptVariants = legalEntity.scriptVariants.map { buildLegalEntityScriptVariant(it.scriptCode, it) },
             createdAt = Instant.MIN,
             updatedAt = Instant.MIN
         )
@@ -66,7 +66,11 @@ class BusinessPartnerOutputDtoV7Factory {
             site = buildSiteRepresentation(site.site),
             address = buildAddressRepresentation(legalEntity.legalAddress, AddressType.LegalAndSiteMainAddress),
             externalSequenceTimestamp = null,
-            scriptVariants = legalEntity.scriptVariants.zip(site.site.scriptVariants){ leScript, siteScript -> buildLegalEntityScriptVariant(leScript, siteScript) },
+            scriptVariants = run {
+                val leByCode = legalEntity.scriptVariants.associateBy { it.scriptCode }
+                val siteByCode = site.site.scriptVariants.associateBy { it.scriptCode }
+                (leByCode.keys + siteByCode.keys).map { code -> buildLegalEntityScriptVariant(code, leByCode[code], siteByCode[code]) }
+            },
             createdAt = Instant.MIN,
             updatedAt = Instant.MIN
         )
@@ -84,7 +88,11 @@ class BusinessPartnerOutputDtoV7Factory {
             site = buildSiteRepresentation(site.site),
             address = buildAddressRepresentation(site.mainAddress, AddressType.SiteMainAddress),
             externalSequenceTimestamp = null,
-            scriptVariants = legalEntity.scriptVariants.zip(site.site.scriptVariants){ leScript, siteScript -> buildSiteScriptVariant(leScript, siteScript) },
+            scriptVariants = run {
+                val leByCode = legalEntity.scriptVariants.associateBy { it.scriptCode }
+                val siteByCode = site.site.scriptVariants.associateBy { it.scriptCode }
+                (leByCode.keys + siteByCode.keys).map { code -> buildSiteScriptVariant(code, leByCode[code], siteByCode[code]) }
+            },
             createdAt = Instant.MIN,
             updatedAt = Instant.MIN
         )
@@ -107,7 +115,12 @@ class BusinessPartnerOutputDtoV7Factory {
             site = buildSiteRepresentation(site.site),
             address = buildAddressRepresentation(additionalAddress.address, AddressType.AdditionalAddress),
             externalSequenceTimestamp = null,
-            scriptVariants = legalEntity.scriptVariants.zip(site.site.scriptVariants).zip(additionalAddress.scriptVariants){ (leScript, siteScript), addScript -> buildAdditionalAddressScriptVariant(leScript, addScript, siteScript) },
+            scriptVariants = run {
+                val leByCode = legalEntity.scriptVariants.associateBy { it.scriptCode }
+                val siteByCode = site.site.scriptVariants.associateBy { it.scriptCode }
+                val addByCode = additionalAddress.scriptVariants.associateBy { it.scriptCode }
+                (leByCode.keys + siteByCode.keys + addByCode.keys).map { code -> buildAdditionalAddressScriptVariant(code, leByCode[code], addByCode[code], siteByCode[code]) }
+            },
             createdAt = Instant.MIN,
             updatedAt = Instant.MIN
         )
@@ -205,51 +218,51 @@ class BusinessPartnerOutputDtoV7Factory {
         }
     }
 
-    private fun buildLegalEntityScriptVariant(legalEntityScriptVariant: LegalEntityScriptVariantDto, site: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto? = null): BusinessPartnerScriptVariantDto{
+    private fun buildLegalEntityScriptVariant(scriptCode: String, legalEntityScriptVariant: LegalEntityScriptVariantDto?, site: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto? = null): BusinessPartnerScriptVariantDto{
         return BusinessPartnerScriptVariantDto(
-            scriptCode = legalEntityScriptVariant.scriptCode,
+            scriptCode = scriptCode,
             nameParts = emptyList(),
             legalEntity = buildScriptVariantLegalEntityComponent(legalEntityScriptVariant),
             site = site?.let { buildScriptVariantSiteComponent(it) } ?: SiteScriptVariantDto(),
-            address = buildScriptVariantAddressComponent(legalEntityScriptVariant.legalAddress)
+            address = buildScriptVariantAddressComponent(legalEntityScriptVariant?.legalAddress)
         )
     }
 
-    private fun buildSiteScriptVariant(legalEntityScriptVariant: LegalEntityScriptVariantDto, siteScriptVariant: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto): BusinessPartnerScriptVariantDto{
+    private fun buildSiteScriptVariant(scriptCode: String, legalEntityScriptVariant: LegalEntityScriptVariantDto?, siteScriptVariant: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto?): BusinessPartnerScriptVariantDto{
         return BusinessPartnerScriptVariantDto(
-            scriptCode = siteScriptVariant.scriptCode,
+            scriptCode = scriptCode,
             nameParts = emptyList(),
             legalEntity = buildScriptVariantLegalEntityComponent(legalEntityScriptVariant),
-            site = buildScriptVariantSiteComponent(siteScriptVariant),
-            address = buildScriptVariantAddressComponent(siteScriptVariant.mainAddress)
+            site = siteScriptVariant?.let { buildScriptVariantSiteComponent(it) } ?: SiteScriptVariantDto(),
+            address = buildScriptVariantAddressComponent(siteScriptVariant?.mainAddress)
         )
     }
 
-    private fun buildAdditionalAddressScriptVariant(legalEntityScriptVariant: LegalEntityScriptVariantDto, addressScriptVariant: LogisticAddressScriptVariantDto, site: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto? = null): BusinessPartnerScriptVariantDto{
+    private fun buildAdditionalAddressScriptVariant(scriptCode: String, legalEntityScriptVariant: LegalEntityScriptVariantDto?, addressScriptVariant: LogisticAddressScriptVariantDto?, site: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto? = null): BusinessPartnerScriptVariantDto{
         return BusinessPartnerScriptVariantDto(
-            scriptCode = addressScriptVariant.scriptCode,
+            scriptCode = scriptCode,
             nameParts = emptyList(),
             legalEntity = buildScriptVariantLegalEntityComponent(legalEntityScriptVariant),
             site = site?.let { buildScriptVariantSiteComponent(it) } ?: SiteScriptVariantDto(),
-            address = buildScriptVariantAddressComponent(addressScriptVariant.address)
+            address = buildScriptVariantAddressComponent(addressScriptVariant?.address)
         )
     }
 
-    private fun buildScriptVariantLegalEntityComponent(legalEntityScriptVariant: LegalEntityScriptVariantDto): org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityScriptVariantDto{
+    private fun buildScriptVariantLegalEntityComponent(legalEntityScriptVariant: LegalEntityScriptVariantDto?): org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityScriptVariantDto{
         return org.eclipse.tractusx.bpdm.gate.api.model.LegalEntityScriptVariantDto(
-            legalName = legalEntityScriptVariant.legalName,
-            shortName = legalEntityScriptVariant.shortName
+            legalName = legalEntityScriptVariant?.legalName,
+            shortName = legalEntityScriptVariant?.shortName
         )
     }
 
-    private fun buildScriptVariantSiteComponent(siteScriptVariant: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto): SiteScriptVariantDto{
-        return SiteScriptVariantDto(siteScriptVariant.name)
+    private fun buildScriptVariantSiteComponent(siteScriptVariant: org.eclipse.tractusx.bpdm.pool.api.model.SiteScriptVariantDto?): SiteScriptVariantDto{
+        return SiteScriptVariantDto(siteScriptVariant?.name)
     }
 
-    private fun buildScriptVariantAddressComponent(addressScriptVariant: PostalAddressScriptVariantDto): AddressScriptVariantDto {
+    private fun buildScriptVariantAddressComponent(addressScriptVariant: PostalAddressScriptVariantDto?): AddressScriptVariantDto {
         return AddressScriptVariantDto(
-            name = addressScriptVariant.addressName,
-            physicalAddress = addressScriptVariant.physicalAddress.let { p ->
+            name = addressScriptVariant?.addressName,
+            physicalAddress = addressScriptVariant?.physicalAddress?.let { p ->
                 PhysicalAddressScriptVariantDto(
                     postalCode = p.postalCode,
                     city = p.city,
@@ -262,8 +275,8 @@ class BusinessPartnerOutputDtoV7Factory {
                     door = p.door,
                     taxJurisdictionCode = p.taxJurisdictionCode
                 )
-            },
-            alternativeAddress = addressScriptVariant.alternativeAddress?.let { a ->
+            } ?: PhysicalAddressScriptVariantDto(null, null, null, StreetDto(), null, null, null, null, null, null),
+            alternativeAddress = addressScriptVariant?.alternativeAddress?.let { a ->
                 org.eclipse.tractusx.bpdm.gate.api.model.AlternativeAddressScriptVariantDto(
                     postalCode = a.postalCode,
                     city = a.city,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/GoldenRecordUpdateServices.kt
@@ -351,9 +351,12 @@ class GoldenRecordUpdateChunkService(
         businessPartner.siteName = site.name
         businessPartner.siteConfidence?.let { update(it,  site.confidenceCriteria) }
 
-        val goldenRecordVariantByCode = site.scriptVariants.associateBy { it.scriptCode }
-        businessPartner.scriptVariants.forEach { variant ->
-            val goldenRecordVariant = goldenRecordVariantByCode[variant.scriptCode] ?: return@forEach
+        val goldenRecordVariantByCode = businessPartner.scriptVariants.associateBy { it.scriptCode }
+
+        site.scriptVariants.groupBy { it.scriptCode }.map { it.value.first() }.forEach { goldenRecordVariant ->
+            val variant = goldenRecordVariantByCode[goldenRecordVariant.scriptCode]
+                ?: BusinessPartnerScriptVariantDb(goldenRecordVariant.scriptCode, businessPartner).apply {   businessPartner.scriptVariants.add(this) }
+
             variant.siteName = goldenRecordVariant.name
         }
     }
@@ -370,9 +373,11 @@ class GoldenRecordUpdateChunkService(
         businessPartner.addressConfidence?.let { update(it,  addressProperties.confidenceCriteria) }
         businessPartner.addressGoldenRecordRelations.addAll(addressProperties.relations.map(::toEntity))
 
-        val goldenRecordVariantByCode = address.scriptVariants.associateBy { it.scriptCode }
-        businessPartner.scriptVariants.forEach { variant ->
-            val goldenRecordVariant = goldenRecordVariantByCode[variant.scriptCode] ?: return@forEach
+        val goldenRecordVariantByCode = businessPartner.scriptVariants.associateBy { it.scriptCode }
+        address.scriptVariants.groupBy { it.scriptCode }.map { it.value.first() }.forEach { goldenRecordVariant ->
+            val variant = goldenRecordVariantByCode[goldenRecordVariant.scriptCode]
+                ?: BusinessPartnerScriptVariantDb(goldenRecordVariant.scriptCode, businessPartner).apply {   businessPartner.scriptVariants.add(this) }
+
             variant.addressName = goldenRecordVariant.address.addressName
             variant.physicalAddress = goldenRecordVariant.address.physicalAddress.toEntity()
             variant.alternativeAddress = goldenRecordVariant.address.alternativeAddress?.toEntity()

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/OrchestratorMappings.kt
@@ -268,15 +268,18 @@ class OrchestratorMappings(
             AddressType.AdditionalAddress -> dto.additionalAddress!!.scriptVariants.map { it }
         }
 
+        val addressVariantByCode = addressScriptVariants.associateBy { it.scriptCode }
         val legalEntityVariantsByCode = dto.legalEntity.scriptVariants.associateBy { it.scriptCode }
         val siteScriptVariantsByCode = dto.site?.scriptVariants?.associateBy { it.scriptCode } ?: emptyMap()
 
-        return addressScriptVariants.map { addressVariant ->
-            val legalEntityVariant = toLegalEntityScriptVariant(legalEntityVariantsByCode[addressVariant.scriptCode]) ?: LegalEntityScriptVariantDto()
-            val siteScriptVariant = toSiteScriptVariant(siteScriptVariantsByCode[addressVariant.scriptCode]) ?: SiteScriptVariantDto()
-            val addressScriptVariant = toAddressScriptVariant(addressVariant.postalProperties)
+        val allScriptCodes = addressVariantByCode.keys.plus(legalEntityVariantsByCode.keys).plus(siteScriptVariantsByCode.keys)
 
-            BusinessPartnerScriptVariantDto(addressVariant.scriptCode, legalEntity = legalEntityVariant, site = siteScriptVariant, address = addressScriptVariant)
+        return allScriptCodes.map { scriptCode ->
+            val legalEntityVariant = toLegalEntityScriptVariant(legalEntityVariantsByCode[scriptCode]) ?: LegalEntityScriptVariantDto()
+            val siteScriptVariant = toSiteScriptVariant(siteScriptVariantsByCode[scriptCode]) ?: SiteScriptVariantDto()
+            val addressScriptVariant = addressVariantByCode[scriptCode]?.let { toAddressScriptVariant(it.postalProperties)  }?: AddressScriptVariantDto()
+
+            BusinessPartnerScriptVariantDto(scriptCode, legalEntity = legalEntityVariant, site = siteScriptVariant, address = addressScriptVariant)
         }
     }
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes legal entity and site values for script variants dropped in the output when the referenced golden record address has not the same script code script variant. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #1701 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
