### PR TITLE
build(deps): increase tomcat dependencies to 11.0.22

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -128,9 +128,9 @@ maven/mavencentral/org.apache.james/apache-mime4j-dom/0.8.9, Apache-2.0, approve
 maven/mavencentral/org.apache.james/apache-mime4j-storage/0.8.9, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.25.4, Apache-2.0, approved, #21940
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.25.4, Apache-2.0, approved, #21937
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/11.0.21, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-or-later), approved, #19217
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/11.0.21, Apache-2.0, approved, #22421
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/11.0.21, Apache-2.0, approved, #21065
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/11.0.22, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-or-later), approved, #19217
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/11.0.22, Apache-2.0, approved, #22421
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/11.0.22, Apache-2.0, approved, #21065
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641
 maven/mavencentral/org.aspectj/aspectjweaver/1.9.25.1, EPL-1.0, approved, tools.aspectj
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
         <postgresql.version>42.7.11</postgresql.version>
         <netty.version>4.2.13.Final</netty.version>
+        <tomcat.version>11.0.22</tomcat.version>
     </properties>
 
     <pluginRepositories>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request overrides the spring starter parent tomcat library version with a newer 11.0.22 to mitigate security vulnerabilities.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
