### PR TITLE
fix: sharing member count not increasing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ For changes to the BPDM Helm charts please consult the [changelog](charts/bpdm/C
 - BPDM Pool: An update of data space participants (`memberships` in the deprecated v6 API) that names the same legal entity in more than one entry is now rejected as a bad request and nothing is written.
   Such a request previously succeeded, silently applying the last of the conflicting entries
 
+### Fixed
+
+- BPDM Orchestrator and Pool: The sharing member count of a golden record stopped rising when a further sharing member shared it, leaving the count and the derived confidence level permanently too low.
+  The Pool reads sharing member record updates from the Orchestrator as a timestamp cursor, but they were returned unordered, so updates beyond the first page could be skipped and were never re-sent [#1810](https://github.com/eclipse-tractusx/bpdm/issues/1810)
+
 ## [7.4.0] - 2026-06-10
 
 ### Breaking

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/SharingMemberRecordDb.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/entity/SharingMemberRecordDb.kt
@@ -29,7 +29,8 @@ import java.util.*
 @Table(
     name = "gate_records",
     indexes = [
-        Index(name = "index_gate_records_private_uuid", columnList = "private_uuid")
+        Index(name = "index_gate_records_private_uuid", columnList = "private_uuid"),
+        Index(name = "index_gate_records_updated_at", columnList = "updated_at")
     ]
 )
 class SharingMemberRecordDb (

--- a/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/SharingMemberRecordService.kt
+++ b/bpdm-orchestrator/src/main/kotlin/org/eclipse/tractusx/bpdm/orchestrator/service/SharingMemberRecordService.kt
@@ -31,6 +31,7 @@ import org.eclipse.tractusx.orchestrator.api.model.SharingMemberRecordQueryReque
 import org.eclipse.tractusx.orchestrator.api.model.SharingMemberRecordUpdateRequest
 import org.eclipse.tractusx.orchestrator.api.model.TaskCreateRequestEntry
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.util.*
@@ -40,8 +41,14 @@ class SharingMemberRecordService(
     private val sharingMemberRecordRepository: SharingMemberRecordRepository
 ) {
 
+    /**
+     * Returns the sharing member records updated after the requested timestamp, oldest update first.
+     *
+     * The ascending order is what makes the result usable as a timestamp cursor: a consumer resuming after the last
+     * entry of a page only avoids skipping records when no unread record precedes it.
+     */
     fun queryRecords(request: SharingMemberRecordQueryRequest, paginationRequest: PaginationRequest): PageDto<SharingMemberRecord>{
-        val pageable = PageRequest.of(paginationRequest.page, paginationRequest.size)
+        val pageable = PageRequest.of(paginationRequest.page, paginationRequest.size, Sort.Direction.ASC, "updatedAt")
         val recordPage = sharingMemberRecordRepository.findByUpdatedAtAfter(request.timestampAfter, pageable)
 
         return recordPage.toPageDto { toPublicDto(it) }

--- a/bpdm-orchestrator/src/main/resources/db/migration/V7_5_0_4__add_gate_record_updated_at_index.sql
+++ b/bpdm-orchestrator/src/main/resources/db/migration/V7_5_0_4__add_gate_record_updated_at_index.sql
@@ -1,0 +1,1 @@
+create index index_gate_records_updated_at on gate_records (updated_at);

--- a/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/v7/sharingmemberrecord/SharingMemberRecordSearchV7IT.kt
+++ b/bpdm-orchestrator/src/test/kotlin/org/eclipse/tractusx/bpdm/orchestrator/v7/sharingmemberrecord/SharingMemberRecordSearchV7IT.kt
@@ -126,4 +126,37 @@ class SharingMemberRecordSearchV7IT: UnscheduledOrchestratorTestBaseV7() {
 
         assertRepo.assertSharingMemberRecordEqual(searchResult, expectedResult)
     }
+
+    /**
+     * GIVEN sharing member records whose update order differs from their creation order
+     * WHEN user searches for records
+     * THEN user sees the records oldest update first
+     */
+    @Test
+    fun `search sharing member records ordered by oldest update first`(){
+        //GIVEN
+        val createdTask1 = testDataClient.createBusinessPartnerTask("$testName 1")
+        val createdTask2 = testDataClient.createBusinessPartnerTask("$testName 2")
+        val createdTask3 = testDataClient.createBusinessPartnerTask("$testName 3")
+        orchestratorClient.sharingMemberRecords.update(SharingMemberRecordUpdateRequest(createdTask2.recordId, true))
+        orchestratorClient.sharingMemberRecords.update(SharingMemberRecordUpdateRequest(createdTask1.recordId, true))
+
+        //WHEN
+        val searchResult = orchestratorClient.sharingMemberRecords.queryRecords(SharingMemberRecordQueryRequest(beforeTestingTime), PaginationRequest())
+
+        //THEN
+        //Get sharing member record IDs for golden record process services
+        val sharingMemberRecordIdsByTaskId = testDataClient.reserveBusinessPartnerTasks(createdTask1.processingState.step)
+            .reservedTasks.associate { it.taskId to it.recordId }
+        val expectedResult = PageDto(
+            3, 1, 0, 3,
+            listOf(
+                SharingMemberRecord(sharingMemberRecordIdsByTaskId[createdTask3.taskId]!!, null, Instant.now(), Instant.now()),
+                SharingMemberRecord(sharingMemberRecordIdsByTaskId[createdTask2.taskId]!!, true, Instant.now(), Instant.now()),
+                SharingMemberRecord(sharingMemberRecordIdsByTaskId[createdTask1.taskId]!!, true, Instant.now(), Instant.now())
+            )
+        )
+
+        assertRepo.assertSharingMemberRecordEqual(searchResult, expectedResult)
+    }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SharingMemberRecordSyncService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/SharingMemberRecordSyncService.kt
@@ -70,7 +70,10 @@ class SharingMemberRecordSyncService(
         val syncRecord = syncRecordService.getOrCreateRecord(SyncType.SHARING_MEMBER_RECORDS)
 
         val queryRequest = SharingMemberRecordQueryRequest(syncRecord.fromTime)
-        val updatedSharingMemberRecords = orchestrationApiClient.sharingMemberRecords.queryRecords(queryRequest, PaginationRequest())
+        val updatedSharingMemberRecords = orchestrationApiClient.sharingMemberRecords.queryRecords(
+            queryRequest,
+            PaginationRequest(size = syncConfigProperties.batchSize)
+        )
 
         val changedRecords = updatedSharingMemberRecords.content
             .mapNotNull { sharingMemberConfidenceService.updateGoldenRecordCounted(it.recordId, it.isGoldenRecordCounted) }
@@ -83,6 +86,8 @@ class SharingMemberRecordSyncService(
                         changedRecords.map { "${it.recordId} (${it.address.bpn})" }.joinIdentifiersForLog()
             }
 
+        // Resuming after the last entry of the page is only lossless because the Orchestrator returns the records
+        // oldest update first: every record this batch has not seen was updated after the one the cursor stops at.
         syncRecord.fromTime =  updatedSharingMemberRecords.content.lastOrNull()?.updatedAt ?: syncRecord.fromTime
         syncRecordRepository.save(syncRecord)
 


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request fixes business partner records sharing member count not increasing sometimes because the Orchestrator returned records unorded.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes #1810 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
