### PR TITLE
feat: add general address succession logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
   A succession carries no further consequences: nothing is inherited from the predecessor, no addresses or site memberships move, and its state is unchanged.
   A Gate relation of this type is shared as a site relation only when both business partners are refined to a site whose main address is its own; where a site shares its legal entity's address, `IsReplacedBy` continues to mean that the two legal entities succeed each other, so such a site cannot be replaced.
   Because a site name is unique within its legal entity, a site and its successor always carry different names [#1676](https://github.com/eclipse-tractusx/bpdm/issues/1676)
+- BPDM Pool and Gate: `IsReplacedBy` between two addresses (BPNA to BPNA) is now valid in every constellation, not only where a legal entity relocates its headquarters from its legal address to one of its additional addresses [#1787](https://github.com/eclipse-tractusx/bpdm/issues/1787)
 
 ### Changed
 

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskCreationService.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/service/RelationTaskCreationService.kt
@@ -186,7 +186,7 @@ class RelationTaskCreationService(
         relationType: RelationType
     ): RelationTaskKind? {
 
-        fun isLegalEntityLike(t: AddressType?) = when (t) {
+        fun isLegalEntityLike(t: AddressType) = when (t) {
             AddressType.LegalAndSiteMainAddress,
             AddressType.LegalAddress -> true
 
@@ -196,20 +196,24 @@ class RelationTaskCreationService(
         // A site relation requires SiteMainAddress on both sides rather than everything a site can be reached through:
         // LegalAndSiteMainAddress is a legal entity too, and IsReplacedBy between two of those already means the legal
         // entities succeed each other. A site sharing its legal entity's address can therefore not be replaced.
-        fun isSiteMainOnly(t: AddressType?) = t == AddressType.SiteMainAddress
+        fun isSiteMainOnly(t: AddressType) = t == AddressType.SiteMainAddress
 
-        fun isAdditional(t: AddressType?) = t == AddressType.AdditionalAddress
+        if (sourceAddressType == null || targetAddressType == null) return null
 
-        return when {
-            isLegalEntityLike(sourceAddressType) && isLegalEntityLike(targetAddressType) && relationType in listOf(
-                RelationType.IsAlternativeHeadquarterFor,
-                RelationType.IsOwnedBy,
-                RelationType.IsManagedBy,
-                RelationType.IsReplacedBy
-            ) -> RelationTaskKind.LegalEntity
-            isSiteMainOnly(sourceAddressType) && isSiteMainOnly(targetAddressType) && relationType == RelationType.IsReplacedBy -> RelationTaskKind.Site
-            ((isAdditional(sourceAddressType) && isLegalEntityLike(targetAddressType)) || (isLegalEntityLike(sourceAddressType) && isAdditional(targetAddressType))) && relationType == RelationType.IsReplacedBy -> RelationTaskKind.Address
-            else -> null
+        val bothLegalEntityLike = isLegalEntityLike(sourceAddressType) && isLegalEntityLike(targetAddressType)
+
+        return when (relationType) {
+            RelationType.IsAlternativeHeadquarterFor,
+            RelationType.IsOwnedBy,
+            RelationType.IsManagedBy -> if (bothLegalEntityLike) RelationTaskKind.LegalEntity else null
+
+            // An address succession is what remains once neither higher level claims the pair: every refined record has
+            // a BPNA, so any other IsReplacedBy pair is a succession between the two addresses themselves.
+            RelationType.IsReplacedBy -> when {
+                bothLegalEntityLike -> RelationTaskKind.LegalEntity
+                isSiteMainOnly(sourceAddressType) && isSiteMainOnly(targetAddressType) -> RelationTaskKind.Site
+                else -> RelationTaskKind.Address
+            }
         }
     }
 

--- a/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/v7/sharingstate/FindRelationSharingStatesV7IT.kt
+++ b/bpdm-gate/src/test/kotlin/org/eclipse/tractusx/bpdm/gate/v7/sharingstate/FindRelationSharingStatesV7IT.kt
@@ -296,12 +296,7 @@ class FindRelationSharingStatesV7IT : UnscheduledGateTestBaseV7() {
         val actual = gateClient.relationSharingState.get(externalIds = listOf(relation.externalId))
 
         //THEN
-        val expected = RelationSharingStateDto(
-            externalId = relation.externalId,
-            sharingStateType = RelationSharingStateType.Pending,
-            taskId = createdTask.taskId,
-            updatedAt = Instant.MIN
-        )
+        val expected = expectedPendingState(relation.externalId, createdTask.taskId)
         assertRepo.assertRelationSharingStates(actual, PageDto(1L, 1, 0, 1, listOf(expected)))
     }
 
@@ -471,22 +466,23 @@ class FindRelationSharingStatesV7IT : UnscheduledGateTestBaseV7() {
      * GIVEN an IsReplacedBy relation where the source has a site output and the target has an additional address output,
      *   and the golden record task creation has been triggered
      * WHEN input consumer searches for the relation sharing state
-     * THEN the sharing state shows Error because IsReplacedBy requires the non-additional side to be a legal entity, not a site
+     * THEN the sharing state shows Pending because a pair claimed by neither the legal entity nor the site level
+     *   is shared as a succession between the two addresses
      */
     @Test
-    fun `IsReplacedBy between site source and additional address target leads to sharing error`() {
+    fun `IsReplacedBy between site source and additional address target is shared as address relation`() {
         //GIVEN
         val relation = testDataClient.relation.createRelationWithOutputs(testName, RelationType.IsReplacedBy,
             { testDataClient.businessPartner.refineToSite(it) },
             { testDataClient.businessPartner.refineToAdditionalAddressOfSite(it) }
         )
-        relationTaskCreationService.sendTasks()
+        val createdTask = testDataClient.relation.setRelationStateToPending(relation.externalId, testName)
 
         //WHEN
         val actual = gateClient.relationSharingState.get(externalIds = listOf(relation.externalId))
 
         //THEN
-        val expected = expectedErrorState(relation.externalId)
+        val expected = expectedPendingState(relation.externalId, createdTask.taskId)
         assertRepo.assertRelationSharingStates(actual, PageDto(1L, 1, 0, 1, listOf(expected)))
     }
 
@@ -494,22 +490,23 @@ class FindRelationSharingStatesV7IT : UnscheduledGateTestBaseV7() {
      * GIVEN an IsReplacedBy relation where the source has a legal entity output and the target has a site output,
      *   and the golden record task creation has been triggered
      * WHEN input consumer searches for the relation sharing state
-     * THEN the sharing state shows Error because IsReplacedBy requires the non-legal-entity side to be an additional address, not a site
+     * THEN the sharing state shows Pending because only two legal entities succeed each other as legal entities,
+     *   so this pair is shared as a succession between the two addresses
      */
     @Test
-    fun `IsReplacedBy between legal entity source and site target leads to sharing error`() {
+    fun `IsReplacedBy between legal entity source and site target is shared as address relation`() {
         //GIVEN
         val relation = testDataClient.relation.createRelationWithOutputs(testName, RelationType.IsReplacedBy,
             { testDataClient.businessPartner.refineToLegalEntity(it) },
             { testDataClient.businessPartner.refineToSite(it) }
         )
-        relationTaskCreationService.sendTasks()
+        val createdTask = testDataClient.relation.setRelationStateToPending(relation.externalId, testName)
 
         //WHEN
         val actual = gateClient.relationSharingState.get(externalIds = listOf(relation.externalId))
 
         //THEN
-        val expected = expectedErrorState(relation.externalId)
+        val expected = expectedPendingState(relation.externalId, createdTask.taskId)
         assertRepo.assertRelationSharingStates(actual, PageDto(1L, 1, 0, 1, listOf(expected)))
     }
 
@@ -517,24 +514,31 @@ class FindRelationSharingStatesV7IT : UnscheduledGateTestBaseV7() {
      * GIVEN an IsReplacedBy relation where both source and target have additional address outputs,
      *   and the golden record task creation has been triggered
      * WHEN input consumer searches for the relation sharing state
-     * THEN the sharing state shows Error because IsReplacedBy requires one side to be a legal entity
+     * THEN the sharing state shows Pending because an additional address can be replaced by another address
      */
     @Test
-    fun `IsReplacedBy between two additional addresses leads to sharing error`() {
+    fun `IsReplacedBy between two additional addresses is shared as address relation`() {
         //GIVEN
         val relation = testDataClient.relation.createRelationWithOutputs(testName, RelationType.IsReplacedBy,
             { testDataClient.businessPartner.refineToAdditionalAddressOfSite(it) },
             { testDataClient.businessPartner.refineToAdditionalAddressOfSite(it) }
         )
-        relationTaskCreationService.sendTasks()
+        val createdTask = testDataClient.relation.setRelationStateToPending(relation.externalId, testName)
 
         //WHEN
         val actual = gateClient.relationSharingState.get(externalIds = listOf(relation.externalId))
 
         //THEN
-        val expected = expectedErrorState(relation.externalId)
+        val expected = expectedPendingState(relation.externalId, createdTask.taskId)
         assertRepo.assertRelationSharingStates(actual, PageDto(1L, 1, 0, 1, listOf(expected)))
     }
+
+    private fun expectedPendingState(externalId: String, taskId: String?) = RelationSharingStateDto(
+        externalId = externalId,
+        sharingStateType = RelationSharingStateType.Pending,
+        taskId = taskId,
+        updatedAt = Instant.MIN
+    )
 
     private fun expectedErrorState(externalId: String) = RelationSharingStateDto(
         externalId = externalId,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationUpsertService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/AddressRelationUpsertService.kt
@@ -19,22 +19,24 @@
 
 package org.eclipse.tractusx.bpdm.pool.service
 
-import org.eclipse.tractusx.bpdm.common.dto.AddressType
 import org.eclipse.tractusx.bpdm.common.dto.BusinessPartnerType
 import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
 import org.eclipse.tractusx.bpdm.pool.api.model.ChangelogType
-import org.eclipse.tractusx.bpdm.pool.model.ChangelogRecord
-import org.eclipse.tractusx.bpdm.pool.service.operation.ChangelogCreateService
 import org.eclipse.tractusx.bpdm.pool.dto.UpsertResult
 import org.eclipse.tractusx.bpdm.pool.dto.UpsertType
 import org.eclipse.tractusx.bpdm.pool.entity.*
 import org.eclipse.tractusx.bpdm.pool.exception.BpdmValidationException
+import org.eclipse.tractusx.bpdm.pool.model.ChangelogRecord
 import org.eclipse.tractusx.bpdm.pool.repository.AddressRelationEventTriggerRepository
 import org.eclipse.tractusx.bpdm.pool.repository.AddressRelationRepository
+import org.eclipse.tractusx.bpdm.pool.service.operation.ChangelogCreateService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
+/**
+ * Writes succession between two addresses of one legal entity, in which the source address is replaced by the target address.
+ */
 @Service
 class AddressRelationUpsertService(
     private val addressRelationRepository: AddressRelationRepository,
@@ -43,76 +45,141 @@ class AddressRelationUpsertService(
     private val addressRelationEventTriggerRepository: AddressRelationEventTriggerRepository
 ): IAddressRelationUpsertStratergyService {
 
+    /**
+     * Persists the succession and rejects it if the two addresses belong to different legal entities, if the predecessor
+     * already has a different successor in an overlapping validity period, or if it would close a replacement cycle over
+     * overlapping periods. A succession that starts at a legal entity's legal address also relocates that legal entity's
+     * headquarters to the successor.
+     */
     @Transactional
     override fun upsertRelation(upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest): UpsertResult<AddressRelationDb> {
-        val sourceAddress = upsertRequest.source
-        val targetAddress = upsertRequest.target
-        val addressRelationType = AddressRelationType.IsReplacedBy //As of now, only IsReplacedBy is supported for address relations
-        val validityPeriods = upsertRequest.validityPeriods
+        validateNoSelfReference(upsertRequest)
+        validateSameLegalEntity(upsertRequest)
 
-        // Prevent self-referencing relations
-        if (sourceAddress == targetAddress) {
-            throw BpdmValidationException("A Address cannot have a relation to itself (BPNA: ${sourceAddress.bpn}).")
+        val existingRelation = findExistingRelation(upsertRequest)
+
+        validateSingleSuccessor(upsertRequest, existingRelation)
+        validateNoCycles(upsertRequest, existingRelation)
+
+        if (existingRelation == null) {
+            val newRelation = createRelation(upsertRequest)
+            handleHeadquarterSynchronization(newRelation)
+
+            return UpsertResult(newRelation, UpsertType.Created)
         }
 
-        validateSoureAndTargetAddress(sourceAddress, targetAddress)
+        if (!validityPeriodsDiffer(existingRelation.validityPeriods, upsertRequest.validityPeriods)) {
+            return UpsertResult(existingRelation, UpsertType.NoChange)
+        }
 
-        val existingRelation = addressRelationRepository.findAll(
+        existingRelation.validityPeriods.clear()
+        existingRelation.validityPeriods.addAll(upsertRequest.validityPeriods)
+        addressRelationRepository.saveAndFlush(existingRelation)
+
+        handleHeadquarterSynchronization(existingRelation)
+
+        return UpsertResult(existingRelation, UpsertType.Updated)
+    }
+
+    private fun findExistingRelation(upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest): AddressRelationDb? =
+        addressRelationRepository.findAll(
             AddressRelationRepository.byRelation(
-                startAddress = sourceAddress,
-                endAddress = targetAddress,
-                type = addressRelationType
+                startAddress = upsertRequest.source,
+                endAddress = upsertRequest.target,
+                type = AddressRelationType.IsReplacedBy
             )
         ).singleOrNull()
 
-        val upsertResult = if (existingRelation != null) {
-            // Update validity periods if changed
-            if (validityPeriodsDiffer(existingRelation.validityPeriods, upsertRequest.validityPeriods)) {
-                existingRelation.validityPeriods.clear()
-                existingRelation.validityPeriods.addAll(upsertRequest.validityPeriods)
-                addressRelationRepository.saveAndFlush(existingRelation)
-
-                handleHeadquarterSynchronization(existingRelation)
-                UpsertResult(existingRelation, UpsertType.Updated)
-            } else {
-                UpsertResult(existingRelation, UpsertType.NoChange)
-            }
-        } else {
-            val newRelation = createNewAddressRelation(
-                UpsertRequest(
-                    source = sourceAddress,
-                    target = targetAddress,
-                    addressRelationType = addressRelationType,
-                    validityPeriods = validityPeriods,
-                    reasonCode = upsertRequest.reasonCode
-                )
-            )
-
-            handleHeadquarterSynchronization(newRelation)
-
-            UpsertResult(newRelation, UpsertType.Created)
-        }
-
-        return upsertResult
-
+    private fun validateNoSelfReference(upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest) {
+        if (upsertRequest.source.bpn == upsertRequest.target.bpn)
+            throw BpdmValidationException("An address cannot have a relation to itself (BPNA: ${upsertRequest.source.bpn}).")
     }
 
-    private fun validateSoureAndTargetAddress(source: LogisticAddressDb, target: LogisticAddressDb) {
+    private fun validateSameLegalEntity(upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest) {
+        val source = upsertRequest.source
+        val target = upsertRequest.target
+
         if (source.legalEntity!!.bpn != target.legalEntity!!.bpn) {
             throw BpdmValidationException("Invalid 'IsReplacedBy' relation: The source address with BPNA '${source.bpn}' and target address with BPNA '${target.bpn}' do not belong to the same Legal Entity (BPNL '${source.legalEntity!!.bpn}' and '${target.legalEntity!!.bpn}'). "
                     + "Both addresses must belong to the same Legal Entity to create an 'IsReplacedBy' relation.")
         }
-        if (source.addressType != AddressType.LegalAddress) {
-            throw BpdmValidationException("Invalid source address type for 'IsReplacedBy' relation: The source address with BPNA '${source.bpn}' is of type '${source.addressType}'. "
-                    + "Only addresses of type 'LegalAddress' can be the source of an 'IsReplacedBy' relation.")
-        }
-        if (target.addressType != AddressType.AdditionalAddress) {
-            throw BpdmValidationException("Invalid target address type for 'IsReplacedBy' relation: The target address with BPNA '${target.bpn}' is of type '${target.addressType}'. "
-                    + "Only addresses of type 'AdditionalAddress' can be the target of an 'IsReplacedBy' relation.")
+    }
+
+    // Several predecessors may share one successor, so the mirror image of this check is deliberately absent: a merger
+    // of multiple addresses into one is a valid succession.
+    private fun validateSingleSuccessor(
+        upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest,
+        existingRelation: AddressRelationDb?
+    ) {
+        val predecessor = upsertRequest.source
+        val successor = upsertRequest.target
+
+        val existingSuccessions = addressRelationRepository.findByTypeAndStartAddress(AddressRelationType.IsReplacedBy, predecessor)
+
+        filterOverlappingRelations(upsertRequest, existingRelation, existingSuccessions).forEach { succession ->
+            if (succession.endAddress.bpn != successor.bpn)
+                throw BpdmValidationException(
+                    "Multiple successors assigned to the same address: address '${predecessor.bpn}' can't be replaced by " +
+                            "'${successor.bpn}' as it is already replaced by '${succession.endAddress.bpn}' in an overlapping validity period."
+                )
         }
     }
 
-    private fun createNewAddressRelation(upsertRequest: UpsertRequest): AddressRelationDb {
+    private fun validateNoCycles(
+        upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest,
+        existingRelation: AddressRelationDb?
+    ) {
+        val predecessor = upsertRequest.source
+        val successor = upsertRequest.target
+
+        if (getAllSuccessors(upsertRequest, existingRelation).contains(predecessor.bpn))
+            throw BpdmValidationException(
+                "Circular replacement detected: address '${predecessor.bpn}' is (transitively) replacing '${successor.bpn}' " +
+                        "and therefore can't be replaced by '${successor.bpn}'."
+            )
+    }
+
+    private fun getAllSuccessors(
+        upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest,
+        existingRelation: AddressRelationDb?
+    ): Set<String> {
+        val visitedBpns = mutableSetOf<String>()
+        val successorProcessingQueue = ArrayDeque<LogisticAddressDb>()
+
+        successorProcessingQueue.addFirst(upsertRequest.target)
+
+        while (successorProcessingQueue.isNotEmpty()) {
+            val currentSuccessor = successorProcessingQueue.removeFirst()
+
+            if (!visitedBpns.add(currentSuccessor.bpn))
+                continue
+
+            val successionsOfCurrent = addressRelationRepository.findByTypeAndStartAddress(AddressRelationType.IsReplacedBy, currentSuccessor)
+            filterOverlappingRelations(upsertRequest, existingRelation, successionsOfCurrent)
+                .forEach { successorProcessingQueue.addFirst(it.endAddress) }
+        }
+
+        return visitedBpns
+    }
+
+    private fun filterOverlappingRelations(
+        upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest,
+        existingRelation: AddressRelationDb?,
+        relations: Collection<AddressRelationDb>
+    ): Collection<AddressRelationDb> =
+        relations
+            .filterNot { relation -> existingRelation?.id == relation.id }
+            .filter { relation -> hasOverlap(upsertRequest.validityPeriods, relation.validityPeriods) }
+
+    private fun hasOverlap(validityPeriods: Collection<RelationValidityPeriodDb>, otherValidityPeriods: Collection<RelationValidityPeriodDb>): Boolean =
+        validityPeriods.any { period ->
+            otherValidityPeriods.any { otherPeriod ->
+                RelationTimePeriod.fromUnlimited(period.validFrom, period.validTo)
+                    .hasOverlap(RelationTimePeriod.fromUnlimited(otherPeriod.validFrom, otherPeriod.validTo))
+            }
+        }
+
+    private fun createRelation(upsertRequest: IAddressRelationUpsertStratergyService.UpsertRequest): AddressRelationDb {
         val source = upsertRequest.source
         val target = upsertRequest.target
         val validityPeriods = upsertRequest.validityPeriods.map {
@@ -123,7 +190,7 @@ class AddressRelationUpsertService(
         }.toMutableList()
 
         val newRelation = AddressRelationDb(
-            type = upsertRequest.addressRelationType,
+            type = AddressRelationType.IsReplacedBy,
             startAddress = source,
             endAddress = target,
             validityPeriods = validityPeriods,
@@ -138,6 +205,9 @@ class AddressRelationUpsertService(
         return newRelation
     }
 
+    // Every succession is synchronized and triggered, not only one starting at a legal address: the synchronization walks
+    // forward from the legal entity's legal address, so a succession off that chain reaches nothing. Which future-dated
+    // succession will be on the chain once it becomes active is not known when it is written.
     private fun handleHeadquarterSynchronization(relation: AddressRelationDb){
         val today = LocalDate.now()
 
@@ -157,14 +227,6 @@ class AddressRelationUpsertService(
 
         addressRelationEventTriggerRepository.saveAll(futureEventTriggers)
     }
-
-    data class UpsertRequest(
-        val source: LogisticAddressDb,
-        val target: LogisticAddressDb,
-        val addressRelationType: AddressRelationType,
-        val validityPeriods: Collection<RelationValidityPeriodDb>,
-        val reasonCode: ReasonCodeDb?
-    )
 
     private fun validityPeriodsDiffer(existingValidityPeriods: Collection<RelationValidityPeriodDb>, newValidityPeriods: Collection<RelationValidityPeriodDb>): Boolean {
         if (existingValidityPeriods.size != newValidityPeriods.size) return true

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionAddressSuccessionIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionAddressSuccessionIT.kt
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.pool.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.tractusx.bpdm.common.dto.AddressType
+import org.eclipse.tractusx.bpdm.common.dto.PaginationRequest
+import org.eclipse.tractusx.bpdm.pool.Application
+import org.eclipse.tractusx.bpdm.pool.api.client.PoolApiClient
+import org.eclipse.tractusx.bpdm.pool.api.model.AddressRelationType
+import org.eclipse.tractusx.bpdm.test.containers.OrchestratorMockConfiguration
+import org.eclipse.tractusx.bpdm.test.containers.PostgreSQLContextInitializer
+import org.eclipse.tractusx.bpdm.test.testdata.pool.BusinessPartnerRequestFactory
+import org.eclipse.tractusx.bpdm.test.testdata.pool.PoolDataHelper
+import org.eclipse.tractusx.bpdm.test.testdata.pool.TestDataEnvironment
+import org.eclipse.tractusx.bpdm.test.util.DbTestHelpers
+import org.eclipse.tractusx.orchestrator.api.model.BusinessPartnerRelations
+import org.eclipse.tractusx.orchestrator.api.model.RelationType
+import org.eclipse.tractusx.orchestrator.api.model.RelationValidityPeriod
+import org.eclipse.tractusx.orchestrator.api.model.TaskRelationsStepReservationEntryDto
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import java.time.LocalDate
+
+/**
+ * A succession between addresses relocates the headquarters only where it starts at the legal address, which
+ * TaskRelationsResolutionHeadquarterRelocationIT covers. This class covers the successions that leave the involved
+ * business partners as they are.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class]
+)
+@ActiveProfiles("test-no-auth", "test-scheduling-disabled")
+@Import(OrchestratorMockConfiguration::class)
+@ContextConfiguration(initializers = [PostgreSQLContextInitializer::class])
+class TaskRelationsResolutionAddressSuccessionIT @Autowired constructor(
+    private val taskRelationsResolutionService: TaskRelationsResolutionService,
+    private val poolApiClient: PoolApiClient,
+    private val dataHelper: PoolDataHelper,
+    private val dbTestHelpers: DbTestHelpers
+) {
+
+    private lateinit var testDataEnvironment: TestDataEnvironment
+    private lateinit var testName: String
+    private lateinit var requestFactory: BusinessPartnerRequestFactory
+
+    @BeforeEach
+    fun beforeEach(testInfo: TestInfo) {
+        dbTestHelpers.truncateDbTables()
+        testDataEnvironment = dataHelper.createTestDataEnvironment()
+        requestFactory = testDataEnvironment.requestFactory
+        testName = testInfo.displayName
+    }
+
+    /**
+     * GIVEN a legal entity with two additional addresses
+     * WHEN one additional address replaces the other effective immediately
+     * THEN user sees the legal entity keeps its legal address and both addresses keep their address type
+     */
+    @Test
+    fun `succession between two additional addresses keeps headquarter and address types`() {
+        //GIVEN
+        val legalEntityRequest = requestFactory.createLegalEntityRequest(testName, true)
+        val createdLegalEntity = poolApiClient.legalEntities.createBusinessPartners(listOf(legalEntityRequest)).entities.single()
+        val legalEntityBpnl = createdLegalEntity.legalEntity.header.bpnl
+
+        val predecessorRequest = requestFactory.buildAdditionalAddressCreateRequest("$testName A", legalEntityBpnl).copy(scriptVariants = emptyList())
+        val successorRequest = requestFactory.buildAdditionalAddressCreateRequest("$testName B", legalEntityBpnl).copy(scriptVariants = emptyList())
+        val createdAddresses = poolApiClient.addresses.createAddresses(listOf(predecessorRequest, successorRequest)).entities.toList()
+        val predecessor = createdAddresses[0]
+        val successor = createdAddresses[1]
+
+        //WHEN
+        resolveSuccession(predecessor.address.bpna, successor.address.bpna)
+
+        //THEN
+        val actualLegalEntity = poolApiClient.legalEntities.getLegalEntity(legalEntityBpnl)
+        assertThat(actualLegalEntity.legalAddress.bpna).isEqualTo(createdLegalEntity.legalEntity.legalAddress.bpna)
+
+        assertThat(addressTypeOf(predecessor.address.bpna)).isEqualTo(AddressType.AdditionalAddress)
+        assertThat(addressTypeOf(successor.address.bpna)).isEqualTo(AddressType.AdditionalAddress)
+        assertThat(successionsOf(predecessor.address.bpna)).hasSize(1)
+    }
+
+    /**
+     * GIVEN a legal entity and an additional address
+     * WHEN the legal address replaces the additional address effective immediately
+     * THEN user sees the legal entity keeps its legal address and both addresses keep their address type
+     */
+    @Test
+    fun `succession from additional address to legal address keeps headquarter and address types`() {
+        //GIVEN
+        val legalEntityRequest = requestFactory.createLegalEntityRequest(testName, true)
+        val createdLegalEntity = poolApiClient.legalEntities.createBusinessPartners(listOf(legalEntityRequest)).entities.single()
+        val legalAddressBpna = createdLegalEntity.legalEntity.legalAddress.bpna
+
+        val predecessorRequest = requestFactory
+            .buildAdditionalAddressCreateRequest("$testName A", createdLegalEntity.legalEntity.header.bpnl)
+            .copy(scriptVariants = emptyList())
+        val predecessor = poolApiClient.addresses.createAddresses(listOf(predecessorRequest)).entities.single()
+
+        //WHEN
+        resolveSuccession(predecessor.address.bpna, legalAddressBpna)
+
+        //THEN
+        val actualLegalEntity = poolApiClient.legalEntities.getLegalEntity(createdLegalEntity.legalEntity.header.bpnl)
+        assertThat(actualLegalEntity.legalAddress.bpna).isEqualTo(legalAddressBpna)
+
+        assertThat(addressTypeOf(predecessor.address.bpna)).isEqualTo(AddressType.AdditionalAddress)
+        assertThat(addressTypeOf(legalAddressBpna)).isEqualTo(AddressType.LegalAddress)
+        assertThat(successionsOf(predecessor.address.bpna)).hasSize(1)
+    }
+
+    private fun resolveSuccession(predecessorBpna: String, successorBpna: String) {
+        val activeNow = listOf(RelationValidityPeriod(LocalDate.now(), null))
+        val succession = BusinessPartnerRelations(RelationType.IsReplacedBy, predecessorBpna, successorBpna, activeNow, anyReasonCode())
+        val taskToResolve = TaskRelationsStepReservationEntryDto("Any", "Any", succession)
+
+        val results = taskRelationsResolutionService.upsertRelationsGoldenRecordIntoPool(listOf(taskToResolve))
+
+        assertThat(results.single().errors).isEmpty()
+    }
+
+    private fun addressTypeOf(bpna: String) = poolApiClient.addresses.getAddress(bpna).address.addressType
+
+    private fun successionsOf(bpna: String) =
+        poolApiClient.addresses.getAddress(bpna).address.relations.filter { it.type == AddressRelationType.IsReplacedBy }
+
+    private fun anyReasonCode(): String {
+        return poolApiClient.metadata.getReasonCodes(PaginationRequest()).content.first().technicalKey
+    }
+}

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionHeadquarterRelocationIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionHeadquarterRelocationIT.kt
@@ -119,6 +119,36 @@ class TaskRelationsResolutionHeadquarterRelocationIT @Autowired constructor(
     }
 
     /**
+     * GIVEN a legal entity and a site whose main address is its own
+     * WHEN the site main address replaces the legal address effective immediately
+     * THEN user sees the site main address as new legal address, now serving both roles
+     */
+    @Test
+    fun `legal address replaced by site main address changes headquarter`(){
+        //GIVEN
+        val legalEntityRequest = requestFactory.createLegalEntityRequest(testName, true)
+        val createdLegalEntity = poolApiClient.legalEntities.createBusinessPartners(listOf(legalEntityRequest)).entities.single()
+
+        val siteRequest = requestFactory.buildSiteCreateRequest("$testName 2", createdLegalEntity.legalEntity.header.bpnl)
+        val createdSite = poolApiClient.sites.createSite(listOf(siteRequest)).entities.single()
+
+        //WHEN
+        val activeNow = listOf(RelationValidityPeriod(LocalDate.now(), null))
+        val replacedByRelation = BusinessPartnerRelations(
+            RelationType.IsReplacedBy, createdLegalEntity.legalEntity.legalAddress.bpna, createdSite.mainAddress.bpna, activeNow, anyReasonCode()
+        )
+        val taskToResolve = TaskRelationsStepReservationEntryDto("Any", "Any", replacedByRelation)
+        val results = taskRelationsResolutionService.upsertRelationsGoldenRecordIntoPool(listOf(taskToResolve))
+
+        //THEN
+        assertThat(results.single().errors).isEmpty()
+
+        val actualLegalEntity = poolApiClient.legalEntities.getLegalEntity(createdLegalEntity.legalEntity.header.bpnl)
+        assertThat(actualLegalEntity.legalAddress.bpna).isEqualTo(createdSite.mainAddress.bpna)
+        assertThat(actualLegalEntity.legalAddress.addressType).isEqualTo(AddressType.LegalAndSiteMainAddress)
+    }
+
+    /**
      * GIVEN a legal entity and an additional address
      * WHEN additional address replaces legal address effective some point in the future
      * THEN user sees legal address of legal entity did not change

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/service/TaskRelationsResolutionServiceTest.kt
@@ -697,30 +697,203 @@ class TaskRelationsResolutionServiceTest @Autowired constructor(
     }
 
     /**
-     * GIVEN an address relation upsert request
-     *   AND source address is of type AdditionalAddress
-     *   AND target address is of type AdditionalAddress
-     * WHEN trying to upsert an address relation
-     * THEN validation exception is thrown indicating invalid source address type
+     * GIVEN two additional addresses of the same legal entity
+     * WHEN creating relation 'address A is replaced by address B'
+     * THEN the succession is accepted and reported back with both BPNA
      */
-    @ParameterizedTest
-    @EnumSource(AddressRelationType::class)
-    fun `reject address relation when source is not LegalAddress `(relationType: AddressRelationType) {
-        //Given
-        val legalEntity1 = createLegalEntity("$testName 1")
-        val additionalAddress1 = createAdditionalAddress("$testName Addr 1", legalEntity1)
-        val additionalAddress2 = createAdditionalAddress("$testName Addr 2", legalEntity1)
+    @Test
+    fun `create address IsReplacedBy relation between two additional addresses`() {
+        //GIVEN
+        val legalEntity = createLegalEntity(testName)
+        val addressA = createAdditionalAddress("$testName A", legalEntity)
+        val addressB = createAdditionalAddress("$testName B", legalEntity)
 
-        val createAddressRelationsRequest = buildAlwaysActiveRelationRequest(
-            relationType = relationType,
-            businessPartnerSourceBpn = additionalAddress1.address.bpna,
-            businessPartnerTargetBpn = additionalAddress2.address.bpna
+        val aReplacedByB = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressA.address.bpna,
+            businessPartnerTargetBpn = addressB.address.bpna
         )
 
-        val result = upsertRelationsGoldenRecordIntoPool(taskId = "TASK_1", businessPartnerRelations = createAddressRelationsRequest)
-        assertThat(result[0].taskId).isEqualTo("TASK_1")
-        assertThat(result[0].errors.size).isEqualTo(1)
-        assertThat(result[0].errors[0].description).contains("Invalid source address type for 'IsReplacedBy' relation")
+        //WHEN
+        val result = upsertRelationsGoldenRecordIntoPool("TASK_CREATE_ADDRESS_SUCCESSION", aReplacedByB).single()
+
+        //THEN
+        assertThat(result.errors).isEmpty()
+        assertThat(result.businessPartnerRelations.relationType).isEqualTo(RelationType.IsReplacedBy)
+        assertThat(result.businessPartnerRelations.businessPartnerSourceBpn).isEqualTo(addressA.address.bpna)
+        assertThat(result.businessPartnerRelations.businessPartnerTargetBpn).isEqualTo(addressB.address.bpna)
+        assertThat(result.businessPartnerRelations.validityPeriods).isEqualTo(aReplacedByB.validityPeriods)
+    }
+
+    /**
+     * GIVEN a site main address and an additional address of the same legal entity
+     * WHEN creating relation 'the site main address is replaced by the additional address'
+     * THEN the succession is accepted
+     */
+    @Test
+    fun `create address IsReplacedBy relation from site main address to additional address`() {
+        //GIVEN
+        val legalEntity = createLegalEntity(testName)
+        val site = createSite("$testName Site", legalEntity)
+        val additionalAddress = createAdditionalAddress("$testName Addr", legalEntity)
+
+        val mainAddressReplacedByAdditional = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = site.mainAddress.bpna,
+            businessPartnerTargetBpn = additionalAddress.address.bpna
+        )
+
+        //WHEN
+        val result = upsertRelationsGoldenRecordIntoPool("TASK_SITE_MAIN_ADDRESS_SUCCESSION", mainAddressReplacedByAdditional).single()
+
+        //THEN
+        assertThat(result.errors).isEmpty()
+        assertThat(result.businessPartnerRelations.businessPartnerSourceBpn).isEqualTo(site.mainAddress.bpna)
+        assertThat(result.businessPartnerRelations.businessPartnerTargetBpn).isEqualTo(additionalAddress.address.bpna)
+    }
+
+    /**
+     * GIVEN address A is replaced by address B
+     * WHEN trying to create relation 'address A is replaced by address C' in an overlapping validity period
+     * THEN return multiple successors error
+     */
+    @Test
+    fun `create address IsReplacedBy relation - violate single successor`() {
+        //GIVEN
+        val legalEntity = createLegalEntity(testName)
+        val addressA = createAdditionalAddress("$testName A", legalEntity)
+        val addressB = createAdditionalAddress("$testName B", legalEntity)
+        val addressC = createAdditionalAddress("$testName C", legalEntity)
+
+        val validReplacedByB = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressA.address.bpna,
+            businessPartnerTargetBpn = addressB.address.bpna
+        )
+        upsertRelationsGoldenRecordIntoPool("TASK_VALID", validReplacedByB)
+
+        val violatingSingleSuccessor = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressA.address.bpna,
+            businessPartnerTargetBpn = addressC.address.bpna
+        )
+
+        //WHEN
+        val result = upsertRelationsGoldenRecordIntoPool("TASK_VIOLATE_SINGLE_SUCCESSOR", violatingSingleSuccessor).single()
+
+        //THEN
+        assertThat(result.errors.size).isEqualTo(1)
+        assertThat(result.errors[0].description).contains("Multiple successors assigned to the same address")
+    }
+
+    /**
+     * GIVEN address A is replaced by address C
+     * WHEN creating relation 'address B is replaced by address C' in an overlapping validity period
+     * THEN the merger of both predecessors into one successor is accepted
+     */
+    @Test
+    fun `create address IsReplacedBy relation - allow merger into a shared successor`() {
+        //GIVEN
+        val legalEntity = createLegalEntity(testName)
+        val addressA = createAdditionalAddress("$testName A", legalEntity)
+        val addressB = createAdditionalAddress("$testName B", legalEntity)
+        val addressC = createAdditionalAddress("$testName C", legalEntity)
+
+        val aReplacedByC = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressA.address.bpna,
+            businessPartnerTargetBpn = addressC.address.bpna
+        )
+        upsertRelationsGoldenRecordIntoPool("TASK_FIRST_PREDECESSOR", aReplacedByC)
+
+        val bReplacedByC = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressB.address.bpna,
+            businessPartnerTargetBpn = addressC.address.bpna
+        )
+
+        //WHEN
+        val result = upsertRelationsGoldenRecordIntoPool("TASK_SECOND_PREDECESSOR", bReplacedByC).single()
+
+        //THEN
+        assertThat(result.errors).isEmpty()
+    }
+
+    /**
+     * GIVEN address A is replaced by address B which is replaced by address C
+     * WHEN trying to create relation 'address C is replaced by address A'
+     * THEN return circular replacement error
+     */
+    @Test
+    fun `create address IsReplacedBy relation - violate no cycles`() {
+        //GIVEN
+        val legalEntity = createLegalEntity(testName)
+        val addressA = createAdditionalAddress("$testName A", legalEntity)
+        val addressB = createAdditionalAddress("$testName B", legalEntity)
+        val addressC = createAdditionalAddress("$testName C", legalEntity)
+
+        val aReplacedByB = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressA.address.bpna,
+            businessPartnerTargetBpn = addressB.address.bpna
+        )
+        upsertRelationsGoldenRecordIntoPool("TASK_VALID_1", aReplacedByB)
+
+        val bReplacedByC = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressB.address.bpna,
+            businessPartnerTargetBpn = addressC.address.bpna
+        )
+        upsertRelationsGoldenRecordIntoPool("TASK_VALID_2", bReplacedByC)
+
+        val violatingNoCycles = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressC.address.bpna,
+            businessPartnerTargetBpn = addressA.address.bpna
+        )
+
+        //WHEN
+        val result = upsertRelationsGoldenRecordIntoPool("TASK_VIOLATE_NO_CYCLES", violatingNoCycles).single()
+
+        //THEN
+        assertThat(result.errors.size).isEqualTo(1)
+        assertThat(result.errors[0].description).contains("Circular replacement detected")
+    }
+
+    /**
+     * GIVEN address A is replaced by address B
+     * WHEN creating relation 'address B is replaced by address C'
+     * THEN the succession chain is accepted and both relations are reported on B
+     */
+    @Test
+    fun `create address IsReplacedBy relation - extend succession chain`() {
+        //GIVEN
+        val legalEntity = createLegalEntity(testName)
+        val addressA = createAdditionalAddress("$testName A", legalEntity)
+        val addressB = createAdditionalAddress("$testName B", legalEntity)
+        val addressC = createAdditionalAddress("$testName C", legalEntity)
+
+        val aReplacedByB = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressA.address.bpna,
+            businessPartnerTargetBpn = addressB.address.bpna
+        )
+        upsertRelationsGoldenRecordIntoPool("TASK_INITIAL", aReplacedByB)
+
+        val bReplacedByC = buildAlwaysActiveRelationRequest(
+            relationType = RelationType.IsReplacedBy,
+            businessPartnerSourceBpn = addressB.address.bpna,
+            businessPartnerTargetBpn = addressC.address.bpna
+        )
+
+        //WHEN
+        val result = upsertRelationsGoldenRecordIntoPool("TASK_CHAIN_EXTENSION", bReplacedByC).single()
+
+        //THEN
+        assertThat(result.errors).isEmpty()
+        val fetchedB = poolClient.addresses.getAddress(addressB.address.bpna)
+        assertThat(fetchedB.address.relations.filter { it.type == AddressRelationType.IsReplacedBy })
+            .hasSize(2)
     }
 
     /**

--- a/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/stepdefinations/GoldenRecordRelationsInOutputStepDefs.kt
+++ b/bpdm-system-tester/src/main/kotlin/org/eclipse/tractusx/bpdm/test/system/stepdefinations/GoldenRecordRelationsInOutputStepDefs.kt
@@ -308,14 +308,6 @@ class GoldenRecordRelationsInOutputStepDefs(
     // Private helpers
     // -------------------------------------------------------------------------
 
-    private fun addressBpnOf(addressId: String): String =
-        context.addressBpnByLabel[addressId]
-            ?: error("address '$addressId' must be named by an earlier refinement step")
-
-    private fun bpnlOf(legalEntityId: String): String =
-        context.legalEntities[legalEntityId]?.header?.bpnl
-            ?: error("legal entity '$legalEntityId' must be defined by an earlier refinement step")
-
     private fun goldenRecordOutputOf(recordId: String): BusinessPartnerOutputDto {
         val runId = context.runId(recordId)
         val outputPage = gateClient.businessParters.getBusinessPartnersOutput(listOf(runId))
@@ -334,18 +326,16 @@ class GoldenRecordRelationsInOutputStepDefs(
         targetOutput: BusinessPartnerOutputDto
     ): Pair<String, String> {
         val outputs = listOf(sourceOutput, targetOutput)
+        val bothLegalEntities = outputs.all { it.address.addressType in LEGAL_ADDRESS_TYPES }
         val bothSiteMain = outputs.all { it.address.addressType == AddressType.SiteMainAddress }
-        val anyAdditional = outputs.any { it.address.addressType == AddressType.AdditionalAddress }
 
         return when {
-            relationType !in ADDRESS_CAPABLE_RELATION_TYPES ->
+            relationType !in ADDRESS_CAPABLE_RELATION_TYPES || bothLegalEntities ->
                 sourceOutput.legalEntity.legalEntityBpn to targetOutput.legalEntity.legalEntityBpn
             bothSiteMain ->
                 siteBpnOf(sourceOutput) to siteBpnOf(targetOutput)
-            anyAdditional ->
-                sourceOutput.address.addressBpn to targetOutput.address.addressBpn
             else ->
-                sourceOutput.legalEntity.legalEntityBpn to targetOutput.legalEntity.legalEntityBpn
+                sourceOutput.address.addressBpn to targetOutput.address.addressBpn
         }
     }
 

--- a/bpdm-system-tester/src/main/resources/cucumber/address_succession.feature
+++ b/bpdm-system-tester/src/main/resources/cucumber/address_succession.feature
@@ -1,0 +1,57 @@
+# An address is succeeded by another address of the same legal entity, expressed as an IsReplacedBy relation between
+# the predecessor (source) and the successor (target). Any pair of addresses can succeed each other, as long as the
+# pair is not already a succession on a higher level: two records refined to legal entities succeed each other as
+# legal entities (legal_entity_succession.feature) and two records refined to sites with their own main address as
+# sites (site_succession.feature).
+# Only a succession that starts at a legal entity's legal address carries a consequence, in which case it relocates
+# the headquarters (headquarter_relocation.feature). Every other address succession leaves both addresses as they are:
+# nothing is reclassified, nothing is inherited and no state changes. This feature gathers the scenarios for those
+# successions.
+@CXTPM-1039
+Feature: Address Succession
+
+  #h3. Test Objective:
+  #
+  #* Verify the sharing member's relation output reflects an established IsReplacedBy golden record relation between two addresses.
+  #
+  #h3. Preconditions:
+  #
+  ## Two records each reflect an additional address of the same legal entity (predecessor and successor).
+  #
+  #h3. Description:
+  #
+  ## The sharing member shares an IsReplacedBy relation from the predecessor address record to the successor address record, effective immediately.
+  ## The golden record process establishes the relation between the two BPNA.
+  ## The relation output reflects the established golden record relation.
+  @BPDM
+  Scenario: IsReplacedBy Relation Between Addresses Reflected In Sharing Member Relation Output
+    Given record "predecessor-address-record" reflects additional address "predecessor-address" of legal entity "acme"
+    And record "successor-address-record" reflects additional address "successor-address" of the existing legal entity "acme"
+    When the sharing member shares relation "address-succession" of type "IsReplacedBy" from "predecessor-address-record" to "successor-address-record" effective immediately
+    And the golden record process establishes relation "address-succession"
+    Then relation "address-succession" output reflects the established golden record relation
+
+  #h3. Test Objective:
+  #
+  #* Verify an established IsReplacedBy relation between two addresses surfaces on the address output of both involved records.
+  #
+  #h3. Preconditions:
+  #
+  ## Two records each reflect an additional address of the same legal entity (predecessor and successor).
+  #
+  #h3. Description:
+  #
+  ## The sharing member shares an IsReplacedBy relation from the predecessor address record to the successor address record, effective immediately.
+  ## The golden record process establishes the relation between the two BPNA.
+  ## Both records' outputs reflect the relation on their address.
+  ## Both records still reflect their address as additional address, as an address succession outside the headquarters relocation reclassifies nothing.
+  @BPDM
+  Scenario: IsReplacedBy Relation Between Addresses Reflected In Address Outputs
+    Given record "predecessor-address-record" reflects additional address "predecessor-address" of legal entity "acme"
+    And record "successor-address-record" reflects additional address "successor-address" of the existing legal entity "acme"
+    When the sharing member shares relation "address-succession" of type "IsReplacedBy" from "predecessor-address-record" to "successor-address-record" effective immediately
+    And the golden record process establishes relation "address-succession"
+    Then "predecessor-address-record" output reflects the address golden record relation "address-succession"
+    And "successor-address-record" output reflects the address golden record relation "address-succession"
+    And record "predecessor-address-record" reflects "predecessor-address" as additional address of "acme"
+    And record "successor-address-record" reflects "successor-address" as additional address of "acme"

--- a/bpdm-system-tester/src/main/resources/cucumber/output_reflects_golden_record_relations.feature
+++ b/bpdm-system-tester/src/main/resources/cucumber/output_reflects_golden_record_relations.feature
@@ -8,7 +8,8 @@
 #   - site relations (IsReplacedBy between sites) surface on the output's site,
 #   - address relations (IsReplacedBy between addresses) surface on the output's address.
 # IsReplacedBy also exists between two legal entities, where it surfaces on the legal entity; that variant is
-# covered in legal_entity_succession.feature and the site variant in site_succession.feature.
+# covered in legal_entity_succession.feature, the site variant in site_succession.feature and the address
+# variant in address_succession.feature.
 # All levels are shown regardless of what the record itself was refined to. In particular, a record refined
 # as an additional address still shows the relations of its parent legal entity, even though the record is
 # technically the additional address and the legal entity is only its parent.
@@ -18,10 +19,9 @@
 #   - IsOwnedBy and IsAlternativeHeadquarterFor are relations between two legal entities.
 #   - IsManagedBy is between two legal entities; the managing entity must be a dataspace participant (own
 #     company data) and the validity must not start in the past.
-#   - IsReplacedBy at address level is between a legal address and an additional address of the SAME legal entity and must be
-#     currently valid. The Pool expects the legal address as the relation source and the additional address
-#     as the target, and reclassifies (swaps) the two addresses; this feature only asserts that the relation
-#     is reflected and accepts the swap.
+#   - IsReplacedBy at address level is between two addresses of the SAME legal entity. Where the relation
+#     source is the legal address and it is currently valid, the Pool reclassifies (swaps) the two addresses;
+#     this feature only asserts that the relation is reflected and accepts the swap.
 @CXTPM-1039
 Feature: Output Reflects Golden Record Relations
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request implements the succession logic between addresses that are not in the headquarter relocation use case. The general address succession is simpler - just a designation in the golden record that an address has been replaced by another address. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Implements #1787 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
