### PR TITLE
fix: possible log injection on user name

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/LoggingConfig.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/config/LoggingConfig.kt
@@ -33,7 +33,6 @@ import org.springframework.scheduling.Trigger
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
-import org.springframework.web.util.HtmlUtils
 import java.time.Duration
 import java.time.Instant
 import java.util.*
@@ -51,13 +50,10 @@ class UserLoggingFilter(
         request.requestURI.startsWith(ACTUATOR_PATH)
 
     override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
-        val userName = request.userPrincipal?.name ?: logConfigProperties.unknownUser
-        val escapedUserName = HtmlUtils.htmlEscape(userName)
-        val escapedRequest = HtmlUtils.htmlEscape(request.requestURI)
-        val escapedMethod = HtmlUtils.htmlEscape(request.method)
+        val userName = sanitize(request.userPrincipal?.name ?: logConfigProperties.unknownUser)
 
         withLoggingContext(
-            "user" to escapedUserName,
+            "user" to userName,
         ) {
             val startedAt = System.nanoTime()
             try {
@@ -66,7 +62,7 @@ class UserLoggingFilter(
                 if (logger.isDebugEnabled) {
                     val durationMillis = (System.nanoTime() - startedAt) / 1_000_000
                     logger.debug(
-                        "User '$escapedUserName' requested $escapedMethod $escapedRequest: " +
+                        "User '$userName' requested ${request.method} ${request.requestURI}: " +
                                 "${response.status} in ${durationMillis}ms"
                     )
                 }
@@ -74,8 +70,18 @@ class UserLoggingFilter(
         }
     }
 
+    // The name comes from a token claim, and the logging context puts it on every line the request writes: a line
+    // break in it would forge a log record. The request method and URI need no such treatment, as the servlet
+    // container already rejects control characters in the request line.
+    private fun sanitize(userName: String) =
+        userName.asSequence()
+            .map { if (it.isISOControl()) CONTROL_CHARACTER_REPLACEMENT else it }
+            .take(logConfigProperties.userMaxLength)
+            .joinToString("")
+
     companion object {
         private const val ACTUATOR_PATH = "/actuator"
+        private const val CONTROL_CHARACTER_REPLACEMENT = '_'
     }
 }
 

--- a/bpdm-common/src/test/kotlin/org/eclipse/tractusx/bpdm/common/config/UserLoggingFilterTest.kt
+++ b/bpdm-common/src/test/kotlin/org/eclipse/tractusx/bpdm/common/config/UserLoggingFilterTest.kt
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.bpdm.common.config
+
+import jakarta.servlet.FilterChain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.security.Principal
+
+class UserLoggingFilterTest {
+
+    @Test
+    fun `a line break in the user name can not forge a log record`() {
+        //GIVEN
+        val request = requestOf("admin\r\nERROR forged line")
+
+        //WHEN
+        val loggedUserName = loggedUserNameOf(request)
+
+        //THEN
+        assertThat(loggedUserName).isEqualTo("admin__ERROR forged line")
+    }
+
+    @Test
+    fun `a user name longer than the configured maximum is shortened`() {
+        //GIVEN
+        val request = requestOf("a".repeat(100))
+
+        //WHEN
+        val loggedUserName = loggedUserNameOf(request, LogConfigProperties(userMaxLength = 12))
+
+        //THEN
+        assertThat(loggedUserName).isEqualTo("a".repeat(12))
+    }
+
+    @Test
+    fun `a user name without control characters is logged unchanged`() {
+        //GIVEN
+        val request = requestOf("Müller & Söhne")
+
+        //WHEN
+        val loggedUserName = loggedUserNameOf(request)
+
+        //THEN
+        assertThat(loggedUserName).isEqualTo("Müller & Söhne")
+    }
+
+    @Test
+    fun `a request without a principal is logged under the configured unknown user`() {
+        //GIVEN
+        val request = MockHttpServletRequest("GET", "/api/catena/legal-entities")
+
+        //WHEN
+        val loggedUserName = loggedUserNameOf(request, LogConfigProperties(unknownUser = "Nobody"))
+
+        //THEN
+        assertThat(loggedUserName).isEqualTo("Nobody")
+    }
+
+    private fun requestOf(userName: String) =
+        MockHttpServletRequest("GET", "/api/catena/legal-entities").apply {
+            userPrincipal = Principal { userName }
+        }
+
+    private fun loggedUserNameOf(request: MockHttpServletRequest, logConfigProperties: LogConfigProperties = LogConfigProperties()): String? {
+        var loggedUserName: String? = null
+        val chain = FilterChain { _, _ -> loggedUserName = MDC.get(USER_CONTEXT_KEY) }
+
+        UserLoggingFilter(logConfigProperties).doFilter(request, MockHttpServletResponse(), chain)
+
+        return loggedUserName
+    }
+
+    companion object {
+        private const val USER_CONTEXT_KEY = "user"
+    }
+}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request removes a possible log injection vulnerability on the user name. Now the user name is properly sanitized from all control characters.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
