### PR TITLE
fix: add migration script to enforce unique constraints for parallel …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Gate: Golden record relations to business partner output [#1630](https://github.com/eclipse-tractusx/bpdm/issues/1630)
 - BPDM Pool: Seed default Business Partner Relation Reason Code via Flyway migration [#1679](https://github.com/eclipse-tractusx/bpdm/issues/1679)
 
+
+### Added
+
+- BPDM Gate: Migration script to enforce unique constraints to fix parallel inserts with same external id being accepted in Gate [#1546](https://github.com/eclipse-tractusx/bpdm/issues/1546)
+
 ### Changed
 
 - BPDM Gate: Fix V7 relation output changelog always showing "UPDATE" type even if the relation output has been created [#1665](https://github.com/eclipse-tractusx/bpdm/issues/1665)

--- a/bpdm-gate/src/main/resources/db/migration/V7_4_0_5__enforce_unique_external_id_constraints.sql
+++ b/bpdm-gate/src/main/resources/db/migration/V7_4_0_5__enforce_unique_external_id_constraints.sql
@@ -1,0 +1,10 @@
+CREATE UNIQUE INDEX IF NOT EXISTS ux_sharing_states_external_id_null_tenant
+    ON sharing_states (external_id)
+    WHERE tenant_bpnl IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_sharing_states_tenant_external_id
+    ON sharing_states (tenant_bpnl, external_id)
+    WHERE tenant_bpnl IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_business_partners_sharing_state_stage
+    ON business_partners (sharing_state_id, stage);


### PR DESCRIPTION
…inserts with same external id (#1546)

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->



## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

BPDM Gate: The issue with parallel inserts using the same external ID being accepted has been fixed.
 #1546
 
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
