### PR TITLE
build(deps): increase netty dependencies to 4.2.15.Final

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -72,27 +72,27 @@ maven/mavencentral/io.mockk/mockk-agent-jvm/1.14.6, Apache-2.0, approved, clearl
 maven/mavencentral/io.mockk/mockk-core-jvm/1.14.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-dsl-jvm/1.14.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.mockk/mockk-jvm/1.14.6, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.netty/netty-buffer/4.2.13.Final, Apache-2.0, approved, #16116
-maven/mavencentral/io.netty/netty-codec-base/4.2.13.Final, Apache-2.0, approved, #21322
-maven/mavencentral/io.netty/netty-codec-classes-quic/4.2.13.Final, Apache-2.0, approved, #21311
-maven/mavencentral/io.netty/netty-codec-compression/4.2.13.Final, Apache-2.0, approved, #16109
-maven/mavencentral/io.netty/netty-codec-dns/4.2.13.Final, Apache-2.0, approved, #16112
-maven/mavencentral/io.netty/netty-codec-http/4.2.13.Final, Apache-2.0 AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND BSD-3-Clause), approved, #16121
-maven/mavencentral/io.netty/netty-codec-http2/4.2.13.Final, Apache-2.0, approved, #16125
-maven/mavencentral/io.netty/netty-codec-http3/4.2.13.Final, Apache-2.0, approved, #25607
-maven/mavencentral/io.netty/netty-codec-native-quic/4.2.13.Final, Apache-2.0, approved, #21319
-maven/mavencentral/io.netty/netty-codec-socks/4.2.13.Final, Apache-2.0, approved, #16117
-maven/mavencentral/io.netty/netty-common/4.2.13.Final, Apache-2.0 AND (Apache-2.0 AND CC0-1.0) AND (Apache-2.0 AND MIT), approved, #16124
-maven/mavencentral/io.netty/netty-handler-proxy/4.2.13.Final, Apache-2.0, approved, #16111
-maven/mavencentral/io.netty/netty-handler/4.2.13.Final, Apache-2.0, approved, #16123
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.2.13.Final, Apache-2.0, approved, #21316
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.2.13.Final, Apache-2.0, approved, #21330
-maven/mavencentral/io.netty/netty-resolver-dns/4.2.13.Final, Apache-2.0, approved, #16110
-maven/mavencentral/io.netty/netty-resolver/4.2.13.Final, Apache-2.0, approved, #16126
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.2.13.Final, Apache-2.0, approved, #21317
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.2.13.Final, Apache-2.0, approved, #21327
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.2.13.Final, Apache-2.0, approved, #21329
-maven/mavencentral/io.netty/netty-transport/4.2.13.Final, Apache-2.0, approved, #16113
+maven/mavencentral/io.netty/netty-buffer/4.2.15.Final, Apache-2.0, approved, #16116
+maven/mavencentral/io.netty/netty-codec-base/4.2.15.Final, Apache-2.0, approved, #21322
+maven/mavencentral/io.netty/netty-codec-classes-quic/4.2.15.Final, Apache-2.0, approved, #21311
+maven/mavencentral/io.netty/netty-codec-compression/4.2.15.Final, Apache-2.0, approved, #16109
+maven/mavencentral/io.netty/netty-codec-dns/4.2.15.Final, Apache-2.0, approved, #16112
+maven/mavencentral/io.netty/netty-codec-http/4.2.15.Final, Apache-2.0 AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND BSD-3-Clause), approved, #16121
+maven/mavencentral/io.netty/netty-codec-http2/4.2.15.Final, Apache-2.0, approved, #16125
+maven/mavencentral/io.netty/netty-codec-http3/4.2.15.Final, Apache-2.0, approved, #25607
+maven/mavencentral/io.netty/netty-codec-native-quic/4.2.15.Final, Apache-2.0, approved, #21319
+maven/mavencentral/io.netty/netty-codec-socks/4.2.15.Final, Apache-2.0, approved, #16117
+maven/mavencentral/io.netty/netty-common/4.2.15.Final, Apache-2.0 AND (Apache-2.0 AND CC0-1.0) AND (Apache-2.0 AND MIT), approved, #16124
+maven/mavencentral/io.netty/netty-handler-proxy/4.2.15.Final, Apache-2.0, approved, #16111
+maven/mavencentral/io.netty/netty-handler/4.2.15.Final, Apache-2.0, approved, #16123
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.2.15.Final, Apache-2.0, approved, #21316
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.2.15.Final, Apache-2.0, approved, #21330
+maven/mavencentral/io.netty/netty-resolver-dns/4.2.15.Final, Apache-2.0, approved, #16110
+maven/mavencentral/io.netty/netty-resolver/4.2.15.Final, Apache-2.0, approved, #16126
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.2.15.Final, Apache-2.0, approved, #21317
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.2.15.Final, Apache-2.0, approved, #21327
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.2.15.Final, Apache-2.0, approved, #21329
+maven/mavencentral/io.netty/netty-transport/4.2.15.Final, Apache-2.0, approved, #16113
 maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.3.5, Apache-2.0, approved, #25603
 maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.3.5, Apache-2.0, approved, #25597
 maven/mavencentral/io.projectreactor/reactor-core/3.8.5, Apache-2.0, approved, #25635

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <jackson-bom.version>3.1.1</jackson-bom.version>
         <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
         <postgresql.version>42.7.11</postgresql.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
         <tomcat.version>11.0.22</tomcat.version>
     </properties>
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request increases the netty dependencies to version 4.2.15.Final in order to mitigate vulnerabilities.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
