### PR TITLE
deps: Consider a switch to use maintained nv-i18n package

### DIFF
--- a/bpdm-common-test/pom.xml
+++ b/bpdm-common-test/pom.xml
@@ -84,7 +84,7 @@
             <artifactId>kotlin-reflect</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.neovisionaries</groupId>
+            <groupId>uk.co.foundationsedge</groupId>
             <artifactId>nv-i18n</artifactId>
         </dependency>
         <dependency>

--- a/bpdm-common/pom.xml
+++ b/bpdm-common/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>kotlin-reflect</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.neovisionaries</groupId>
+            <groupId>uk.co.foundationsedge</groupId>
             <artifactId>nv-i18n</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <kotlin.version>2.3.21</kotlin.version>
         <kotlin.coroutines.version>1.8.1</kotlin.coroutines.version>
         <springdoc.version>3.1.0</springdoc.version>
-        <nv-i18n.version>1.29</nv-i18n.version>
+        <nv-i18n.version>1.34.1</nv-i18n.version>
         <kotlin-logging.version>3.0.5</kotlin-logging.version>
         <common-csv.version>1.14.1</common-csv.version>
         <wiremock.version>2.35.2</wiremock.version>
@@ -157,7 +157,7 @@
             </dependency>
             <!-- Contains country and language codes per ISO 3166-1 alpha-2 and ISO 639-1 -->
             <dependency>
-                <groupId>com.neovisionaries</groupId>
+                <groupId>uk.co.foundationsedge</groupId>
                 <artifactId>nv-i18n</artifactId>
                 <version>${nv-i18n.version}</version>
             </dependency>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

The original nv-i18n is no longer being maintained. Our company app relies on it, and needed newly created entries. A colleague and I have forked and published a new version of it. Due to our reliance on it we will be continuing to maintain it.

Fork location

https://github.com/foundationsedge/nv-i18n

Mvn Repo location

https://central.sonatype.com/artifact/uk.co.foundationsedge/nv-i18n
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
